### PR TITLE
chore(astro): upgrade Astro dependency to the latest version

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -84,7 +84,7 @@
     "@storyblok/eslint-config": "workspace:*",
     "@types/lodash.mergewith": "^4.6.9",
     "@types/node": "^22.15.18",
-    "astro": "^5.0.9",
+    "astro": "^5.13.2",
     "cypress": "^14.3.3",
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^10.0.1",

--- a/packages/astro/playground/ssg/package.json
+++ b/packages/astro/playground/ssg/package.json
@@ -14,7 +14,7 @@
     "@astrojs/tailwind": "^5.1.3",
     "@astrojs/vue": "^5.0.2",
     "@storyblok/astro": "workspace:*",
-    "astro": "^5.0.9",
+    "astro": "^5.13.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "svelte": "^5.14.1",

--- a/packages/astro/playground/ssg/src/pages/[...slug].astro
+++ b/packages/astro/playground/ssg/src/pages/[...slug].astro
@@ -1,15 +1,15 @@
 ---
-import { useStoryblokApi } from "@storyblok/astro";
-import StoryblokComponent from "@storyblok/astro/StoryblokComponent.astro";
-import BaseLayout from "../layouts/BaseLayout.astro";
+import { useStoryblokApi } from '@storyblok/astro';
+import StoryblokComponent from '@storyblok/astro/StoryblokComponent.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
 
 export async function getStaticPaths() {
   const sbApi = useStoryblokApi();
-  const { data } = await sbApi.get("cdn/links", {
-    version: "draft",
+  const { data } = await sbApi.get('cdn/links', {
+    version: 'draft',
   });
-  let links = data.links;
-  links = Object.values(links);
+  let linksObj = data.links;
+  let links = Object.values(linksObj);
 
   return links.map((link) => {
     return {
@@ -21,8 +21,8 @@ const { slug } = Astro.params;
 
 const sbApi = useStoryblokApi();
 const { data } = await sbApi.get(`cdn/stories/${slug}`, {
-  version: "draft",
-  resolve_relations: ["featured-articles.posts"],
+  version: 'draft',
+  resolve_relations: ['featured-articles.posts'],
 });
 
 const story = data.story;

--- a/packages/astro/playground/ssr/package.json
+++ b/packages/astro/playground/ssr/package.json
@@ -15,7 +15,7 @@
     "@astrojs/vercel": "^8.0.1",
     "@astrojs/vue": "^5.0.2",
     "@storyblok/astro": "workspace:*",
-    "astro": "^5.0.9",
+    "astro": "^5.13.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "svelte": "^5.14.1",

--- a/packages/astro/playground/test/package.json
+++ b/packages/astro/playground/test/package.json
@@ -14,7 +14,7 @@
     "@astrojs/tailwind": "^5.1.3",
     "@astrojs/vue": "^5.0.2",
     "@storyblok/astro": "workspace:*",
-    "astro": "^5.0.9",
+    "astro": "^5.13.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "svelte": "^5.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: ^22.15.18
         version: 22.15.18
       astro:
-        specifier: ^5.0.9
-        version: 5.7.13(@types/node@22.15.18)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        specifier: ^5.13.2
+        version: 5.13.2(@types/node@22.15.18)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       cypress:
         specifier: ^14.3.3
         version: 14.3.3
@@ -111,19 +111,19 @@ importers:
         version: 4.2.7(@types/node@24.1.0)(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)
       '@astrojs/svelte':
         specifier: ^7.0.1
-        version: 7.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 7.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       '@astrojs/tailwind':
         specifier: ^5.1.3
-        version: 5.1.5(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
+        version: 5.1.5(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
       '@astrojs/vue':
         specifier: ^5.0.2
-        version: 5.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)
+        version: 5.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
-        specifier: ^5.0.9
-        version: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        specifier: ^5.13.2
+        version: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -151,22 +151,22 @@ importers:
         version: 4.2.7(@types/node@24.1.0)(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)
       '@astrojs/svelte':
         specifier: ^7.0.1
-        version: 7.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 7.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       '@astrojs/tailwind':
         specifier: ^5.1.3
-        version: 5.1.5(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
+        version: 5.1.5(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
       '@astrojs/vercel':
         specifier: ^8.0.1
-        version: 8.1.4(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(svelte@5.30.1)(vue-router@4.5.1(vue@3.5.14(typescript@5.8.3)))(vue@3.5.14(typescript@5.8.3))
+        version: 8.1.4(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(svelte@5.30.1)(vue-router@4.5.1(vue@3.5.14(typescript@5.8.3)))(vue@3.5.14(typescript@5.8.3))
       '@astrojs/vue':
         specifier: ^5.0.2
-        version: 5.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)
+        version: 5.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
-        specifier: ^5.0.9
-        version: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        specifier: ^5.13.2
+        version: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -194,19 +194,19 @@ importers:
         version: 4.2.7(@types/node@24.1.0)(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)
       '@astrojs/svelte':
         specifier: ^7.0.1
-        version: 7.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 7.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       '@astrojs/tailwind':
         specifier: ^5.1.3
-        version: 5.1.5(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
+        version: 5.1.5(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
       '@astrojs/vue':
         specifier: ^5.0.2
-        version: 5.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)
+        version: 5.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
-        specifier: ^5.0.9
-        version: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        specifier: ^5.13.2
+        version: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -1023,7 +1023,7 @@ importers:
         version: link:../../../astro
       astro:
         specifier: ^5.5.3
-        version: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
 
   packages/richtext/playground/node:
     dependencies:
@@ -1448,15 +1448,21 @@ packages:
   '@astrojs/compiler@2.12.0':
     resolution: {integrity: sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA==}
 
+  '@astrojs/compiler@2.12.2':
+    resolution: {integrity: sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==}
+
   '@astrojs/internal-helpers@0.6.1':
     resolution: {integrity: sha512-l5Pqf6uZu31aG+3Lv8nl/3s4DbUzdlxTWDof4pEpto6GUJNhhCbelVi9dEyurOVyqaelwmS9oSyOWOENSfgo9A==}
 
-  '@astrojs/markdown-remark@6.3.1':
-    resolution: {integrity: sha512-c5F5gGrkczUaTVgmMW9g1YMJGzOtRvjjhw6IfGuxarM6ct09MpwysP10US729dy07gg8y+ofVifezvP3BNsWZg==}
+  '@astrojs/internal-helpers@0.7.2':
+    resolution: {integrity: sha512-KCkCqR3Goym79soqEtbtLzJfqhTWMyVaizUi35FLzgGSzBotSw8DB1qwsu7U96ihOJgYhDk2nVPz+3LnXPeX6g==}
 
-  '@astrojs/prism@3.2.0':
-    resolution: {integrity: sha512-GilTHKGCW6HMq7y3BUv9Ac7GMe/MO9gi9GW62GzKtth0SwukCu/qp2wLiGpEujhY+VVhaG9v7kv/5vFzvf4NYw==}
-    engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0}
+  '@astrojs/markdown-remark@6.3.6':
+    resolution: {integrity: sha512-bwylYktCTsLMVoCOEHbn2GSUA3c5KT/qilekBKA3CBng0bo1TYjNZPr761vxumRk9kJGqTOtU+fgCAp5Vwokug==}
+
+  '@astrojs/prism@3.3.0':
+    resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/react@4.2.7':
     resolution: {integrity: sha512-/wM90noT/6QyJEOGdDmDbq2D9qZooKTJNG1M8olmsW5ns6bJ7uxG5fzkYxcpA3WUTD6Dj6NtpEqchvb5h8Fa+g==}
@@ -1481,9 +1487,9 @@ packages:
       astro: ^3.0.0 || ^4.0.0 || ^5.0.0
       tailwindcss: ^3.0.24
 
-  '@astrojs/telemetry@3.2.1':
-    resolution: {integrity: sha512-SSVM820Jqc6wjsn7qYfV9qfeQvePtVc1nSofhyap7l0/iakUKywj3hfy3UJAOV4sGV4Q/u450RD4AaCaFvNPlg==}
-    engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0}
+  '@astrojs/telemetry@3.3.0':
+    resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/vercel@8.1.4':
     resolution: {integrity: sha512-mJAbaXwLBVsk+5JNwzKIrpvIQ4llW/gS9ut5Rot5x6D+9DYSqfZ6PRIT0YvyzgUackahYAQdH/MZWeqVrcmwuA==}
@@ -6263,9 +6269,9 @@ packages:
     resolution: {integrity: sha512-JepyLROIad6f44uyqMF6HKE2QbunNzp3mYKRcPoDGt0QkxXmH222FAFC64WTyQu2Kg8NNEXHTN/sWuUId9sSxw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  astro@5.7.13:
-    resolution: {integrity: sha512-cRGq2llKOhV3XMcYwQpfBIUcssN6HEK5CRbcMxAfd9OcFhvWE7KUy50zLioAZVVl3AqgUTJoNTlmZfD2eG0G1w==}
-    engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
+  astro@5.13.2:
+    resolution: {integrity: sha512-yjcXY0Ua3EwjpVd3GoUXa65HQ6qgmURBptA+M9GzE0oYvgfuyM7bIbH8IR/TWIbdefVUJR5b7nZ0oVnMytmyfQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
   astrojs-compiler-sync@1.1.1:
@@ -13934,12 +13940,16 @@ snapshots:
 
   '@astrojs/compiler@2.12.0': {}
 
+  '@astrojs/compiler@2.12.2': {}
+
   '@astrojs/internal-helpers@0.6.1': {}
 
-  '@astrojs/markdown-remark@6.3.1':
+  '@astrojs/internal-helpers@0.7.2': {}
+
+  '@astrojs/markdown-remark@6.3.6':
     dependencies:
-      '@astrojs/internal-helpers': 0.6.1
-      '@astrojs/prism': 3.2.0
+      '@astrojs/internal-helpers': 0.7.2
+      '@astrojs/prism': 3.3.0
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
@@ -13962,7 +13972,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/prism@3.2.0':
+  '@astrojs/prism@3.3.0':
     dependencies:
       prismjs: 1.30.0
 
@@ -13989,10 +13999,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)':
+  '@astrojs/svelte@7.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.30.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0))
-      astro: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       svelte: 5.30.1
       svelte2tsx: 0.7.39(svelte@5.30.1)(typescript@5.8.3)
       typescript: 5.8.3
@@ -14011,9 +14021,9 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/tailwind@5.1.5(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))':
+  '@astrojs/tailwind@5.1.5(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))':
     dependencies:
-      astro: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       autoprefixer: 10.4.21(postcss@8.5.3)
       postcss: 8.5.3
       postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
@@ -14021,7 +14031,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  '@astrojs/telemetry@3.2.1':
+  '@astrojs/telemetry@3.3.0':
     dependencies:
       ci-info: 4.2.0
       debug: 4.4.1(supports-color@8.1.1)
@@ -14033,14 +14043,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@8.1.4(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(svelte@5.30.1)(vue-router@4.5.1(vue@3.5.14(typescript@5.8.3)))(vue@3.5.14(typescript@5.8.3))':
+  '@astrojs/vercel@8.1.4(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(svelte@5.30.1)(vue-router@4.5.1(vue@3.5.14(typescript@5.8.3)))(vue@3.5.14(typescript@5.8.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.6.1
       '@vercel/analytics': 1.5.0(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.30.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)))(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(svelte@5.30.1)(vue-router@4.5.1(vue@3.5.14(typescript@5.8.3)))(vue@3.5.14(typescript@5.8.3))
       '@vercel/edge': 1.2.1
       '@vercel/nft': 0.29.3(rollup@4.40.2)
       '@vercel/routing-utils': 5.0.4
-      astro: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       esbuild: 0.25.4
       tinyglobby: 0.2.13
     transitivePeerDependencies:
@@ -14055,12 +14065,12 @@ snapshots:
       - vue
       - vue-router
 
-  '@astrojs/vue@5.0.13(@types/node@24.1.0)(astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)':
+  '@astrojs/vue@5.0.13(@types/node@24.1.0)(astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(vue@3.5.14(typescript@5.8.3))(yaml@2.8.0)':
     dependencies:
       '@vitejs/plugin-vue': 5.2.1(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.14(typescript@5.8.3))
       '@vitejs/plugin-vue-jsx': 4.1.2(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.14(typescript@5.8.3))
       '@vue/compiler-sfc': 3.5.14
-      astro: 5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)
       vite-plugin-vue-devtools: 7.7.6(rollup@4.40.2)(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.14(typescript@5.8.3))
       vue: 3.5.14(typescript@5.8.3)
@@ -15786,7 +15796,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.4.3
+      '@emnapi/runtime': 1.4.5
     optional: true
 
   '@img/sharp-wasm32@0.34.1':
@@ -16898,7 +16908,7 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-vue: 9.33.0(eslint@9.26.0(jiti@2.4.2))
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -16909,8 +16919,8 @@ snapshots:
   '@nuxtjs/eslint-config@12.0.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))':
     dependencies:
       eslint: 9.26.0(jiti@2.4.2)
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-n@15.7.0(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-promise@6.6.0(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-n@15.7.0(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-promise@6.6.0(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-n: 15.7.0(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-node: 11.1.0(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-promise: 6.6.0(eslint@9.26.0(jiti@2.4.2))
@@ -17759,7 +17769,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.7
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 3.29.5
 
@@ -17767,7 +17777,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.7
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.40.2
 
@@ -19786,12 +19796,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@5.7.13(@types/node@22.15.18)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0):
+  astro@5.13.2(@types/node@22.15.18)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
-      '@astrojs/compiler': 2.12.0
-      '@astrojs/internal-helpers': 0.6.1
-      '@astrojs/markdown-remark': 6.3.1
-      '@astrojs/telemetry': 3.2.1
+      '@astrojs/compiler': 2.12.2
+      '@astrojs/internal-helpers': 0.7.2
+      '@astrojs/markdown-remark': 6.3.6
+      '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 2.4.0
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.1.4(rollup@4.40.2)
@@ -19818,6 +19828,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
+      import-meta-resolve: 4.1.0
       js-yaml: 4.1.0
       kleur: 4.1.5
       magic-string: 0.30.17
@@ -19827,13 +19838,14 @@ snapshots:
       p-limit: 6.2.0
       p-queue: 8.1.0
       package-manager-detector: 1.3.0
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       prompts: 2.4.2
       rehype: 13.0.2
       semver: 7.7.2
       shiki: 3.4.2
+      smol-toml: 1.3.4
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       tsconfck: 3.1.5(typescript@5.8.3)
       ultrahtml: 1.6.0
       unifont: 0.5.0
@@ -19885,12 +19897,12 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.7.13(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0):
+  astro@5.13.2(@types/node@24.1.0)(db0@0.3.2(@libsql/client@0.15.4))(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.40.2)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
-      '@astrojs/compiler': 2.12.0
-      '@astrojs/internal-helpers': 0.6.1
-      '@astrojs/markdown-remark': 6.3.1
-      '@astrojs/telemetry': 3.2.1
+      '@astrojs/compiler': 2.12.2
+      '@astrojs/internal-helpers': 0.7.2
+      '@astrojs/markdown-remark': 6.3.6
+      '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 2.4.0
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.1.4(rollup@4.40.2)
@@ -19917,6 +19929,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
+      import-meta-resolve: 4.1.0
       js-yaml: 4.1.0
       kleur: 4.1.5
       magic-string: 0.30.17
@@ -19926,13 +19939,14 @@ snapshots:
       p-limit: 6.2.0
       p-queue: 8.1.0
       package-manager-detector: 1.3.0
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       prompts: 2.4.2
       rehype: 13.0.2
       semver: 7.7.2
       shiki: 3.4.2
+      smol-toml: 1.3.4
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       tsconfck: 3.1.5(typescript@5.8.3)
       ultrahtml: 1.6.0
       unifont: 0.5.0
@@ -21643,7 +21657,7 @@ snapshots:
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.55.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(eslint@8.55.0))(eslint@8.55.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.55.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.55.0)
       eslint-plugin-react: 7.37.5(eslint@8.55.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.55.0)
@@ -21662,7 +21676,7 @@ snapshots:
       '@typescript-eslint/parser': 8.37.0(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-react: 7.37.5(eslint@8.57.0)
@@ -21678,10 +21692,10 @@ snapshots:
     dependencies:
       eslint: 9.26.0(jiti@2.4.2)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-n@15.7.0(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-promise@6.6.0(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-n@15.7.0(eslint@9.26.0(jiti@2.4.2)))(eslint-plugin-promise@6.6.0(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.26.0(jiti@2.4.2)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-n: 15.7.0(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-promise: 6.6.0(eslint@9.26.0(jiti@2.4.2))
 
@@ -21729,12 +21743,12 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.55.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
       eslint-plugin-import-x: 4.11.1(eslint@8.55.0)(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@8.1.1)
@@ -21761,7 +21775,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-import-x: 4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
@@ -21802,14 +21816,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 8.37.0(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21930,7 +21944,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.55.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -21959,7 +21973,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -21999,7 +22013,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24544,8 +24558,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
       source-map-js: 1.2.1
 
   make-dir@3.1.0:


### PR DESCRIPTION
**This PR upgrades the Astro dependency to the latest version across the SDK and playgrounds.** The previous version was behind several minor releases, which caused type mismatches when using the SDK with the most recent Astro features.

### Changes

* **Astro Upgrade**

  * Updated Astro to the latest version in the SDK and playground projects.
  * Resolved type mismatches related to outdated Astro types.

Closes #99