### PR TITLE
fix(cli): pushing stories with required fields

### DIFF
--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -242,8 +242,8 @@ export const makeCreateStoryAPITransport = ({ spaceId }: {
     story: {
       ...newStoryData,
       content: {
-        // @ts-expect-error Our types are wrong.
-        component: content?.component,
+        _uid: '',
+        component: '__tmp__',
       },
     },
     publish: 0,


### PR DESCRIPTION
In the first pass of pushing stories, we don't send any content. This is problematic if the story component has required fields. By setting the component type to a non-existing component, we avoid problems with required fields.

Fixes WDX-255