### PR TITLE
fix(cli): return non-zero exit code for invalid commands

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,8 @@ program.helpOption('-h, --help', 'Display help for command');
 program.on('command:*', () => {
   console.error(`Invalid command: ${program.args.join(' ')}`);
   konsola.br();
-  program.help();
+  program.outputHelp();
+  process.exit(1);
 });
 
 try {


### PR DESCRIPTION
When using an invalid command, the CLI was returning exit code 0 instead of a non-zero exit code to indicate an error. This prevented proper error handling in CI systems and shell scripts.

Changed program.help() to program.outputHelp() + process.exit(1) to ensure invalid commands return exit code 1 while preserving the help display functionality.

Closes WDX-57