### PR TITLE
fix(types): multilink story type for different `resolve_link` values

### DIFF
--- a/packages/cli/src/types/storyblok.ts
+++ b/packages/cli/src/types/storyblok.ts
@@ -25,6 +25,54 @@ export interface StoryblokAsset {
 
 export interface StoryblokMultiasset extends Array<StoryblokAsset> {}
 
+export interface StoryblokMultilinkStory {
+  name: string;
+  created_at: string;
+  published_at: string;
+  id: number;
+  uuid: string;
+  content: Record<string, any>;
+  slug: string;
+  full_slug: string;
+  sort_by_date?: string;
+  position?: number;
+  tag_list?: string[];
+  is_startpage?: boolean;
+  parent_id?: number | null;
+  meta_data?: Record<string, any> | null;
+  group_id?: string;
+  first_published_at?: string;
+  release_id?: number | null;
+  lang?: string;
+  path?: string | null;
+  alternates?: any[];
+  default_full_slug?: string | null;
+  translated_slugs?: any[] | null;
+}
+
+export interface StoryblokMultilinkLink {
+  id: number;
+  uuid: string;
+  slug: string;
+  path: string | null;
+  parent_id: number;
+  name: string;
+  is_folder: boolean;
+  published: boolean;
+  is_startpage: boolean;
+  position: number;
+  real_path: string;
+}
+
+export interface StoryblokMultilinkUrl {
+  name: string;
+  id: number;
+  uuid: string;
+  slug: string;
+  url: string;
+  full_slug: string;
+}
+
 export interface StoryblokMultilink {
   fieldtype: 'multilink';
   id: string;
@@ -36,30 +84,7 @@ export interface StoryblokMultilink {
   title?: string;
   prep?: string;
   linktype: 'story' | 'url' | 'email' | 'asset';
-  story?: {
-    name: string;
-    created_at: string;
-    published_at: string;
-    id: number;
-    uuid: string;
-    content: Record<string, any>;
-    slug: string;
-    full_slug: string;
-    sort_by_date?: string;
-    position?: number;
-    tag_list?: string[];
-    is_startpage?: boolean;
-    parent_id?: number | null;
-    meta_data?: Record<string, any> | null;
-    group_id?: string;
-    first_published_at?: string;
-    release_id?: number | null;
-    lang?: string;
-    path?: string | null;
-    alternates?: any[];
-    default_full_slug?: string | null;
-    translated_slugs?: any[] | null;
-  };
+  story?: StoryblokMultilinkStory | StoryblokMultilinkLink | StoryblokMultilinkUrl;
   email?: string;
 }
 


### PR DESCRIPTION
A resolved story of a multilink has differnt types based on the `resolve_links` value used. With this fix we correctly type the `story` property on the multilink type according to the potential values it can contain.

Fixes WDX-145