### PR TITLE
fix(richtext): handling of nested elements

### DIFF
--- a/packages/richtext/src/html-parser.test.ts
+++ b/packages/richtext/src/html-parser.test.ts
@@ -525,6 +525,235 @@ describe('htmlToStoryblokRichtext', () => {
     });
   });
 
+  it('parses multiple marks on one node', () => {
+    const md = [
+      '<p><strong><em>bold and italic</em></strong></p>',
+      '<p><strong>bold and <em>italic</em></strong></p>',
+      '<p><em><strong>italic and bold</strong></em></p>',
+      '<p><strong><a href="https://bold.storyblok.com">bold link</a></strong></p>',
+      '<p><a href="https://bold.storyblok.com"><strong>bold link 2</strong></a></p>',
+      '<p><em><a href="https://italic.storyblok.com">italic link</a></em></p>',
+      '<p><strong><em><a href="https://bold-italic.storyblok.com">bold and italic link</a></em></strong></p>',
+      '<p><a href="https://bold-italic.storyblok.com"><strong>bold </strong><em>and italic link</em></a></p>',
+      '<p><a href="https://mixed.storyblok.com"><strong>bold</strong>, normal <em>and italic link</em></a></p>',
+    ].join('\n');
+    const result = htmlToStoryblokRichtext(md);
+    expect(result).toMatchObject({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'bold and italic',
+              marks: [
+                { type: 'italic' },
+                { type: 'bold' },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'bold and ',
+              marks: [{ type: 'bold' }],
+            },
+            {
+              type: 'text',
+              text: 'italic',
+              marks: [
+                { type: 'italic' },
+                { type: 'bold' },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'italic and bold',
+              marks: [
+                { type: 'bold' },
+                { type: 'italic' },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://bold.storyblok.com',
+                  },
+                },
+                {
+                  type: 'bold',
+                },
+              ],
+              text: 'bold link',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://bold.storyblok.com',
+                  },
+                },
+                {
+                  type: 'bold',
+                },
+              ],
+              text: 'bold link 2',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://italic.storyblok.com',
+                  },
+                },
+                {
+                  type: 'italic',
+                },
+              ],
+              text: 'italic link',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://bold-italic.storyblok.com',
+                  },
+                },
+                {
+                  type: 'italic',
+                },
+                {
+                  type: 'bold',
+                },
+              ],
+              text: 'bold and italic link',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://bold-italic.storyblok.com',
+                  },
+                },
+                {
+                  type: 'bold',
+                },
+              ],
+              text: 'bold ',
+            },
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://bold-italic.storyblok.com',
+                  },
+                },
+                {
+                  type: 'italic',
+                },
+              ],
+              text: 'and italic link',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://mixed.storyblok.com',
+                  },
+                },
+                {
+                  type: 'bold',
+                },
+              ],
+              text: 'bold',
+            },
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://mixed.storyblok.com',
+                  },
+                },
+              ],
+              text: ', normal ',
+            },
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://mixed.storyblok.com',
+                  },
+                },
+                {
+                  type: 'italic',
+                },
+              ],
+              text: 'and italic link',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('does not preserve unsupported attributes by default', () => {
     const resultDefault = htmlToStoryblokRichtext(
       '<p class="unsupported">Hello <a data-unsupported-custom-attribute="whatever" target="_blank" href="/home">world!</a></p>',

--- a/packages/richtext/src/markdown-parser.test.ts
+++ b/packages/richtext/src/markdown-parser.test.ts
@@ -477,6 +477,130 @@ describe('markdownToStoryblokRichtext', () => {
     });
   });
 
+  it('parses multiple marks on one node', () => {
+    const md = [
+      '***bold and italic***',
+      '**bold and *italic***',
+      '_**italic and bold**_',
+      '**[bold link](https://bold.storyblok.com)**',
+      '_[italic link](https://italic.storyblok.com)_',
+      '**_[bold and italic link](https://bold-italic.storyblok.com)_**',
+    ].join('\n\n');
+    const result = markdownToStoryblokRichtext(md);
+    expect(result).toMatchObject({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'bold and italic',
+              marks: [
+                { type: 'bold' },
+                { type: 'italic' },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'bold and ',
+              marks: [{ type: 'bold' }],
+            },
+            {
+              type: 'text',
+              text: 'italic',
+              marks: [
+                { type: 'italic' },
+                { type: 'bold' },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'italic and bold',
+              marks: [
+                { type: 'bold' },
+                { type: 'italic' },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://bold.storyblok.com',
+                  },
+                },
+                {
+                  type: 'bold',
+                },
+              ],
+              text: 'bold link',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://italic.storyblok.com',
+                  },
+                },
+                {
+                  type: 'italic',
+                },
+              ],
+              text: 'italic link',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://bold-italic.storyblok.com',
+                  },
+                },
+                {
+                  type: 'italic',
+                },
+                {
+                  type: 'bold',
+                },
+              ],
+              text: 'bold and italic link',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('uses a custom heading resolver', () => {
     const md = '# Custom Heading';
     const result = markdownToStoryblokRichtext(md, {

--- a/packages/richtext/src/markdown-parser.ts
+++ b/packages/richtext/src/markdown-parser.ts
@@ -75,6 +75,38 @@ export const MarkdownTokenTypes = {
 export type MarkdownTokenType = keyof typeof MarkdownTokenTypes;
 
 /**
+ * Mark all text nodes in-place (including nested inline content).
+ */
+function applyMarkInPlace(
+  nodes: StoryblokRichTextDocumentNode[] | undefined,
+  mark: { type: string; attrs?: Record<string, unknown> | null },
+) {
+  if (!nodes) {
+    return;
+  }
+
+  for (const node of nodes) {
+    // If we’re applying a mark (bold/italic/strike) and encounter a link node,
+    // flatten it: apply link mark first, then the outer mark, then replace the
+    // link wrapper with its content.
+    if (node.type === MarkTypes.LINK && Array.isArray(node.content)) {
+      const linkMark = { type: MarkTypes.LINK, attrs: node.attrs ?? null };
+
+      // Apply link first to ensure expected order [link, <outer mark>]
+      applyMarkInPlace(node.content, linkMark);
+      applyMarkInPlace(node.content, mark);
+
+      // Replace the link node with its now-marked children
+      nodes.splice(nodes.indexOf(node), 1, ...node.content);
+      continue;
+    }
+
+    const existing = (node.marks || []) as Array<any>;
+    node.marks = [...existing, mark];
+  }
+}
+
+/**
  * Default resolvers for supported Markdown token types.
  * These map markdown-it tokens to Storyblok RichText nodes.
  */
@@ -105,20 +137,12 @@ const defaultResolvers: Record<string, MarkdownNodeResolver> = {
     };
   },
   [MarkdownTokenTypes.STRONG]: (_token, children) => {
-    const text = children?.map(c => c.text).join('') ?? '';
-    return {
-      type: TextTypes.TEXT,
-      text,
-      marks: [{ type: MarkTypes.BOLD }],
-    };
+    applyMarkInPlace(children, { type: MarkTypes.BOLD });
+    return null; // flatten children
   },
   [MarkdownTokenTypes.EMP]: (_token, children) => {
-    const text = children?.map(c => c.text).join('') ?? '';
-    return {
-      type: TextTypes.TEXT,
-      text,
-      marks: [{ type: MarkTypes.ITALIC }],
-    };
+    applyMarkInPlace(children, { type: MarkTypes.ITALIC });
+    return null; // flatten children
   },
   [MarkdownTokenTypes.ORDERED_LIST]: (_token, children) => {
     return {
@@ -208,12 +232,8 @@ const defaultResolvers: Record<string, MarkdownNodeResolver> = {
     };
   },
   [MarkdownTokenTypes.DEL]: (_token, children) => {
-    const text = children?.map(c => c.text).join('') ?? '';
-    return {
-      type: TextTypes.TEXT,
-      text,
-      marks: [{ type: MarkTypes.STRIKE }],
-    };
+    applyMarkInPlace(children, { type: MarkTypes.STRIKE });
+    return null; // flatten children
   },
   [MarkdownTokenTypes.HARD_BREAK]: () => {
     return {
@@ -253,11 +273,10 @@ const defaultResolvers: Record<string, MarkdownNodeResolver> = {
     ],
   }),
   // Strikethrough support (GFM strikethrough is enabled by default in markdown-it)
-  [MarkdownTokenTypes.S]: (_token, children) => ({
-    type: TextTypes.TEXT,
-    text: children?.map(c => c.text).join('') ?? '',
-    marks: [{ type: MarkTypes.STRIKE }],
-  }),
+  [MarkdownTokenTypes.S]: (_token, children) => {
+    applyMarkInPlace(children, { type: MarkTypes.STRIKE });
+    return null; // flatten children
+  },
 };
 
 /**


### PR DESCRIPTION
Both HTML and Markdown richtext parsers now handle nested elements correctly.

For the HTML parser link normalizing is necessary because the richtext format can't deal with elements nested inside of links.

Fixes WDX-118
Fixes #268