### PR TITLE
fix: don't import useAsyncStoryblok twice

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -91,11 +91,6 @@ export default defineNuxtModule<AllModuleOptions>({
     for (const name of names) {
       addImports({ name, as: name, from: '@storyblok/vue' });
     }
-    addImports({
-      name: 'useAsyncStoryblok',
-      as: 'useAsyncStoryblok',
-      from: resolver.resolve('runtime/composables/useAsyncStoryblok'),
-    });
 
     nuxt.options.typescript.hoist.push('@storyblok/vue');
 


### PR DESCRIPTION
The composables folder is already auto imported:

```
addImportsDir(resolver.resolve('./runtime/composables'));
```

fixes #331