### PR TITLE
refactor: make `bridge` key in useAsyncStoryblok optional

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -32,7 +32,7 @@
     "dev:build": "nuxi build playground",
     "dev:preview": "nuxi preview playground",
     "prepare:playground": "nuxi prepare playground",
-    "dev:prepare": "nuxt-module-build build --stub && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test:e2e": "start-server-and-test dev http://localhost:3000 cy:run",

--- a/packages/nuxt/playground-e2e/pages/[...slug].vue
+++ b/packages/nuxt/playground-e2e/pages/[...slug].vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 const route = useRoute();
 
 const { story, error } = await useAsyncStoryblok(route.path, {

--- a/packages/nuxt/playground-e2e/pages/[...slug].vue
+++ b/packages/nuxt/playground-e2e/pages/[...slug].vue
@@ -5,7 +5,10 @@ const { story, error } = await useAsyncStoryblok(route.path, {
   api: {
     version: 'draft',
     language: 'en',
-    resolve_relations: ['popular-articles.articles'],
+    resolve_relations: 'popular-articles.articles',
+  },
+  bridge: {
+    resolveRelations: 'popular-articles.articles',
   },
 });
 

--- a/packages/nuxt/playground/pages/[...slug].vue
+++ b/packages/nuxt/playground/pages/[...slug].vue
@@ -1,12 +1,15 @@
-<script setup>
+<script setup lang="ts">
 const { slug } = useRoute().params;
 const { story } = await useAsyncStoryblok(
-  slug && slug.length > 0 ? slug.join('/') : 'home',
+  slug && slug.length > 0 ? (slug as string[]).join('/') : 'home',
   {
     api: {
       version: 'draft',
       language: 'en',
       resolve_relations: ['popular-articles.articles'],
+    },
+    bridge: {
+      resolveRelations: 'popular-articles.articles',
     },
   },
 );

--- a/packages/nuxt/playground/pages/articles/[slug].vue
+++ b/packages/nuxt/playground/pages/articles/[slug].vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 const path = useRoute();
 const story = await useAsyncStoryblok(`vue/articles/${path.params.slug}`, {
-  version: 'draft',
-  language: 'en',
+  api: {
+    version: 'draft',
+    language: 'en',
+  },
+  bridge: {},
 });
 </script>
 

--- a/packages/nuxt/playground/pages/articles/[slug].vue
+++ b/packages/nuxt/playground/pages/articles/[slug].vue
@@ -5,7 +5,6 @@ const story = await useAsyncStoryblok(`vue/articles/${path.params.slug}`, {
     version: 'draft',
     language: 'en',
   },
-  bridge: {},
 });
 </script>
 

--- a/packages/nuxt/playground/pages/articles/index.vue
+++ b/packages/nuxt/playground/pages/articles/index.vue
@@ -6,15 +6,6 @@ const { data: articles } = await storyblokApi.get('cdn/stories/', {
   starts_with: 'vue/articles',
   is_startpage: false,
 });
-/* const storyblokApi = useStoryblokApi()
-
-const { data: articles } = await storyblokApi.get('cdn/stories/vue', {
-  version: 'draft',
-  starts_with: 'articles',
-  is_startpage: false,
-})
-
-console.count('Articles Fetch') */
 </script>
 
 <template>

--- a/packages/nuxt/playground/pages/index.vue
+++ b/packages/nuxt/playground/pages/index.vue
@@ -1,10 +1,4 @@
 <script setup lang="ts">
-/* import type { SbBlokData } from '@storyblok/vue'; */
-
-// const storyblokApi = useStoryblokApi();
-// // Checking custom Flush method
-// storyblokApi.flushCache();
-
 const { story, error } = await useAsyncStoryblok('vue', {
   api: {
     version: 'draft',
@@ -19,10 +13,9 @@ const { story, error } = await useAsyncStoryblok('vue', {
 if (error.value) {
   throw createError({
     statusCode: error.value.statusCode,
-    statusMessage: error.value.statusMessage
+    statusMessage: error.value.statusMessage,
   });
 }
-
 </script>
 
 <template>

--- a/packages/nuxt/playground/pages/richtext.vue
+++ b/packages/nuxt/playground/pages/richtext.vue
@@ -2,16 +2,11 @@
 import { NuxtLink } from '#build/components';
 import { MarkTypes, type StoryblokRichTextNode } from '@storyblok/vue';
 
-const story = await useAsyncStoryblok(
-  'vue/test-richtext',
-  {
-    api: {
-      version: 'draft',
-    },
-    bridge: {},
+const story = await useAsyncStoryblok('vue/test-richtext', {
+  api: {
+    version: 'draft',
   },
-  // { resolveRelations: "Article.categories" }
-);
+});
 
 const resolvers = {
   [MarkTypes.LINK]: (node: StoryblokRichTextNode<VNode>) => {

--- a/packages/nuxt/playground/pages/richtext.vue
+++ b/packages/nuxt/playground/pages/richtext.vue
@@ -3,33 +3,36 @@ import { NuxtLink } from '#build/components';
 import { MarkTypes, type StoryblokRichTextNode } from '@storyblok/vue';
 
 const story = await useAsyncStoryblok(
-  "vue/test-richtext",
+  'vue/test-richtext',
   {
-    version: "draft"
-  }
+    api: {
+      version: 'draft',
+    },
+    bridge: {},
+  },
   // { resolveRelations: "Article.categories" }
 );
 
 const resolvers = {
   [MarkTypes.LINK]: (node: StoryblokRichTextNode<VNode>) => {
-    return node.attrs?.linktype === "STORY"
+    return node.attrs?.linktype === 'STORY'
       ? h(
           NuxtLink,
           {
             to: node.attrs?.href,
-            target: node.attrs?.target
+            target: node.attrs?.target,
           },
-          node.text
+          node.text,
         )
       : h(
-          "a",
+          'a',
           {
             href: node.attrs?.href,
-            target: node.attrs?.target
+            target: node.attrs?.target,
           },
-          node.text
+          node.text,
         );
-  }
+  },
 };
 </script>
 

--- a/packages/nuxt/src/types/index.ts
+++ b/packages/nuxt/src/types/index.ts
@@ -1,5 +1,9 @@
 import type { AsyncData, AsyncDataOptions, NuxtError } from 'nuxt/app';
-import type { ISbResult, ISbStoriesParams, StoryblokBridgeConfigV2 } from '@storyblok/vue';
+import type {
+  ISbResult,
+  ISbStoriesParams,
+  StoryblokBridgeConfigV2,
+} from '@storyblok/vue';
 import type { ComputedRef } from 'vue';
 
 /**
@@ -10,10 +14,11 @@ export interface UseAsyncStoryblokOptions extends AsyncDataOptions<ISbResult> {
   /** Storyblok API parameters for fetching stories */
   api: ISbStoriesParams;
   /** Storyblok Bridge configuration for live preview */
-  bridge: StoryblokBridgeConfigV2;
+  bridge?: StoryblokBridgeConfigV2;
 }
 
-export interface UseAsyncStoryblokResult extends AsyncData<ISbResult, NuxtError<unknown>> {
+export interface UseAsyncStoryblokResult
+  extends AsyncData<ISbResult, NuxtError<unknown>> {
   story: ComputedRef<ISbResult['data']['story']>;
 }
 


### PR DESCRIPTION
- Makes `bridge` an optional key in `UseAsyncStoryblokOptions`. This seeks to remove the need to pass a redundant empty bridge options property in `useAsyncStoryblok` where bridge options are not needed.
- Removes duplicate declaration of `UseAsyncStoryblokOptions` interface from `packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts` & imports it from `packages/nuxt/src/types/index.ts` instead to maintain a single source of truth
- Sets `script setup` lang to `ts` across `/playground` and `/playground-e2e` pages for clearer typescript error handling
- Updates the nuxt module's `dev:prepare` script in line with the Nuxt module builder (see [here](https://github.com/nuxt/starter/blob/module/package.json))
- Adds missing options keys in `useAsyncStoryblok` across `/playground` and `/playground-e2e`