### PR TITLE
chore: improve login UX with clearer token option and guidance

### DIFF
--- a/packages/cli/src/commands/login/README.md
+++ b/packages/cli/src/commands/login/README.md
@@ -10,11 +10,11 @@ storyblok login
 
 This will start an interactive login process where you can choose between:
 - Email and password login
-- Token-based login (SSO)
+- Token login (Personal Access Token – recommended for CI and required for SSO users)
 
 ### Get your personal access token
 
-Go to https://app.storyblok.com/#/me/account?tab=token and click on **Generate new token**.
+Go to [https://app.storyblok.com/#/me/account?tab=token] and click on **Generate new token**.
 
 ## Options
 
@@ -47,6 +47,8 @@ storyblok login --token PERSONAL_ACCESS_TOKEN --region us
 - If you're already logged in, you'll need to logout first to switch accounts
 - For CI environments, it's recommended to use the `--token` option
 - The CLI supports two-factor authentication (2FA) when using email login
+> If you sign in with SSO (e.g., Google, GitHub, Azure AD), you must use a Personal Access Token.  
+> Generate one in your account settings: [Generate token](https://app.storyblok.com/#/me/account?tab=token).
 
 ## Available Regions
 

--- a/packages/cli/src/commands/login/index.test.ts
+++ b/packages/cli/src/commands/login/index.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../utils', async () => {
       title: vi.fn(),
       br: vi.fn(),
       error: vi.fn(),
+      info: vi.fn(),
     },
     isVitestRunning: true,
     handleError: (error: Error, header = false) => {
@@ -153,8 +154,15 @@ describe('loginCommand', () => {
 
         await loginCommand.parseAsync(['node', 'test']);
 
+        expect(konsola.info).toHaveBeenCalledWith(
+          expect.stringContaining('You can use a Personal Access Token to log in')
+        );
+        expect(konsola.info).toHaveBeenCalledWith(
+          expect.stringContaining('https://app.storyblok.com/#/me/account?tab=token')
+        );
+
         expect(password).toHaveBeenCalledWith(expect.objectContaining({
-          message: 'Please enter your token:',
+          message: 'Please enter your Personal Access Token:',
         }));
       });
 
@@ -167,7 +175,7 @@ describe('loginCommand', () => {
         await loginCommand.parseAsync(['node', 'test', '--region', 'eu']);
 
         expect(password).toHaveBeenCalledWith(expect.objectContaining({
-          message: 'Please enter your token:',
+          message: 'Please enter your Personal Access Token:',
         }));
         // Verify that loginWithToken was called with the correct arguments
         expect(loginWithToken).toHaveBeenCalledWith('test-token', 'eu');

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -20,7 +20,7 @@ const loginStrategy = {
       short: 'Email',
     },
     {
-      name: 'With Token (SSO)',
+      name: 'With Token (Personal Access Token – works also for SSO accounts)',
       value: 'login-with-token',
       short: 'Token',
     },
@@ -99,8 +99,16 @@ export const loginCommand = program
       try {
         const strategy = await select(loginStrategy);
         if (strategy === 'login-with-token') {
+          konsola.info(
+            `🔑 You can use a Personal Access Token to log in. 
+            This works for all accounts, including SSO accounts.
+            Generate one in your Storyblok account settings: ${chalk.underline.blue(
+              'https://app.storyblok.com/#/me/account?tab=token'
+            )}`
+          );
+
           const userToken = await password({
-            message: 'Please enter your token:',
+            message: 'Please enter your Personal Access Token:',
             validate: (value: string) => {
               return value.length > 0;
             },


### PR DESCRIPTION
### Description
- Renamed "SSO" login option to "Personal Access Token" to avoid confusion
- Added inline CLI hint with link to generate token
- Clarified that tokens work for all accounts, including SSO
- Updated README with clearer token login instructions