### PR TITLE
fix(cli): handle uniqueness for nested presets with hierarchical keys

### DIFF
--- a/packages/cli/src/commands/components/push/graph-operations/__tests__/test-data.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/__tests__/test-data.ts
@@ -227,6 +227,20 @@ export function createTestSpaceDataState(
     presets?: SpaceComponentPreset[];
   } = {},
 ): SpaceDataState {
+  const targetComponents = targetData.components || [];
+  const targetPresets = targetData.presets || [];
+
+  // Create preset map with hierarchical keys reflecting nested resource structure
+  // Presets are scoped to components: component.name:preset.name (parent:child)
+  const presetMap = new Map<string, SpaceComponentPreset>();
+  targetPresets.forEach((preset) => {
+    const targetComponent = targetComponents.find(c => c.id === preset.component_id);
+    if (targetComponent) {
+      const compositeKey = `${targetComponent.name}:${preset.name}`;
+      presetMap.set(compositeKey, preset);
+    }
+  });
+
   return {
     local: {
       components: localData.components || [],
@@ -238,7 +252,7 @@ export function createTestSpaceDataState(
       components: new Map((targetData.components || []).map(c => [c.name, c])),
       groups: new Map((targetData.groups || []).map(g => [g.name, g])),
       tags: new Map((targetData.tags || []).map(t => [t.name, t])),
-      presets: new Map((targetData.presets || []).map(p => [p.name, p])),
+      presets: presetMap,
     },
   };
 }

--- a/packages/cli/src/commands/components/push/index.ts
+++ b/packages/cli/src/commands/components/push/index.ts
@@ -103,7 +103,14 @@ componentsCommand
 
       if (presets) {
         (presets as SpaceComponentPreset[]).forEach((preset) => {
-          spaceState.target.presets.set(preset.name, preset);
+          // Find the parent component for this nested preset resource
+          const targetComponent = (components as SpaceComponent[])?.find(c => c.id === preset.component_id);
+          if (targetComponent) {
+            // Store presets using hierarchical key: component.name:preset.name (parent:child)
+            // This reflects the nested resource relationship where presets are scoped to components
+            const compositeKey = `${targetComponent.name}:${preset.name}`;
+            spaceState.target.presets.set(compositeKey, preset);
+          }
         });
       }
 


### PR DESCRIPTION
Presets were incorrectly identified by name instead of ID, causing data conflicts when multiple presets had the same name across different components.

The root cause was that presets are nested resources (unique by name within each component) but the code treated them as globally unique by name.

fixes #154