### PR TITLE
fix(cli): removing fields via migrations

### DIFF
--- a/packages/cli/src/commands/migrations/run/actions.ts
+++ b/packages/cli/src/commands/migrations/run/actions.ts
@@ -111,44 +111,47 @@ export async function getMigrationFunction(fileName: string, space: string, base
  * @returns Whether any blocks were modified
  */
 export function applyMigrationToAllBlocks(content: StoryContent, migrationFunction: (block: StoryContent) => StoryContent, targetComponent: string): boolean {
-  if (!content || typeof content !== 'object') {
-    return false;
-  }
+  let processed = false;
 
-  let modified = false;
+  if (!content || typeof content !== 'object') {
+    return processed;
+  }
 
   // Get the base component name (everything before the first dot)
   const baseTargetComponent = targetComponent.split('.')[0];
 
   // If the content has a component property and it matches the base component name
+  let migratedContent = null;
   if (content.component === baseTargetComponent) {
-    // Apply the migration function to this block
-    const migratedContent = migrationFunction({ ...content });
-    Object.assign(content, migratedContent);
-    modified = true;
+    migratedContent = migrationFunction({ ...content });
+    processed = true;
   }
 
-  // Recursively process all properties that might contain nested blocks
-  for (const key in content) {
-    if (Object.prototype.hasOwnProperty.call(content, key)) {
-      const value = content[key];
+  for (const key of Object.keys(content)) {
+    if (migratedContent) {
+      if (!(key in migratedContent)) {
+        delete content[key];
+        continue;
+      }
+      content[key] = migratedContent[key];
+    }
 
-      // Process arrays (might contain blocks)
-      if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          if (value[i] && typeof value[i] === 'object') {
-            const blockModified = applyMigrationToAllBlocks(value[i], migrationFunction, targetComponent);
-            modified = modified || blockModified;
-          }
+    // Recursively process all properties that might contain nested blocks
+    // Process arrays (might contain blocks)
+    if (Array.isArray(content[key])) {
+      for (const value of content[key]) {
+        if (value && typeof value === 'object') {
+          const blockProcessed = applyMigrationToAllBlocks(value, migrationFunction, targetComponent);
+          processed = processed || blockProcessed;
         }
       }
-      // Process nested objects (might be blocks)
-      else if (value && typeof value === 'object') {
-        const blockModified = applyMigrationToAllBlocks(value, migrationFunction, targetComponent);
-        modified = modified || blockModified;
-      }
+    }
+    // Process nested objects (might be blocks)
+    else if (content[key] && typeof content[key] === 'object') {
+      const blockProcessed = applyMigrationToAllBlocks(content[key], migrationFunction, targetComponent);
+      processed = processed || blockProcessed;
     }
   }
 
-  return modified;
+  return processed;
 }

--- a/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
+++ b/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
@@ -135,13 +135,13 @@ export class MigrationStream extends Transform {
       const storyContent = structuredClone(story.content) as StoryContent;
 
       // Calculate original content hash
-      const originalContentHash = hash(story.content);
+      const originalContentHash = hash(storyContent);
 
       // Determine the target component
       const targetComponent = this.options.componentName || getComponentNameFromFilename(migrationFile.name);
 
       // Apply the migration
-      const modified = applyMigrationToAllBlocks(storyContent, migrationFunction, targetComponent);
+      const processed = applyMigrationToAllBlocks(storyContent, migrationFunction, targetComponent);
 
       // Calculate new content hash
       const newContentHash = hash(storyContent);
@@ -149,7 +149,7 @@ export class MigrationStream extends Transform {
       // Check if content was actually modified
       const contentChanged = originalContentHash !== newContentHash;
 
-      if (modified && contentChanged) {
+      if (processed && contentChanged) {
         this.results.successful.push({
           storyId: story.id,
           name: story.name,
@@ -163,7 +163,7 @@ export class MigrationStream extends Transform {
           content: storyContent,
         };
       }
-      else if (modified && !contentChanged) {
+      else if (processed && !contentChanged) {
         this.results.skipped.push({
           storyId: story.id,
           name: story.name,


### PR DESCRIPTION
Since `Object.assign()` is only additive, we have introduced a check to support subtractive migrations: if a property is absent from the migrated content, it will now be removed from the target object as well.

`modified` was renamed to `processed` so it better describes the fact that although we handled a migration, it might not have affected the content.