### PR TITLE
feat(cli): Allow target space for CLI migrations

### DIFF
--- a/packages/cli/src/commands/components/push/actions.test.ts
+++ b/packages/cli/src/commands/components/push/actions.test.ts
@@ -454,24 +454,6 @@ describe('push components actions', () => {
         expect(result.components[0]).toEqual(mockComponent1);
       });
 
-      it('should use the target space as from space if from option is omitted', async () => {
-        // When from is not specified, it should use the target space
-        vol.fromJSON({
-          '/mock/path/components/target-space/components.json': JSON.stringify([mockComponent1, mockComponent2]),
-        });
-
-        const result = await readComponentsFiles({
-          from: undefined,
-          path: '/mock/path',
-          space: 'target-space',
-          separateFiles: false,
-          verbose: false,
-        });
-        expect(result.components).toHaveLength(2);
-        expect(result.components).toContainEqual(mockComponent1);
-        expect(result.components).toContainEqual(mockComponent2);
-      });
-
       it('should read from different source space than target space', async () => {
         // Simulate cross-space migration scenario
         vol.fromJSON({

--- a/packages/cli/src/commands/components/push/actions.ts
+++ b/packages/cli/src/commands/components/push/actions.ts
@@ -250,22 +250,21 @@ export const upsertComponentInternalTag = async (
 
 export const readComponentsFiles = async (
   options: ReadComponentsOptions): Promise<ComponentsData> => {
-  const { from, path, space, separateFiles = false, suffix } = options;
-  const sourceSpace = from ?? space;
-  const resolvedPath = resolvePath(path, `components/${sourceSpace}`);
+  const { from, path, separateFiles = false, suffix } = options;
+  const resolvedPath = resolvePath(path, `components/${from}`);
 
   // Check if directory exists first
   try {
     await readdir(resolvedPath);
   }
   catch (error) {
-    const message = `No local components found for space ${chalk.bold(sourceSpace)}. To push components, you need to pull them first:
+    const message = `No local components found for space ${chalk.bold(from)}. To push components, you need to pull them first:
 
 1. Pull the components from your source space:
-   ${chalk.cyan(`storyblok components pull --space ${sourceSpace}`)}
+   ${chalk.cyan(`storyblok components pull --space ${from}`)}
 
 2. Then try pushing again:
-   ${chalk.cyan(`storyblok components push --space <target_space> --from ${sourceSpace}`)}`;
+   ${chalk.cyan(`storyblok components push --space <target_space> --from ${from}`)}`;
 
     throw new FileSystemError(
       'file_not_found',

--- a/packages/cli/src/commands/components/push/index.test.ts
+++ b/packages/cli/src/commands/components/push/index.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { session } from '../../../session';
+import { CommandError, konsola } from '../../../utils';
+import { vol } from 'memfs';
+import type { SpaceComponent } from '../constants';
+// Import the main components module first to ensure proper initialization
+import '../index';
+import { componentsCommand } from '../command';
+
+// Mock filesystem modules
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+
+vi.mock('./actions', async () => {
+  const actual = await vi.importActual('./actions');
+  return {
+    ...actual,
+    pushComponent: vi.fn(),
+    updateComponent: vi.fn(),
+    upsertComponent: vi.fn(),
+    pushComponentGroup: vi.fn(),
+    updateComponentGroup: vi.fn(),
+    upsertComponentGroup: vi.fn(),
+    pushComponentPreset: vi.fn(),
+    updateComponentPreset: vi.fn(),
+    upsertComponentPreset: vi.fn(),
+    pushComponentInternalTag: vi.fn(),
+    updateComponentInternalTag: vi.fn(),
+    upsertComponentInternalTag: vi.fn(),
+  };
+});
+
+vi.mock('../actions', () => ({
+  fetchComponents: vi.fn().mockResolvedValue([]),
+  fetchComponentGroups: vi.fn().mockResolvedValue([]),
+  fetchComponentPresets: vi.fn().mockResolvedValue([]),
+  fetchComponentInternalTags: vi.fn().mockResolvedValue([]),
+}));
+
+// Mocking the session module
+vi.mock('../../../session', () => {
+  let _cache: Record<string, any> | null = null;
+  const session = () => {
+    if (!_cache) {
+      _cache = {
+        state: {
+          isLoggedIn: false,
+        },
+        updateSession: vi.fn(),
+        persistCredentials: vi.fn(),
+        initializeSession: vi.fn(),
+      };
+    }
+    return _cache;
+  };
+
+  return {
+    session,
+  };
+});
+
+vi.mock('../../../utils/konsola');
+
+const mockComponent: SpaceComponent = {
+  name: 'test-component',
+  display_name: 'Test Component',
+  created_at: '2021-08-09T12:00:00Z',
+  updated_at: '2021-08-09T12:00:00Z',
+  id: 1,
+  schema: { type: 'object' },
+  is_root: false,
+  is_nestable: true,
+  all_presets: [],
+  real_name: 'test-component',
+  internal_tags_list: [],
+  internal_tag_ids: [],
+};
+
+describe('push', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+    vol.reset();
+    // Reset the option values
+    (componentsCommand as any)._optionValues = {};
+    (componentsCommand as any)._optionValueSources = {};
+    for (const command of componentsCommand.commands) {
+      (command as any)._optionValueSources = {};
+      (command as any)._optionValues = {};
+    }
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  describe('default mode', () => {
+    it('should use target space as from space when --from option is not provided', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      // Create mock filesystem with components for the target space
+      vol.fromJSON({
+        '.storyblok/components/12345/components.json': JSON.stringify([mockComponent]),
+      });
+
+      await componentsCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      // The readComponentsFiles should have been called and should read from space 12345
+      // Since we're reading from the same space as we're pushing to
+      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('from') && expect.stringContaining('12345'));
+    });
+
+    it('should use the --from option when provided', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      // Create mock filesystem with components for the source space
+      vol.fromJSON({
+        '.storyblok/components/source-space/components.json': JSON.stringify([mockComponent]),
+      });
+
+      await componentsCommand.parseAsync(['node', 'test', 'push', '--space', 'target-space', '--from', 'source-space']);
+
+      // The command should indicate pushing from source-space to target-space
+      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('source-space'));
+      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('target-space'));
+    });
+
+    it('should throw an error if the user is not logged in', async () => {
+      session().state = {
+        isLoggedIn: false,
+      };
+
+      await componentsCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      expect(konsola.error).toHaveBeenCalledWith(
+        'You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.',
+        null,
+        {
+          header: true,
+        },
+      );
+    });
+
+    it('should throw an error if the space is not provided', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      const mockError = new CommandError(`Please provide the target space as argument --space TARGET_SPACE_ID.`);
+
+      await componentsCommand.parseAsync(['node', 'test', 'push']);
+
+      expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
+        header: true,
+      });
+    });
+  });
+
+  describe('--separate-files option', () => {
+    it('should read from separate files when specified', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      // Create mock filesystem with separate files
+      vol.fromJSON({
+        '.storyblok/components/12345/test-component.json': JSON.stringify([mockComponent]),
+      });
+
+      await componentsCommand.parseAsync(['node', 'test', 'push', '--space', '12345', '--separate-files']);
+
+      // Should proceed without errors if files are found
+      expect(konsola.info).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/commands/components/push/index.ts
+++ b/packages/cli/src/commands/components/push/index.ts
@@ -69,7 +69,7 @@ componentsCommand
       const componentsData = await readComponentsFiles({
         ...options,
         path,
-        space,
+        from: fromSpace,
       });
 
       // Combine into the expected structure

--- a/packages/cli/src/commands/datasources/push/actions.test.ts
+++ b/packages/cli/src/commands/datasources/push/actions.test.ts
@@ -372,25 +372,6 @@ describe('push datasources actions', () => {
         expect(result.datasources).toContainEqual(mockDatasource1);
         expect(result.datasources).toContainEqual(mockDatasource2);
       });
-
-      it('should use the target space as from space if from option is omitted', async () => {
-        // When from is not specified, it should use the target space
-        vol.fromJSON({
-          '/mock/path/datasources/target-space/datasources.json': JSON.stringify([mockDatasource1, mockDatasource2]),
-        });
-
-        const result = await readDatasourcesFiles({
-          from: undefined,
-          path: '/mock/path',
-          space: 'target-space',
-          separateFiles: false,
-          verbose: false,
-        });
-
-        expect(result.datasources).toHaveLength(2);
-        expect(result.datasources).toContainEqual(mockDatasource1);
-        expect(result.datasources).toContainEqual(mockDatasource2);
-      });
     });
   });
 });

--- a/packages/cli/src/commands/datasources/push/actions.ts
+++ b/packages/cli/src/commands/datasources/push/actions.ts
@@ -138,22 +138,21 @@ export const upsertDatasourceEntry = async (
 };
 
 export const readDatasourcesFiles = async (options: ReadDatasourcesOptions): Promise<SpaceDatasourcesData> => {
-  const { from, path, separateFiles = false, suffix, space } = options;
-  const sourceSpace = from ?? space;
-  const resolvedPath = resolvePath(path, `datasources/${sourceSpace}`);
+  const { from, path, separateFiles = false, suffix } = options;
+  const resolvedPath = resolvePath(path, `datasources/${from}`);
 
   // Check if directory exists first
   try {
     await readdir(resolvedPath);
   }
   catch (error) {
-    const message = `No local datasources found for space ${chalk.bold(sourceSpace)}. To push datasources, you need to pull them first:
+    const message = `No local datasources found for space ${chalk.bold(from)}. To push datasources, you need to pull them first:
 
 1. Pull the datasources from your source space:
-   ${chalk.cyan(`storyblok datasources pull --space ${sourceSpace}`)}
+   ${chalk.cyan(`storyblok datasources pull --space ${from}`)}
 
 2. Then try pushing again:
-   ${chalk.cyan(`storyblok datasources push --space <target_space> --from ${sourceSpace}`)}`;
+   ${chalk.cyan(`storyblok datasources push --space <target_space> --from ${from}`)}`;
 
     throw new FileSystemError(
       'file_not_found',

--- a/packages/cli/src/commands/datasources/push/index.test.ts
+++ b/packages/cli/src/commands/datasources/push/index.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { session } from '../../../session';
+import { CommandError, konsola } from '../../../utils';
+import { vol } from 'memfs';
+import type { SpaceDatasource } from '../constants';
+// Import the main datasources module first to ensure proper initialization
+import '../index';
+import { datasourcesCommand } from '../command';
+
+// Mock filesystem modules
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+
+vi.mock('./actions', async () => {
+  const actual = await vi.importActual('./actions');
+  return {
+    ...actual,
+    pushDatasource: vi.fn(),
+    updateDatasource: vi.fn(),
+    upsertDatasource: vi.fn().mockResolvedValue({ id: 1, name: 'test' }),
+    pushDatasourceEntry: vi.fn(),
+    updateDatasourceEntry: vi.fn(),
+    upsertDatasourceEntry: vi.fn(),
+  };
+});
+
+vi.mock('../pull/actions', () => ({
+  fetchDatasources: vi.fn().mockResolvedValue([]),
+}));
+
+// Mocking the session module
+vi.mock('../../../session', () => {
+  let _cache: Record<string, any> | null = null;
+  const session = () => {
+    if (!_cache) {
+      _cache = {
+        state: {
+          isLoggedIn: false,
+        },
+        updateSession: vi.fn(),
+        persistCredentials: vi.fn(),
+        initializeSession: vi.fn(),
+      };
+    }
+    return _cache;
+  };
+
+  return {
+    session,
+  };
+});
+
+vi.mock('../../../utils/konsola');
+
+const mockDatasource: SpaceDatasource = {
+  id: 1,
+  name: 'test-datasource',
+  slug: 'test-datasource',
+  created_at: '2021-08-09T12:00:00Z',
+  updated_at: '2021-08-09T12:00:00Z',
+  dimensions: [],
+  entries: [],
+};
+
+describe('push datasources', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+    vol.reset();
+    // Reset the option values
+    (datasourcesCommand as any)._optionValues = {};
+    (datasourcesCommand as any)._optionValueSources = {};
+    for (const command of datasourcesCommand.commands) {
+      (command as any)._optionValueSources = {};
+      (command as any)._optionValues = {};
+    }
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  describe('default mode', () => {
+    it('should use target space as from space when --from option is not provided', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      // Create mock filesystem with datasources for the target space
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify([mockDatasource]),
+      });
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      // The readDatasourcesFiles should have been called and should read from space 12345
+      // Since we're reading from the same space as we're pushing to
+      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('from') && expect.stringContaining('12345'));
+    });
+
+    it('should use the --from option when provided', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      // Create mock filesystem with datasources for the source space
+      vol.fromJSON({
+        '.storyblok/datasources/source-space/datasources.json': JSON.stringify([mockDatasource]),
+      });
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', 'target-space', '--from', 'source-space']);
+
+      // The command should indicate pushing from source-space to target-space
+      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('source-space'));
+      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('target-space'));
+    });
+
+    it('should throw an error if the user is not logged in', async () => {
+      session().state = {
+        isLoggedIn: false,
+      };
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      expect(konsola.error).toHaveBeenCalledWith(
+        'You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.',
+        null,
+        {
+          header: true,
+        },
+      );
+    });
+
+    it('should throw an error if the space is not provided', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      const mockError = new CommandError(`Please provide the target space as argument --space TARGET_SPACE_ID.`);
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push']);
+
+      expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
+        header: true,
+      });
+    });
+  });
+
+  describe('--separate-files option', () => {
+    it('should read from separate files when specified', async () => {
+      session().state = {
+        isLoggedIn: true,
+        password: 'valid-token',
+        region: 'eu',
+      };
+
+      // Create mock filesystem with separate files
+      vol.fromJSON({
+        '.storyblok/datasources/12345/test-datasource.json': JSON.stringify([mockDatasource]),
+      });
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345', '--separate-files']);
+
+      // Should proceed without errors if files are found
+      expect(konsola.info).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -60,7 +60,7 @@ datasourcesCommand
         local: await readDatasourcesFiles({
           ...options,
           path,
-          space,
+          from: fromSpace,
         }),
         target: {
           datasources: new Map(),


### PR DESCRIPTION
This PR adds the `--from` option to both `datasources push` and `components push` commands, enabling users to specify a source space when migrating resources between Storyblok spaces.

## What Changed

### Datasources Push Command
- Added `-f, --from <from>` option to specify source space ID
- Reads datasource files from the source space directory instead of requiring them in the target space directory
- Defaults to target space if `--from` is not provided (backward compatible)

### Components Push Command  
- Added `-f, --from <from>` option to specify source space ID
- Reads component files from the source space directory
- Defaults to target space if `--from` is not provided (backward compatible)

## Why This Matters

**Before**: Users had to manually copy/rename directories when migrating between spaces:
```bash
# Old workflow
storyblok datasources pull --space 12345
# Manually copy .storyblok/datasources/12345/ to .storyblok/datasources/67890/
storyblok datasources push --space 67890
```

**After**: Direct migration with the `--from` flag:
```bash
# New workflow
storyblok datasources pull --space 12345
storyblok datasources push --space 67890 --from 12345
```

## Use Cases

### 1. Copy datasources between spaces
```bash
storyblok datasources pull --space PROD_SPACE_ID
storyblok datasources push --space STAGING_SPACE_ID --from PROD_SPACE_ID
```

### 2. Copy components between spaces
```bash
storyblok components pull --space PROD_SPACE_ID
storyblok components push --space STAGING_SPACE_ID --from PROD_SPACE_ID
```

### 3. Combined workflow (components + datasources)
```bash
# Pull from production
storyblok datasources pull --space PROD_SPACE_ID
storyblok components pull --space PROD_SPACE_ID

# Push to staging
storyblok datasources push --space STAGING_SPACE_ID --from PROD_SPACE_ID
storyblok components push --space STAGING_SPACE_ID --from PROD_SPACE_ID
```


**Backward Compatibility**: If `--from` is omitted, defaults to target space (existing behavior)

## Testing

Tested with:
- ✅ Default behavior (no `--from` flag)
- ✅ Cross-space migration with `--from` flag
- ✅ Combined with `--filter`, `--separate-files`, and `--suffix` options
- ✅ Error handling when source files don't exist