### PR TITLE
refactor(cli): use mapi client on migrations

### DIFF
--- a/packages/cli/src/commands/migrations/run/index.ts
+++ b/packages/cli/src/commands/migrations/run/index.ts
@@ -11,6 +11,7 @@ import { handleMigrations, summarizeMigrationResults } from './operations';
 import type { Story, StoryContent } from '../../stories/constants';
 import chalk from 'chalk';
 import { isStoryPublishedWithoutChanges, isStoryWithUnpublishedChanges } from '../../stories/utils';
+import { mapiClient } from '../../../api';
 
 const program = getProgram();
 
@@ -44,6 +45,11 @@ migrationsCommand.command('run [componentName]')
     }
 
     const { password, region } = state;
+
+    mapiClient({
+      token: password,
+      region,
+    });
 
     try {
       const spinner = new Spinner({
@@ -84,8 +90,6 @@ migrationsCommand.command('run [componentName]')
       const stories = await fetchStoriesByComponent(
         {
           spaceId: space,
-          token: password,
-          region,
         },
         // Filter options
         {
@@ -102,7 +106,7 @@ migrationsCommand.command('run [componentName]')
 
       // Fetch full content for each story
       const storiesWithContent = await Promise.all(stories.map(async (story) => {
-        const fullStory = await fetchStory(space, password, region, story.id.toString());
+        const fullStory = await fetchStory(space, story.id.toString());
         return {
           ...story,
           content: fullStory?.content,
@@ -213,7 +217,7 @@ migrationsCommand.command('run [componentName]')
             }
 
             try {
-              const updatedStory = await updateStory(space, password, region, story.id, payload);
+              const updatedStory = await updateStory(space, story.id, payload);
 
               if (updatedStory) {
                 successCount++;

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -82,6 +82,4 @@ export const DEFAULT_AGENT = {
 
 export interface SpaceOptions {
   spaceId: string;
-  token: string;
-  region: RegionCode;
 }


### PR DESCRIPTION
- Removed `token` and `region` properties from the `SpaceOptions` interface in `constants.ts`.
- Updated the `fetchStories` and `fetchStory` functions to no longer require `token` and `region` parameters, utilizing `mapiClient` for authentication instead.
- Adjusted related tests to reflect these changes, ensuring that the functionality remains intact while simplifying the API calls.