### PR TITLE
feat: add region-helper import and integrate region resolution

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@inquirer/prompts": "^7.5.1",
     "@storyblok/js": "workspace:*",
+    "@storyblok/region-helper": "workspace:*",
     "@topcli/spinner": "^2.1.2",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/packages/cli/src/commands/components/command.ts
+++ b/packages/cli/src/commands/components/command.ts
@@ -1,5 +1,6 @@
 import { commands } from '../../constants';
 import { getProgram } from '../../program';
+import { resolveRegion } from '../../utils/region';
 
 const program = getProgram(); // Get the shared singleton instance
 
@@ -9,4 +10,5 @@ export const componentsCommand = program
   .alias('comp')
   .description(`Manage your space's block schema`)
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/components');
+  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/components')
+  .hook('preAction', resolveRegion);

--- a/packages/cli/src/commands/datasources/command.ts
+++ b/packages/cli/src/commands/datasources/command.ts
@@ -1,3 +1,4 @@
+import { resolveRegion } from '../../utils/region';
 import { commands } from '../../constants';
 import { getProgram } from '../../program';
 
@@ -9,4 +10,5 @@ export const datasourcesCommand = program
   .alias('ds')
   .description(`Manage your space's datasources`)
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/datasources');
+  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/datasources')
+  .hook('preAction', resolveRegion);

--- a/packages/cli/src/commands/languages/index.ts
+++ b/packages/cli/src/commands/languages/index.ts
@@ -6,6 +6,7 @@ import { fetchLanguages, saveLanguagesToFile } from './actions';
 import chalk from 'chalk';
 import type { PullLanguagesOptions } from './constants';
 import { Spinner } from '@topcli/spinner';
+import { resolveRegion } from '../../utils/region';
 
 const program = getProgram(); // Get the shared singleton instance
 
@@ -14,7 +15,8 @@ export const languagesCommand = program
   .alias('lang')
   .description(`Manage your space's languages`)
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/languages');
+  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/languages')
+  .hook('preAction', resolveRegion);
 
 languagesCommand
   .command('pull')

--- a/packages/cli/src/commands/migrations/command.ts
+++ b/packages/cli/src/commands/migrations/command.ts
@@ -1,3 +1,4 @@
+import { resolveRegion } from '../../utils/region';
 import { commands } from '../../constants';
 import { getProgram } from '../../program';
 
@@ -9,4 +10,5 @@ export const migrationsCommand = program
   .alias('mig')
   .description(`Manage your space's migrations`)
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/migrations');
+  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/migrations')
+  .hook('preAction', resolveRegion);

--- a/packages/cli/src/commands/types/command.ts
+++ b/packages/cli/src/commands/types/command.ts
@@ -1,5 +1,6 @@
 import { commands } from '../../constants';
 import { getProgram } from '../../program';
+import { resolveRegion } from '../../utils/region';
 
 const program = getProgram(); // Get the shared singleton instance
 
@@ -9,4 +10,5 @@ export const typesCommand = program
   .alias('ts')
   .description(`Generate types d.ts for your component schemas`)
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/types');
+  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/types')
+  .hook('preAction', resolveRegion);

--- a/packages/cli/src/utils/region.ts
+++ b/packages/cli/src/utils/region.ts
@@ -1,0 +1,43 @@
+import { getRegion } from '@storyblok/region-helper';
+import type { Command } from 'commander';
+import { session } from '../session';
+
+/**
+ * Automatically determines the region code based on the space ID
+ * @param spaceId - The Storyblok space ID
+ * @returns The region code or undefined if it cannot be determined
+ */
+export function getRegionFromSpaceId(spaceId: string): string | undefined {
+  try {
+    const region = getRegion(spaceId);
+    return region || undefined;
+  }
+  catch (error) {
+    console.warn(`Failed to determine region from space ID: ${error}`);
+    return undefined;
+  }
+}
+
+/**
+ * Resolves the region for a given space ID
+ * @param thisCommand - The command instance
+ * @param _actionCommand - The action command instance
+ * @returns void
+ */
+export const resolveRegion = async (thisCommand: Command, _actionCommand: Command): Promise<void> => {
+  // Pre-action hook to handle automatic region detection
+  const options = thisCommand.opts();
+  const spaceId = options.space;
+
+  // If space ID is provided but no region is set, try to auto-detect region
+  if (spaceId) {
+    const { state, initializeSession } = session();
+    await initializeSession();
+
+    const detectedRegion = getRegionFromSpaceId(spaceId);
+
+    if (detectedRegion) {
+      state.region = detectedRegion as any;
+    }
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@storyblok/js':
         specifier: workspace:*
         version: link:../js
+      '@storyblok/region-helper':
+        specifier: workspace:*
+        version: link:../region-helper
       '@topcli/spinner':
         specifier: ^2.1.2
         version: 2.1.2


### PR DESCRIPTION
Enable automatic region detection in CLI commands by leveraging the region-helper package. The CLI now determines the correct API region based on the provided space ID, reducing the need for manual region selection.