### PR TITLE
fix(cli): support tag-based restrictions in bloks type generation

### DIFF
--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -225,6 +225,24 @@ const getComponentPropertiesTypeAnnotations = async (
               = componentsInGroupWhitelist.length > 0 ? `(${componentsInGroupWhitelist.join(' | ')})[]` : `never[]`;
           }
         }
+        else if (value.restrict_type === 'tags') {
+          // Components restricted by tags
+          if (Array.isArray(value.component_tag_whitelist) && value.component_tag_whitelist.length > 0) {
+            // Find components that have any of the whitelisted tag IDs
+            const componentsWithTags = spaceData.components.filter(
+              component =>
+                component.internal_tag_ids
+                && component.internal_tag_ids.some(tagId =>
+                  value.component_tag_whitelist.includes(Number(tagId)),
+                ),
+            );
+
+            propertyTypeAnnotation[key].tsType
+              = componentsWithTags.length > 0
+                ? `(${componentsWithTags.map(component => getComponentType(component.name, options)).join(' | ')})[]`
+                : `never[]`;
+          }
+        }
         else {
           // Components restricted by 1-by-1 list
           if (Array.isArray(value.component_whitelist) && value.component_whitelist.length > 0) {


### PR DESCRIPTION
When using restrict_type: 'tags' with component_tag_whitelist, the CLI now generates proper union types instead of unknown[]. This enables accurate TypeScript types when using tag-based component whitelists in Storyblok.
    
fixes WDX-47
fixes #192 