### PR TITLE
fix(richtext): allow width or height to be 0 in optimizeImage

### DIFF
--- a/packages/richtext/src/images-optimization.test.ts
+++ b/packages/richtext/src/images-optimization.test.ts
@@ -42,8 +42,10 @@ describe('images-optimization', () => {
 
   it('should not add width or height to the src if both are at 0', async () => {
     const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
+    const consoleWarnSpy = vi.spyOn(console, 'warn');
     const { src: resultSrc } = optimizeImage(src, { width: 0, height: 0 });
     expect(resultSrc).toBe(`${src}/m/`);
+    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Width and height values cannot both be 0');
   });
 
   it('should not add width to the src if width is not a number', async () => {
@@ -63,10 +65,30 @@ describe('images-optimization', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('should add width to the attrs if provided', async () => {
+  it('should add width and height to the attrs if provided', async () => {
     const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
     const { attrs } = optimizeImage(src, { width: 800, height: 600 });
     expect(attrs).toEqual({ width: 800, height: 600 });
+  });
+
+  it('should add width to the attrs if provided', async () => {
+    const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
+    const { attrs } = optimizeImage(src, { width: 800 });
+    expect(attrs).toEqual({ width: 800 });
+  });
+
+  it('should add height to the attrs if provided', async () => {
+    const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
+    const { attrs } = optimizeImage(src, { height: 600 });
+    expect(attrs).toEqual({ height: 600 });
+  });
+
+  it('should not add width or height to the attrs if both are at 0', async () => {
+    const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
+    const consoleWarnSpy = vi.spyOn(console, 'warn');
+    const { attrs } = optimizeImage(src, { width: 0, height: 0 });
+    expect(attrs).toEqual({});
+    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Width and height values cannot both be 0');
   });
 
   it('should not add height to the src if height is not a number', async () => {

--- a/packages/richtext/src/images-optimization.test.ts
+++ b/packages/richtext/src/images-optimization.test.ts
@@ -28,12 +28,30 @@ describe('images-optimization', () => {
     expect(resultSrc).toBe(`${src}/m/800x600/`);
   });
 
+  it('should add width to the src if provided', async () => {
+    const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
+    const { src: resultSrc } = optimizeImage(src, { width: 800 });
+    expect(resultSrc).toBe(`${src}/m/800x0/`);
+  });
+
+  it('should add height to the src if provided', async () => {
+    const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
+    const { src: resultSrc } = optimizeImage(src, { height: 600 });
+    expect(resultSrc).toBe(`${src}/m/0x600/`);
+  });
+
+  it('should not add width or height to the src if both are at 0', async () => {
+    const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
+    const { src: resultSrc } = optimizeImage(src, { width: 0, height: 0 });
+    expect(resultSrc).toBe(`${src}/m/`);
+  });
+
   it('should not add width to the src if width is not a number', async () => {
     const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
     const consoleWarnSpy = vi.spyOn(console, 'warn');
     // @ts-expect-error provide width as string for testing
     optimizeImage(src, { width: '800', height: 600 });
-    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Width value must be a number greater than 0');
+    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Width value must be a number greater than or equal to 0');
     consoleWarnSpy.mockRestore();
   });
 
@@ -41,7 +59,7 @@ describe('images-optimization', () => {
     const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
     const consoleWarnSpy = vi.spyOn(console, 'warn');
     optimizeImage(src, { width: -800, height: 600 });
-    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Width value must be a number greater than 0');
+    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Width value must be a number greater than or equal to 0');
     consoleWarnSpy.mockRestore();
   });
 
@@ -56,7 +74,7 @@ describe('images-optimization', () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn');
     // @ts-expect-error provide height as string for testing
     optimizeImage(src, { width: 800, height: '600' });
-    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Height value must be a number greater than 0');
+    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Height value must be a number greater than or equal to 0');
     consoleWarnSpy.mockRestore();
   });
 
@@ -64,7 +82,7 @@ describe('images-optimization', () => {
     const src = 'https://a.storyblok.com/f/279818/710x528/c53330ed26/tresjs-doge.jpg';
     const consoleWarnSpy = vi.spyOn(console, 'warn');
     optimizeImage(src, { width: 800, height: -600 });
-    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Height value must be a number greater than 0');
+    expect(consoleWarnSpy).toBeCalledWith('[StoryblokRichText] - Height value must be a number greater than or equal to 0');
     consoleWarnSpy.mockRestore();
   });
 

--- a/packages/richtext/src/images-optimization.ts
+++ b/packages/richtext/src/images-optimization.ts
@@ -37,6 +37,11 @@ export function optimizeImage(src: string, options?: boolean | Partial<Storyblok
         console.warn('[StoryblokRichText] - Height value must be a number greater than or equal to 0');
       }
     }
+    if (options.height === 0 && options.width === 0) {
+      delete attrs.width;
+      delete attrs.height;
+      console.warn('[StoryblokRichText] - Width and height values cannot both be 0');
+    }
     if (options.loading && ['lazy', 'eager'].includes(options.loading)) {
       attrs.loading = options.loading;
     }

--- a/packages/richtext/src/images-optimization.ts
+++ b/packages/richtext/src/images-optimization.ts
@@ -19,7 +19,7 @@ export function optimizeImage(src: string, options?: boolean | Partial<Storyblok
   }
 
   if (typeof options === 'object') {
-    if (options.width) {
+    if (options.width !== undefined) {
       if (typeof options.width === 'number' && options.width >= 0) {
         attrs.width = options.width;
         w = options.width;
@@ -28,7 +28,7 @@ export function optimizeImage(src: string, options?: boolean | Partial<Storyblok
         console.warn('[StoryblokRichText] - Width value must be a number greater than or equal to 0');
       }
     }
-    if (options.height) {
+    if (options.height !== undefined) {
       if (typeof options.height === 'number' && options.height >= 0) {
         attrs.height = options.height;
         h = options.height;

--- a/packages/richtext/src/images-optimization.ts
+++ b/packages/richtext/src/images-optimization.ts
@@ -19,19 +19,23 @@ export function optimizeImage(src: string, options?: boolean | Partial<Storyblok
   }
 
   if (typeof options === 'object') {
-    if (typeof options.width === 'number' && options.width > 0) {
-      attrs.width = options.width;
-      w = options.width;
+    if (options.width) {
+      if (typeof options.width === 'number' && options.width >= 0) {
+        attrs.width = options.width;
+        w = options.width;
+      }
+      else {
+        console.warn('[StoryblokRichText] - Width value must be a number greater than or equal to 0');
+      }
     }
-    else {
-      console.warn('[StoryblokRichText] - Width value must be a number greater than 0');
-    }
-    if (options.height && typeof options.height === 'number' && options.height > 0) {
-      attrs.height = options.height;
-      h = options.height;
-    }
-    else {
-      console.warn('[StoryblokRichText] - Height value must be a number greater than 0');
+    if (options.height) {
+      if (typeof options.height === 'number' && options.height >= 0) {
+        attrs.height = options.height;
+        h = options.height;
+      }
+      else {
+        console.warn('[StoryblokRichText] - Height value must be a number greater than or equal to 0');
+      }
     }
     if (options.loading && ['lazy', 'eager'].includes(options.loading)) {
       attrs.loading = options.loading;
@@ -93,7 +97,7 @@ export function optimizeImage(src: string, options?: boolean | Partial<Storyblok
   // server-side WebP support detection https://www.storyblok.com/docs/image-service/#optimize
   // https://a.storyblok.com/f/39898/3310x2192/e4ec08624e/demo-image.jpeg/m/
   let resultSrc = `${src}/m/`;
-  if (w > 0 && h > 0) {
+  if (w > 0 || h > 0) {
     resultSrc = `${resultSrc}${w}x${h}/`;
   }
   if (filterParams.length > 0) {


### PR DESCRIPTION
This updates the validation of the `weight` and `height` attributes in `optimizeImage` to consider `0` as a valid value.

Fixes #17