### PR TITLE
fix(build): fix tsdown dts chunk splitting causing mangled type exports

### DIFF
--- a/packages/js-client/tsdown.config.ts
+++ b/packages/js-client/tsdown.config.ts
@@ -11,5 +11,6 @@ export default defineConfig([
     dts: true,
     attw: true,
     exports: true,
+    publint: true,
   },
 ]);

--- a/packages/mapi-client/package.json
+++ b/packages/mapi-client/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@storyblok/management-api-client",
   "version": "0.1.9",
+  "type": "module",
   "description": "Storyblok Management API Client",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "private": false,
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.cts",
   "homepage": "https://github.com/storyblok/monoblok/tree/main/packages/mapi-client#readme",
   "repository": {
     "type": "git",
@@ -20,12 +21,19 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
+    "./package.json": "./package.json",
     "./resources/*": {
-      "types": "./dist/generated/*/types.gen.d.ts"
+      "import": {
+        "types": "./dist/generated/*/types.gen.d.ts",
+        "default": "./dist/generated/*/types.gen.js"
+      },
+      "require": {
+        "types": "./dist/generated/*/types.gen.d.cts",
+        "default": "./dist/generated/*/types.gen.cjs"
+      }
     }
   },
   "scripts": {

--- a/packages/mapi-client/tsdown.config.ts
+++ b/packages/mapi-client/tsdown.config.ts
@@ -10,8 +10,33 @@ export default defineConfig({
   format: ['esm', "commonjs"],
   globalName: 'StoryblokManagementApiClient',
   sourcemap: true,
+  attw: {
+    profile: 'node16',
+  },
   clean: true,
   dts: true,
+  exports: {
+    customExports(pkg) {
+      // Remove auto-generated ./generated/* exports; expose types only via ./resources/*
+      for (const key of Object.keys(pkg)) {
+        if (key.startsWith('./generated/')) {
+          delete pkg[key]
+        }
+      }
+      pkg['./resources/*'] = {
+        import: {
+          types: './dist/generated/*/types.gen.d.ts',
+          default: './dist/generated/*/types.gen.js',
+        },
+        require: {
+          types: './dist/generated/*/types.gen.d.cts',
+          default: './dist/generated/*/types.gen.cjs',
+        },
+      }
+      return pkg
+    },
+  },
+  publint: true,
   unbundle: true,
   external: [
     // Externalize generated client duplicates to reduce bundle size

--- a/packages/richtext/package.json
+++ b/packages/richtext/package.json
@@ -23,38 +23,18 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      },
-      "umd": "./dist/index.umd.js"
-    },
-    "./markdown-parser": {
-      "import": {
-        "types": "./dist/markdown-parser.d.mts",
-        "default": "./dist/markdown-parser.mjs"
-      },
-      "require": {
-        "types": "./dist/markdown-parser.d.cts",
-        "default": "./dist/markdown-parser.cjs"
-      },
-      "umd": "./dist/markdown-parser.umd.js"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     },
     "./html-parser": {
-      "import": {
-        "types": "./dist/html-parser.d.mts",
-        "default": "./dist/html-parser.mjs"
-      },
-      "require": {
-        "types": "./dist/html-parser.d.cts",
-        "default": "./dist/html-parser.cjs"
-      },
-      "umd": "./dist/html-parser.umd.js"
-    }
+      "import": "./dist/html-parser.mjs",
+      "require": "./dist/html-parser.cjs"
+    },
+    "./markdown-parser": {
+      "import": "./dist/markdown-parser.mjs",
+      "require": "./dist/markdown-parser.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/richtext/tsdown.config.ts
+++ b/packages/richtext/tsdown.config.ts
@@ -4,34 +4,40 @@ const sharedConfig = {
   attw: true,
   clean: true,
   dts: true,
+  exports: true,
   external: ['mdast'],
   outDir: './dist',
+  publint: true,
   sourcemap: true,
 };
 
 export default [
+  // ESM — one entry per config to avoid chunk splitting on .d.mts files
   defineConfig({
     ...sharedConfig,
-    entry: {
-      'index': './src/index.ts',
-      'markdown-parser': './src/markdown-parser.ts',
-      'html-parser': './src/html-parser.ts',
-    },
+    entry: { index: './src/index.ts' },
     format: 'esm',
   }),
   defineConfig({
     ...sharedConfig,
-    entry: {
-      index: './src/index.ts',
-    },
+    entry: { 'markdown-parser': './src/markdown-parser.ts' },
+    format: 'esm',
+  }),
+  defineConfig({
+    ...sharedConfig,
+    entry: { 'html-parser': './src/html-parser.ts' },
+    format: 'esm',
+  }),
+  // CJS + UMD
+  defineConfig({
+    ...sharedConfig,
+    entry: { index: './src/index.ts' },
     format: ['cjs', 'umd'],
     globalName: 'StoryblokRichtext',
   }),
   defineConfig({
     ...sharedConfig,
-    entry: {
-      'markdown-parser': './src/markdown-parser.ts',
-    },
+    entry: { 'markdown-parser': './src/markdown-parser.ts' },
     format: ['cjs', 'umd'],
     globalName: 'StoryblokRichtextMarkdownParser',
     outputOptions: {
@@ -42,9 +48,7 @@ export default [
   }),
   defineConfig({
     ...sharedConfig,
-    entry: {
-      'html-parser': './src/html-parser.ts',
-    },
+    entry: { 'html-parser': './src/html-parser.ts' },
     format: ['cjs', 'umd'],
     globalName: 'StoryblokRichtextHtmlParser',
     outputOptions: {


### PR DESCRIPTION
Split multi-entry ESM configs into single-entry configs in @storyblok/richtext to prevent tsdown from chunk-splitting .d.mts declaration files, which was producing mangled single-letter type exports (e.g. StoryblokRichTextOptions as 'm') and breaking downstream packages (@storyblok/astro noImplicitAny errors, @storyblok/react api-extractor crash).

Also add exports: true and publint: true across all tsdown packages so package.json exports are auto-maintained and validated on every build.

Fix @storyblok/management-api-client package.json: add type: module, correct main/module/types fields for ESM-first output, and split export types conditions by import/require with correct .d.ts/.d.cts extensions. Use customExports hook to combine auto-generated exports with the handcrafted ./resources/* wildcard. Set attw profile: node16 since wildcard exports are not resolvable under node10.