### PR TITLE
fix(cli): process multiple migrations

### DIFF
--- a/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
+++ b/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
@@ -132,7 +132,8 @@ export class MigrationStream extends Transform {
         }
 
         const targetComponent = this.options.componentName || getComponentNameFromFilename(migrationFile.name);
-        processed = applyMigrationToAllBlocks(storyContent, migrationFunction, targetComponent);
+        const migrationProcessed = applyMigrationToAllBlocks(storyContent, migrationFunction, targetComponent);
+        processed = processed || migrationProcessed;
       }
 
       const newContentHash = hash(storyContent);


### PR DESCRIPTION
Fixes the issue when story migration is treated as skipped.

### Issue source

If run multiple migrations and last migration has nothing to migrate (no components to migrate in a story) the whole story migration will be skipped.

Example story:
```
page
  ├── hero
  ├── text
  └── button
```

Multiple migrations:
```
.storyblok/
└── migrations/
    └── YOUR_SPACE_ID/
        ├── button.js
        ├── hero.js
        ├── text.js
        └── whatever.js
```

Migration for `whatever` block will return `false` after `applyMigrationToAllBlocks` execution and override all previously `true` processed results.