### PR TITLE
refactor(cli): centralize management API client initialization

### DIFF
--- a/packages/cli/src/api.test.ts
+++ b/packages/cli/src/api.test.ts
@@ -1,10 +1,10 @@
-import { mapiClient } from './api';
+import { getMapiClient } from './api';
 
 // TODO: Test the api client
 describe.todo('api', () => {
-  describe('mapiClient', () => {
+  describe('getMapiClient', () => {
     it('should create a mapi client', () => {
-      const client = mapiClient();
+      const client = getMapiClient();
       expect(client).toBeDefined();
     });
   });

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { basename } from 'node:path';
 import Storyblok from 'storyblok-js-client';
-import { mapiClient } from '../../api';
+import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { toError } from '../../utils/error/error';
 import type { RegionCode } from '../../constants';
@@ -17,7 +17,7 @@ export const fetchAssets = async ({ spaceId, params }: {
   params?: AssetsQueryParams;
 }) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data, response } = await client.assets.list({
       path: {
         space_id: spaceId,
@@ -81,7 +81,7 @@ export const fetchAssetFolders = async ({ spaceId }: {
   spaceId: string;
 }) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data, response } = await client.assetFolders.list({
       path: {
         space_id: spaceId,
@@ -106,7 +106,7 @@ export const createAssetFolder = async (folder: AssetFolderCreate, {
   spaceId: string;
 }) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data } = await client.assetFolders.create({
       path: {
         space_id: spaceId,
@@ -134,7 +134,7 @@ export const updateAssetFolder = async (folder: AssetFolderUpdate, {
   spaceId: string;
 }) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     await client.assetFolders.update({
       path: {
         asset_folder_id: folder.id,
@@ -156,7 +156,7 @@ const requestAssetUpload = async (asset: AssetUpload, { spaceId }: {
   spaceId: string;
 }) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data } = await client.assets.upload({
       path: {
         space_id: spaceId,
@@ -217,7 +217,7 @@ const finishAssetUpload = async (assetId: number, {
   spaceId: string;
 }) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     await client.assets.finalize({
       path: {
         space_id: spaceId,
@@ -324,7 +324,7 @@ export const updateAsset = async (asset: AssetUpdate, fileBuffer: ArrayBuffer | 
       assetWithNewFilename.short_filename = uploadedAsset.short_filename;
     }
 
-    const client = mapiClient();
+    const client = getMapiClient();
     await client.assets.update({
       path: {
         space_id: spaceId,

--- a/packages/cli/src/commands/assets/pull/index.ts
+++ b/packages/cli/src/commands/assets/pull/index.ts
@@ -9,7 +9,6 @@ import { getReporter } from '../../../lib/reporter/reporter';
 import { requireAuthentication } from '../../../utils/auth';
 import { CommandError } from '../../../utils/error/command-error';
 import { handleError, logOnlyError, toError } from '../../../utils/error/error';
-import { mapiClient } from '../../../api';
 import {
   downloadAssetStream,
   fetchAssetFoldersStream,
@@ -40,8 +39,7 @@ assetsCommand
 
     const { space, path: basePath, verbose } = command.optsWithGlobals();
     const assetToken = options.assetToken as string | undefined;
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       process.exitCode = 2;
@@ -53,14 +51,7 @@ assetsCommand
       return;
     }
 
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
+    const { region } = state;
 
     const summary = {
       folderResults: { total: 0, succeeded: 0, failed: 0 },

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -8,7 +8,6 @@ import { session } from '../../../session';
 import { requireAuthentication } from '../../../utils/auth';
 import { CommandError } from '../../../utils/error/command-error';
 import { handleError, toError } from '../../../utils/error/error';
-import { mapiClient } from '../../../api';
 import { deduplicateManifest, resolveCommandPath } from '../../../utils/filesystem';
 import {
   makeAppendAssetFolderManifestFSTransport,
@@ -58,8 +57,7 @@ assetsCommand
     const { space: targetSpace, path: basePath, verbose } = command.optsWithGlobals();
     const fromSpace = (options.from as string | undefined) || targetSpace;
     const assetToken = options.assetToken as string | undefined;
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       process.exitCode = 2;
@@ -71,14 +69,7 @@ assetsCommand
       return;
     }
 
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
+    const { region } = state;
 
     const summaries: [string, Report['summary'][string]][] = [];
     let fatalError = false;

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -8,7 +8,7 @@ import { toError } from '../../utils/error/error';
 import type { RegionCode } from '../../constants';
 import { createAsset, createAssetFolder, downloadAssetFile, downloadFile, fetchAssetFolders, fetchAssets, sha256, updateAsset, updateAssetFolder } from './actions';
 import type { Asset, AssetCreate, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolderUpdate, AssetMap, AssetsQueryParams, AssetUpdate, AssetUpload } from './types';
-import { mapiClient } from '../../api';
+import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { FetchError } from '../../utils/fetch';
 import { getAssetBinaryFilename, getAssetFilename, getFolderFilename, getSidecarFilename, isRemoteSource } from './utils';
@@ -355,7 +355,7 @@ export type GetAssetFolderTransport = (folderId: number) => Promise<AssetFolder 
 export const makeGetAssetFolderAPITransport = ({ spaceId }: {
   spaceId: string;
 }): GetAssetFolderTransport => async (folderId) => {
-  const { data, response } = await mapiClient().assetFolders.get({
+  const { data, response } = await getMapiClient().assetFolders.get({
     path: {
       asset_folder_id: folderId,
       space_id: spaceId,
@@ -577,7 +577,7 @@ export type GetAssetTransport = (assetId: number) => Promise<Asset | undefined>;
 
 export const makeGetAssetAPITransport = ({ spaceId }: { spaceId: string }): GetAssetTransport =>
   async (assetId: number) => {
-    const { data, response } = await mapiClient().assets.get({
+    const { data, response } = await getMapiClient().assets.get({
       path: {
         space_id: spaceId,
         asset_id: assetId,

--- a/packages/cli/src/commands/components/pull/actions.test.ts
+++ b/packages/cli/src/commands/components/pull/actions.test.ts
@@ -3,7 +3,7 @@ import { setupServer } from 'msw/node';
 import { vol } from 'memfs';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { fetchComponent, fetchComponents, saveComponentsToFiles } from './actions';
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 
 const mockedComponents = [{
   name: 'component-name',
@@ -65,7 +65,7 @@ afterAll(() => server.close());
 
 describe('pull components actions', () => {
   beforeEach(() => {
-    mapiClient({
+    getMapiClient({
       token: {
         accessToken: 'valid-token',
       },
@@ -117,7 +117,7 @@ describe('pull components actions', () => {
 
   // TODO: Ask team regarding resseting the mapi client options
   /* it('should throw an masked error for invalid token', async () => {
-    mapiClient({
+    getMapiClient({
       token: {
         accessToken: 'invalid-token',
       },

--- a/packages/cli/src/commands/components/pull/actions.ts
+++ b/packages/cli/src/commands/components/pull/actions.ts
@@ -4,12 +4,12 @@ import { DEFAULT_COMPONENTS_FILENAME, DEFAULT_GROUPS_FILENAME, DEFAULT_PRESETS_F
 import type { SaveComponentsOptions } from './constants';
 import { handleAPIError, handleFileSystemError } from '../../../utils';
 import { resolvePath, sanitizeFilename, saveToFile } from '../../../utils/filesystem';
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 
 // Components
 export const fetchComponents = async (spaceId: string): Promise<SpaceComponent[] | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.components.list({
       path: {
@@ -27,7 +27,7 @@ export const fetchComponents = async (spaceId: string): Promise<SpaceComponent[]
 
 export const fetchComponent = async (spaceId: string, componentName: string): Promise<SpaceComponent | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.components.list({
       path: {
@@ -49,7 +49,7 @@ export const fetchComponent = async (spaceId: string, componentName: string): Pr
 // Component group actions
 export const fetchComponentGroups = async (spaceId: string): Promise<SpaceComponentFolder[] | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.componentFolders.list({
       path: {
@@ -67,7 +67,7 @@ export const fetchComponentGroups = async (spaceId: string): Promise<SpaceCompon
 // Component preset actions
 export const fetchComponentPresets = async (spaceId: string): Promise<SpaceComponentPreset[] | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.presets.list({
       path: {
@@ -85,7 +85,7 @@ export const fetchComponentPresets = async (spaceId: string): Promise<SpaceCompo
 // Component internal tags
 export const fetchComponentInternalTags = async (spaceId: string): Promise<SpaceComponentInternalTag[] | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.internalTags.list({
       path: {

--- a/packages/cli/src/commands/components/pull/index.test.ts
+++ b/packages/cli/src/commands/components/pull/index.test.ts
@@ -7,6 +7,7 @@ import { colorPalette } from '../../../constants';
 // Import the main module first to ensure proper initialization
 import '../index';
 import { componentsCommand } from '../command';
+import { loggedOutSessionState } from '../../../../test/setup';
 
 vi.mock('./actions', () => ({
   fetchComponents: vi.fn(),
@@ -18,6 +19,14 @@ vi.mock('./actions', () => ({
 }));
 
 vi.mock('../../../utils/konsola');
+
+const preconditions = {
+  loggedOut() {
+    vi.mocked(session().initializeSession).mockImplementation(async () => {
+      session().state = loggedOutSessionState();
+    });
+  },
+};
 
 describe('pull', () => {
   beforeEach(() => {
@@ -56,12 +65,6 @@ describe('pull', () => {
         internal_tag_ids: [] as string[],
       }];
 
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
 
       await componentsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
@@ -92,12 +95,6 @@ describe('pull', () => {
         internal_tags_list: [{ id: 1, name: 'tag' }],
         internal_tag_ids: ['1'],
       };
-
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
       vi.mocked(fetchComponent).mockResolvedValue(mockResponse);
       await componentsCommand.parseAsync(['node', 'test', 'pull', 'component-name', '--space', '12345']);
       expect(fetchComponent).toHaveBeenCalledWith('12345', 'component-name');
@@ -118,9 +115,7 @@ describe('pull', () => {
     });
 
     it('should throw an error if the user is not logged in', async () => {
-      session().state = {
-        isLoggedIn: false,
-      };
+      preconditions.loggedOut();
       await componentsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
       expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.', null, {
         header: true,
@@ -128,12 +123,6 @@ describe('pull', () => {
     });
 
     it('should throw an error if the space is not provided', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       const mockError = new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`);
 
       await componentsCommand.parseAsync(['node', 'test', 'pull']);
@@ -156,12 +145,6 @@ describe('pull', () => {
         internal_tags_list: [] as { id?: number; name?: string }[],
         internal_tag_ids: [] as string[],
       }];
-
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
 
@@ -191,12 +174,6 @@ describe('pull', () => {
         internal_tags_list: [] as { id?: number; name?: string }[],
         internal_tag_ids: [] as string[],
       }];
-
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
 
@@ -237,12 +214,6 @@ describe('pull', () => {
         internal_tag_ids: ['1'],
       }];
 
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
 
       await componentsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345', '--separate-files']);
@@ -269,12 +240,6 @@ describe('pull', () => {
         internal_tags_list: [{ id: 1, name: 'tag' }],
         internal_tag_ids: ['1'],
       }];
-
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
 

--- a/packages/cli/src/commands/components/pull/index.ts
+++ b/packages/cli/src/commands/components/pull/index.ts
@@ -8,7 +8,6 @@ import { fetchComponent, fetchComponentGroups, fetchComponentInternalTags, fetch
 import { componentsCommand } from '../command';
 import chalk from 'chalk';
 import { getProgram } from '../../../program';
-import { mapiClient } from '../../../api';
 import { isAbsolute, join, relative } from 'pathe';
 import { resolveCommandPath } from '../../../utils/filesystem';
 import { DEFAULT_COMPONENTS_FILENAME } from '../constants';
@@ -39,8 +38,7 @@ componentsCommand
     // `--path` overrides remain command-scoped; fallback keeps the historic .storyblok output.
     const componentsOutputDir = resolveCommandPath(directories.components, space, path);
 
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -49,15 +47,6 @@ componentsCommand
       handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
       return;
     }
-
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     const spinnerGroups = new Spinner({
       verbose: !isVitest,

--- a/packages/cli/src/commands/components/push/actions.ts
+++ b/packages/cli/src/commands/components/push/actions.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { readdir } from 'node:fs/promises';
 import { readJsonFile, resolvePath } from '../../../utils/filesystem';
 import chalk from 'chalk';
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 
 // Define a type for components data without datasources
 export interface ComponentsData {
@@ -19,7 +19,7 @@ export interface ComponentsData {
 // Component actions
 export const pushComponent = async (space: string, component: SpaceComponent): Promise<SpaceComponent | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.components.create({
       path: {
@@ -39,7 +39,7 @@ export const pushComponent = async (space: string, component: SpaceComponent): P
 
 export const updateComponent = async (space: string, componentId: number, component: SpaceComponent): Promise<SpaceComponent | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.components.update({
       path: {
@@ -78,7 +78,7 @@ export const upsertComponent = async (
 
 export const pushComponentGroup = async (space: string, componentGroup: SpaceComponentFolder): Promise<SpaceComponentFolder | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.componentFolders.create({
       path: {
@@ -99,7 +99,7 @@ export const pushComponentGroup = async (space: string, componentGroup: SpaceCom
 
 export const updateComponentGroup = async (space: string, groupId: number, componentGroup: SpaceComponentFolder): Promise<SpaceComponentFolder | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.componentFolders.update({
       path: {
@@ -137,7 +137,7 @@ export const upsertComponentGroup = async (
 // Component preset actions
 export const pushComponentPreset = async (space: string, preset: SpaceComponentPreset): Promise<SpaceComponentPreset | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.presets.create({
       path: {
@@ -158,7 +158,7 @@ export const pushComponentPreset = async (space: string, preset: SpaceComponentP
 
 export const updateComponentPreset = async (space: string, presetId: number, preset: SpaceComponentPreset): Promise<SpaceComponentPreset | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.presets.update({
       path: {
@@ -197,7 +197,7 @@ export const upsertComponentPreset = async (
 
 export const pushComponentInternalTag = async (space: string, componentInternalTag: SpaceComponentInternalTag): Promise<SpaceComponentInternalTag | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.internalTags.create({
       path: {
@@ -216,7 +216,7 @@ export const pushComponentInternalTag = async (space: string, componentInternalT
 
 export const updateComponentInternalTag = async (space: string, tagId: number, componentInternalTag: SpaceComponentInternalTag): Promise<SpaceComponentInternalTag | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.internalTags.update({
       path: {

--- a/packages/cli/src/commands/components/push/index.ts
+++ b/packages/cli/src/commands/components/push/index.ts
@@ -9,7 +9,7 @@ import { componentsCommand } from '../command';
 import { filterSpaceDataByComponent, filterSpaceDataByPattern } from './utils';
 import { pushWithDependencyGraph } from './graph-operations';
 import chalk from 'chalk';
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 import { fetchComponentGroups, fetchComponentInternalTags, fetchComponentPresets, fetchComponents } from '../actions';
 import type { SpaceComponent, SpaceComponentFolder, SpaceComponentInternalTag, SpaceComponentPreset, SpaceComponentsData, SpaceComponentsDataState } from '../constants';
 
@@ -33,8 +33,7 @@ componentsCommand
     const fromSpace = options.from || space;
 
     // Check if the user is logged in
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -48,16 +47,9 @@ componentsCommand
     konsola.info(`Attempting to push components ${chalk.bold('from')} space ${chalk.hex(colorPalette.COMPONENTS)(fromSpace)} ${chalk.bold('to')} ${chalk.hex(colorPalette.COMPONENTS)(space)}`);
     konsola.br();
 
-    const { password, region } = state;
-
     let requestCount = 0;
 
-    const client = mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
+    const client = getMapiClient();
 
     client.interceptors.request.use((config) => {
       requestCount++;

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -10,7 +10,6 @@ import path from 'node:path';
 import chalk from 'chalk';
 import { createSpace, type SpaceCreate } from '../spaces';
 import { Spinner } from '@topcli/spinner';
-import { mapiClient } from '../../api';
 import type { User } from '../user/actions';
 import { getUser } from '../user/actions';
 
@@ -83,7 +82,6 @@ export const createCommand = program
     }
 
     const { state, initializeSession } = session();
-    await initializeSession();
 
     // Declare these outside to be used throughout the function
     let password: string | undefined;
@@ -117,16 +115,9 @@ export const createCommand = program
         handleError(new CommandError(`Cannot create space in region "${options.region}". Your account is configured for region "${region}". Space creation must use your account's region.`));
         return;
       }
-
-      mapiClient({
-        token: {
-          accessToken: password,
-        },
-        region,
-      });
     }
     else if (state.isLoggedIn && state.password) {
-      // If using --token or --skip-space but user is logged in, still get their credentials for mapiClient
+      // If using --token or --skip-space but user is logged in, still get their credentials for getMapiClient
       password = state.password;
       if (state.region) {
         region = state.region;

--- a/packages/cli/src/commands/datasources/delete/actions.test.ts
+++ b/packages/cli/src/commands/datasources/delete/actions.test.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 import { deleteDatasource } from './actions';
 
 // MSW handlers for mocking the datasources API endpoint
@@ -28,7 +28,7 @@ afterAll(() => server.close());
 describe('delete datasources actions', () => {
   beforeEach(() => {
     // Reset and configure the MAPI client before each test
-    mapiClient({
+    getMapiClient({
       token: {
         accessToken: 'valid-token',
       },

--- a/packages/cli/src/commands/datasources/delete/actions.ts
+++ b/packages/cli/src/commands/datasources/delete/actions.ts
@@ -1,4 +1,4 @@
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 import { handleAPIError } from '../../../utils';
 
 /**
@@ -8,7 +8,7 @@ import { handleAPIError } from '../../../utils';
  */
 export async function deleteDatasource(spaceId: string, id: string): Promise<void> {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     // Call the Storyblok Management API to delete the datasource by id
     await client.datasources.delete({
       path: {

--- a/packages/cli/src/commands/datasources/delete/index.test.ts
+++ b/packages/cli/src/commands/datasources/delete/index.test.ts
@@ -1,4 +1,3 @@
-import { session } from '../../../session';
 import { konsola } from '../../../utils';
 import { deleteDatasource } from './actions';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -42,12 +41,6 @@ describe('datasources delete command', () => {
   });
 
   it('should delete a datasource by id', async () => {
-    session().state = {
-      isLoggedIn: true,
-      password: 'valid-token',
-      region: 'eu',
-    };
-
     vi.mocked(deleteDatasource).mockResolvedValue(undefined);
     await datasourcesCommand.parseAsync(['node', 'test', 'delete', '--space', '12345', '--id', '45678']);
     expect(deleteDatasource).toHaveBeenCalledWith('12345', '45678');
@@ -55,11 +48,6 @@ describe('datasources delete command', () => {
   });
 
   it('should delete a datasource by name', async () => {
-    session().state = {
-      isLoggedIn: true,
-      password: 'valid-token',
-      region: 'eu',
-    };
     vi.mocked(fetchDatasource).mockResolvedValue({
       id: 45678,
       name: 'Countries',
@@ -76,12 +64,6 @@ describe('datasources delete command', () => {
   });
 
   it('should prompt the user with a warning if both name and id are provided', async () => {
-    session().state = {
-      isLoggedIn: true,
-      password: 'valid-token',
-      region: 'eu',
-    };
-
     await datasourcesCommand.parseAsync(['node', 'test', 'delete', 'Countries', '--space', '12345', '--id', '45678']);
     expect(konsola.warn).toHaveBeenCalledWith('Both a datasource name and an id were provided. Only one is required. The id will be used as the source of truth.');
   });

--- a/packages/cli/src/commands/datasources/delete/index.ts
+++ b/packages/cli/src/commands/datasources/delete/index.ts
@@ -6,7 +6,6 @@ import { colorPalette, commands } from '../../../constants';
 import chalk from 'chalk';
 import { Spinner } from '@topcli/spinner';
 import type { DeleteDatasourceOptions } from './constants';
-import { mapiClient } from '../../../api';
 import { fetchDatasource } from '../pull/actions';
 import { confirm } from '@inquirer/prompts';
 
@@ -38,21 +37,12 @@ datasourcesCommand
     const verbose = datasourcesCommand.parent?.opts().verbose;
 
     // Authenticate user
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
     if (!requireAuthentication(state, verbose)) { return; }
     if (!space) {
       handleError(new CommandError('Please provide the space as argument --space YOUR_SPACE_ID.'), verbose);
       return;
     }
-
-    const { password, region } = state;
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     const spinner = new Spinner({
       verbose: !isVitest,

--- a/packages/cli/src/commands/datasources/pull/actions.test.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.test.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import mockedDatasources from './datasource.mock.json' assert { type: 'json' };
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 import { fetchDatasources, saveDatasourcesToFiles } from './actions';
 import { vol } from 'memfs';
 
@@ -71,7 +71,7 @@ describe('pull datasources actions', () => {
     // Reset counters before each test
     datasourcesPageRequests = 0;
     entriesPageRequests = 0;
-    mapiClient({
+    getMapiClient({
       token: {
         accessToken: 'valid-token',
       },
@@ -190,7 +190,7 @@ describe('pull datasources actions', () => {
     });
     /*  it('should throw a masked error for invalid token', async () => {
       // Configure client with invalid token
-      mapiClient({
+      getMapiClient({
         token: {
           accessToken: 'invalid-token',
         },

--- a/packages/cli/src/commands/datasources/pull/actions.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.ts
@@ -1,5 +1,5 @@
 import { handleAPIError, handleFileSystemError } from '../../../utils';
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 import { join, resolve } from 'node:path';
 import { resolvePath, sanitizeFilename, saveToFile } from '../../../utils/filesystem';
 import type { SpaceDatasource, SpaceDatasourceEntry } from '../constants';
@@ -49,7 +49,7 @@ export const fetchDatasourceEntries = async (
   datasourceId: number,
 ): Promise<SpaceDatasourceEntry[] | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     return await fetchAllPages(
       (page: number) => client.datasourceEntries.list({
         path: {
@@ -72,7 +72,7 @@ export const fetchDatasourceEntries = async (
 
 export const fetchDatasources = async (spaceId: string): Promise<SpaceDatasource[] | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const datasources = await fetchAllPages(
       (page: number) => client.datasources.list({
         path: {
@@ -104,7 +104,7 @@ export const fetchDatasources = async (spaceId: string): Promise<SpaceDatasource
 
 export const fetchDatasource = async (spaceId: string, datasourceName: string): Promise<SpaceDatasource | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data } = await client.datasources.list({
       path: {
         space_id: spaceId,

--- a/packages/cli/src/commands/datasources/pull/index.ts
+++ b/packages/cli/src/commands/datasources/pull/index.ts
@@ -3,7 +3,6 @@ import { colorPalette, commands, directories } from '../../../constants';
 import { session } from '../../../session';
 
 import { getProgram } from '../../../program';
-import { mapiClient } from '../../../api';
 import { datasourcesCommand } from '../command';
 import type { PullDatasourcesOptions } from './constants';
 import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../../utils';
@@ -40,8 +39,7 @@ datasourcesCommand
     // Keep writing under .storyblok unless a command-level --path explicitly overrides it.
     const datasourcesOutputDir = resolveCommandPath(directories.datasources, space, path);
 
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -50,15 +48,6 @@ datasourcesCommand
       handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
       return;
     }
-
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     const spinnerDatasources = new Spinner({
       verbose: !isVitest,

--- a/packages/cli/src/commands/datasources/push/actions.ts
+++ b/packages/cli/src/commands/datasources/push/actions.ts
@@ -5,13 +5,13 @@ import type { SpaceDatasource, SpaceDatasourceEntry, SpaceDatasourcesData } from
 import { DEFAULT_DATASOURCES_FILENAME } from '../constants';
 import type { ReadDatasourcesOptions } from './constants';
 import { readJsonFile, resolvePath } from '../../../utils/filesystem';
-import { mapiClient } from '../../../api';
+import { getMapiClient } from '../../../api';
 import { handleAPIError } from '../../../utils/error/api-error';
 import { FileSystemError, handleFileSystemError } from '../../../utils/error/filesystem-error';
 
 export const pushDatasource = async (spaceId: string, datasource: SpaceDatasource): Promise<SpaceDatasource | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.datasources.create({
       path: {
@@ -30,7 +30,7 @@ export const pushDatasource = async (spaceId: string, datasource: SpaceDatasourc
 
 export const updateDatasource = async (spaceId: string, datasourceId: number, datasource: SpaceDatasource): Promise<SpaceDatasource | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.datasources.update({
       path: {
@@ -68,7 +68,7 @@ export const upsertDatasource = async (space: string, datasource: SpaceDatasourc
  */
 export const pushDatasourceEntry = async (spaceId: string, datasourceId: number, entry: SpaceDatasourceEntry): Promise<SpaceDatasourceEntry | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.datasourceEntries.create({
       path: {
@@ -99,7 +99,7 @@ export const pushDatasourceEntry = async (spaceId: string, datasourceId: number,
  */
 export const updateDatasourceEntry = async (spaceId: string, entryId: number, entry: SpaceDatasourceEntry): Promise<void> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     await client.datasourceEntries.updateDatasourceEntry({
       path: {
         space_id: spaceId,

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -5,7 +5,6 @@ import { datasourcesCommand } from '../command';
 import type { PushDatasourcesOptions } from './constants';
 import { session } from '../../../session';
 import chalk from 'chalk';
-import { mapiClient } from '../../../api';
 import type { SpaceDatasource, SpaceDatasourcesDataState } from '../constants';
 import { readDatasourcesFiles, upsertDatasource, upsertDatasourceEntry } from './actions';
 import { fetchDatasources } from '../pull/actions';
@@ -30,8 +29,7 @@ datasourcesCommand
     const fromSpace = options.from || space;
 
     // Check if the user is logged in
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -44,15 +42,6 @@ datasourcesCommand
     }
     konsola.info(`Attempting to push datasources ${chalk.bold('from')} space ${chalk.hex(colorPalette.DATASOURCES)(fromSpace)} ${chalk.bold('to')} ${chalk.hex(colorPalette.DATASOURCES)(space)}`);
     konsola.br();
-
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     try {
       // Read datasources data from source space (from option or target space)

--- a/packages/cli/src/commands/languages/actions.test.ts
+++ b/packages/cli/src/commands/languages/actions.test.ts
@@ -3,7 +3,7 @@ import { setupServer } from 'msw/node';
 import { vol } from 'memfs';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchLanguages, saveLanguagesToFile } from './actions';
-import { mapiClient } from '../../api';
+import { getMapiClient } from '../../api';
 
 const handlers = [
   http.get('https://mapi.storyblok.com/v1/spaces/12345', async ({ request }) => {
@@ -38,7 +38,7 @@ afterAll(() => server.close());
 
 describe('pull languages actions', () => {
   beforeEach(() => {
-    mapiClient({
+    getMapiClient({
       token: {
         accessToken: 'valid-token',
       },

--- a/packages/cli/src/commands/languages/index.test.ts
+++ b/packages/cli/src/commands/languages/index.test.ts
@@ -5,6 +5,7 @@ import { CommandError, konsola } from '../../utils';
 import { fetchLanguages, saveLanguagesToFile } from './actions';
 import { colorPalette } from '../../constants';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loggedOutSessionState } from '../../../test/setup';
 
 vi.mock('./actions', () => ({
   fetchLanguages: vi.fn(),
@@ -19,6 +20,14 @@ vi.mock('../../creds', () => ({
 }));
 
 vi.mock('../../utils/konsola');
+
+const preconditions = {
+  loggedOut() {
+    vi.mocked(session().initializeSession).mockImplementation(async () => {
+      session().state = loggedOutSessionState();
+    });
+  },
+};
 
 describe('languagesCommand', () => {
   describe('pull', () => {
@@ -46,11 +55,6 @@ describe('languagesCommand', () => {
             },
           ],
         };
-        session().state = {
-          isLoggedIn: true,
-          password: 'valid-token',
-          region: 'eu',
-        };
 
         vi.mocked(fetchLanguages).mockResolvedValue(mockResponse);
         await languagesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
@@ -62,9 +66,7 @@ describe('languagesCommand', () => {
       });
 
       it('should throw an error if the user is not logged in', async () => {
-        session().state = {
-          isLoggedIn: false,
-        };
+        preconditions.loggedOut();
         const mockError = new CommandError(`You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.`);
         await languagesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
         expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
@@ -73,12 +75,6 @@ describe('languagesCommand', () => {
       });
 
       it('should throw an error if the space is not provided', async () => {
-        session().state = {
-          isLoggedIn: true,
-          password: 'valid-token',
-          region: 'eu',
-        };
-
         const mockError = new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`);
         try {
           await languagesCommand.parseAsync(['node', 'test', 'pull']);
@@ -95,11 +91,6 @@ describe('languagesCommand', () => {
         const mockResponse = {
           default_lang_name: 'en',
           languages: [],
-        };
-        session().state = {
-          isLoggedIn: true,
-          password: 'valid-token',
-          region: 'eu',
         };
 
         vi.mocked(fetchLanguages).mockResolvedValue(mockResponse);
@@ -123,11 +114,6 @@ describe('languagesCommand', () => {
               name: 'French',
             },
           ],
-        };
-        session().state = {
-          isLoggedIn: true,
-          password: 'valid-token',
-          region: 'eu',
         };
 
         vi.mocked(fetchLanguages).mockResolvedValue(mockResponse);
@@ -155,11 +141,6 @@ describe('languagesCommand', () => {
             },
           ],
         };
-        session().state = {
-          isLoggedIn: true,
-          password: 'valid-token',
-          region: 'eu',
-        };
 
         vi.mocked(fetchLanguages).mockResolvedValue(mockResponse);
         await languagesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345', '--filename', 'custom-languages']);
@@ -186,11 +167,6 @@ describe('languagesCommand', () => {
               name: 'French',
             },
           ],
-        };
-        session().state = {
-          isLoggedIn: true,
-          password: 'valid-token',
-          region: 'eu',
         };
 
         vi.mocked(fetchLanguages).mockResolvedValue(mockResponse);

--- a/packages/cli/src/commands/languages/index.ts
+++ b/packages/cli/src/commands/languages/index.ts
@@ -6,7 +6,6 @@ import { fetchLanguages, saveLanguagesToFile } from './actions';
 import chalk from 'chalk';
 import type { PullLanguagesOptions } from './constants';
 import { Spinner } from '@topcli/spinner';
-import { mapiClient } from '../../api';
 
 const program = getProgram(); // Get the shared singleton instance
 
@@ -32,8 +31,7 @@ languagesCommand
     const { space, path } = languagesCommand.opts();
     const { filename = 'languages', suffix = options.space } = options;
 
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -42,15 +40,6 @@ languagesCommand
       handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
       return;
     }
-
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     const spinner = new Spinner({
       verbose: !isVitest,

--- a/packages/cli/src/commands/login/actions.ts
+++ b/packages/cli/src/commands/login/actions.ts
@@ -33,7 +33,7 @@ export const loginWithToken = async (token: string, region: RegionCode) => {
 
 export const loginWithEmailAndPassword = async (email: string, password: string, region: RegionCode) => {
   try {
-    // TODO: we cant use the mapiClient for now here because token is required for its instantiation
+    // TODO: we cant use the getMapiClient for now here because token is required for its instantiation
     const url = getStoryblokUrl(region);
     return await customFetch<StoryblokLoginResponse>(`${url}/users/login`, {
       method: 'POST',

--- a/packages/cli/src/commands/login/index.test.ts
+++ b/packages/cli/src/commands/login/index.test.ts
@@ -7,6 +7,7 @@ import { regions } from '../../constants';
 import chalk from 'chalk';
 import { session } from '../../session';
 import type { User } from '../user/actions';
+import { loggedOutSessionState } from '../../../test/setup';
 
 vi.mock('./actions', () => ({
   loginWithEmailAndPassword: vi.fn(),
@@ -46,11 +47,19 @@ vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
 }));
 
+const preconditions = {
+  loggedOut() {
+    vi.mocked(session().initializeSession).mockImplementation(async () => {
+      session().state = loggedOutSessionState();
+    });
+  },
+};
+
 describe('loginCommand', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.clearAllMocks();
-    session().logout();
+    preconditions.loggedOut();
   });
 
   describe('default interactive login', () => {
@@ -63,9 +72,6 @@ describe('loginCommand', () => {
     });
 
     describe('login-with-email strategy', () => {
-      beforeEach(() => {
-        vi.resetAllMocks();
-      });
       it('should prompt the user for email and password when login-with-email is selected', async () => {
         vi.mocked(select)
           .mockResolvedValueOnce('login-with-email') // For login strategy

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -31,9 +31,7 @@ export const loginCommand = program
     // Command options
     const { token, region } = options;
 
-    const { state, updateSession, persistCredentials, initializeSession } = session();
-
-    await initializeSession();
+    const { state, updateSession, persistCredentials } = session();
 
     if (state.isLoggedIn && !state.envLogin) {
       konsola.ok(`You are already logged in. If you want to login with a different account, please logout first.`);

--- a/packages/cli/src/commands/logout/index.test.ts
+++ b/packages/cli/src/commands/logout/index.test.ts
@@ -1,7 +1,8 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { logoutCommand } from './';
 import { session } from '../../session';
-
 import { removeAllCredentials } from '../../creds';
+import { loggedOutSessionState } from '../../../test/setup';
 
 vi.mock('../../creds', () => ({
   getCredentials: vi.fn(),
@@ -10,6 +11,14 @@ vi.mock('../../creds', () => ({
   removeAllCredentials: vi.fn(),
 }));
 
+const preconditions = {
+  loggedOut() {
+    vi.mocked(session().initializeSession).mockImplementation(async () => {
+      session().state = loggedOutSessionState();
+    });
+  },
+};
+
 describe('logoutCommand', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -17,19 +26,12 @@ describe('logoutCommand', () => {
   });
 
   it('should log out the user if has previously login', async () => {
-    session().state = {
-      isLoggedIn: true,
-      password: 'valid-token',
-      region: 'eu',
-    };
     await logoutCommand.parseAsync(['node', 'test']);
     expect(removeAllCredentials).toHaveBeenCalled();
   });
 
   it('should not log out the user if has not previously login', async () => {
-    session().state = {
-      isLoggedIn: false,
-    };
+    preconditions.loggedOut();
     await logoutCommand.parseAsync(['node', 'test']);
     expect(removeAllCredentials).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -14,8 +14,7 @@ export const logoutCommand = program
 
     const verbose = program.opts().verbose;
     try {
-      const { state, initializeSession } = session();
-      await initializeSession();
+      const { state } = session();
       if (!state.isLoggedIn || !state.password || !state.region) {
         konsola.warn(`You are already logged out. If you want to login, please use the login command.`);
         konsola.br();

--- a/packages/cli/src/commands/migrations/generate/index.ts
+++ b/packages/cli/src/commands/migrations/generate/index.ts
@@ -8,7 +8,6 @@ import { session } from '../../../session';
 import { fetchComponent } from '../../../commands/components';
 import { migrationsCommand } from '../command';
 import { generateMigration } from './actions';
-import { mapiClient } from '../../../api';
 import { getUI } from '../../../utils/ui';
 import { getLogger } from '../../../lib/logger/logger';
 
@@ -38,8 +37,7 @@ migrationsCommand
       return;
     }
 
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -48,15 +46,6 @@ migrationsCommand
       handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
       return;
     }
-
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     const spinner = ui.createSpinner(`Generating migration for component ${componentName}...`);
     try {

--- a/packages/cli/src/commands/migrations/rollback/index.test.ts
+++ b/packages/cli/src/commands/migrations/rollback/index.test.ts
@@ -9,6 +9,7 @@ import type { RollbackData } from './actions';
 import type { StoryContent } from '../../stories/constants';
 import { getLogFileContents } from '../../__tests__/helpers';
 import { session } from '../../../session';
+import { loggedOutSessionState } from '../../../../test/setup';
 
 vi.mock('./actions', () => ({
   readRollbackFile: vi.fn(),
@@ -45,7 +46,9 @@ const mockRollbackData: RollbackData = {
 
 const preconditions = {
   loggedOut() {
-    session().logout();
+    vi.mocked(session().initializeSession).mockImplementation(async () => {
+      session().state = loggedOutSessionState();
+    });
   },
   canLoadRollbackFile() {
     vi.mocked(readRollbackFile).mockResolvedValue(mockRollbackData);

--- a/packages/cli/src/commands/migrations/rollback/index.ts
+++ b/packages/cli/src/commands/migrations/rollback/index.ts
@@ -5,7 +5,6 @@ import { migrationsCommand } from '../command';
 import { session } from '../../../session';
 import { readRollbackFile } from './actions';
 import { updateStory } from '../../stories/actions';
-import { mapiClient } from '../../../api';
 import { getUI } from '../../../utils/ui';
 import { getLogger } from '../../../lib/logger/logger';
 import chalk from 'chalk';
@@ -36,8 +35,7 @@ migrationsCommand.command('rollback [migrationFile]')
       path,
     });
 
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -47,14 +45,6 @@ migrationsCommand.command('rollback [migrationFile]')
       handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
       return;
     }
-
-    const { password, region } = state;
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     try {
       // Read the rollback data

--- a/packages/cli/src/commands/migrations/run/index.ts
+++ b/packages/cli/src/commands/migrations/run/index.ts
@@ -11,7 +11,6 @@ import { createStoriesStream } from './streams/stories-stream';
 import { readMigrationFiles } from './actions';
 import { MigrationStream } from './streams/migrations-transform';
 import { UpdateStream } from './streams/update-stream';
-import { mapiClient } from '../../../api';
 import { pipeline } from 'node:stream';
 
 migrationsCommand.command('run [componentName]')
@@ -37,8 +36,7 @@ migrationsCommand.command('run [componentName]')
 
     const verbose = program.opts().verbose;
     const { space, path } = migrationsCommand.opts();
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -49,14 +47,6 @@ migrationsCommand.command('run [componentName]')
     }
 
     const { filter, dryRun = false, query, startsWith, publish } = options;
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     try {
       const spinner = ui.createSpinner(`Fetching migration files and stories...`);

--- a/packages/cli/src/commands/signup/index.ts
+++ b/packages/cli/src/commands/signup/index.ts
@@ -14,10 +14,7 @@ export const signupCommand = program
     konsola.title(`${commands.SIGNUP}`, colorPalette.SIGNUP);
     // Global options
     const verbose = program.opts().verbose;
-
-    const { state, initializeSession } = session();
-
-    await initializeSession();
+    const { state } = session();
 
     if (state.isLoggedIn && !state.envLogin) {
       konsola.ok(`You are already logged in. If you want to signup with a different account, please logout first.`);

--- a/packages/cli/src/commands/spaces/actions.ts
+++ b/packages/cli/src/commands/spaces/actions.ts
@@ -1,6 +1,6 @@
 import type { Spaces } from '@storyblok/management-api-client';
 import { handleAPIError } from '../../utils';
-import { mapiClient } from '../../api';
+import { getMapiClient } from '../../api';
 
 export type Space = Spaces.Space;
 export type SpaceCreate = Spaces.SpaceCreateRequest;
@@ -8,7 +8,7 @@ export type SpaceUpdate = Spaces.SpaceUpdateRequest;
 
 export const fetchSpace = async (spaceId: string): Promise<Space | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.spaces.get({
       path: {
@@ -31,7 +31,7 @@ export const fetchSpace = async (spaceId: string): Promise<Space | undefined> =>
  */
 export const createSpace = async (space: SpaceCreate): Promise<Space | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data } = await client.spaces.create({
       body: {
         space,

--- a/packages/cli/src/commands/stories/actions.test.ts
+++ b/packages/cli/src/commands/stories/actions.test.ts
@@ -3,7 +3,7 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Story } from '@storyblok/management-api-client/resources/stories';
 import { fetchStories } from './actions';
-import { mapiClient } from '../../api';
+import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 
 // Mock dependencies
@@ -175,7 +175,7 @@ const server = setupServer(...handlers);
 // Set up the MSW server
 beforeAll(() => server.listen());
 beforeEach(() => {
-  mapiClient({
+  getMapiClient({
     token: {
       accessToken: 'valid-token',
     },
@@ -242,7 +242,7 @@ describe('stories/actions', () => {
 
     it('should handle unauthorized errors', async () => {
       // Temporarily create a client with invalid token
-      mapiClient({
+      getMapiClient({
         token: {
           accessToken: 'invalid-token',
         },
@@ -257,7 +257,7 @@ describe('stories/actions', () => {
       );
 
       // Restore valid client
-      mapiClient({
+      getMapiClient({
         token: {
           accessToken: 'valid-token',
         },

--- a/packages/cli/src/commands/stories/actions.ts
+++ b/packages/cli/src/commands/stories/actions.ts
@@ -1,6 +1,6 @@
 import type { Story } from '@storyblok/management-api-client/resources/stories';
 import type { FetchStoriesResult, StoriesQueryParams } from './constants';
-import { mapiClient } from '../../api';
+import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { toError } from '../../utils/error/error';
 
@@ -15,7 +15,7 @@ export const fetchStories = async (
   params?: StoriesQueryParams,
 ): Promise<FetchStoriesResult | undefined> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data, response } = await client.stories.list({
       path: {
         space_id: spaceId,
@@ -43,7 +43,7 @@ export const fetchStory = async (
   storyId: string,
 ) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.stories.get({
       path: {
@@ -68,7 +68,7 @@ export const createStory = async (
   },
 ): Promise<Story | void> => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
 
     const { data } = await client.stories.create({
       path: {
@@ -108,7 +108,7 @@ export const updateStory = async (
   },
 ) => {
   try {
-    const client = mapiClient();
+    const client = getMapiClient();
     const { data } = await client.stories.updateStory({
       path: {
         space_id: spaceId,

--- a/packages/cli/src/commands/stories/pull/index.ts
+++ b/packages/cli/src/commands/stories/pull/index.ts
@@ -3,7 +3,6 @@ import type { Story } from '@storyblok/management-api-client/resources/stories';
 import { colorPalette, commands, directories } from '../../../constants';
 import { session } from '../../../session';
 import { storiesCommand } from '../command';
-import { mapiClient } from '../../../api';
 import { resolveCommandPath } from '../../../utils/filesystem';
 import { getUI } from '../../../utils/ui';
 import { getLogger } from '../../../lib/logger/logger';
@@ -34,8 +33,7 @@ storiesCommand
     }
 
     const { space, path: basePath, verbose } = command.optsWithGlobals();
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -44,15 +42,6 @@ storiesCommand
       handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
       return;
     }
-
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     const summary = {
       fetchStoryPages: { total: 0, succeeded: 0, failed: 0 },

--- a/packages/cli/src/commands/stories/push/index.ts
+++ b/packages/cli/src/commands/stories/push/index.ts
@@ -5,7 +5,6 @@ import { colorPalette, commands, directories } from '../../../constants';
 import { CommandError, handleError, requireAuthentication, toError } from '../../../utils';
 import { session } from '../../../session';
 import { storiesCommand } from '../command';
-import { mapiClient } from '../../../api';
 import { loadManifest, resolveCommandPath } from '../../../utils/filesystem';
 import { getUI } from '../../../utils/ui';
 import { getLogger } from '../../../lib/logger/logger';
@@ -38,8 +37,7 @@ storiesCommand
 
     const { space, path: basePath, verbose } = command.optsWithGlobals();
     const fromSpace = options.from || space;
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
       return;
@@ -48,15 +46,6 @@ storiesCommand
       handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
       return;
     }
-
-    const { password, region } = state;
-
-    mapiClient({
-      token: {
-        accessToken: password,
-      },
-      region,
-    });
 
     const warnAboutCustomPlugins = (fields: Set<Component['schema']>, story: Story) => {
       const warnedPlugins = new Set<string>();

--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -11,7 +11,7 @@ import { handleAPIError } from '../../utils/error/api-error';
 import { toError } from '../../utils/error/error';
 import { FetchError } from '../../utils/fetch';
 import { type ComponentSchemas, type RefMaps, storyRefMapper } from './ref-mapper';
-import { mapiClient } from '../../api';
+import { getMapiClient } from '../../api';
 import { getStoryFilename } from './utils';
 
 const apiConcurrencyLock = new Sema(12);
@@ -213,7 +213,7 @@ const getRemoteStory = async ({ spaceId, storyId }: {
   spaceId: string;
   storyId: number;
 }) => {
-  const { data, response } = await mapiClient().stories.get({
+  const { data, response } = await getMapiClient().stories.get({
     path: {
       space_id: spaceId,
       story_id: storyId,

--- a/packages/cli/src/commands/types/generate/index.test.ts
+++ b/packages/cli/src/commands/types/generate/index.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { session } from '../../../session';
 import { konsola } from '../../../utils';
 import { generateStoryblokTypes, generateTypes } from './actions';
 import chalk from 'chalk';
@@ -73,12 +72,6 @@ describe('types generate', () => {
 
   describe('default mode', () => {
     it('should prompt the user if the operation was sucessfull', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
 
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
@@ -98,12 +91,6 @@ describe('types generate', () => {
     });
 
     it('should pass strict mode option to generateTypes when --strict flag is used', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
       vi.mocked(generateTypes).mockResolvedValue('// Generated types');
@@ -119,12 +106,6 @@ describe('types generate', () => {
     });
 
     it('should pass typePrefix option to generateTypes when --type-prefix flag is used', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
       vi.mocked(generateTypes).mockResolvedValue('// Generated types');
@@ -155,12 +136,6 @@ describe('types generate', () => {
     });
 
     it('should pass suffix option to generateTypes when --suffix flag is used', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
       vi.mocked(generateTypes).mockResolvedValue('// Generated types');
@@ -176,12 +151,6 @@ describe('types generate', () => {
     });
 
     it('should pass separateFiles option to generateTypes when --separate-files flag is used', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
       vi.mocked(generateTypes).mockResolvedValue('// Generated types');
@@ -197,12 +166,6 @@ describe('types generate', () => {
     });
 
     it('should pass customFieldsParser option to generateTypes when --custom-fields-parser flag is used', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
       vi.mocked(generateTypes).mockResolvedValue('// Generated types');
@@ -218,12 +181,6 @@ describe('types generate', () => {
     });
 
     it('should pass compilerOptions option to generateTypes when --compiler-options flag is used', async () => {
-      session().state = {
-        isLoggedIn: true,
-        password: 'valid-token',
-        region: 'eu',
-      };
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
       vi.mocked(generateTypes).mockResolvedValue('// Generated types');

--- a/packages/cli/src/commands/user/actions.ts
+++ b/packages/cli/src/commands/user/actions.ts
@@ -1,15 +1,15 @@
 import chalk from 'chalk';
+import type { Users } from '@storyblok/management-api-client';
 import { FetchError } from '../../utils/fetch';
 import { APIError, maskToken } from '../../utils';
-import { mapiClient } from '../../api';
-import type { Users } from '@storyblok/management-api-client';
+import { creategetMapiClient } from '../../api';
 import type { RegionCode } from '../../constants';
 
 export type User = Users.User;
 
 export const getUser = async (token: string, region: RegionCode) => {
   try {
-    const client = mapiClient({
+    const client = creategetMapiClient({
       token: {
         accessToken: token,
       },

--- a/packages/cli/src/commands/user/index.ts
+++ b/packages/cli/src/commands/user/index.ts
@@ -13,11 +13,8 @@ export const userCommand = program
   .description('Get the current user')
   .action(async () => {
     konsola.title(`${commands.USER}`, colorPalette.USER);
-
     const verbose = program.opts().verbose;
-
-    const { state, initializeSession } = session();
-    await initializeSession();
+    const { state } = session();
 
     if (!requireAuthentication(state)) {
       return;

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -10,6 +10,8 @@ import { FileTransport } from './lib/logger/logger-transport-file';
 import { ConsoleTransport } from './lib/logger/logger-transport-console';
 import { resolveCommandPath } from './utils/filesystem';
 import { directories } from './constants';
+import { session } from './session';
+import { getMapiClient } from './api';
 import {
   applyConfigToCommander,
   getCommandAncestry,
@@ -68,6 +70,18 @@ export function getProgram(): Command {
       const resolvedConfig = await resolveConfig(targetCommand, ancestry);
       applyConfigToCommander(ancestry, resolvedConfig);
       setActiveConfig(resolvedConfig);
+
+      // Initialize mapiClient
+      const { state, initializeSession } = session();
+      await initializeSession();
+      if (state.password) {
+        getMapiClient({
+          token: {
+            accessToken: state.password,
+          },
+          region: state.region ?? resolvedConfig.region,
+        });
+      }
 
       // Step 2: Setup logging, UI, and reporting with resolved config
       const options = targetCommand.optsWithGlobals();

--- a/packages/cli/test/setup.ts
+++ b/packages/cli/test/setup.ts
@@ -6,16 +6,19 @@ import type { SessionState } from '../src/session';
 vi.mock('node:fs');
 vi.mock('node:fs/promises');
 
-const defaultSessionState: SessionState = {
+export const loggedOutSessionState = (): SessionState => ({
+  isLoggedIn: false,
+});
+export const loggedInSessionState = (): SessionState => ({
   isLoggedIn: true,
   password: 'valid-token',
   region: 'eu',
   envLogin: false,
-};
+});
 const sessionApi = {
-  state: structuredClone(defaultSessionState),
+  state: loggedInSessionState(),
   initializeSession: vi.fn(() => {
-    sessionApi.state = structuredClone(defaultSessionState);
+    sessionApi.state = loggedInSessionState();
   }),
   updateSession: vi.fn((login: string, password: string, region: RegionCode) => {
     sessionApi.state.isLoggedIn = true;
@@ -24,19 +27,13 @@ const sessionApi = {
     sessionApi.state.region = region;
   }),
   persistCredentials: vi.fn().mockResolvedValue(undefined),
-  logout: vi.fn(() => {
-    sessionApi.state.isLoggedIn = false;
-    sessionApi.state.login = undefined;
-    sessionApi.state.password = undefined;
-    sessionApi.state.region = undefined;
-  }),
 };
 
 vi.mock('../src/session.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/session')>();
   return {
     ...actual,
-    session: vi.fn(() => sessionApi),
+    session: () => sessionApi,
   };
 });
 
@@ -51,5 +48,4 @@ vi.mock('../src/lib/config/store', async (importOriginal) => {
 
 beforeEach(() => {
   vol.reset();
-  sessionApi.initializeSession();
 });

--- a/packages/js-client/src/rateLimit.test.ts
+++ b/packages/js-client/src/rateLimit.test.ts
@@ -402,7 +402,7 @@ describe('rateLimit', () => {
     });
 
     it('should use default rate limit of 3 for MAPI single story request', () => {
-      // Simulates: mapiClient.get(`spaces/{SPACE_ID}/stories/{STORY_ID}`)
+      // Simulates: getMapiClient.get(`spaces/{SPACE_ID}/stories/{STORY_ID}`)
       const url = '/spaces/123/stories/456';
       const params: ISbStoriesParams = {};
       const config = {


### PR DESCRIPTION
Unify Management API client creation via getMapiClient and a shared program-level initializer, removing per-command session/config wiring and scattered mapiClient calls. This reduces duplication, ensures consistent rate limiting and region/token handling across commands, and simplifies tests with standardized session state helpers.

Fixes WDX-241