### PR TITLE
fix(cli): skip layout-only fields when generating types

### DIFF
--- a/packages/cli/src/commands/types/generate/actions.test.ts
+++ b/packages/cli/src/commands/types/generate/actions.test.ts
@@ -1053,6 +1053,109 @@ describe("component property type annotations", () => {
     expect(result).not.toContain("tab-content");
   });
 
+  it("should skip group properties", async () => {
+    // The management API represents the editor's "Group" field as a `section`. It only
+    // arranges the fields listed in `keys`, so it never holds a value of its own.
+    const componentWithGroup: Component = {
+      name: "test_component",
+      display_name: "Test Component",
+      created_at: "2023-01-01T00:00:00Z",
+      updated_at: "2023-01-01T00:00:00Z",
+      id: 1,
+      schema: {
+        contact_details: {
+          type: "section",
+          keys: ["title"],
+        },
+        title: {
+          type: "text",
+          required: true,
+        },
+      },
+      internal_tags_list: [],
+      internal_tag_ids: [],
+    };
+
+    const spaceData: SpaceComponentsData = {
+      components: [componentWithGroup],
+      datasources: [],
+      groups: [],
+      presets: [],
+      internalTags: [],
+    };
+
+    const result = await generateTypes(spaceData, { strict: false });
+
+    expect(result).toContain("title: string");
+    expect(result).not.toContain("contact_details");
+  });
+
+  it("should keep a regular field whose name starts with tab-", async () => {
+    // Tabs are identified by their type, not by their key. A content field that merely
+    // happens to be named `tab-...` still holds a value and belongs in the types.
+    const componentWithTabPrefixedField: Component = {
+      name: "test_component",
+      display_name: "Test Component",
+      created_at: "2023-01-01T00:00:00Z",
+      updated_at: "2023-01-01T00:00:00Z",
+      id: 1,
+      schema: {
+        "tab-title": {
+          type: "text",
+          required: true,
+        },
+      },
+      internal_tags_list: [],
+      internal_tag_ids: [],
+    };
+
+    const spaceData: SpaceComponentsData = {
+      components: [componentWithTabPrefixedField],
+      datasources: [],
+      groups: [],
+      presets: [],
+      internalTags: [],
+    };
+
+    const result = await generateTypes(spaceData, { strict: false });
+
+    expect(result).toContain('"tab-title": string');
+  });
+
+  it("should skip malformed schema entries instead of failing", async () => {
+    // The management API types every schema entry as an object, but malformed spaces
+    // do occur. A single bad entry must not take down the whole command.
+    const componentWithMalformedEntry: Component = {
+      name: "test_component",
+      display_name: "Test Component",
+      created_at: "2023-01-01T00:00:00Z",
+      updated_at: "2023-01-01T00:00:00Z",
+      id: 1,
+      schema: {
+        broken: null as unknown as Component["schema"][string],
+        title: {
+          type: "text",
+          required: true,
+        },
+      },
+      internal_tags_list: [],
+      internal_tag_ids: [],
+    };
+
+    const spaceData: SpaceComponentsData = {
+      components: [componentWithMalformedEntry],
+      datasources: [],
+      groups: [],
+      presets: [],
+      internalTags: [],
+    };
+
+    const result = await generateTypes(spaceData, { strict: false });
+
+    expect(result).toContain("title: string");
+    expect(result).not.toContain("broken");
+  });
+
   it("should handle custom property type with customFieldsParser", async () => {
     // Create a component with custom property type
     const componentWithCustomType: Component = {

--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -163,7 +163,7 @@ const getComponentPropertiesTypeAnnotations = async (
     const acc = await accPromise;
 
     // Skip tabbed properties
-    if (key.startsWith('tab-')) {
+    if (key.startsWith('tab-') || value.type === "section") {
       return acc;
     }
 

--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -16,7 +16,7 @@ import { join, resolve } from "pathe";
 import { pathToFileURL } from "node:url";
 import { resolvePath, saveToFile } from "../../../utils/filesystem";
 import { readFileSync } from "node:fs";
-import type { ComponentPropertySchema } from "../../../types/schemas";
+import type { ComponentPropertySchema, ComponentPropertySchemaType } from "../../../types/schemas";
 import {
   createComponentFile,
   createContentTypesFile,
@@ -66,6 +66,11 @@ const SOURCE_MAP_START = "//# sourceMappingURL=";
 // Bundled declarations hoist every import to the top as a single line each. Binding
 // lists are normalized by the bundler, so a regex is sufficient to enumerate them.
 const IMPORT_STATEMENT = /^import\s+(?:(.+?)\s+from\s+)?["'][^"']+["'];?[ \t]*$/gm;
+// Field types that exist purely to arrange other fields in the editor. They carry no
+// value of their own, so a story never stores anything under their key. The management
+// API calls the editor's "Group" field a `section`.
+const LAYOUT_FIELD_TYPES = new Set<ComponentPropertySchemaType>(["section", "tab"]);
+const isLayoutFieldType = (type: ComponentPropertySchemaType) => LAYOUT_FIELD_TYPES.has(type);
 const getDatasourceTypeTitle = (slug: string) => `${toPascalCase(slug)}DataSource`;
 
 const getImportedBindings = (content: string) =>
@@ -256,11 +261,6 @@ const getComponentPropertiesTypeAnnotations = async (
     async (accPromise, [key, value]) => {
       const acc = await accPromise;
 
-      // Skip tabbed properties
-      if (key.startsWith("tab-") || value.type === "section") {
-        return acc;
-      }
-
       // Type guard to ensure value is ComponentPropertySchema
       if (!value || typeof value !== "object" || !("type" in value)) {
         return acc;
@@ -268,6 +268,13 @@ const getComponentPropertiesTypeAnnotations = async (
 
       const schema = value as FieldSchema;
       const propertyType = schema.type;
+
+      // Tabs and groups only arrange fields in the editor, so they never reach the
+      // story content and must not show up in the generated types.
+      if (isLayoutFieldType(propertyType)) {
+        return acc;
+      }
+
       const propertyTypeAnnotation: JSONSchema = {
         [key]: getPropertyTypeAnnotation(schema, options.typePrefix, options.typeSuffix),
       };

--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -257,7 +257,7 @@ const getComponentPropertiesTypeAnnotations = async (
       const acc = await accPromise;
 
       // Skip tabbed properties
-      if (key.startsWith("tab-")) {
+      if (key.startsWith("tab-") || value.type === "section") {
         return acc;
       }
 

--- a/packages/cli/src/types/schemas.ts
+++ b/packages/cli/src/types/schemas.ts
@@ -13,6 +13,8 @@ export type ComponentPropertySchemaType =
   | "number"
   | "option"
   | "options"
+  | "section"
+  | "tab"
   | "text"
   | "textarea";
 


### PR DESCRIPTION
The type generator currently skips tab properties in the JSON schema. Similar to these, "Groups" as described in the documentation provide no utility beyond organising fields in the Storyblok editor. 

Currently, these properties are all generated as `unknown`, this PR proposes extending the tab-skipping logic to avoid generating unrequired unknown values.