### PR TITLE
fix(cli): use companion binary name as a fallback short_filename for S3

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -92,6 +92,50 @@ export interface SpaceOptions {
   spaceId: string;
 }
 
+/**
+ * Supported asset file extensions based on Storyblok's accepted MIME types.
+ * @see https://www.storyblok.com/docs/concepts/assets
+ * @see https://www.storyblok.com/faq/are-there-asset-type-upload-limitations
+ */
+export const SUPPORTED_ASSET_EXTENSIONS = new Set([
+  // Images: image/png, image/x-png, image/gif, image/jpeg, image/avif, image/svg+xml, image/webp
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.svg',
+  // Video: video/*, application/mp4, application/x-mpegurl, application/vnd.apple.mpegurl
+  '.mp4',
+  '.mov',
+  '.avi',
+  '.webm',
+  '.wmv',
+  '.mkv',
+  '.flv',
+  '.ogv',
+  '.3gp',
+  '.m4v',
+  '.mpg',
+  '.mpeg',
+  '.m3u8',
+  // Audio: audio/*
+  '.mp3',
+  '.wav',
+  '.ogg',
+  '.aac',
+  '.flac',
+  '.wma',
+  '.m4a',
+  '.opus',
+  // Documents: application/msword, text/plain, application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.txt',
+]);
+
 export const directories = {
   assets: 'assets',
   components: 'components',


### PR DESCRIPTION
  ## Summary

  Fixes a crash when pushing assets whose metadata doesn't include a `filename` field.

  This is expected for user-defined assets (e.g. CMS migrations) since `filename` is a
  CDN URL that only gets assigned by the backend after upload completes.

  ## Changes

  `short_filename` is now resolved through a fallback chain:
  1. From the metadata (`short_filename` field)
  2. From the CDN URL (`filename` field, for previously pulled assets)
  3. From the companion binary file in the same directory (e.g. `hero.json` → `hero.png`)

  If none resolve, a descriptive error is reported and the asset is skipped.
  
  Fixes WDX-296