### PR TITLE
chore: changing dummy email name for something more profesional

### DIFF
--- a/packages/cli/__mocks__/test.netrc
+++ b/packages/cli/__mocks__/test.netrc
@@ -1,4 +1,4 @@
 machine api.storyblok.com
-    login julio.profesional@storyblok.com
+    login julio.professional@storyblok.com
     password my_access_token
     region eu

--- a/packages/cli/src/commands/login/actions.test.ts
+++ b/packages/cli/src/commands/login/actions.test.ts
@@ -26,7 +26,7 @@ const handlers = [
       return new HttpResponse('Unprocessable Entity', { status: 422 });
     }
 
-    if (body?.email === 'julio.profesional@storyblok.com' && body?.password === 'password') {
+    if (body?.email === 'julio.professional@storyblok.com' && body?.password === 'password') {
       return HttpResponse.json({ otp_required: true });
     }
     else {
@@ -73,7 +73,7 @@ describe('login actions', () => {
   describe('loginWithEmailAndPassword', () => {
     it('should get if the user requires otp', async () => {
       const expected = { otp_required: true, perPage: 0, total: 0 };
-      const result = await loginWithEmailAndPassword('julio.profesional@storyblok.com', 'password', 'eu');
+      const result = await loginWithEmailAndPassword('julio.professional@storyblok.com', 'password', 'eu');
       expect(result).toEqual(expected);
     });
 
@@ -89,7 +89,7 @@ describe('login actions', () => {
       server.use(
         http.post('https://mapi.storyblok.com/v1/users/login', async ({ request }) => {
           const body = await request.json() as { email: string; password: string; otp_attempt: string };
-          if (body?.email === 'julio.profesional@storyblok.com' && body?.password === 'password' && body?.otp_attempt === '123456') {
+          if (body?.email === 'julio.professional@storyblok.com' && body?.password === 'password' && body?.otp_attempt === '123456') {
             return HttpResponse.json({ access_token: 'Awiwi' });
           }
 
@@ -100,7 +100,7 @@ describe('login actions', () => {
       );
       const expected = { access_token: 'Awiwi', perPage: 0, total: 0 };
 
-      const result = await loginWithOtp('julio.profesional@storyblok.com', 'password', '123456', 'eu');
+      const result = await loginWithOtp('julio.professional@storyblok.com', 'password', '123456', 'eu');
 
       expect(result).toEqual(expected);
     });

--- a/packages/cli/src/creds.test.ts
+++ b/packages/cli/src/creds.test.ts
@@ -17,7 +17,7 @@ describe('creds', async () => {
       vol.fromJSON({
         'test/credentials.json': JSON.stringify({
           'api.storyblok.com': {
-            login: 'julio.profesional@storyblok.com',
+            login: 'julio.professional@storyblok.com',
             password: 'my_access_token',
             region: 'eu',
           },
@@ -27,7 +27,7 @@ describe('creds', async () => {
       const credentials = await getCredentials('/temp/test/credentials.json') as StoryblokCredentials;
 
       expect(credentials['api.storyblok.com']).toEqual({
-        login: 'julio.profesional@storyblok.com',
+        login: 'julio.professional@storyblok.com',
         password: 'my_access_token',
         region: 'eu',
       });
@@ -47,13 +47,13 @@ describe('creds', async () => {
       await addCredentials({
         filePath: '/temp/test/credentials.json',
         machineName: 'api.storyblok.com',
-        login: 'julio.profesional@storyblok.com',
+        login: 'julio.professional@storyblok.com',
         password: 'my_access_token',
         region: 'eu',
       });
 
       const content = vol.readFileSync('/temp/test/credentials.json', 'utf8');
-      expect(content).toBe('{\n  "api.storyblok.com": {\n    "login": "julio.profesional@storyblok.com",\n    "password": "my_access_token",\n    "region": "eu"\n  }\n}');
+      expect(content).toBe('{\n  "api.storyblok.com": {\n    "login": "julio.professional@storyblok.com",\n    "password": "my_access_token",\n    "region": "eu"\n  }\n}');
     });
   });
 
@@ -62,7 +62,7 @@ describe('creds', async () => {
       vol.fromJSON({
         'test/credentials.json': JSON.stringify({
           'api.storyblok.com': {
-            login: 'julio.profesional@storyblok.com',
+            login: 'julio.professional@storyblok.com',
             password: 'my_access_token',
             region: 'eu',
           },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the test email with a professional address across CLI tests and mock credentials.
> 
> - **Tests**:
>   - Update login flow tests in `packages/cli/src/commands/login/actions.test.ts` to use `julio.professional@storyblok.com`.
>   - Update credentials tests in `packages/cli/src/creds.test.ts` to use `julio.professional@storyblok.com`.
> - **Mocks/Fixtures**:
>   - Update `packages/cli/__mocks__/test.netrc` to use `julio.professional@storyblok.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 829d8fa549372b1610095871096b207fb85b792f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->