### PR TITLE
feat: add type-suffix option to ts generate command

### DIFF
--- a/packages/cli/src/commands/types/generate/actions.test.ts
+++ b/packages/cli/src/commands/types/generate/actions.test.ts
@@ -292,6 +292,20 @@ describe('getComponentType', () => {
     expect(getComponentType('test_component', options)).toBe('TestComponent');
   });
 
+  it('should apply typeSuffix when provided', () => {
+    const options: GenerateTypesOptions = {
+      typeSuffix: 'CustomSuffixValue',
+    };
+    expect(getComponentType('test_component', options)).toBe('TestComponentCustomSuffixValue');
+  });
+
+  it('should handle empty typeSuffix', () => {
+    const options: GenerateTypesOptions = {
+      typeSuffix: '',
+    };
+    expect(getComponentType('test_component', options)).toBe('TestComponent');
+  });
+
   it('should handle component names with spaces', () => {
     const options: GenerateTypesOptions = {};
     expect(getComponentType('test component', options)).toBe('TestComponent');

--- a/packages/cli/src/commands/types/generate/constants.ts
+++ b/packages/cli/src/commands/types/generate/constants.ts
@@ -2,6 +2,7 @@ export interface GenerateTypesOptions {
   separateFiles?: boolean;
   strict?: boolean;
   typePrefix?: string;
+  typeSuffix?: string;
   filename?: string;
   path?: string;
   suffix?: string;

--- a/packages/cli/src/commands/types/generate/index.test.ts
+++ b/packages/cli/src/commands/types/generate/index.test.ts
@@ -201,6 +201,47 @@ describe('types generate', () => {
       });
     });
 
+    it('should pass typeSuffix option to generateTypes when --type-suffix flag is used', async () => {
+      const mockResponse = [{
+        name: 'component-name',
+        display_name: 'Component Name',
+        created_at: '2021-08-09T12:00:00Z',
+        updated_at: '2021-08-09T12:00:00Z',
+        id: 12345,
+        schema: { type: 'object' },
+        color: null,
+        internal_tags_list: [],
+        internal_tag_ids: [],
+      }];
+
+      const mockSpaceData = {
+        components: mockResponse,
+        groups: [],
+        presets: [],
+        internalTags: [],
+        datasources: [],
+      };
+
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
+      vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
+      vi.mocked(generateTypes).mockResolvedValue('// Generated types');
+
+      // Run the command with the --type-prefix flag
+      await typesCommand.parseAsync(['node', 'test', 'generate', '--space', '12345', '--type-suffix', 'CustomTypeSuffix']);
+
+      // Verify that generateTypes was called with the typePrefix option set to 'Custom'
+      expect(generateTypes).toHaveBeenCalledWith(mockSpaceData, {
+        typeSuffix: 'CustomTypeSuffix',
+        path: undefined,
+      });
+    });
+
     it('should pass suffix option to generateTypes when --suffix flag is used', async () => {
       const mockResponse = [{
         name: 'component-name',

--- a/packages/cli/src/commands/types/generate/index.ts
+++ b/packages/cli/src/commands/types/generate/index.ts
@@ -16,6 +16,7 @@ typesCommand
   .option('--sf, --separate-files', '')
   .option('--strict', 'strict mode, no loose typing')
   .option('--type-prefix <prefix>', 'prefix to be prepended to all generated component type names')
+  .option('--type-suffix <suffix>', 'suffix to be appended to all generated component type names')
   .option('--suffix <suffix>', 'Components suffix')
   .option('--custom-fields-parser <path>', 'Path to the parser file for Custom Field Types')
   .option('--compiler-options <options>', 'path to the compiler options from json-schema-to-typescript')


### PR DESCRIPTION
We need to upgrade from v3 of the storyblok cli as it has a vulnerability in the version of `form-data` via `axios`

The problem we're encountering is that the new type generator removes the behaviour of type suffixes. We use Storyblok types throughout our nextjs app and would rather keep this behaviour the same so:

1. We avoid having to rewrite the names 
2. Types are clearly coming from Storyblok components

This PR adds a flag to the ts generate command to provide the opposite of `prefix` and adds a `--types-suffix` option to the command.

