### PR TITLE
fix: uses datasource slug to avoid issues with paggination

### DIFF
--- a/packages/cli/src/commands/datasources/pull/actions.test.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.test.ts
@@ -89,8 +89,9 @@ const handlers = [
   }),
   http.get('https://mapi.storyblok.com/v1/spaces/:space/datasource_entries', async ({ request }) => {
     const url = new URL(request.url);
-    const datasourceId = url.searchParams.get('datasource_id');
-    const entries = mockedEntries[Number(datasourceId)] || [];
+    const datasourceSlug = url.searchParams.get('datasource_slug');
+    const datasource = mockedDatasources.find(ds => ds.slug === datasourceSlug);
+    const entries = mockedEntries[Number(datasource?.id)] || [];
     return HttpResponse.json({ datasource_entries: entries });
   }),
 ];

--- a/packages/cli/src/commands/datasources/pull/actions.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.ts
@@ -13,7 +13,7 @@ import type { SaveDatasourcesOptions } from './constants';
  */
 export const fetchDatasourceEntries = async (
   spaceId: string,
-  datasourceId: number,
+  datasourceSlug: string,
 ): Promise<SpaceDatasourceEntry[] | undefined> => {
   try {
     const client = mapiClient();
@@ -22,7 +22,7 @@ export const fetchDatasourceEntries = async (
         space_id: spaceId,
       },
       query: {
-        datasource_id: datasourceId,
+        datasource_slug: datasourceSlug,
       },
       throwOnError: true,
     });
@@ -47,10 +47,10 @@ export const fetchDatasources = async (spaceId: string): Promise<SpaceDatasource
     // Fetch entries for each datasource in parallel
     const datasourcesWithEntries = await Promise.all(
       datasources?.map(async (ds) => {
-        if (!ds.id) {
+        if (!ds.slug) {
           return { ...ds, entries: [] };
         }
-        const entries = await fetchDatasourceEntries(spaceId, ds.id);
+        const entries = await fetchDatasourceEntries(spaceId, ds.slug);
         return { ...ds, entries };
       }) || [],
     );
@@ -76,7 +76,7 @@ export const fetchDatasource = async (spaceId: string, datasourceName: string): 
     const found = data?.datasources?.find(d => d.name === datasourceName);
     if (!found) { return undefined; }
     // Fetch entries for the found datasource
-    const entries = await fetchDatasourceEntries(spaceId, found.id as number);
+    const entries = await fetchDatasourceEntries(spaceId, found.slug as string);
     return { ...found, entries: entries || [] } as SpaceDatasource;
   }
   catch (error) {


### PR DESCRIPTION
The current implementation with the id faces the issue that when pulling the data we only get the first 25 items, that is the first page, to avoid issue with pagination the documentation suggest to use datasource_slug instead. 