### PR TITLE
docs(cli): Add --type-suffix to types generate docs 

### DIFF
--- a/packages/cli/src/commands/types/generate/README.md
+++ b/packages/cli/src/commands/types/generate/README.md
@@ -18,6 +18,7 @@ storyblok types generate --space <spaceId>
 | `--sf, --separate-files` | Generate separate type definition files for each component | `false` |
 | `--strict` | Enable strict mode with no loose typing | `false` |
 | `--type-prefix <prefix>` | Prefix to be prepended to all generated component type names | - |
+| `--type-suffix <suffix>` | Suffix to be appended to all generated component type names | - |
 | `--suffix <suffix>` | Suffix for component names | - |
 | `--custom-fields-parser <path>` | Path to the parser file for Custom Field Types | - |
 | `--compiler-options <options>` | Path to the compiler options from json-schema-to-typescript | - |


### PR DESCRIPTION
## How to test this PR

View the Readme at https://github.com/storyblok/storyblok-cli/blob/next/src/commands/types/generate/README.md
Verify that the docs in the readme for the `type-suffix` option match the documentation that is in the CLI help command.

Run `yarn storyblok types generate --help` and see that the option name and description match the readme

## What is the new behavior?

No functional behaviour changes, just updated readme documentation