### PR TITLE
fix(richtext): markdown parser link parsing

### DIFF
--- a/packages/richtext/src/markdown-parser.test.ts
+++ b/packages/richtext/src/markdown-parser.test.ts
@@ -400,13 +400,59 @@ describe('markdownToStoryblokRichtext', () => {
           content: [
             { type: 'text', text: 'This is a ' },
             {
-              type: 'link',
-              attrs: {
-                href: 'https://www.storyblok.com/',
-                title: null,
-              },
-              content: [
-                { type: 'text', text: 'Storyblok link' },
+              type: 'text',
+              text: 'Storyblok link',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://www.storyblok.com/',
+                  },
+                },
+              ],
+            },
+            { type: 'text', text: '.' },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('parses formatting inside links', () => {
+    const md = 'This is a [Storyblok _link_](https://www.storyblok.com/).';
+    const result = markdownToStoryblokRichtext(md);
+    expect(result).toMatchObject({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'This is a ' },
+            {
+              type: 'text',
+              text: 'Storyblok ',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://www.storyblok.com/',
+                  },
+                },
+              ],
+            },
+            {
+              type: 'text',
+              text: 'link',
+              marks: [
+                {
+                  type: 'italic',
+                },
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://www.storyblok.com/',
+                  },
+                },
               ],
             },
             { type: 'text', text: '.' },

--- a/packages/richtext/src/markdown-parser.ts
+++ b/packages/richtext/src/markdown-parser.ts
@@ -217,14 +217,14 @@ const defaultResolvers: Record<string, MarkdownNodeResolver> = {
     };
   },
   [MarkdownTokenTypes.LINK]: (token, children) => {
-    return {
+    applyMarkInPlace(children, {
       type: MarkTypes.LINK,
       attrs: {
         href: token.attrGet('href'),
         title: token.attrGet('title') || null,
       },
-      content: children,
-    };
+    });
+    return null;
   },
   [MarkdownTokenTypes.HR]: () => {
     return {


### PR DESCRIPTION
Fix parsing of links and make it possible to parse styles within links.

Fixes WDX-97
Fixes #251