### PR TITLE
fix(bridge): warn if not in Draft Mode or Visual Editor

### DIFF
--- a/packages/js/src/bridge.ts
+++ b/packages/js/src/bridge.ts
@@ -10,6 +10,11 @@ export const loadBridge = (src: string) => {
 
     // Way to make sure all event handlers are called after loading
     window.storyblokRegisterEvent = (cb: () => void) => {
+      if (!window.location.search.includes('_storyblok')) {
+        console.warn('You are not in Draft Mode or in the Visual Editor.');
+        return;
+      }
+
       if (!loaded) {
         callbacks.push(cb);
       }

--- a/packages/js/src/index.test.ts
+++ b/packages/js/src/index.test.ts
@@ -374,8 +374,8 @@ describe('@storyblok/js', () => {
         ...originalLocation,
         href: 'http://localhost',
       };
-      Object.defineProperty(window, 'parent', {
-        value: { location: { href: 'http://different-origin.com' } },
+      Object.defineProperty(window, 'location', {
+        value: { search: '?_storyblok' },
         writable: true,
       });
 
@@ -395,6 +395,25 @@ describe('@storyblok/js', () => {
       window.location = originalLocation;
     });
 
+    it('should warn when not in editor mode', () => {
+      const consoleSpy = vi.spyOn(console, 'warn');
+      const callback = vi.fn();
+
+      // Ensure we're not in an iframe
+      Object.defineProperty(window, 'location', {
+        value: { search: '?test=123' },
+        writable: true,
+      });
+
+      loadBridge('https://app.storyblok.com/f/storyblok-v2-latest.js');
+      window.storyblokRegisterEvent(callback);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'You are not in Draft Mode or in the Visual Editor.',
+      );
+      expect(callback).not.toHaveBeenCalled();
+    });
+
     it('should execute callbacks in order of registration', async () => {
       const executionOrder: number[] = [];
       const callback1 = vi.fn(() => executionOrder.push(1));
@@ -402,8 +421,8 @@ describe('@storyblok/js', () => {
       const callback3 = vi.fn(() => executionOrder.push(3));
 
       // Mock being in an iframe
-      Object.defineProperty(window, 'parent', {
-        value: { location: { href: 'http://different-origin.com' } },
+      Object.defineProperty(window, 'location', {
+        value: { search: '?_storyblok' },
         writable: true,
       });
 


### PR DESCRIPTION
The previous PR removed the `window.parent` check, and in hindsight it should've kept it to preserve the function interface. This change reimplements it whilst defending against CSP errors.