### PR TITLE
test: add test script to nuxt package

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -40,7 +40,8 @@
     "pretest:e2e-static": "nuxi generate playground",
     "test:e2e-static": "start-server-and-test dev:preview http://localhost:3000 cy:run",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "pnpm run test:e2e"
   },
   "dependencies": {
     "@storyblok/vue": "workspace:*"


### PR DESCRIPTION
+ This commit enables e2e testing of the @storyblok/nuxt package when running `pnpm nx run-many --target=test --all`