### PR TITLE
fix: calculate remaining pages from API response

### DIFF
--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -262,7 +262,7 @@ class Storyblok {
       firstPage,
       fetchOptions,
     );
-    const lastPage = firstRes.total ? Math.ceil(firstRes.total / perPage) : 1;
+    const lastPage = firstRes.total ? Math.ceil(firstRes.total / (firstRes.perPage || perPage)) : 1;
 
     const restRes: any = await asyncMap(
       range(firstPage, lastPage),


### PR DESCRIPTION
This pull request enhances the pagination logic in the Storyblok client and adds corresponding unit tests to ensure correct behavior. The changes focus on improving how the client calculates the number of pages based on the API response and fallback mechanisms.

### Enhancements to pagination logic:

* [`packages/js-client/src/index.ts`](diffhunk://#diff-8b93c79e77de0f37b0f8b1bcce59ac79b134dd55e28004ff1abdc905e5c521a7L265-R265): Updated the pagination calculation to prioritize the `perPage` value returned by the API. If the API does not provide `perPage`, the client falls back to its default value.

### Unit tests for pagination behavior:

* [`packages/js-client/src/index.test.ts`](diffhunk://#diff-9baa281b0ff913c43e55dff3a42cfdca92f626e8a53c2290aa32dd62732d0e7bR597-R643): Added a test case to verify that the client uses the API's `perPage` value for pagination when provided.
* [`packages/js-client/src/index.test.ts`](diffhunk://#diff-9baa281b0ff913c43e55dff3a42cfdca92f626e8a53c2290aa32dd62732d0e7bR597-R643): Added a test case to ensure the client falls back to its default `perPage` value when the API does not return a `perPage` value.

fixes #191 