### PR TITLE
fix(nuxt): prevent duplicate auto-import of `useAsyncStoryblok`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -91,11 +91,13 @@ export default defineNuxtModule<AllModuleOptions>({
     for (const name of names) {
       addImports({ name, as: name, from: '@storyblok/vue' });
     }
-    addImports({
-      name: 'useAsyncStoryblok',
-      as: 'useAsyncStoryblok',
-      from: resolver.resolve('runtime/composables/useAsyncStoryblok'),
-    });
+    if (!nuxt.options.imports.scan) {
+      addImports({
+        name: 'useAsyncStoryblok',
+        as: 'useAsyncStoryblok',
+        from: resolver.resolve('runtime/composables/useAsyncStoryblok'),
+      });
+    }
 
     nuxt.options.typescript.hoist.push('@storyblok/vue');
 


### PR DESCRIPTION
Ensure Nuxt only adds an import for `useAsyncStoryblok` if `import.scan` is disabled because otherwise it is imported twice, leading to a warning in the console.

Fixes #331
Fixes WDX-166