### PR TITLE
docs: remove server provided rate limit doc

### DIFF
--- a/packages/js-client/README.md
+++ b/packages/js-client/README.md
@@ -218,17 +218,7 @@ const Storyblok = new StoryblokClient({
 The client determines rate limits in this order:
 
 1. **Custom `rateLimit`** - Your explicitly set rate limit (highest priority)
-2. **Server headers** - `X-RateLimit-Policy` header from API responses
-3. **Automatic** - Smart tier-based limits based on request type (default)
-
-#### Server-Provided Rate Limits
-
-The client automatically parses and respects rate limit headers from Storyblok API responses:
-
-- `X-RateLimit` - Remaining requests in current window (e.g., `r=29`)
-- `X-RateLimit-Policy` - Maximum requests allowed (e.g., `q=30`)
-
-When these headers are present, the client dynamically adjusts rate limiting for subsequent requests.
+2. **Automatic** - Smart tier-based limits based on request type (default)
 
 ### Passing response interceptor
 


### PR DESCRIPTION
Removing the Server-Provided Rate Limits mention from the documentation so users following the docs do not get confused. We will add this back once the feature becomes available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes outdated server-provided rate limit docs from `packages/js-client/README.md` and clarifies the rate limit priority order.
> 
> - Deletes the "Server-Provided Rate Limits" section and references to `X-RateLimit` / `X-RateLimit-Policy`
> - Updates priority list to only include `Custom rateLimit` and `Automatic` tier-based limits
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddf0de7cfb654b5dc17de96a82b0985cca556559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->