### PR TITLE
feat(js-client): return a deep clone of a cached response

### DIFF
--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -203,6 +203,26 @@ describe('storyblokClient', () => {
       });
     });
 
+    it('should return a clone from the cache', async () => {
+      const mockThrottle = vi.fn().mockResolvedValue({
+        data: {
+          stories: [{ id: 1, title: 'Maybe Cached' }],
+          cv: 1645521118,
+        },
+        headers: {},
+        status: 200,
+      });
+      client.throttle = mockThrottle;
+      client.cache.type = 'memory';
+
+      const result = await client.get('test', { version: 'published', token: 'test-token' });
+      const resultFromCache = await client.get('test', { version: 'published', token: 'test-token' });
+
+      expect(mockThrottle).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(resultFromCache);
+      expect(result).not.toBe(resultFromCache);
+    });
+
     it('should clear the cache', async () => {
       // Mock the cacheProvider and its flush method
       client.cacheProvider = vi.fn().mockReturnValue({

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -674,7 +674,23 @@ export class Storyblok {
     if (params.version === 'published' && url !== '/cdn/spaces/me') {
       const cache = await provider.get(cacheKey);
       if (cache) {
-        return Promise.resolve(cache);
+        try {
+          if (typeof structuredClone !== 'function') {
+            return JSON.parse(JSON.stringify(cache));
+          }
+          return structuredClone(cache);
+        }
+
+        catch (error: Error | any) {
+          console.warn(
+            'Failed to clone a cached object. This can happen with complex data types like functions or circular references. '
+            + 'The cache is returning a direct, un-cloned reference to the data to prevent a crash.\n\n'
+            + '⚠️ To avoid unpredictable bugs and data pollution, DO NOT MUTATE this object.\n',
+            'Original cloning error:',
+            error,
+          );
+          return cache;
+        }
       }
     }
 


### PR DESCRIPTION
Returning a direct reference to the cached object allows consumers to inadvertently mutate the shared state, leading to unpredictable behavior and data pollution across different parts of an application.

This change ensures cache integrity by returning a deep clone of the data using the native `structuredClone` function (with a JSON.stringify).

fixes WDX-8
fixes #131