### PR TITLE
fix(react): richtext table and custom attribute casing

### DIFF
--- a/packages/react/src/__tests__/utils.test.ts
+++ b/packages/react/src/__tests__/utils.test.ts
@@ -4,18 +4,23 @@ import { convertAttributesInElement } from '../utils';
 
 describe('utils', () => {
   describe('convertAttributesInElement', () => {
-    it('should convert HTML class attribute to React className', () => {
-      const input = React.createElement('div', { class: 'test-class' });
+    it('should convert HTML various lower case attributes to React camelCase', () => {
+      // The logic is always the same; we test only the most important cases.
+      const someAttributes = {
+        class: ['className', 'test-class'],
+        colspan: ['colSpan', '2'],
+        for: ['htmlFor', 'foo'],
+        rowspan: ['rowSpan', '3'],
+      };
+      const input = React.createElement(
+        'div',
+        Object.fromEntries(Object.entries(someAttributes).map(([attr, [_, value]]) => [attr, value])),
+      );
       const output = convertAttributesInElement(input);
-      expect(output.props).toHaveProperty('className', 'test-class');
-      expect(output.props).not.toHaveProperty('class');
-    });
-
-    it('should convert HTML for attribute to React htmlFor', () => {
-      const input = React.createElement('label', { for: 'test-input' });
-      const output = convertAttributesInElement(input);
-      expect(output.props).toHaveProperty('htmlFor', 'test-input');
-      expect(output.props).not.toHaveProperty('for');
+      for (const [original, [transformed, value]] of Object.entries(someAttributes)) {
+        expect(output.props).toHaveProperty(transformed, value);
+        expect(output.props).not.toHaveProperty(original);
+      }
     });
 
     it('should convert string style attributes to style objects', () => {

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -29,10 +29,34 @@ export function convertAttributesInElement(element: React.ReactElement | React.R
 
   // Convert attributes of the current element.
   const attributeMap: { [key: string]: string } = {
+    allowfullscreen: 'allowFullScreen',
+    autocomplete: 'autoComplete',
+    autofocus: 'autoFocus',
+    autoplay: 'autoPlay',
+    charset: 'charSet',
     class: 'className',
+    colspan: 'colSpan',
+    colwidth: 'colWidth',
+    contenteditable: 'contentEditable',
+    crossorigin: 'crossOrigin',
+    enctype: 'encType',
     for: 'htmlFor',
+    formnovalidate: 'formNoValidate',
+    frameborder: 'frameBorder',
+    inputmode: 'inputMode',
+    marginheight: 'marginHeight',
+    marginwidth: 'marginWidth',
+    maxlength: 'maxLength',
+    minlength: 'minLength',
+    novalidate: 'noValidate',
+    playsinline: 'playsInline',
+    readonly: 'readOnly',
+    referrerpolicy: 'referrerPolicy',
+    rowspan: 'rowSpan',
+    srcset: 'srcSet',
+    tabindex: 'tabIndex',
     targetAttr: 'targetattr',
-    // Add more attribute conversions here as needed
+    usemap: 'useMap',
   };
 
   const newProps: { [key: string]: unknown } = Object.keys((element.props as Record<string, unknown>)).reduce((acc: { [key: string]: unknown }, key) => {


### PR DESCRIPTION
I’ve decided to add as many attributes as possible to the map of HTML attributes that must be converted to camelCase for React. Although only a couple of attributes are supported by default, it is possible to allow custom attributes on links, so in practice, there could be all the double-word HTML attributes. I’ve also added colwidth, although this is not a standard attribute, because the table module seems to set it.

Fixes WDX-82
Fixes #239