### PR TITLE
feat: 116 implement storyblok datasources push command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -343,6 +343,28 @@
       "console": "integratedTerminal",
       "sourceMaps": true,
       "outFiles": ["${workspaceFolder}/packages/cli/dist/**/*.js"]
-    }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Pull datasources",
+      "program": "${workspaceFolder}/packages/cli/dist/index.mjs",
+      "args": ["datasources", "pull", "--space", "295017", "--verbose"],
+      "cwd": "${workspaceFolder}/packages/cli",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/packages/cli/dist/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Pull one datasource",
+      "program": "${workspaceFolder}/packages/cli/dist/index.mjs",
+      "args": ["datasources", "pull", "colors", "--space", "295017", "--verbose"],
+      "cwd": "${workspaceFolder}/packages/cli",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/packages/cli/dist/**/*.js"]
+    },
   ],
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -366,5 +366,27 @@
       "sourceMaps": true,
       "outFiles": ["${workspaceFolder}/packages/cli/dist/**/*.js"]
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Push datasources",
+      "program": "${workspaceFolder}/packages/cli/dist/index.mjs",
+      "args": ["datasources", "push", "--space", "295018", "--from", "295017", "--verbose"],
+      "cwd": "${workspaceFolder}/packages/cli",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/packages/cli/dist/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Push datasources --separate-files",
+      "program": "${workspaceFolder}/packages/cli/dist/index.mjs",
+      "args": ["datasources", "push", "--space", "295018", "--from", "295017", "--sf"],
+      "cwd": "${workspaceFolder}/packages/cli",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/packages/cli/dist/**/*.js"]
+    }
   ],
 }

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -102,15 +102,21 @@ const createMapiClient = (options: ManagementApiClientOptions): MapiClient => {
       });
 
       let data;
-      try {
-        data = await res.json();
+      // Handle responses with no content (204, etc.)
+      if (res.status === 204 || res.headers.get('content-length') === '0') {
+        data = null;
       }
-      catch {
-        throw new FetchError('Non-JSON response', {
-          status: res.status,
-          statusText: res.statusText,
-          data: null,
-        });
+      else {
+        try {
+          data = await res.json();
+        }
+        catch {
+          throw new FetchError('Non-JSON response', {
+            status: res.status,
+            statusText: res.statusText,
+            data: null,
+          });
+        }
       }
 
       // Call response interceptor if provided

--- a/packages/cli/src/commands/components/constants.ts
+++ b/packages/cli/src/commands/components/constants.ts
@@ -48,15 +48,15 @@ export interface SpaceComponentInternalTag {
   object_type?: 'asset' | 'component';
 }
 
-export interface SpaceData {
+export interface SpaceComponentsData {
   components: SpaceComponent[];
   groups: SpaceComponentGroup[];
   presets: SpaceComponentPreset[];
   internalTags: SpaceComponentInternalTag[];
 }
 
-export interface SpaceDataState {
-  local: SpaceData;
+export interface SpaceComponentsDataState {
+  local: SpaceComponentsData;
   target: {
     components: Map<string, SpaceComponent>;
     tags: Map<string, SpaceComponentInternalTag>;

--- a/packages/cli/src/commands/components/pull/actions.ts
+++ b/packages/cli/src/commands/components/pull/actions.ts
@@ -1,5 +1,5 @@
 import { handleAPIError, handleFileSystemError } from '../../../utils';
-import type { SpaceComponent, SpaceComponentGroup, SpaceComponentInternalTag, SpaceComponentPreset, SpaceData } from '../constants';
+import type { SpaceComponent, SpaceComponentGroup, SpaceComponentInternalTag, SpaceComponentPreset, SpaceComponentsData } from '../constants';
 import { join, resolve } from 'node:path';
 import { resolvePath, saveToFile } from '../../../utils/filesystem';
 import type { SaveComponentsOptions } from './constants';
@@ -85,7 +85,7 @@ export const fetchComponentInternalTags = async (space: string): Promise<SpaceCo
 
 export const saveComponentsToFiles = async (
   space: string,
-  spaceData: SpaceData,
+  spaceData: SpaceComponentsData,
   options: SaveComponentsOptions,
 ) => {
   const { components = [], groups = [], presets = [], internalTags = [] } = spaceData;

--- a/packages/cli/src/commands/components/pull/constants.ts
+++ b/packages/cli/src/commands/components/pull/constants.ts
@@ -1,7 +1,7 @@
 import type { CommandOptions } from '../../../types';
 
 /**
- * Interface representing the options for the `pull-components` command.
+ * Interface representing the options for the `components pull` command.
  */
 export interface PullComponentsOptions extends CommandOptions {
 

--- a/packages/cli/src/commands/components/push/actions.ts
+++ b/packages/cli/src/commands/components/push/actions.ts
@@ -2,9 +2,8 @@ import { FileSystemError, handleAPIError, handleFileSystemError } from '../../..
 import type { SpaceComponent, SpaceComponentGroup, SpaceComponentInternalTag, SpaceComponentPreset, SpaceComponentsData } from '../constants';
 import type { ReadComponentsOptions } from './constants';
 import { join } from 'node:path';
-import { readdir, readFile } from 'node:fs/promises';
-import { resolvePath } from '../../../utils/filesystem';
-import type { FileReaderResult } from '../../../types';
+import { readdir } from 'node:fs/promises';
+import { readJsonFile, resolvePath } from '../../../utils/filesystem';
 import chalk from 'chalk';
 import { mapiClient } from '../../../api';
 
@@ -206,20 +205,6 @@ export const upsertComponentInternalTag = async (
     return await pushComponentInternalTag(space, tag);
   }
 };
-
-async function readJsonFile<T>(filePath: string): Promise<FileReaderResult<T>> {
-  try {
-    const content = (await readFile(filePath)).toString();
-    if (!content) {
-      return { data: [] };
-    }
-    const parsed = JSON.parse(content);
-    return { data: Array.isArray(parsed) ? parsed : [parsed] };
-  }
-  catch (error) {
-    return { data: [], error: error as Error };
-  }
-}
 
 export const readComponentsFiles = async (
   options: ReadComponentsOptions): Promise<SpaceComponentsData> => {

--- a/packages/cli/src/commands/components/push/actions.ts
+++ b/packages/cli/src/commands/components/push/actions.ts
@@ -1,5 +1,5 @@
 import { FileSystemError, handleAPIError, handleFileSystemError } from '../../../utils';
-import type { SpaceComponent, SpaceComponentGroup, SpaceComponentInternalTag, SpaceComponentPreset, SpaceData } from '../constants';
+import type { SpaceComponent, SpaceComponentGroup, SpaceComponentInternalTag, SpaceComponentPreset, SpaceComponentsData } from '../constants';
 import type { ReadComponentsOptions } from './constants';
 import { join } from 'node:path';
 import { readdir, readFile } from 'node:fs/promises';
@@ -222,7 +222,7 @@ async function readJsonFile<T>(filePath: string): Promise<FileReaderResult<T>> {
 }
 
 export const readComponentsFiles = async (
-  options: ReadComponentsOptions): Promise<SpaceData> => {
+  options: ReadComponentsOptions): Promise<SpaceComponentsData> => {
   const { from, path, separateFiles = false, suffix, space } = options;
   const resolvedPath = resolvePath(path, `components/${from}`);
 
@@ -254,7 +254,7 @@ export const readComponentsFiles = async (
   return await readConsolidatedFiles(resolvedPath, suffix);
 };
 
-async function readSeparateFiles(resolvedPath: string, suffix?: string): Promise<SpaceData> {
+async function readSeparateFiles(resolvedPath: string, suffix?: string): Promise<SpaceComponentsData> {
   const files = await readdir(resolvedPath);
   const components: SpaceComponent[] = [];
   const presets: SpaceComponentPreset[] = [];
@@ -319,7 +319,7 @@ async function readSeparateFiles(resolvedPath: string, suffix?: string): Promise
   };
 }
 
-async function readConsolidatedFiles(resolvedPath: string, suffix?: string): Promise<SpaceData> {
+async function readConsolidatedFiles(resolvedPath: string, suffix?: string): Promise<SpaceComponentsData> {
   // Read required components file
   const componentsPath = join(resolvedPath, suffix ? `components.${suffix}.json` : 'components.json');
   const componentsResult = await readJsonFile<SpaceComponent>(componentsPath);

--- a/packages/cli/src/commands/components/push/graph-operations/__tests__/graph-integration.test.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/__tests__/graph-integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildDependencyGraph, determineProcessingOrder, validateGraph } from '../dependency-graph';
 import { processAllResources } from '../resource-processor';
-import type { SpaceDataState } from '../../../constants';
+import type { SpaceComponentsDataState } from '../../../constants';
 
 // Mock the API functions
 vi.mock('../../actions', () => ({
@@ -28,7 +28,7 @@ describe('graph Integration Tests', () => {
   describe('source/Target Reconciliation', () => {
     it('should correctly reconcile resources with different IDs between source and target spaces', () => {
       // Scenario: Source space has resources with IDs 100-400, target space has same resources with IDs 500-800
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [{
             id: 300,
@@ -142,7 +142,7 @@ describe('graph Integration Tests', () => {
     });
 
     it('should handle hierarchical group dependencies correctly', () => {
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [],
           groups: [
@@ -227,7 +227,7 @@ describe('graph Integration Tests', () => {
         description: '',
       });
 
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [{
             id: 100,
@@ -325,7 +325,7 @@ describe('graph Integration Tests', () => {
           internal_tag_ids: [],
         });
 
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [
             {
@@ -403,7 +403,7 @@ describe('graph Integration Tests', () => {
     it('should correctly handle presets with the same name but different IDs', () => {
       // Presets are nested resources under components - they can have the same name across different components
       // but are unique by ID globally, and by name within each component context
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [{
             id: 1,
@@ -490,7 +490,7 @@ describe('graph Integration Tests', () => {
     it('should create separate nodes for presets with duplicate names', () => {
       // Edge case: Multiple presets with the same name within the same component
       // While presets should be uniquely named within a component, this tests graceful handling of invalid data
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [{
             id: 1,
@@ -577,7 +577,7 @@ describe('graph Integration Tests', () => {
     it('should skip presets when their components are missing to prevent key inconsistencies', () => {
       // This test demonstrates data integrity: presets are nested resources that must have valid parent components
       // When a preset references a missing component, it's skipped to maintain the hierarchical relationship
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [{
             id: 1,
@@ -655,7 +655,7 @@ describe('graph Integration Tests', () => {
 
   describe('error Handling', () => {
     it('should handle missing dependencies gracefully', () => {
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [{
             id: 1,
@@ -689,7 +689,7 @@ describe('graph Integration Tests', () => {
     });
 
     it('should detect circular dependencies', () => {
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: {
           components: [
             {

--- a/packages/cli/src/commands/components/push/graph-operations/__tests__/test-data.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/__tests__/test-data.ts
@@ -3,7 +3,7 @@ import type {
   SpaceComponentGroup,
   SpaceComponentInternalTag,
   SpaceComponentPreset,
-  SpaceDataState,
+  SpaceComponentsDataState,
 } from '../../../constants';
 
 // =============================================================================
@@ -226,7 +226,7 @@ export function createTestSpaceDataState(
     tags?: SpaceComponentInternalTag[];
     presets?: SpaceComponentPreset[];
   } = {},
-): SpaceDataState {
+): SpaceComponentsDataState {
   const targetComponents = targetData.components || [];
   const targetPresets = targetData.presets || [];
 

--- a/packages/cli/src/commands/components/push/graph-operations/index.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/index.ts
@@ -1,4 +1,4 @@
-import type { SpaceDataState } from '../../constants';
+import type { SpaceComponentsDataState } from '../../constants';
 import type { GraphBuildingContext, PushResults } from './types';
 
 import { buildDependencyGraph, validateGraph } from './dependency-graph';
@@ -27,7 +27,7 @@ export type { PushResults } from './types';
  */
 export async function pushWithDependencyGraph(
   space: string,
-  spaceState: SpaceDataState,
+  spaceState: SpaceComponentsDataState,
   maxConcurrency: number = 5,
 ): Promise<PushResults> {
   // Build and validate the dependency graph with colocated target data

--- a/packages/cli/src/commands/components/push/graph-operations/types.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/types.ts
@@ -4,7 +4,7 @@ import type {
   SpaceComponentGroup,
   SpaceComponentInternalTag,
   SpaceComponentPreset,
-  SpaceDataState,
+  SpaceComponentsDataState,
 } from '../../constants';
 
 // =============================================================================
@@ -84,5 +84,5 @@ export interface PushConfig {
 
 /** Graph building context with source and target data */
 export interface GraphBuildingContext {
-  spaceState: SpaceDataState;
+  spaceState: SpaceComponentsDataState;
 }

--- a/packages/cli/src/commands/components/push/index.ts
+++ b/packages/cli/src/commands/components/push/index.ts
@@ -11,7 +11,7 @@ import { pushWithDependencyGraph } from './graph-operations';
 import chalk from 'chalk';
 import { mapiClient } from '../../../api';
 import { fetchComponentGroups, fetchComponentInternalTags, fetchComponentPresets, fetchComponents } from '../actions';
-import type { SpaceComponent, SpaceComponentGroup, SpaceComponentInternalTag, SpaceComponentPreset, SpaceDataState } from '../constants';
+import type { SpaceComponent, SpaceComponentGroup, SpaceComponentInternalTag, SpaceComponentPreset, SpaceComponentsDataState } from '../constants';
 
 const program = getProgram(); // Get the shared singleton instance
 
@@ -66,7 +66,7 @@ componentsCommand
     });
 
     try {
-      const spaceState: SpaceDataState = {
+      const spaceState: SpaceComponentsDataState = {
         local: await readComponentsFiles({
           ...options,
           path,

--- a/packages/cli/src/commands/components/push/utils.ts
+++ b/packages/cli/src/commands/components/push/utils.ts
@@ -1,4 +1,4 @@
-import type { SpaceData } from '../constants';
+import type { SpaceComponentsData } from '../constants';
 import { minimatch } from 'minimatch';
 import { collectWhitelistDependencies } from './graph-operations/dependency-graph';
 
@@ -6,10 +6,10 @@ import { collectWhitelistDependencies } from './graph-operations/dependency-grap
  * Collects all dependencies (groups, tags, and components) for a set of components
  */
 function collectAllDependencies(
-  components: SpaceData['components'],
-  allComponents: SpaceData['components'],
-  allGroups: SpaceData['groups'],
-  allTags: SpaceData['internalTags'],
+  components: SpaceComponentsData['components'],
+  allComponents: SpaceComponentsData['components'],
+  allGroups: SpaceComponentsData['groups'],
+  allTags: SpaceComponentsData['internalTags'],
 ) {
   const requiredComponents = new Set<string>();
   const requiredGroupUuids = new Set<string>();
@@ -96,7 +96,7 @@ function collectAllDependencies(
 /**
  * Filters space data to only include a specific component and its dependencies
  */
-export function filterSpaceDataByComponent(spaceData: SpaceData, componentName: string): SpaceData {
+export function filterSpaceDataByComponent(spaceData: SpaceComponentsData, componentName: string): SpaceComponentsData {
   // Find the target component
   const targetComponent = spaceData.components.find(component => component.name === componentName);
   if (!targetComponent) {
@@ -133,7 +133,7 @@ export function filterSpaceDataByComponent(spaceData: SpaceData, componentName: 
 /**
  * Filters space data to only include components matching a glob pattern and their dependencies
  */
-export function filterSpaceDataByPattern(spaceData: SpaceData, pattern: string): SpaceData {
+export function filterSpaceDataByPattern(spaceData: SpaceComponentsData, pattern: string): SpaceComponentsData {
   // Filter components by pattern
   const matchingComponents = spaceData.components.filter(component =>
     minimatch(component.name, pattern),

--- a/packages/cli/src/commands/datasources/README.md
+++ b/packages/cli/src/commands/datasources/README.md
@@ -1,0 +1,11 @@
+# Datasources Command
+
+The `datasources` module provides tools to manage Storyblok datasources and their entries.
+
+## Subcommands
+
+- [`pull`](./pull/): Download datasources and their entries from your Storyblok space. Supports saving as a single file or separate files per datasource.
+- `push` (planned): Upload datasources and their entries to your Storyblok space.
+- `delete` (planned): Remove datasources from your Storyblok space.
+
+> See each subcommand for detailed usage, options, and examples.

--- a/packages/cli/src/commands/datasources/command.ts
+++ b/packages/cli/src/commands/datasources/command.ts
@@ -1,0 +1,11 @@
+import { getProgram } from '../../program';
+
+const program = getProgram(); // Get the shared singleton instance
+
+// Components root command
+export const datasourcesCommand = program
+  .command('datasources')
+  .alias('ds')
+  .description(`Manage your space's datasources`)
+  .option('-s, --space <space>', 'space ID')
+  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/datasources');

--- a/packages/cli/src/commands/datasources/constants.ts
+++ b/packages/cli/src/commands/datasources/constants.ts
@@ -12,6 +12,7 @@ export interface SpaceDatasourceEntry {
   name: string;
   value: string;
   dimension_value: string;
+  datasource_id: number;
 }
 
 export interface SpaceDatasource {

--- a/packages/cli/src/commands/datasources/constants.ts
+++ b/packages/cli/src/commands/datasources/constants.ts
@@ -1,0 +1,28 @@
+export interface SpaceDatasourceDimension {
+  name: string;
+  type: string;
+  entry_value: string;
+  datasource_id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SpaceDatasourceEntry {
+  id: number;
+  name: string;
+  value: string;
+  dimension_value: string;
+}
+
+export interface SpaceDatasource {
+  id: number;
+  name: string;
+  slug: string;
+  dimensions: SpaceDatasourceDimension[];
+  created_at: string;
+  updated_at: string;
+  /**
+   * Optionally include entries when resolving datasources with their entries
+   */
+  entries?: SpaceDatasourceEntry[];
+}

--- a/packages/cli/src/commands/datasources/constants.ts
+++ b/packages/cli/src/commands/datasources/constants.ts
@@ -26,3 +26,14 @@ export interface SpaceDatasource {
    */
   entries?: SpaceDatasourceEntry[];
 }
+
+export interface SpaceDatasourcesData {
+  datasources: SpaceDatasource[];
+}
+
+export interface SpaceDatasourcesDataState {
+  local: SpaceDatasourcesData;
+  target: {
+    datasources: Map<string, SpaceDatasource>;
+  };
+}

--- a/packages/cli/src/commands/datasources/index.ts
+++ b/packages/cli/src/commands/datasources/index.ts
@@ -1,5 +1,8 @@
 import './command';
 import './pull';
+import './push';
 
 export * from './pull/actions';
 export * from './pull/constants';
+
+export * from './push/constants';

--- a/packages/cli/src/commands/datasources/index.ts
+++ b/packages/cli/src/commands/datasources/index.ts
@@ -1,0 +1,5 @@
+import './command';
+import './pull';
+
+export * from './pull/actions';
+export * from './pull/constants';

--- a/packages/cli/src/commands/datasources/pull/README.md
+++ b/packages/cli/src/commands/datasources/pull/README.md
@@ -1,0 +1,141 @@
+# `datasources pull`
+
+Download datasources and their entries from your Storyblok space.
+
+## Basic Usage
+
+```sh
+storyblok datasources pull --space <SPACE_ID>
+```
+
+This will download all datasources and their entries to a consolidated file:
+```
+.storyblok/
+└── datasources/
+    └── <SPACE_ID>/
+        └── datasources.json      # All datasources with entries
+```
+
+> [!WARNING]
+> The `--filename` option is ignored when using `--separate-files`. Each datasource will be saved with its own name.
+
+## Pull a Single Datasource
+
+```sh
+storyblok datasources pull <DATASOURCE_NAME> --space <SPACE_ID>
+```
+
+This will download a single datasource and its entries to:
+```
+.storyblok/
+└── datasources/
+    └── <SPACE_ID>/
+        └── <DATASOURCE_NAME>.json  # Single datasource with entries
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-s, --space <space>` | (Required) The ID of the space to pull datasources from | - |
+| `-f, --filename <filename>` | Custom name for the datasources file | `datasources` |
+| `--sf, --separate-files` | Create a separate file for each datasource | `false` |
+| `--su, --suffix <suffix>` | Suffix to add to the files names  | |
+| `-p, --path <path>` | Custom path to store the files | `.storyblok/datasources` |
+
+## Examples
+
+### Pull all datasources with default settings
+```sh
+storyblok datasources pull --space 12345
+```
+Generates:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        └── datasources.json      # All datasources with entries
+```
+
+### Pull datasources with a custom file name
+```sh
+storyblok datasources pull --space 12345 --filename my-datasources
+```
+Generates:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        └── my-datasources.json  # All datasources with entries
+```
+
+### Pull datasources with custom suffix
+```sh
+storyblok datasources pull --space 12345 --suffix dev
+```
+Generates:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        └── datasources.dev.json  # All datasources with entries
+```
+
+### Pull datasources to separate files
+```sh
+storyblok datasources pull --space 12345 --separate-files
+```
+Generates:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        ├── colors.json           # Individual datasources with entries
+        └── numbers.json
+```
+
+### Pull datasources to a custom path
+```sh
+storyblok datasources pull --space 12345 --path ./backup
+```
+Generates:
+```
+backup/
+└── datasources/
+    └── 12345/
+        └── datasources.json      # All datasources with entries
+```
+
+## File Structure
+
+The command follows this pattern for file generation:
+```
+{path}/
+└── datasources/
+    └── {spaceId}/
+        └── {filename}.{suffix}.json  # Datasources file (all datasources with entries)
+```
+
+When using `--separate-files` or pulling a single datasource:
+```
+{path}/
+└── datasources/
+    └── {spaceId}/
+        ├── {datasourceName1}.json   # Individual datasources with entries
+        ├── {datasourceName2}.json
+        └── ...
+```
+
+Where:
+- `{path}` is the base path (default: `.storyblok`)
+- `{spaceId}` is your Storyblok Space ID
+- `{filename}` is the name you specified (default: `datasources`)
+- `{suffix}` is the suffix you specified (default: space ID)
+- `{datasourceName}` is the name of the datasource
+
+## Notes
+
+- The space ID is required
+- The command will create the necessary directories if they don't exist
+- When using `--separate-files` or single datasource, each datasource is saved in its own file
+- All files include the datasource entries resolved automatically

--- a/packages/cli/src/commands/datasources/pull/actions.test.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.test.ts
@@ -1,0 +1,340 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchDatasources, saveDatasourcesToFiles } from './actions';
+import { mapiClient } from '../../../api';
+import type { SpaceDatasource, SpaceDatasourceEntry } from '../constants';
+import { vol } from 'memfs';
+
+// Mock datasources data that matches the SpaceDatasource interface
+const mockedDatasources: SpaceDatasource[] = [
+  {
+    id: 1,
+    name: 'Countries',
+    slug: 'countries',
+    dimensions: [
+      {
+        name: 'United States',
+        type: 'option',
+        entry_value: 'us',
+        datasource_id: 1,
+        created_at: '2021-08-09T12:00:00Z',
+        updated_at: '2021-08-09T12:00:00Z',
+      },
+      {
+        name: 'Canada',
+        type: 'option',
+        entry_value: 'ca',
+        datasource_id: 1,
+        created_at: '2021-08-09T12:00:00Z',
+        updated_at: '2021-08-09T12:00:00Z',
+      },
+    ],
+    created_at: '2021-08-09T12:00:00Z',
+    updated_at: '2021-08-09T12:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'Categories',
+    slug: 'categories',
+    dimensions: [
+      {
+        name: 'Technology',
+        type: 'option',
+        entry_value: 'tech',
+        datasource_id: 2,
+        created_at: '2021-08-09T12:00:00Z',
+        updated_at: '2021-08-09T12:00:00Z',
+      },
+      {
+        name: 'Business',
+        type: 'option',
+        entry_value: 'business',
+        datasource_id: 2,
+        created_at: '2021-08-09T12:00:00Z',
+        updated_at: '2021-08-09T12:00:00Z',
+      },
+    ],
+    created_at: '2021-08-09T12:00:00Z',
+    updated_at: '2021-08-09T12:00:00Z',
+  },
+];
+
+// Mock datasource entries data
+const mockedEntries: Record<number, SpaceDatasourceEntry[]> = {
+  1: [
+    { id: 101, name: 'blue', value: '#0000ff', dimension_value: '' },
+    { id: 102, name: 'red', value: '#ff0000', dimension_value: '' },
+  ],
+  2: [
+    { id: 201, name: 'tech', value: 'Technology', dimension_value: '' },
+    { id: 202, name: 'business', value: 'Business', dimension_value: '' },
+  ],
+};
+
+// MSW handlers for mocking the datasources API endpoint
+const handlers = [
+  http.get('https://api.storyblok.com/v1/spaces/12345/datasources', async ({ request }) => {
+    const token = request.headers.get('Authorization');
+
+    // Return success response for valid token
+    if (token === 'valid-token') {
+      return HttpResponse.json({
+        datasources: mockedDatasources,
+      });
+    }
+
+    // Return unauthorized error for invalid token
+    return new HttpResponse('Unauthorized', { status: 401 });
+  }),
+  http.get('https://api.storyblok.com/v1/spaces/:space/datasource_entries', async ({ request }) => {
+    const url = new URL(request.url);
+    const datasourceId = url.searchParams.get('datasource_id');
+    const entries = mockedEntries[Number(datasourceId)] || [];
+    return HttpResponse.json({ datasource_entries: entries });
+  }),
+];
+
+// Set up MSW server
+const server = setupServer(...handlers);
+
+// Setup and teardown for MSW server
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// Mock filesystem modules
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+
+describe('pull datasources actions', () => {
+  beforeEach(() => {
+    // Reset and configure the MAPI client before each test
+    mapiClient().dispose();
+    mapiClient({
+      token: 'valid-token',
+      region: 'eu',
+    });
+  });
+
+  describe('fetchDatasources', () => {
+    it('should fetch datasources successfully with a valid token', async () => {
+      const result = await fetchDatasources('12345');
+
+      // Each datasource should now have an 'entries' property
+      expect(result).toHaveLength(2);
+      expect(result?.[0]).toMatchObject({
+        id: 1,
+        name: 'Countries',
+        slug: 'countries',
+        dimensions: expect.any(Array),
+        entries: mockedEntries[1],
+      });
+      expect(result?.[1]).toMatchObject({
+        id: 2,
+        name: 'Categories',
+        slug: 'categories',
+        dimensions: expect.any(Array),
+        entries: mockedEntries[2],
+      });
+      // Ensure entries is an array
+      expect(Array.isArray(result?.[0].entries)).toBe(true);
+      expect(Array.isArray(result?.[1].entries)).toBe(true);
+    });
+
+    it('should return datasources with correct structure', async () => {
+      const result = await fetchDatasources('12345');
+
+      expect(result).toBeDefined();
+
+      // Test the structure of the first datasource
+      const firstDatasource = result?.[0];
+      expect(firstDatasource).toMatchObject({
+        id: expect.any(Number),
+        name: expect.any(String),
+        slug: expect.any(String),
+        dimensions: expect.any(Array),
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+        entries: expect.any(Array), // New: entries property
+      });
+      // Test the structure of an entry
+      const firstEntry = firstDatasource?.entries?.[0];
+      if (firstEntry) {
+        expect(firstEntry).toMatchObject({
+          id: expect.any(Number),
+          name: expect.any(String),
+          value: expect.any(String),
+          dimension_value: expect.any(String),
+        });
+      }
+    });
+
+    it('should handle empty datasources response', async () => {
+      // Override the handler to return empty datasources
+      server.use(
+        http.get('https://api.storyblok.com/v1/spaces/12345/datasources', () => {
+          return HttpResponse.json({
+            datasources: [],
+          });
+        }),
+      );
+
+      const result = await fetchDatasources('12345');
+
+      expect(result).toEqual([]);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should throw a masked error for invalid token', async () => {
+      // Configure client with invalid token
+      mapiClient().dispose();
+      mapiClient({
+        token: 'invalid-token',
+        region: 'eu',
+      });
+
+      await expect(fetchDatasources('12345')).rejects.toThrow(
+        expect.objectContaining({
+          name: 'API Error',
+          message: 'The user is not authorized to access the API',
+          cause: 'The user is not authorized to access the API',
+          errorId: 'unauthorized',
+          code: 401,
+          messageStack: [
+            'Failed to pull datasources',
+            'The user is not authorized to access the API',
+          ],
+        }),
+      );
+    });
+
+    it('should handle network errors', async () => {
+      // Override the handler to simulate network error
+      server.use(
+        http.get('https://api.storyblok.com/v1/spaces/12345/datasources', () => {
+          return HttpResponse.error();
+        }),
+      );
+
+      await expect(fetchDatasources('12345')).rejects.toThrow();
+    });
+
+    it('should handle server errors', async () => {
+      // Override the handler to return server error
+      server.use(
+        http.get('https://api.storyblok.com/v1/spaces/12345/datasources', () => {
+          return new HttpResponse('Internal Server Error', { status: 500 });
+        }),
+      );
+
+      await expect(fetchDatasources('12345')).rejects.toThrow();
+    });
+
+    it('should make request to correct endpoint with space parameter', async () => {
+      let requestUrl = '';
+
+      // Override handler to capture request URL
+      server.use(
+        http.get('https://api.storyblok.com/v1/spaces/*/datasources', ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({
+            datasources: mockedDatasources,
+          });
+        }),
+      );
+
+      await fetchDatasources('54321');
+
+      expect(requestUrl).toBe('https://api.storyblok.com/v1/spaces/54321/datasources');
+    });
+  });
+
+  describe('saveDatasourcesToFiles', () => {
+    beforeEach(() => {
+      vol.reset();
+    });
+
+    it('should save datasources to a single consolidated file', async () => {
+      vol.fromJSON({
+        '/mock/path/': null,
+      });
+      const datasources = [
+        {
+          id: 1,
+          name: 'colors',
+          slug: 'colors',
+          dimensions: [],
+          created_at: '2024-10-15T07:57:12.655Z',
+          updated_at: '2024-10-15T07:57:12.655Z',
+          entries: [
+            { id: 101, name: 'blue', value: '#0000ff', dimension_value: '' },
+          ],
+        },
+        {
+          id: 2,
+          name: 'numbers',
+          slug: 'numbers',
+          dimensions: [],
+          created_at: '2025-04-09T08:56:07.819Z',
+          updated_at: '2025-04-09T08:56:07.819Z',
+          entries: [
+            { id: 201, name: 'one', value: '1', dimension_value: '' },
+          ],
+        },
+      ];
+      await saveDatasourcesToFiles('12345', datasources, {
+        path: '/mock/path/',
+        filename: 'datasources',
+        verbose: false,
+      });
+      const files = vol.readdirSync('/mock/path/datasources/12345');
+      expect(files).toEqual(['datasources.json']);
+      const fileContent = vol.readFileSync('/mock/path/datasources/12345/datasources.json').toString();
+      const parsed = JSON.parse(fileContent);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0]).toHaveProperty('entries');
+    });
+
+    it('should save datasources to separate files', async () => {
+      vol.fromJSON({
+        '/mock/path2/': null,
+      });
+      const datasources = [
+        {
+          id: 1,
+          name: 'colors',
+          slug: 'colors',
+          dimensions: [],
+          created_at: '2024-10-15T07:57:12.655Z',
+          updated_at: '2024-10-15T07:57:12.655Z',
+          entries: [
+            { id: 101, name: 'blue', value: '#0000ff', dimension_value: '' },
+          ],
+        },
+        {
+          id: 2,
+          name: 'numbers',
+          slug: 'numbers',
+          dimensions: [],
+          created_at: '2025-04-09T08:56:07.819Z',
+          updated_at: '2025-04-09T08:56:07.819Z',
+          entries: [
+            { id: 201, name: 'one', value: '1', dimension_value: '' },
+          ],
+        },
+      ];
+      await saveDatasourcesToFiles('12345', datasources, {
+        path: '/mock/path2/',
+        separateFiles: true,
+        verbose: false,
+      });
+      const files = vol.readdirSync('/mock/path2/datasources/12345');
+      expect(files.sort()).toEqual(['colors.json', 'numbers.json']);
+      const colorsContent = vol.readFileSync('/mock/path2/datasources/12345/colors.json').toString();
+      const parsedColors = JSON.parse(colorsContent);
+      expect(parsedColors).toHaveProperty('entries');
+      expect(parsedColors.entries[0].name).toBe('blue');
+    });
+  });
+});

--- a/packages/cli/src/commands/datasources/pull/actions.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.ts
@@ -1,0 +1,99 @@
+import { handleAPIError, handleFileSystemError } from '../../../utils';
+import { mapiClient } from '../../../api';
+import { join, resolve } from 'node:path';
+import { resolvePath, saveToFile } from '../../../utils/filesystem';
+import type { SpaceDatasource, SpaceDatasourceEntry } from '../constants';
+import type { SaveDatasourcesOptions } from './constants';
+
+/**
+ * Fetches entries for a given datasource id in a space.
+ * @param space - The space ID
+ * @param datasourceId - The datasource ID
+ * @returns Array of datasource entries
+ */
+export const fetchDatasourceEntries = async (
+  space: string,
+  datasourceId: number,
+): Promise<SpaceDatasourceEntry[] | undefined> => {
+  try {
+    const client = mapiClient();
+    const { data } = await client.get<{
+      datasource_entries: SpaceDatasourceEntry[];
+    }>(`spaces/${space}/datasource_entries?datasource_id=${datasourceId}`);
+    return data.datasource_entries;
+  }
+  catch (error) {
+    // Use 'pull_datasources' as the closest valid action for datasource entries errors
+    handleAPIError('pull_datasources', error as Error);
+  }
+};
+
+export const fetchDatasources = async (space: string): Promise<SpaceDatasource[] | undefined> => {
+  try {
+    const client = mapiClient();
+    const { data } = await client.get<{
+      datasources: SpaceDatasource[];
+    }>(`spaces/${space}/datasources`);
+    const datasources = data.datasources;
+    // Fetch entries for each datasource in parallel
+    const datasourcesWithEntries = await Promise.all(
+      datasources.map(async (ds) => {
+        const entries = await fetchDatasourceEntries(space, ds.id);
+        return { ...ds, entries };
+      }),
+    );
+    return datasourcesWithEntries;
+  }
+  catch (error) {
+    handleAPIError('pull_datasources', error as Error);
+  }
+};
+
+export const fetchDatasource = async (space: string, datasourceName: string): Promise<SpaceDatasource | undefined> => {
+  try {
+    const client = mapiClient();
+    const { data } = await client.get<{
+      datasources: SpaceDatasource[];
+    }>(`spaces/${space}/datasources?search=${encodeURIComponent(datasourceName)}`);
+    const found = data.datasources?.find(d => d.name === datasourceName);
+    if (!found) { return undefined; }
+    // Fetch entries for the found datasource
+    const entries = await fetchDatasourceEntries(space, found.id);
+    return { ...found, entries };
+  }
+  catch (error) {
+    handleAPIError('pull_datasources', error as Error, `Failed to fetch datasource ${datasourceName}`);
+  }
+};
+
+// Filesystem actions
+
+export const saveDatasourcesToFiles = async (
+  space: string,
+  datasources: SpaceDatasource[],
+  options: SaveDatasourcesOptions,
+) => {
+  const { filename = 'datasources', suffix, path, separateFiles } = options;
+  // Ensure we always include the datasources/space folder structure regardless of custom path
+  const resolvedPath = path
+    ? resolve(process.cwd(), path, 'datasources', space)
+    : resolvePath(path, `datasources/${space}`);
+
+  try {
+    if (separateFiles) {
+      // Save in separate files without nested structure
+      for (const datasource of datasources) {
+        const datasourceFilePath = join(resolvedPath, suffix ? `${datasource.name}.${suffix}.json` : `${datasource.name}.json`);
+        await saveToFile(datasourceFilePath, JSON.stringify(datasource, null, 2));
+      }
+      return;
+    }
+
+    // Default to saving consolidated files
+    const datasourcesFilePath = join(resolvedPath, suffix ? `${filename}.${suffix}.json` : `${filename}.json`);
+    await saveToFile(datasourcesFilePath, JSON.stringify(datasources, null, 2));
+  }
+  catch (error) {
+    handleFileSystemError('write', error as Error);
+  }
+};

--- a/packages/cli/src/commands/datasources/pull/constants.ts
+++ b/packages/cli/src/commands/datasources/pull/constants.ts
@@ -1,0 +1,45 @@
+import type { CommandOptions } from '../../../types';
+
+/**
+ * Interface representing the options for the `datasources pull` command.
+ */
+export interface PullDatasourcesOptions extends CommandOptions {
+
+  /**
+   * The filename to save the file as.
+   * Defaults to `datasources`. The file will be saved as `<filename>.<space>.json`.
+   * @default `datasources
+   */
+  filename?: string;
+  /**
+   * The suffix to add to the filename.
+   * Defaults to the space ID.
+   * @default space
+   */
+  suffix?: string;
+  /**
+   * Indicates whether to save each datasource to a separate file.
+   * @default false
+   */
+  separateFiles?: boolean;
+}
+
+export interface SaveDatasourcesOptions extends PullDatasourcesOptions {
+  /**
+   * The path to save the datasources file to.
+   * Defaults to `.storyblok/datasources`.
+   * @default `.storyblok/datasources`
+   */
+  path?: string;
+  /**
+   * The regex filter to apply to the datasources before pushing.
+   * @default `.*`
+   */
+  filter?: string;
+  /**
+   * Indicates whether to read each datasource to a separate file.
+   * @default false
+   */
+  separateFiles?: boolean;
+
+}

--- a/packages/cli/src/commands/datasources/pull/index.ts
+++ b/packages/cli/src/commands/datasources/pull/index.ts
@@ -1,0 +1,105 @@
+import { Spinner } from '@topcli/spinner';
+import { colorPalette, commands } from '../../../constants';
+import { session } from '../../../session';
+
+import { getProgram } from '../../../program';
+import { mapiClient } from '../../../api';
+import { datasourcesCommand } from '../command';
+import type { PullDatasourcesOptions } from './constants';
+import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../../utils';
+import chalk from 'chalk';
+import { fetchDatasource, fetchDatasources, saveDatasourcesToFiles } from './actions';
+
+const program = getProgram();
+
+datasourcesCommand
+  .command('pull [datasourceName]')
+  .option('-f, --filename <filename>', 'custom name to be used in file(s) name instead of space id')
+  .option('--sf, --separate-files', 'Argument to create a single file for each datasource')
+  .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. datasources.<suffix>.json)')
+  .description('Pull datasources from your space')
+  .action(async (datasourceName: string | undefined, options: PullDatasourcesOptions) => {
+    konsola.title(` ${commands.DATASOURCES} `, colorPalette.DATASOURCES, datasourceName ? `Pulling datasource ${datasourceName}...` : 'Pulling datasources...');
+
+    // Global options
+    const verbose = program.opts().verbose;
+
+    // Command options
+    const { space, path } = datasourcesCommand.opts();
+    const { separateFiles, suffix, filename = 'datasources' } = options;
+
+    const { state, initializeSession } = session();
+    await initializeSession();
+
+    if (!requireAuthentication(state, verbose)) {
+      return;
+    }
+    if (!space) {
+      handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
+      return;
+    }
+
+    const { password, region } = state;
+
+    mapiClient({
+      token: password,
+      region,
+    });
+
+    const spinnerDatasources = new Spinner({
+      verbose: !isVitest,
+    });
+
+    try {
+      spinnerDatasources.start(`Fetching ${chalk.hex(colorPalette.DATASOURCES)('datasources')}`);
+
+      let datasources;
+      if (datasourceName) {
+        const datasource = await fetchDatasource(space, datasourceName);
+        if (!datasource) {
+          konsola.warn(`No datasource found with name "${datasourceName}"`);
+          return;
+        }
+        datasources = [datasource];
+      }
+      else {
+        datasources = await fetchDatasources(space);
+        if (!datasources || datasources.length === 0) {
+          konsola.warn(`No datasources found in the space ${space}`);
+          return;
+        }
+      }
+
+      spinnerDatasources.succeed(`${chalk.hex(colorPalette.DATASOURCES)('Datasources')} - Completed in ${spinnerDatasources.elapsedTime.toFixed(2)}ms`);
+
+      await saveDatasourcesToFiles(
+        space,
+        datasources,
+        { ...options, path, separateFiles: separateFiles || !!datasourceName },
+      );
+      konsola.br();
+      if (separateFiles) {
+        if (filename !== 'datasources') {
+          konsola.warn(`The --filename option is ignored when using --separate-files`);
+        }
+        const filePath = path ? `${path}/datasources/${space}/` : `.storyblok/datasources/${space}/`;
+        konsola.ok(`Datasources downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(filePath)}`);
+      }
+      else if (datasourceName) {
+        const fileName = suffix ? `${filename}.${suffix}.json` : `${datasourceName}.json`;
+        const filePath = path ? `${path}/datasources/${space}/${fileName}` : `.storyblok/datasources/${space}/${fileName}`;
+        konsola.ok(`Datasource ${chalk.hex(colorPalette.PRIMARY)(datasourceName)} downloaded successfully in ${chalk.hex(colorPalette.PRIMARY)(filePath)}`);
+      }
+      else {
+        const fileName = suffix ? `${filename}.${suffix}.json` : `${filename}.json`;
+        const filePath = path ? `${path}/datasources/${space}/${fileName}` : `.storyblok/datasources/${space}/${fileName}`;
+        konsola.ok(`Datasources downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(filePath)}`);
+      }
+      konsola.br();
+    }
+    catch (error) {
+      spinnerDatasources.failed(`Fetching ${chalk.hex(colorPalette.DATASOURCES)('Datasources')} - Failed`);
+      konsola.br();
+      handleError(error as Error, verbose);
+    }
+  });

--- a/packages/cli/src/commands/datasources/push/README.md
+++ b/packages/cli/src/commands/datasources/push/README.md
@@ -225,7 +225,7 @@ storyblok datasources push --space 12345 --filter "color"
 ```bash
 # If you pulled with separate files, push with the same flag
 storyblok datasources push --space 12345 --separate-files
-``` 
+```
 
 ## ⚠️ Known Caveats
 

--- a/packages/cli/src/commands/datasources/push/README.md
+++ b/packages/cli/src/commands/datasources/push/README.md
@@ -1,0 +1,244 @@
+# Datasources Push Command
+
+The `datasources push` command allows you to upload datasources and their entries to your Storyblok space.
+
+> [!WARNING]
+> This command requires you have previously used the `datasources pull` command to download those datasources. If you used any flags during the pull (like `--suffix` or `--separate-files`), you must apply them with the same values when pushing to ensure files are found correctly.
+
+## Basic Usage
+
+```bash
+storyblok datasources push --space YOUR_SPACE_ID
+```
+
+This will upload all datasources and their entries from:
+```
+.storyblok/
+└── datasources/
+    └── YOUR_SPACE_ID/
+        ├── datasources.json      # All datasources with entries
+```
+
+## Push a Single Datasource
+
+```bash
+storyblok datasources push DATASOURCE_NAME --space YOUR_SPACE_ID
+```
+
+This will upload a single datasource and its entries from:
+```
+.storyblok/
+└── datasources/
+    └── YOUR_SPACE_ID/
+        ├── DATASOURCE_NAME.json  # Single datasource with entries
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-s, --space <space>` | (Required) The ID of the space to push datasources to | - |
+| `-f, --from <from>` | Source space ID to read datasources from | Target space ID |
+| `--fi, --filter <filter>` | Filter to apply to datasources by their name (e.g., "color" will match datasources containing "color") | - |
+| `--sf, --separate-files` | Read from separate files instead of consolidated files | `false` |
+| `--su, --suffix <suffix>` | Suffix to add to the files names | - |
+| `-p, --path <path>` | Custom path to read the files from | `.storyblok/datasources` |
+
+## Examples
+
+1. Push all datasources with default settings:
+```bash
+storyblok datasources push --space 12345
+```
+Reads from:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        ├── datasources.json      # All datasources with entries
+```
+
+2. Push a single datasource:
+```bash
+storyblok datasources push colors --space 12345
+```
+Reads from:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        ├── colors.json           # Single datasource with entries
+```
+
+3. Push datasources with filter:
+```bash
+storyblok datasources push --space 12345 --filter "color"
+```
+Reads from:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        ├── datasources.json      # All datasources with entries (filtered by name)
+```
+
+4. Push datasources from a different space:
+```bash
+storyblok datasources push --space 12345 --from 67890
+```
+Reads from:
+```
+.storyblok/
+└── datasources/
+    └── 67890/
+        ├── datasources.json      # All datasources with entries
+```
+
+5. Push datasources from separate files:
+```bash
+storyblok datasources push --space 12345 --separate-files
+```
+Reads from:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        ├── colors.json           # Individual datasources with entries
+        ├── categories.json
+        ├── countries.json
+        ├── ...
+```
+
+6. Push datasources with suffix:
+```bash
+storyblok datasources push --space 12345 --suffix dev
+```
+Reads from:
+```
+.storyblok/
+└── datasources/
+    └── 12345/
+        ├── datasources.dev.json  # All datasources with entries
+```
+
+7. Push datasources from a custom path:
+```bash
+storyblok datasources push --space 12345 --path ./backup
+```
+Reads from:
+```
+backup/
+└── datasources/
+    └── 12345/
+        ├── datasources.json      # All datasources with entries
+```
+
+## File Structure
+
+The command reads from the following file structure:
+```
+{path}/
+└── datasources/
+    └── {spaceId}/
+        ├── datasources.{suffix}.json  # Datasources file with entries
+```
+
+When using `--separate-files`:
+```
+{path}/
+└── datasources/
+    └── {spaceId}/
+        ├── {datasourceName1}.{suffix}.json        # Individual datasources with entries
+        ├── {datasourceName2}.{suffix}.json
+        ├── ...
+```
+
+Where:
+- `{path}` is the base path (default: `.storyblok`)
+- `{spaceId}` is your Storyblok space ID
+- `{suffix}` is the suffix in the file name if provided
+- `{datasourceName}` is the name of the datasource
+
+## Behavior
+
+The command performs the following operations:
+
+1. **Upsert Datasources**: Creates new datasources or updates existing ones based on name matching
+2. **Upsert Entries**: Creates new entries or updates existing ones for each datasource
+3. **Progress Tracking**: Shows individual progress for each datasource being pushed
+4. **Error Handling**: Continues processing other datasources if one fails
+
+## Data Structure
+
+Each datasource file contains:
+- **Datasource metadata**: `id`, `name`, `slug`, `dimensions`, timestamps
+- **Entries**: Array of datasource entries with `id`, `name`, `value`, `dimension_value`
+
+Example datasource file:
+```json
+{
+  "id": 1,
+  "name": "colors",
+  "slug": "colors",
+  "dimensions": [],
+  "created_at": "2024-01-01T00:00:00.000Z",
+  "updated_at": "2024-01-01T00:00:00.000Z",
+  "entries": [
+    {
+      "id": 101,
+      "name": "blue",
+      "value": "#0000ff",
+      "dimension_value": "",
+      "datasource_id": 1
+    }
+  ]
+}
+```
+
+## Notes
+
+- The target space ID is required
+- The command will read from the specified path and source space
+- Datasources are matched by name for updates
+- Entries are matched by name within each datasource for updates
+- The command uploads both datasources and their associated entries
+- If no source space is specified (`--from`), it uses the target space as the source
+
+## Common Use Cases
+
+### Copy datasources between spaces
+```bash
+# Pull from production space
+storyblok datasources pull --space 12345
+
+# Push to staging space
+storyblok datasources push --space 67890 --from 12345
+```
+
+### Update specific datasources
+```bash
+# Push only color-related datasources
+storyblok datasources push --space 12345 --filter "color"
+```
+
+### Work with separate files
+```bash
+# If you pulled with separate files, push with the same flag
+storyblok datasources push --space 12345 --separate-files
+``` 
+
+## ⚠️ Known Caveats
+
+### Entry Name Dependencies
+- **Cross-space operations**: If you modify the `name` property of a datasource entry when pushing between different spaces, this will create a **new entry** instead of updating the existing one
+- **Reason**: Since datasource entry IDs are different between spaces, the `name` field is the only reliable property for matching entries across spaces
+- **Recommendation**: Avoid changing entry names when copying datasources between spaces, or manually clean up duplicate entries afterward
+
+### Matching Logic
+- **Datasources**: Matched by `name` field for upserts
+- **Entries**: Matched by `name` field within each datasource for upserts
+- **IDs**: Local file IDs are ignored during push operations (server assigns new IDs)
+
+### File Consistency
+- Must use the same flags (`--suffix`, `--separate-files`) as used during the original `pull` operation
+- Command expects files to exist in the exact structure created by `datasources pull`

--- a/packages/cli/src/commands/datasources/push/actions.test.ts
+++ b/packages/cli/src/commands/datasources/push/actions.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readDatasourcesFiles } from './actions';
+import type { SpaceDatasource } from '../constants';
+import { vol } from 'memfs';
+import { FileSystemError } from '../../../utils';
+
+// Mock filesystem modules
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+
+// Mock datasources data that matches the SpaceDatasource interface
+const mockDatasource1: SpaceDatasource = {
+  id: 1,
+  name: 'Countries',
+  slug: 'countries',
+  dimensions: [
+    {
+      name: 'United States',
+      type: 'option',
+      entry_value: 'us',
+      datasource_id: 1,
+      created_at: '2021-08-09T12:00:00Z',
+      updated_at: '2021-08-09T12:00:00Z',
+    },
+    {
+      name: 'Canada',
+      type: 'option',
+      entry_value: 'ca',
+      datasource_id: 1,
+      created_at: '2021-08-09T12:00:00Z',
+      updated_at: '2021-08-09T12:00:00Z',
+    },
+  ],
+  created_at: '2021-08-09T12:00:00Z',
+  updated_at: '2021-08-09T12:00:00Z',
+  entries: [
+    { id: 101, name: 'blue', value: '#0000ff', dimension_value: '' },
+    { id: 102, name: 'red', value: '#ff0000', dimension_value: '' },
+  ],
+};
+
+const mockDatasource2: SpaceDatasource = {
+  id: 2,
+  name: 'Categories',
+  slug: 'categories',
+  dimensions: [
+    {
+      name: 'Technology',
+      type: 'option',
+      entry_value: 'tech',
+      datasource_id: 2,
+      created_at: '2021-08-09T12:00:00Z',
+      updated_at: '2021-08-09T12:00:00Z',
+    },
+  ],
+  created_at: '2021-08-09T12:00:00Z',
+  updated_at: '2021-08-09T12:00:00Z',
+  entries: [
+    { id: 201, name: 'tech', value: 'Technology', dimension_value: '' },
+    { id: 202, name: 'business', value: 'Business', dimension_value: '' },
+  ],
+};
+
+describe('push datasources actions', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  describe('readDatasourcesFiles', () => {
+    describe('error handling', () => {
+      it('should throw FileSystemError when directory does not exist', async () => {
+        // Don't create any directory structure
+
+        await expect(
+          readDatasourcesFiles({
+            from: 'source-space',
+            path: '/mock/path',
+            space: 'target-space',
+            separateFiles: true,
+            verbose: false,
+          }),
+        ).rejects.toThrow(FileSystemError);
+
+        try {
+          await readDatasourcesFiles({
+            from: 'source-space',
+            path: '/mock/path',
+            space: 'target-space',
+            separateFiles: true,
+            verbose: false,
+          });
+        }
+        catch (error) {
+          expect(error).toBeInstanceOf(FileSystemError);
+          expect((error as FileSystemError).message).toContain('No local datasources found for space source-space');
+          expect((error as FileSystemError).message).toContain('storyblok datasources pull --space source-space');
+          expect((error as FileSystemError).message).toContain('storyblok datasources push --space target-space --from source-space');
+        }
+      });
+    });
+
+    describe('separate files mode', () => {
+      it('should read datasources from separate files without suffix', async () => {
+        // Create mock filesystem with separate files
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/countries.json': JSON.stringify([mockDatasource1]),
+          '/mock/path/datasources/source-space/categories.json': JSON.stringify([mockDatasource2]),
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: true,
+          verbose: false,
+        });
+
+        expect(result.datasources).toHaveLength(2);
+        // Don't rely on order since readdir doesn't guarantee specific order
+        expect(result.datasources).toContainEqual(mockDatasource1);
+        expect(result.datasources).toContainEqual(mockDatasource2);
+      });
+
+      it('should read datasources from separate files with suffix', async () => {
+        // Create mock filesystem with suffixed files
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/countries.dev.json': JSON.stringify([mockDatasource1]),
+          '/mock/path/datasources/source-space/categories.dev.json': JSON.stringify([mockDatasource2]),
+          '/mock/path/datasources/source-space/other.json': JSON.stringify([mockDatasource1]), // Should be ignored
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: true,
+          suffix: 'dev',
+          verbose: false,
+        });
+
+        expect(result.datasources).toHaveLength(2);
+        // Don't rely on order since readdir doesn't guarantee specific order
+        expect(result.datasources).toContainEqual(mockDatasource1);
+        expect(result.datasources).toContainEqual(mockDatasource2);
+      });
+
+      it('should filter out consolidated files when reading separate files', async () => {
+        // Create mock filesystem with mixed files
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/countries.json': JSON.stringify([mockDatasource1]),
+          '/mock/path/datasources/source-space/datasources.json': JSON.stringify([mockDatasource1, mockDatasource2]), // Should be ignored
+          '/mock/path/datasources/source-space/datasources.dev.json': JSON.stringify([mockDatasource1, mockDatasource2]), // Should be ignored
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: true,
+          verbose: false,
+        });
+
+        // Should only include the separate file, not the consolidated files
+        expect(result.datasources).toHaveLength(1);
+        expect(result.datasources[0]).toEqual(mockDatasource1);
+      });
+
+      it('should handle empty directory in separate files mode', async () => {
+        // Create empty directory
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/': null,
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: true,
+          verbose: false,
+        });
+
+        expect(result.datasources).toHaveLength(0);
+      });
+
+      it('should handle files without suffix pattern correctly', async () => {
+        // Create files with various patterns
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/countries.json': JSON.stringify([mockDatasource1]),
+          '/mock/path/datasources/source-space/categories.dev.json': JSON.stringify([mockDatasource2]), // Has suffix pattern, should be ignored when no suffix specified
+          '/mock/path/datasources/source-space/simple.json': JSON.stringify([mockDatasource1]),
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: true,
+          verbose: false,
+        });
+
+        // Should only include files without suffix pattern
+        expect(result.datasources).toHaveLength(2);
+      });
+
+      it('should handle non-JSON files gracefully', async () => {
+        // Create directory with mixed file types
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/countries.json': JSON.stringify([mockDatasource1]),
+          '/mock/path/datasources/source-space/readme.txt': 'This is a text file',
+          '/mock/path/datasources/source-space/config.yaml': 'key: value',
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: true,
+          verbose: false,
+        });
+
+        expect(result.datasources).toHaveLength(1);
+        expect(result.datasources[0]).toEqual(mockDatasource1);
+      });
+    });
+
+    describe('consolidated files mode', () => {
+      it('should read datasources from consolidated file without suffix', async () => {
+        // Create mock filesystem with consolidated file
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/datasources.json': JSON.stringify([mockDatasource1, mockDatasource2]),
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: false,
+          verbose: false,
+        });
+
+        expect(result.datasources).toHaveLength(2);
+        // For consolidated files, the order should be preserved as stored in JSON
+        expect(result.datasources[0]).toEqual(mockDatasource1);
+        expect(result.datasources[1]).toEqual(mockDatasource2);
+      });
+
+      it('should read datasources from consolidated file with suffix', async () => {
+        // Create mock filesystem with suffixed consolidated file
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/datasources.dev.json': JSON.stringify([mockDatasource1, mockDatasource2]),
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'source-space',
+          path: '/mock/path',
+          space: 'target-space',
+          separateFiles: false,
+          suffix: 'dev',
+          verbose: false,
+        });
+
+        expect(result.datasources).toHaveLength(2);
+        // For consolidated files, the order should be preserved as stored in JSON
+        expect(result.datasources[0]).toEqual(mockDatasource1);
+        expect(result.datasources[1]).toEqual(mockDatasource2);
+      });
+
+      it('should throw error when consolidated file does not exist', async () => {
+        // Create directory but no consolidated file
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/': null,
+        });
+
+        await expect(
+          readDatasourcesFiles({
+            from: 'source-space',
+            path: '/mock/path',
+            space: 'target-space',
+            separateFiles: false,
+            verbose: false,
+          }),
+        ).rejects.toThrow(FileSystemError);
+      });
+
+      it('should throw error when consolidated file is empty', async () => {
+        // Create empty consolidated file
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/datasources.json': JSON.stringify([]),
+        });
+
+        await expect(
+          readDatasourcesFiles({
+            from: 'source-space',
+            path: '/mock/path',
+            space: 'target-space',
+            separateFiles: false,
+            verbose: false,
+          }),
+        ).rejects.toThrow(FileSystemError);
+
+        try {
+          await readDatasourcesFiles({
+            from: 'source-space',
+            path: '/mock/path',
+            space: 'target-space',
+            separateFiles: false,
+            verbose: false,
+          });
+        }
+        catch (error) {
+          expect(error).toBeInstanceOf(FileSystemError);
+          expect((error as FileSystemError).message).toContain('No datasources found');
+          expect((error as FileSystemError).message).toContain('Please make sure you have pulled the datasources first');
+        }
+      });
+
+      it('should throw error when consolidated file contains invalid JSON', async () => {
+        // Create file with invalid JSON
+        vol.fromJSON({
+          '/mock/path/datasources/source-space/datasources.json': '{ invalid json }',
+        });
+
+        await expect(
+          readDatasourcesFiles({
+            from: 'source-space',
+            path: '/mock/path',
+            space: 'target-space',
+            separateFiles: false,
+            verbose: false,
+          }),
+        ).rejects.toThrow();
+      });
+    });
+
+    describe('path resolution', () => {
+      it('should use correct path resolution', async () => {
+        // Test that the function looks in the right directory structure
+        vol.fromJSON({
+          '/custom/base/path/datasources/my-space/datasources.json': JSON.stringify([mockDatasource1]),
+        });
+
+        const result = await readDatasourcesFiles({
+          from: 'my-space',
+          path: '/custom/base/path',
+          space: 'target-space',
+          separateFiles: false,
+          verbose: false,
+        });
+
+        expect(result.datasources).toHaveLength(1);
+        expect(result.datasources[0]).toEqual(mockDatasource1);
+      });
+    });
+  });
+});

--- a/packages/cli/src/commands/datasources/push/constants.ts
+++ b/packages/cli/src/commands/datasources/push/constants.ts
@@ -1,0 +1,36 @@
+import type { CommandOptions } from '../../../types';
+
+export interface PushDatasourcesOptions extends CommandOptions {
+
+  /**
+   * The glob pattern filter to apply to datasources before pushing.
+   * @default `.*`
+   */
+  filter?: string;
+  /**
+   * Indicates whether to save each component to a separate file.
+   * @default false
+   */
+  separateFiles?: boolean;
+  /**
+   * The source space id.
+   */
+  from?: string;
+  /**
+   * Suffix to add to the component name.
+   */
+  suffix?: string;
+}
+
+export interface ReadDatasourcesOptions extends PushDatasourcesOptions {
+  /**
+   * The path to read the datasources file from.
+   * Defaults to `.storyblok/datasources`.
+   * @default `.storyblok/datasources`
+   */
+  path?: string;
+  /**
+   * Target space
+   */
+  space?: string;
+}

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -1,0 +1,55 @@
+import { colorPalette, commands } from '../../../constants';
+import { CommandError, handleError, konsola, requireAuthentication } from '../../../utils';
+import { getProgram } from '../../../program';
+import { datasourcesCommand } from '../command';
+import type { PushDatasourcesOptions } from './constants';
+import { session } from '../../../session';
+import chalk from 'chalk';
+import { mapiClient } from '../../../api';
+
+const program = getProgram(); // Get the shared singleton instance
+
+datasourcesCommand
+  .command('push [datasourceName]')
+  .description(`Push your space's datasources schema as json`)
+  .option('-f, --from <from>', 'source space id')
+  .option('--fi, --filter <filter>', 'glob filter to apply to the datasources before pushing')
+  .option('--sf, --separate-files', 'Read from separate files instead of consolidated files')
+  .option('--su, --suffix <suffix>', 'Suffix to add to the datasource name')
+  .action(async (datasourceName: string | undefined, options: PushDatasourcesOptions) => {
+    konsola.title(` ${commands.DATASOURCES} `, colorPalette.DATASOURCES, datasourceName ? `Pushing datasource ${datasourceName}...` : 'Pushing datasources...');
+    // Global options
+    const verbose = program.opts().verbose;
+    const { space /* path */ } = datasourcesCommand.opts();
+
+    // Check if the user is logged in
+    const { state, initializeSession } = session();
+    await initializeSession();
+
+    if (!requireAuthentication(state, verbose)) {
+      return;
+    }
+
+    // Check if the space is provided
+    if (!space) {
+      handleError(new CommandError(`Please provide the target space as argument --space TARGET_SPACE_ID.`), verbose);
+      return;
+    }
+
+    konsola.info(`Attempting to push datasources ${chalk.bold('from')} space ${chalk.hex(colorPalette.DATASOURCES)(options.from)} ${chalk.bold('to')} ${chalk.hex(colorPalette.DATASOURCES)(space)}`);
+    konsola.br();
+
+    const { password, region } = state;
+
+    mapiClient({
+      token: password,
+      region,
+    });
+
+    try {
+      console.log('pushing datasources');
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -36,7 +36,7 @@ datasourcesCommand
       return;
     }
 
-    konsola.info(`Attempting to push datasources ${chalk.bold('from')} space ${chalk.hex(colorPalette.DATASOURCES)(options.from)} ${chalk.bold('to')} ${chalk.hex(colorPalette.DATASOURCES)(space)}`);
+    konsola.info(`Attempting to push datasources ${chalk.bold('from')} space ${chalk.hex(colorPalette.DATASOURCES)(options.from || space)} ${chalk.bold('to')} ${chalk.hex(colorPalette.DATASOURCES)(space)}`);
     konsola.br();
 
     const { password, region } = state;

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -47,7 +47,13 @@ datasourcesCommand
     });
 
     try {
-      console.log('pushing datasources');
+      /* const spaceState: SpaceDataState = {
+        local: await readDatasourcesFiles({
+          ...options,
+          path,
+          space,
+        }),
+      }; */
     }
     catch (error) {
       handleError(error as Error, verbose);

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -6,6 +6,8 @@ import type { PushDatasourcesOptions } from './constants';
 import { session } from '../../../session';
 import chalk from 'chalk';
 import { mapiClient } from '../../../api';
+import type { SpaceDatasourcesDataState } from '../constants';
+import { readDatasourcesFiles } from './actions';
 
 const program = getProgram(); // Get the shared singleton instance
 
@@ -20,7 +22,7 @@ datasourcesCommand
     konsola.title(` ${commands.DATASOURCES} `, colorPalette.DATASOURCES, datasourceName ? `Pushing datasource ${datasourceName}...` : 'Pushing datasources...');
     // Global options
     const verbose = program.opts().verbose;
-    const { space /* path */ } = datasourcesCommand.opts();
+    const { space, path } = datasourcesCommand.opts();
 
     // Check if the user is logged in
     const { state, initializeSession } = session();
@@ -47,13 +49,15 @@ datasourcesCommand
     });
 
     try {
-      /* const spaceState: SpaceDataState = {
+      const spaceState: SpaceDatasourcesDataState = {
         local: await readDatasourcesFiles({
           ...options,
           path,
           space,
         }),
-      }; */
+      };
+
+      console.log(spaceState.local.datasources);
     }
     catch (error) {
       handleError(error as Error, verbose);

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -1,13 +1,15 @@
 import { colorPalette, commands } from '../../../constants';
-import { CommandError, handleError, konsola, requireAuthentication } from '../../../utils';
+import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../../utils';
 import { getProgram } from '../../../program';
 import { datasourcesCommand } from '../command';
 import type { PushDatasourcesOptions } from './constants';
 import { session } from '../../../session';
 import chalk from 'chalk';
 import { mapiClient } from '../../../api';
-import type { SpaceDatasourcesDataState } from '../constants';
-import { readDatasourcesFiles } from './actions';
+import type { SpaceDatasource, SpaceDatasourcesDataState } from '../constants';
+import { readDatasourcesFiles, upsertDatasource } from './actions';
+import { fetchDatasources } from '../pull/actions';
+import { Spinner } from '@topcli/spinner';
 
 const program = getProgram(); // Get the shared singleton instance
 
@@ -24,6 +26,8 @@ datasourcesCommand
     const verbose = program.opts().verbose;
     const { space, path } = datasourcesCommand.opts();
 
+    const { from, filter } = options;
+
     // Check if the user is logged in
     const { state, initializeSession } = session();
     await initializeSession();
@@ -38,6 +42,11 @@ datasourcesCommand
       return;
     }
 
+    if (!from) {
+      // If no source space is provided, use the target space as source
+      options.from = space;
+    }
+
     konsola.info(`Attempting to push datasources ${chalk.bold('from')} space ${chalk.hex(colorPalette.DATASOURCES)(options.from || space)} ${chalk.bold('to')} ${chalk.hex(colorPalette.DATASOURCES)(space)}`);
     konsola.br();
 
@@ -48,6 +57,10 @@ datasourcesCommand
       region,
     });
 
+    const spinner = new Spinner({
+      verbose: !isVitest,
+    });
+
     try {
       const spaceState: SpaceDatasourcesDataState = {
         local: await readDatasourcesFiles({
@@ -55,9 +68,67 @@ datasourcesCommand
           path,
           space,
         }),
+        target: {
+          datasources: new Map(),
+        },
       };
 
-      console.log(spaceState.local.datasources);
+      const targetSpaceDatasources = await fetchDatasources(space);
+
+      if (targetSpaceDatasources) {
+        (targetSpaceDatasources as SpaceDatasource[]).forEach((datasource) => {
+          spaceState.target.datasources.set(datasource.name, datasource);
+        });
+      }
+
+      if (datasourceName) {
+        spaceState.local = {
+          datasources: [spaceState.local.datasources.find(datasource => datasource.name === datasourceName) || [] as unknown as SpaceDatasource],
+        };
+        if (!spaceState.local.datasources.length) {
+          handleError(new CommandError(`Datasource "${datasourceName}" not found.`), verbose);
+          return;
+        }
+      }
+      else if (filter) {
+        spaceState.local.datasources = spaceState.local.datasources.filter(datasource => datasource.name.includes(filter));
+        if (!spaceState.local.datasources.length) {
+          handleError(new CommandError(`No datasources found matching pattern "${filter}".`), verbose);
+          return;
+        }
+        konsola.info(`Filter applied: ${filter}`);
+      }
+
+      if (!spaceState.local.datasources.length) {
+        konsola.warn('No datasources found. Please make sure you have pulled the datasources first.');
+        return;
+      }
+
+      const results = {
+        successful: [] as string[],
+        failed: [] as Array<{ name: string; error: unknown }>,
+      };
+
+      spinner.start(`Pushing ${chalk.hex(colorPalette.DATASOURCES)('datasources')}`);
+      for (const datasource of spaceState.local.datasources) {
+        // Check if datasource already exists in target space by name
+        const existingDatasource = spaceState.target.datasources.get(datasource.name);
+        const existingId = existingDatasource?.id;
+
+        // Extract entries to handle separately (entries are not part of datasource definition)
+        const { entries, ...datasourceDefinition } = datasource;
+
+        const result = await upsertDatasource(space, datasourceDefinition, existingId);
+        if (result) {
+          results.successful.push(datasource.name);
+
+          spinner.succeed(`${chalk.hex(colorPalette.DATASOURCES)('Datasources')} - Completed in ${spinner.elapsedTime.toFixed(2)}ms`);
+        }
+        else {
+          results.failed.push({ name: datasource.name, error: result });
+          spinner.failed(`${chalk.hex(colorPalette.DATASOURCES)('Datasources')} - Failed in ${spinner.elapsedTime.toFixed(2)}ms`);
+        }
+      }
     }
     catch (error) {
       handleError(error as Error, verbose);

--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -1,5 +1,5 @@
 import { compile, type JSONSchema } from 'json-schema-to-typescript';
-import type { SpaceComponent, SpaceData } from '../../../commands/components/constants';
+import type { SpaceComponent, SpaceComponentsData } from '../../../commands/components/constants';
 import { __dirname, capitalize, handleError, handleFileSystemError, toCamelCase, toPascalCase } from '../../../utils';
 import type { GenerateTypesOptions } from './constants';
 import type { StoryblokPropertyType } from '../../../types/storyblok';
@@ -154,7 +154,7 @@ export const getComponentType = (
 const getComponentPropertiesTypeAnnotations = async (
   component: SpaceComponent,
   options: GenerateTypesOptions,
-  spaceData: SpaceData,
+  spaceData: SpaceComponentsData,
   customFieldsParser?: (key: string, value: Record<string, unknown>) => Record<string, unknown>,
 ): Promise<JSONSchema['properties']> => {
   return Object.entries<Record<string, any>>(component.schema).reduce(async (accPromise, [key, value]) => {
@@ -272,7 +272,7 @@ async function loadCompilerOptions(path: string) {
 }
 
 export const generateTypes = async (
-  spaceData: SpaceData,
+  spaceData: SpaceComponentsData,
   options: GenerateTypesOptions = {
     strict: false,
   },

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -7,6 +7,7 @@ export const commands = {
   LANGUAGES: 'languages',
   MIGRATIONS: 'Migrations',
   TYPES: 'Types',
+  DATASOURCES: 'Datasources',
 } as const;
 
 export const colorPalette = {
@@ -22,6 +23,7 @@ export const colorPalette = {
   GROUPS: '#4ade80',
   TAGS: '#fbbf24',
   PRESETS: '#a855f7',
+  DATASOURCES: '#4ade80',
 } as const;
 
 export interface ReadonlyArray<T> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import './commands/components';
 import './commands/languages';
 import './commands/migrations';
 import './commands/types';
+import './commands/datasources';
 import pkg from '../package.json';
 
 import { colorPalette } from './constants';

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -23,6 +23,8 @@ export const API_ACTIONS = {
   pull_story: 'Failed to pull story',
   update_story: 'Failed to update story',
   pull_datasources: 'Failed to pull datasources',
+  push_datasource: 'Failed to push datasource',
+  update_datasource: 'Failed to update datasource',
 } as const;
 
 export const API_ERRORS = {

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -22,6 +22,7 @@ export const API_ACTIONS = {
   pull_stories: 'Failed to pull stories',
   pull_story: 'Failed to pull story',
   update_story: 'Failed to update story',
+  pull_datasources: 'Failed to pull datasources',
 } as const;
 
 export const API_ERRORS = {

--- a/packages/cli/src/utils/filesystem.ts
+++ b/packages/cli/src/utils/filesystem.ts
@@ -1,6 +1,7 @@
 import { join, parse, resolve } from 'node:path';
 import { mkdir, readFile as readFileImpl, writeFile } from 'node:fs/promises';
 import { handleFileSystemError } from './error/filesystem-error';
+import type { FileReaderResult } from '../types';
 
 export interface FileOptions {
   mode?: number;
@@ -64,3 +65,17 @@ export const getComponentNameFromFilename = (filename: string): string => {
   // Remove the .js extension
   return filename.replace(/\.js$/, '');
 };
+
+export async function readJsonFile<T>(filePath: string): Promise<FileReaderResult<T>> {
+  try {
+    const content = (await readFile(filePath)).toString();
+    if (!content) {
+      return { data: [] };
+    }
+    const parsed = JSON.parse(content);
+    return { data: Array.isArray(parsed) ? parsed : [parsed] };
+  }
+  catch (error) {
+    return { data: [], error: error as Error };
+  }
+}


### PR DESCRIPTION
## 📝 Summary

This PR implements the `storyblok datasources push` command, allowing users to upload datasources and their entries from local files to their Storyblok spaces. This completes the datasources workflow by providing the counterpart to the existing `datasources pull` command.

## ✨ Features Added

- **Full datasources push functionality** - Upload datasources and entries to any Storyblok space
- **Single datasource targeting** - Push specific datasources by name
- **Cross-space operations** - Copy datasources from one space to another using `--from` flag
- **Flexible file structure support** - Works with both consolidated and separate file formats
- **Smart upsert logic** - Creates new datasources/entries or updates existing ones based on name matching
- **Filtering capabilities** - Filter datasources by name patterns before pushing
- **Progress tracking** - Individual spinners show progress for each datasource
- **Error resilience** - Continues processing other datasources if one fails

## 🚀 Usage Examples

### Basic usage
```bash
# Push all datasources to target space
storyblok datasources push --space 12345

# Push single datasource
storyblok datasources push colors --space 12345

# Copy datasources between spaces
storyblok datasources push --space 67890 --from 12345
```

### Advanced usage
```bash
# Push with filtering
storyblok datasources push --space 12345 --filter "color"

# Push from separate files
storyblok datasources push --space 12345 --separate-files

# Push with custom suffix
storyblok datasources push --space 12345 --suffix dev
```

## 🔧 Implementation Details

- **Upsert Operations**: Datasources are matched by name for updates, with fallback to creation
- **Entry Management**: Datasource entries are also upserted based on name matching
- **File Reading**: Supports both consolidated (`datasources.json`) and separate file formats
- **API Integration**: Uses the Management API for creating/updating datasources and entries
- **Error Handling**: Comprehensive error handling with detailed feedback


## ⚠️ Known Caveats

### Entry Name Dependencies
- **Cross-space operations**: If you modify the `name` property of a datasource entry when pushing between different spaces, this will create a **new entry** instead of updating the existing one
- **Reason**: Since datasource entry IDs are different between spaces, the `name` field is the only reliable property for matching entries across spaces
- **Recommendation**: Avoid changing entry names when copying datasources between spaces, or manually clean up duplicate entries afterward

### Matching Logic
- **Datasources**: Matched by `name` field for upserts
- **Entries**: Matched by `name` field within each datasource for upserts
- **IDs**: Local file IDs are ignored during push operations (server assigns new IDs)

### File Consistency
- Must use the same flags (`--suffix`, `--separate-files`) as used during the original `pull` operation
- Command expects files to exist in the exact structure created by `datasources pull`