### PR TITLE
feat(react): prevent unnecessary re-rendering

### DIFF
--- a/packages/react/src/core/use-storyblok-state.ts
+++ b/packages/react/src/core/use-storyblok-state.ts
@@ -26,7 +26,7 @@ export const useStoryblokState: TUseStoryblokState = (
       newStory => setStory(newStory),
       bridgeOptions,
     );
-  }, [initialStory]);
+  }, [initialStory, bridgeOptions]);
 
   return story;
 };

--- a/packages/react/src/core/use-storyblok-state.ts
+++ b/packages/react/src/core/use-storyblok-state.ts
@@ -14,9 +14,11 @@ export const useStoryblokState: TUseStoryblokState = (
   const isBridgeEnabled = typeof window !== 'undefined'
     && typeof window.storyblokRegisterEvent !== 'undefined';
 
-  useEffect(() => {
+  if (initialStory !== story) {
     setStory(initialStory);
+  }
 
+  useEffect(() => {
     if (!isBridgeEnabled || !initialStory) {
       return;
     }


### PR DESCRIPTION
Updating the state on prop change is an anti pattern. See: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes

Also see discussion in #280