### PR TITLE
fix(nuxt): add server exports and register alias for TypeScript resolution

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -17,6 +17,10 @@
     ".": {
       "types": "./dist/types.d.mts",
       "import": "./dist/module.mjs"
+    },
+    "./server": {
+      "types": "./dist/runtime/server/index.d.ts",
+      "import": "./dist/runtime/server/index.js"
     }
   },
   "main": "./dist/module.mjs",

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -67,6 +67,7 @@ export default defineNuxtModule<AllModuleOptions>({
       nitroConfig.alias = nitroConfig.alias || {};
       nitroConfig.alias['#storyblok/server'] = resolver.resolve('./runtime/server');
     });
+    nuxt.options.alias['#storyblok/server'] = resolver.resolve('./runtime/server');
 
     // Add auto imports
     const names = [


### PR DESCRIPTION
fixes #429

**The Problem:**
While the Nitro alias was registered internally, it wasn't exposed to the global Nuxt context or defined in the package.json exports. This caused ERR_PACKAGE_PATH_NOT_EXPORTED when trying to resolve the types in external projects.

**The Fix:**
1. Added ./server to the exports map in package.json.
2. Registered #storyblok/server in nuxt.options.alias within src/module.ts.

**Verification:**
Verified by building the package and installing the resulting tarball in a separate Nuxt project. vue-tsc now correctly resolves the server client types."