### PR TITLE
fix(cli): standardize command casing and improve konsola title formatting

### DIFF
--- a/packages/cli/src/commands/components/command.ts
+++ b/packages/cli/src/commands/components/command.ts
@@ -1,10 +1,11 @@
+import { commands } from '../../constants';
 import { getProgram } from '../../program';
 
 const program = getProgram(); // Get the shared singleton instance
 
 // Components root command
 export const componentsCommand = program
-  .command('components')
+  .command(commands.COMPONENTS)
   .alias('comp')
   .description(`Manage your space's block schema`)
   .option('-s, --space <space>', 'space ID')

--- a/packages/cli/src/commands/components/pull/index.ts
+++ b/packages/cli/src/commands/components/pull/index.ts
@@ -19,7 +19,7 @@ componentsCommand
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. components.<suffix>.json)')
   .description(`Download your space's components schema as json. Optionally specify a component name to pull a single component.`)
   .action(async (componentName: string | undefined, options: PullComponentsOptions) => {
-    konsola.title(` ${commands.COMPONENTS} `, colorPalette.COMPONENTS, componentName ? `Pulling component ${componentName}...` : 'Pulling components...');
+    konsola.title(`${commands.COMPONENTS}`, colorPalette.COMPONENTS, componentName ? `Pulling component ${componentName}...` : 'Pulling components...');
     // Global options
     const verbose = program.opts().verbose;
 

--- a/packages/cli/src/commands/components/push/index.ts
+++ b/packages/cli/src/commands/components/push/index.ts
@@ -26,7 +26,7 @@ componentsCommand
   .option('--su, --suffix <suffix>', 'Suffix to add to the component name')
 
   .action(async (componentName: string | undefined, options: PushComponentsOptions) => {
-    konsola.title(` ${commands.COMPONENTS} `, colorPalette.COMPONENTS, componentName ? `Pushing component ${componentName}...` : 'Pushing components...');
+    konsola.title(`${commands.COMPONENTS}`, colorPalette.COMPONENTS, componentName ? `Pushing component ${componentName}...` : 'Pushing components...');
     // Global options
     const verbose = program.opts().verbose;
     const { space, path } = componentsCommand.opts();

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -21,7 +21,7 @@ export const createCommand = program
   .option('-b, --blueprint <blueprint>', 'technology starter blueprint')
   .option('--skip-space', 'skip space creation')
   .action(async (projectPath: string, options: CreateOptions) => {
-    konsola.title(` ${commands.CREATE} `, colorPalette.CREATE);
+    konsola.title(`${commands.CREATE}`, colorPalette.CREATE);
     // Global options
     const verbose = program.opts().verbose;
     // Command options

--- a/packages/cli/src/commands/datasources/command.ts
+++ b/packages/cli/src/commands/datasources/command.ts
@@ -1,10 +1,11 @@
+import { commands } from '../../constants';
 import { getProgram } from '../../program';
 
 const program = getProgram(); // Get the shared singleton instance
 
 // Components root command
 export const datasourcesCommand = program
-  .command('datasources')
+  .command(commands.DATASOURCES)
   .alias('ds')
   .description(`Manage your space's datasources`)
   .option('-s, --space <space>', 'space ID')

--- a/packages/cli/src/commands/datasources/delete/index.ts
+++ b/packages/cli/src/commands/datasources/delete/index.ts
@@ -19,7 +19,7 @@ datasourcesCommand
   .option('--force', 'Skip confirmation prompt for deletion (useful for CI)')
   .action(async (name: string, options: DeleteDatasourceOptions) => {
     konsola.title(
-      ` ${commands.DATASOURCES} `,
+      `${commands.DATASOURCES}`,
       colorPalette.DATASOURCES,
       options.id
         ? `Deleting datasource with id ${options.id}...`

--- a/packages/cli/src/commands/datasources/pull/index.ts
+++ b/packages/cli/src/commands/datasources/pull/index.ts
@@ -19,7 +19,7 @@ datasourcesCommand
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. datasources.<suffix>.json)')
   .description('Pull datasources from your space')
   .action(async (datasourceName: string | undefined, options: PullDatasourcesOptions) => {
-    konsola.title(` ${commands.DATASOURCES} `, colorPalette.DATASOURCES, datasourceName ? `Pulling datasource ${datasourceName}...` : 'Pulling datasources...');
+    konsola.title(`${commands.DATASOURCES}`, colorPalette.DATASOURCES, datasourceName ? `Pulling datasource ${datasourceName}...` : 'Pulling datasources...');
 
     // Global options
     const verbose = program.opts().verbose;

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -21,7 +21,7 @@ datasourcesCommand
   .option('--sf, --separate-files', 'Read from separate files instead of consolidated files')
   .option('--su, --suffix <suffix>', 'Suffix to add to the datasource name')
   .action(async (datasourceName: string | undefined, options: PushDatasourcesOptions) => {
-    konsola.title(` ${commands.DATASOURCES} `, colorPalette.DATASOURCES, datasourceName ? `Pushing datasource ${datasourceName}...` : 'Pushing datasources...');
+    konsola.title(`${commands.DATASOURCES}`, colorPalette.DATASOURCES, datasourceName ? `Pushing datasource ${datasourceName}...` : 'Pushing datasources...');
     // Global options
     const verbose = program.opts().verbose;
     const { space, path } = datasourcesCommand.opts();

--- a/packages/cli/src/commands/languages/index.ts
+++ b/packages/cli/src/commands/languages/index.ts
@@ -10,7 +10,7 @@ import { Spinner } from '@topcli/spinner';
 const program = getProgram(); // Get the shared singleton instance
 
 export const languagesCommand = program
-  .command('languages')
+  .command(commands.LANGUAGES)
   .alias('lang')
   .description(`Manage your space's languages`)
   .option('-s, --space <space>', 'space ID')
@@ -22,7 +22,7 @@ languagesCommand
   .option('-f, --filename <filename>', 'filename to save the file as <filename>.<suffix>.json')
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. languages.<suffix>.json). By default, the space ID is used.')
   .action(async (options: PullLanguagesOptions) => {
-    konsola.title(` ${commands.LANGUAGES} `, colorPalette.LANGUAGES);
+    konsola.title(`${commands.LANGUAGES}`, colorPalette.LANGUAGES);
 
     // Global options
     const verbose = program.opts().verbose;

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -39,7 +39,7 @@ export const loginCommand = program
     token: string;
     region: RegionCode;
   }) => {
-    konsola.title(` ${commands.LOGIN} `, colorPalette.LOGIN);
+    konsola.title(`${commands.LOGIN}`, colorPalette.LOGIN);
     // Global options
     const verbose = program.opts().verbose;
     // Command options

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -10,7 +10,7 @@ export const logoutCommand = program
   .command(commands.LOGOUT)
   .description('Logout from the Storyblok CLI')
   .action(async () => {
-    konsola.title(` ${commands.LOGOUT} `, colorPalette.LOGOUT);
+    konsola.title(`${commands.LOGOUT}`, colorPalette.LOGOUT);
 
     const verbose = program.opts().verbose;
     try {

--- a/packages/cli/src/commands/migrations/command.ts
+++ b/packages/cli/src/commands/migrations/command.ts
@@ -1,10 +1,11 @@
+import { commands } from '../../constants';
 import { getProgram } from '../../program';
 
 const program = getProgram(); // Get the shared singleton instance
 
 // Components root command
 export const migrationsCommand = program
-  .command('migrations')
+  .command(commands.MIGRATIONS)
   .alias('mig')
   .description(`Manage your space's migrations`)
   .option('-s, --space <space>', 'space ID')

--- a/packages/cli/src/commands/migrations/generate/index.ts
+++ b/packages/cli/src/commands/migrations/generate/index.ts
@@ -18,7 +18,7 @@ migrationsCommand
   .description('Generate a migration file')
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. {component-name}.<suffix>.js)')
   .action(async (componentName: string | undefined, options: MigrationsGenerateOptions) => {
-    konsola.title(` ${commands.MIGRATIONS} `, colorPalette.MIGRATIONS, componentName ? `Generating migration for component ${componentName}...` : 'Generating migrations...');
+    konsola.title(`${commands.MIGRATIONS}`, colorPalette.MIGRATIONS, componentName ? `Generating migration for component ${componentName}...` : 'Generating migrations...');
     // Global options
     const verbose = program.opts().verbose;
 

--- a/packages/cli/src/commands/migrations/rollback/index.ts
+++ b/packages/cli/src/commands/migrations/rollback/index.ts
@@ -13,7 +13,7 @@ const program = getProgram();
 migrationsCommand.command('rollback [migrationFile]')
   .description('Rollback a migration')
   .action(async (migrationFile: string) => {
-    konsola.title(` ${commands.MIGRATIONS} `, colorPalette.MIGRATIONS, `Rolling back migration ${chalk.hex(colorPalette.MIGRATIONS)(migrationFile)}...`);
+    konsola.title(`${commands.MIGRATIONS}`, colorPalette.MIGRATIONS, `Rolling back migration ${chalk.hex(colorPalette.MIGRATIONS)(migrationFile)}...`);
 
     const verbose = program.opts().verbose;
 

--- a/packages/cli/src/commands/migrations/run/index.ts
+++ b/packages/cli/src/commands/migrations/run/index.ts
@@ -22,7 +22,7 @@ migrationsCommand.command('run [componentName]')
   .option('--starts-with <path>', 'Filter stories by path. Example: --starts-with="/en/blog/"')
   .option('--publish <publish>', 'Options for publication mode: all | published | published-with-changes')
   .action(async (componentName: string | undefined, options: MigrationsRunOptions) => {
-    konsola.title(` ${commands.MIGRATIONS} `, colorPalette.MIGRATIONS, componentName ? `Running migrations for component ${componentName}...` : 'Running migrations...');
+    konsola.title(`${commands.MIGRATIONS}`, colorPalette.MIGRATIONS, componentName ? `Running migrations for component ${componentName}...` : 'Running migrations...');
 
     // Global options
     const verbose = program.opts().verbose;

--- a/packages/cli/src/commands/signup/index.ts
+++ b/packages/cli/src/commands/signup/index.ts
@@ -11,7 +11,7 @@ export const signupCommand = program
   .command(commands.SIGNUP)
   .description('Sign up for Storyblok')
   .action(async () => {
-    konsola.title(` ${commands.SIGNUP} `, colorPalette.SIGNUP);
+    konsola.title(`${commands.SIGNUP}`, colorPalette.SIGNUP);
     // Global options
     const verbose = program.opts().verbose;
 

--- a/packages/cli/src/commands/types/generate/index.ts
+++ b/packages/cli/src/commands/types/generate/index.ts
@@ -20,7 +20,7 @@ typesCommand
   .option('--custom-fields-parser <path>', 'Path to the parser file for Custom Field Types')
   .option('--compiler-options <options>', 'path to the compiler options from json-schema-to-typescript')
   .action(async (options: GenerateTypesOptions) => {
-    konsola.title(` ${commands.TYPES} `, colorPalette.TYPES, 'Generating types...');
+    konsola.title(`${commands.TYPES}`, colorPalette.TYPES, 'Generating types...');
     // Global options
     const verbose = program.opts().verbose;
 

--- a/packages/cli/src/commands/user/index.ts
+++ b/packages/cli/src/commands/user/index.ts
@@ -12,7 +12,7 @@ export const userCommand = program
   .command(commands.USER)
   .description('Get the current user')
   .action(async () => {
-    konsola.title(` ${commands.USER} `, colorPalette.USER);
+    konsola.title(`${commands.USER}`, colorPalette.USER);
     const { state, initializeSession } = session();
     await initializeSession();
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,3 +1,4 @@
+// Please do not change the casing of the commands, it's used for the CLI commands definition
 export const commands = {
   LOGIN: 'login',
   LOGOUT: 'logout',
@@ -5,9 +6,9 @@ export const commands = {
   USER: 'user',
   COMPONENTS: 'components',
   LANGUAGES: 'languages',
-  MIGRATIONS: 'Migrations',
-  TYPES: 'Types',
-  DATASOURCES: 'Datasources',
+  MIGRATIONS: 'migrations',
+  TYPES: 'types',
+  DATASOURCES: 'datasources',
   CREATE: 'create',
 } as const;
 

--- a/packages/cli/src/utils/konsola.ts
+++ b/packages/cli/src/utils/konsola.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { capitalize } from './format';
 
 export interface KonsolaFormatOptions {
   header?: boolean;
@@ -11,10 +12,10 @@ export function formatHeader(title: string) {
 export const konsola = {
   title: (message: string, color: string, subtitle?: string) => {
     if (subtitle) {
-      console.log(`${formatHeader(chalk.bgHex(color).bold(` ${message} `))} ${subtitle}`);
+      console.log(`${formatHeader(chalk.bgHex(color).bold(` ${capitalize(message)} `))} ${subtitle}`);
     }
     else {
-      console.log(formatHeader(chalk.bgHex(color).bold(` ${message} `)));
+      console.log(formatHeader(chalk.bgHex(color).bold(` ${capitalize(message)} `)));
     }
     console.log(''); // Add a line break
     console.log(''); // Add a line break


### PR DESCRIPTION
- Updated command constants to use lowercase for MIGRATIONS, TYPES, and DATASOURCES for consistency.
- Refactored konsola.title calls to remove unnecessary whitespace around command names for cleaner output.
- Added a comment in constants.ts to clarify the importance of command casing for CLI definitions.