### PR TITLE
feat(js): add fallbackLang types to bridge

### DIFF
--- a/packages/js/src/types/index.ts
+++ b/packages/js/src/types/index.ts
@@ -58,6 +58,7 @@ export interface StoryblokBridgeConfigV2 {
   preventClicks?: boolean;
   language?: string;
   resolveLinks?: 'url' | 'story' | '0' | '1' | 'link';
+  fallbackLang?: 'string';
 }
 
 export interface StoryblokBridgeV2 {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,9 +736,6 @@ importers:
       '@storyblok/react':
         specifier: workspace:*
         version: file:packages/react(next@13.5.11(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    dependenciesMeta:
-      '@storyblok/react':
-        injected: true
     devDependencies:
       '@types/node':
         specifier: ^20.17.10
@@ -758,6 +755,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.8.3
+    dependenciesMeta:
+      '@storyblok/react':
+        injected: true
 
   packages/react/playground/next13-app-router:
     dependencies:


### PR DESCRIPTION
Following up the addition of `fallbackLang` option in the [latest bridge release](https://www.npmjs.com/package/@storyblok/preview-bridge), this PR adds the type in the Frontend SDKs