### PR TITLE
fix(js-client): fix get condition for MAPI rate limit

### DIFF
--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -684,7 +684,10 @@ export class Storyblok {
     }
 
     // Calculate appropriate rate limit for this request
-    const rateLimit = determineRateLimit(url, params, this.rateLimitConfig);
+    // For Management API requests (non-CDN URLs), use the MAPI rate limit
+    const isMapi = !isCDNUrl(url) && this.rateLimitConfig.isManagementApi;
+    const defaultLimit = isMapi ? MANAGEMENT_API_DEFAULT_RATE_LIMIT : undefined;
+    const rateLimit = determineRateLimit(url, params, this.rateLimitConfig, defaultLimit);
 
     return new Promise(async (resolve, reject) => {
       try {

--- a/packages/js-client/src/rateLimit.test.ts
+++ b/packages/js-client/src/rateLimit.test.ts
@@ -386,5 +386,32 @@ describe('rateLimit', () => {
         serverHeadersRateLimit: 25,
       }, MANAGEMENT_API_DEFAULT_RATE_LIMIT)).toBe(10);
     });
+
+    it('should use default rate limit of 3 for MAPI requests with params (regression test)', () => {
+      // This tests the bug fix where MAPI requests with params were incorrectly
+      // getting rate limit 1000 instead of 3 because they were treated as "cached" requests
+      const params: ISbStoriesParams = {};
+      const config = {
+        isManagementApi: true,
+      };
+
+      // MAPI request with empty params should use default rate limit (3)
+      const result = determineRateLimit(undefined, params, config, MANAGEMENT_API_DEFAULT_RATE_LIMIT);
+      expect(result).toBe(MANAGEMENT_API_DEFAULT_RATE_LIMIT);
+      expect(result).toBe(3);
+    });
+
+    it('should use default rate limit of 3 for MAPI single story request', () => {
+      // Simulates: mapiClient.get(`spaces/{SPACE_ID}/stories/{STORY_ID}`)
+      const url = '/spaces/123/stories/456';
+      const params: ISbStoriesParams = {};
+      const config = {
+        isManagementApi: true,
+      };
+
+      // Should use MAPI default (3), not CDN cached rate limit (1000)
+      const result = determineRateLimit(url, params, config, MANAGEMENT_API_DEFAULT_RATE_LIMIT);
+      expect(result).toBe(3);
+    });
   });
 });

--- a/packages/js-client/src/rateLimit.ts
+++ b/packages/js-client/src/rateLimit.ts
@@ -95,8 +95,9 @@ export function determineRateLimit(
   // Priority order for all requests:
   // 1. User-provided rate limit (highest priority, applies to all requests)
   // 2. Server-provided rate limit (from response headers)
-  // 3. For cached requests (published), use the maximum rate limit
-  // 4. Automatic tier calculation (CDN) or default (Management API)
+  // 3. Default rate limit (Management API)
+  // 4. For cached requests (published), use the maximum rate limit
+  // 5. Automatic tier calculation (CDN)
 
   if (config.userRateLimit !== undefined) {
     return Math.min(config.userRateLimit, MAX_RATE_LIMIT);
@@ -106,14 +107,14 @@ export function determineRateLimit(
     return Math.min(config.serverHeadersRateLimit, MAX_RATE_LIMIT);
   }
 
-  // For cached requests, use the maximum rate limit
-  if (params && !isUncachedRequest(params)) {
-    return MAX_RATE_LIMIT;
-  }
-
   // If a default rate limit is provided (Management API), use it
   if (defaultRateLimit !== undefined) {
     return defaultRateLimit;
+  }
+
+  // For cached requests, use the maximum rate limit
+  if (params && !isUncachedRequest(params)) {
+    return MAX_RATE_LIMIT;
   }
 
   // For CDN API, calculate based on request type


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure Management API requests use a 3 req/s default rate limit (distinct from CDN) and add tests verifying separate throttle queues and precedence.
> 
> - **Rate limiting**:
>   - Use `MANAGEMENT_API_DEFAULT_RATE_LIMIT` (3 req/s) for non-CDN URLs in `cacheResponse` by passing `defaultLimit` to `determineRateLimit`.
>   - Update `determineRateLimit` precedence: user > server > default (MAPI) > cached max (1000) > CDN automatic tiers; move cached check after default.
> - **Tests**:
>   - Add MAPI throttling tests in `packages/js-client/src/index.test.ts` validating 3 req/s rate and separate CDN (50 req/s) vs MAPI (3 req/s) queues.
>   - Add regression tests in `packages/js-client/src/rateLimit.test.ts` ensuring MAPI requests with params and single-story URLs use 3 req/s default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68e4be95dd811883ccc2cf214065aee6060b0586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->