### PR TITLE
chore(cli): improve UX when generating types with mismatched component paths

### DIFF
--- a/packages/cli/src/commands/components/push/constants.ts
+++ b/packages/cli/src/commands/components/push/constants.ts
@@ -26,7 +26,13 @@ export interface PushComponentsOptions extends CommandOptions {
 
 export interface ReadComponentsOptions extends PushComponentsOptions {
   /**
-   * The path to read the components file from.
+   * Local path where component JSON files are located.
+   *
+   * ⚠️ Important: When using types generation command,
+   * if you provide a custom `--path`, it must be the same
+   * `--path` that was used when running
+   * `storyblok components pull`.
+   *
    * Defaults to `.storyblok/components`.
    * @default `.storyblok/components`
    */
@@ -35,4 +41,10 @@ export interface ReadComponentsOptions extends PushComponentsOptions {
    * Target space
    */
   space?: string;
+  /**
+   * Determines the flow:
+   * - `push-components`: pushing local components to Storyblok
+   * - `types-generate`: generating type definitions from local JSON files
+   */
+  purpose?: 'push-components' | 'types-generate';
 }


### PR DESCRIPTION
**Description**
This PR improves the user experience in the `types generate` flow when the component JSON files are not found due to a path mismatch. Previously, users might hit a vague "file not found" error if:

* Components were pulled with a custom `--path`, but `types generate` was run without the same `--path`.
* Components were pulled with the default path, but `types generate` was run with a custom `--path`.

**What’s Changed**

* Clarified `ReadComponentsOptions` JSDoc: `path` is optional, but for `types generate` it must always match the path used when running `components pull`.
* Updated error messages in `readComponentsFiles` to explicitly reference `storyblok types generate` vs `storyblok components pull`.
* Added clearer feedback about which directory was checked (e.g., `Looked for components in: ...`).
* Added a runtime warning when no `components.json` is found in the resolved path while running `types generate`.

**Notes**

* No changes to `push components` flow.
* Backwards compatible — only improves error communication and developer guidance.