### PR TITLE
fix(astro): ensure @storyblok/js is bundled correctly with pnpm

### DIFF
--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -14,3 +14,4 @@ export {
   storyblokEditable,
 } from '@storyblok/js';
 export { storyblokIntegration as storyblok };
+export { apiPlugin, storyblokInit } from '@storyblok/js';

--- a/packages/astro/src/vite-plugins/vite-plugin-storyblok-init.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-storyblok-init.ts
@@ -19,7 +19,7 @@ export function vitePluginStoryblokInit(
     async load(id: string) {
       if (id === resolvedVirtualModuleId) {
         return `
-          import { storyblokInit, apiPlugin } from "@storyblok/js";
+          import { storyblokInit, apiPlugin } from "@storyblok/astro";
           const { storyblokApi } = storyblokInit({
             accessToken: "${accessToken}",
             use: ${useCustomApi ? '[]' : '[apiPlugin]'},


### PR DESCRIPTION
- re-export storyblokInit and apiPlugin from SDK index
- update virtual module to import from @storyblok/astro instead of @storyblok/js
- fixes "Cannot find module '@storyblok/js' imported from 'virtual:storyblok-init'" when using pnpm