### PR TITLE
docs(cli): update README for installation instructions

### DIFF
--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -4,16 +4,16 @@
 
 ## Installation
 
-For the latest beta version, install the package using the following command:
+For the latest version, install the package using the following command:
 
 ```bash
-npm install storyblok@beta
+npm install storyblok
 ```
 
-Or for an specific beta version:
+Or for a specific version:
 
 ```bash
-npm install storyblok@4.0.0-beta.<version>
+npm install storyblok@<version>
 ```
 
 ## API


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates CLI README to use stable installation commands (`npm install storyblok` or `storyblok@<version>`) instead of beta-specific instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f92c98f33d428d85b574f45c8b9bcf03e00aa78a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->