### PR TITLE
fix(migrations): update stream callback and add story_only flag

### DIFF
--- a/packages/cli/src/commands/migrations/run/index.test.ts
+++ b/packages/cli/src/commands/migrations/run/index.test.ts
@@ -160,6 +160,7 @@ describe('migrations run command - streaming approach', () => {
       expect.objectContaining({
         per_page: 500,
         page: 1,
+        story_only: true,
       }),
     );
 
@@ -228,6 +229,7 @@ describe('migrations run command - streaming approach', () => {
       expect.objectContaining({
         per_page: 500,
         page: 1,
+        story_only: true,
       }),
     );
 
@@ -297,6 +299,7 @@ describe('migrations run command - streaming approach', () => {
       expect.objectContaining({
         per_page: 500,
         page: 1,
+        story_only: true,
       }),
     );
 
@@ -367,6 +370,7 @@ describe('migrations run command - streaming approach', () => {
         per_page: 500,
         page: 1,
         contain_component: 'migration-component',
+        story_only: true,
       }),
     );
 

--- a/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
+++ b/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
@@ -44,21 +44,23 @@ export class MigrationStream extends Transform {
     };
   }
 
-  _transform(chunk: Story, _encoding: string, callback: (error?: Error | null, data?: any) => void) {
+  async _transform(chunk: Story, _encoding: string, callback: (error?: Error | null, data?: any) => void) {
     try {
-      this.processStory(chunk).then((results) => {
-        this.results.totalProcessed++;
-        this.options.onProgress?.(this.results.totalProcessed);
+      const results = await this.processStory(chunk);
 
-        // Output successful migration results for further processing
-        if (results.length > 0) {
-          this.totalProcessed += results.length;
-          this.options.onTotal?.(this.totalProcessed);
-          for (const result of results) {
-            callback(null, result);
-          }
+      this.results.totalProcessed++;
+      this.options.onProgress?.(this.results.totalProcessed);
+
+      // Output successful migration results for further processing
+      if (results.length > 0) {
+        this.totalProcessed += results.length;
+        this.options.onTotal?.(this.totalProcessed);
+        for (const result of results) {
+          this.push(result);
         }
-      });
+      }
+
+      callback();
     }
     catch (error) {
       callback(error as Error);

--- a/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
+++ b/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
@@ -55,12 +55,10 @@ export class MigrationStream extends Transform {
           this.totalProcessed += results.length;
           this.options.onTotal?.(this.totalProcessed);
           for (const result of results) {
-            this.push(result);
+            callback(null, result);
           }
         }
       });
-
-      callback();
     }
     catch (error) {
       callback(error as Error);

--- a/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
@@ -40,6 +40,7 @@ export async function* storiesIterator(
       ...transformedParams,
       per_page: perPage,
       page: 1,
+      story_only: true,
     });
 
     if (!result) {
@@ -60,6 +61,7 @@ export async function* storiesIterator(
         ...transformedParams,
         per_page: perPage,
         page,
+        story_only: true,
       });
 
       if (!result) {


### PR DESCRIPTION
- Migrations can only operate on stories but we were including the folder which skews the report counter. Adding the `story_only` flag fixes this.
- The migrations transform is synchronous and shouldn't progress on until migration has been processed otherwise the stream can appear to be drained before it has completed processing.