### PR TITLE
feat(nuxt): make it possible to import `useAsyncStoryblok`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -78,6 +78,11 @@ export default defineNuxtModule<ModuleOptions>({
     for (const name of names) {
       addImports({ name, as: name, from: '@storyblok/vue' });
     }
+    addImports({
+      name: 'useAsyncStoryblok',
+      as: 'useAsyncStoryblok',
+      from: resolver.resolve('runtime/composables/useAsyncStoryblok'),
+    });
 
     nuxt.options.typescript.hoist.push('@storyblok/vue');
 


### PR DESCRIPTION
See: https://nuxt.com/docs/4.x/guide/going-further/modules#injecting-composables-with-addimports-and-addimportsdir

Fixes WDX-116
Fixes #264