### PR TITLE
fix(cli): retry mechanism when multiple systems query the MAPI

### DIFF
--- a/packages/cli/src/commands/migrations/run/index.ts
+++ b/packages/cli/src/commands/migrations/run/index.ts
@@ -114,7 +114,7 @@ migrationsCommand.command('run [componentName]')
           query,
           starts_with: startsWith,
         },
-        batchSize: 100,
+        batchSize: 12,
         onTotal: (total) => {
           storiesProgress.setTotal(total);
           migrationsProgress.setTotal(total);
@@ -141,7 +141,7 @@ migrationsCommand.command('run [componentName]')
         space,
         publish,
         dryRun,
-        batchSize: 100,
+        batchSize: 12,
         onProgress: () => {
           updateProgress.increment();
         },

--- a/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
@@ -91,9 +91,7 @@ class StoriesStream extends Transform {
       objectMode: true,
     });
 
-    this.semaphore = new Sema(this.batchSize, {
-      capacity: this.batchSize,
-    });
+    this.semaphore = new Sema(this.batchSize);
   }
 
   async _transform(chunk: Omit<Story, 'content'>, _encoding: string, callback: (error?: Error | null, data?: any) => void) {

--- a/packages/cli/src/commands/migrations/run/streams/update-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/update-stream.ts
@@ -40,9 +40,7 @@ export class UpdateStream extends Writable {
       totalProcessed: 0,
     };
 
-    this.semaphore = new Sema(this.batchSize, {
-      capacity: this.batchSize,
-    });
+    this.semaphore = new Sema(this.batchSize);
   }
 
   async _write(chunk: { storyId: number; name: string | undefined; content: StoryContent; published?: boolean; unpublished_changes?: boolean }, _encoding: string, callback: (error?: Error | null) => void) {

--- a/packages/mapi-client/README.md
+++ b/packages/mapi-client/README.md
@@ -140,7 +140,7 @@ The client includes built-in retry handling for rate limits and network errors:
 
 ```typescript
 // The client automatically handles retries with these defaults:
-// - maxRetries: 3
+// - maxRetries: 12
 // - retryDelay: 1000ms
 // - Respects retry-after headers from 429 responses
 
@@ -148,7 +148,7 @@ const stories = await client.stories.list({
   path: { space_id: 123456 },
   query: { per_page: 10 }
 });
-// If rate limited, will automatically retry up to 3 times
+// If rate limited, will automatically retry up to 12 times
 ```
 
 ## Runtime Configuration

--- a/packages/mapi-client/src/__tests__/integration.test.ts
+++ b/packages/mapi-client/src/__tests__/integration.test.ts
@@ -103,12 +103,12 @@ describe('ManagementApiClient Integration - Per-Instance Rate Limiting', () => {
     const promise = client.spaces.list({});
     
     // Advance timers to allow all retries
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(14000);
     
     const result = await promise;
     
-    // Should make initial + maxRetries calls (3 retries = 4 total)
-    expect(mockFetch).toHaveBeenCalledTimes(4);
+    // Should make initial + maxRetries calls (12 retries = 13 total)
+    expect(mockFetch).toHaveBeenCalledTimes(13);
     
     // Result should contain the error since all retries failed
     expect(result).toBeDefined();

--- a/packages/mapi-client/src/utils/calculate-retry-delay.ts
+++ b/packages/mapi-client/src/utils/calculate-retry-delay.ts
@@ -1,0 +1,20 @@
+/**
+ * Calculates the delay for the next retry attempt using exponential backoff with full jitter.
+ *
+ * @param attempt The current retry attempt number (starting from 0 for the first retry).
+ * @param baseDelay The initial delay in milliseconds (e.g., 100).
+ * @param maxDelay The maximum possible delay in milliseconds (e.g., 20000).
+ * @returns The calculated delay in milliseconds to wait before the next attempt.
+ */
+export function calculateRetryDelay(
+  attempt: number,
+  baseDelay: number = 100,
+  maxDelay: number = 20000,
+): number {
+  const exponentialBackoff = baseDelay * 2 ** attempt;
+  const cappedBackoff = Math.min(exponentialBackoff, maxDelay);
+  // Apply full jitter: a random value between 0 and the capped backoff
+  const jitter = Math.random() * cappedBackoff;
+
+  return jitter;
+}

--- a/packages/mapi-client/src/utils/delay.ts
+++ b/packages/mapi-client/src/utils/delay.ts
@@ -1,0 +1,1 @@
+export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
When multiple systems hit the MAPI with the same access token, the retry mechanisms quickly gave up. By decreasing the semaphore batch size and increasing the max retries, we make such situations less likely. However, it is still possible to run into limits when many systems query the MAPI with the same access token in parallel.

See the following article for the rational behind the full jitter retry delay: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/