### PR TITLE
fix(js-client): `inlineAssets` prefer story meta data

### DIFF
--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -390,6 +390,118 @@ describe('storyblokClient', () => {
       expect(mockGet).toHaveBeenCalledTimes(1);
     });
 
+    it('should enrich inline assets with data from an asset object', async () => {
+      const story = {
+        data: {
+          story: {
+            id: 123456,
+            uuid: 'story-uuid-123',
+            name: 'Page',
+            slug: 'page',
+            full_slug: 'folder/page',
+            created_at: '2023-01-01T12:00:00.000Z',
+            published_at: '2023-01-02T12:00:00.000Z',
+            first_published_at: '2023-01-02T12:00:00.000Z',
+            content: {
+              _uid: 'content-123',
+              component: 'page',
+              image: {
+                id: 87196701025710,
+                alt: 'story alt',
+                name: 'image',
+                focus: '',
+                title: '',
+                source: '',
+                filename: 'https://a.storyblok.com/f/286701504322473/1888x1538/3cc0705569/image.jpeg',
+                copyright: '',
+                fieldtype: 'asset',
+                meta_data: {
+                  alt: 'story alt',
+                  title: '',
+                  source: '',
+                  copyright: '',
+                },
+                is_external_url: false,
+              },
+            },
+            position: 1,
+            is_startpage: false,
+            parent_id: 654321,
+            group_id: '789-group',
+            alternates: [],
+            translated_slugs: [],
+            default_full_slug: null,
+            lang: 'default',
+          },
+          rels: [],
+          links: [],
+          assets: [
+            {
+              id: 87196701025710,
+              content_type: 'image/jpeg',
+              content_length: 438695,
+              created_at: '2025-09-04T09:24:17.084Z',
+              updated_at: '2025-09-04T09:35:53.799Z',
+              deleted_at: null,
+              alt: 'asset alt',
+              title: '',
+              copyright: '',
+              focus: '',
+              is_private: false,
+              s3_filename: 'https://a.storyblok.com/f/286701504322473/1888x1538/3cc0705569/image.jpeg',
+              meta_data: {
+                alt: 'asset alt',
+                title: '',
+                source: '',
+                copyright: '',
+              },
+            },
+          ],
+        },
+        headers: {},
+        status: 200,
+        statusText: 'OK',
+      };
+
+      const mockGet = vi.fn().mockResolvedValue(story);
+
+      client.client = {
+        get: mockGet,
+        post: vi.fn(),
+        setFetchOptions: vi.fn(),
+        baseURL: 'https://api.storyblok.com/v2',
+      };
+      client.inlineAssets = true;
+
+      const result = await client.get('cdn/stories/folder/complex-page');
+
+      expect(result.data.story.content.image).toEqual({
+        alt: 'story alt',
+        content_length: 438695,
+        content_type: 'image/jpeg',
+        copyright: '',
+        created_at: '2025-09-04T09:24:17.084Z',
+        deleted_at: null,
+        fieldtype: 'asset',
+        filename: 'https://a.storyblok.com/f/286701504322473/1888x1538/3cc0705569/image.jpeg',
+        focus: '',
+        id: 87196701025710,
+        is_external_url: false,
+        is_private: false,
+        meta_data: {
+          alt: 'story alt',
+          copyright: '',
+          source: '',
+          title: '',
+        },
+        name: 'image',
+        s3_filename: 'https://a.storyblok.com/f/286701504322473/1888x1538/3cc0705569/image.jpeg',
+        source: '',
+        title: '',
+        updated_at: '2025-09-04T09:35:53.799Z',
+      });
+    });
+
     describe('cdn/links endpoint', () => {
       it('should fetch links with dates when include_dates is set to 1', async () => {
         const mockLinksResponse = {

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -843,7 +843,7 @@ export class Storyblok {
 
       let processedNode = { ...node };
       if (processedNode.fieldtype === 'asset' && Array.isArray(response.data.assets)) {
-        // Enricht the asset with an actual asset object
+        // Enrich the asset with an actual asset object
         processedNode = {
           ...response.data.assets.find((asset: any) => asset.id === processedNode.id),
           ...processedNode,

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -837,20 +837,16 @@ export class Storyblok {
         return node;
       }
 
-      // Handle arrays
       if (Array.isArray(node)) {
         return node.map(item => processNode(item));
       }
 
-      // Process object
       let processedNode = { ...node };
-
-      // Check if this is an asset field
       if (processedNode.fieldtype === 'asset' && Array.isArray(response.data.assets)) {
-        // Replace the assets array with the actual asset objects
+        // Enricht the asset with an actual asset object
         processedNode = {
-          ...processedNode,
           ...response.data.assets.find((asset: any) => asset.id === processedNode.id),
+          ...processedNode,
         };
       }
 


### PR DESCRIPTION
When asset meta data is overwritten at the story level, we should prefer and keep the story meta data instead of the global asset meta data.

This is especially important for `alt` texts of images because it should be context specific.

Fixes WDX-165
Fixes #328