### PR TITLE
fix(js-client): replace real-API e2e tests with MSW integration tests

### DIFF
--- a/packages/js-client/package.json
+++ b/packages/js-client/package.json
@@ -61,6 +61,7 @@
     "@vitest/coverage-v8": "^3.1.3",
     "@vitest/ui": "^3.1.3",
     "eslint": "^9.26.0",
+    "msw": "^2.10.2",
     "tsdown": "^0.20.3",
     "typescript": "5.8.3",
     "vite": "^7.0.6",

--- a/packages/js-client/tests/api/index.e2e.ts
+++ b/packages/js-client/tests/api/index.e2e.ts
@@ -1,147 +1,60 @@
 import StoryblokClient from 'storyblok-js-client';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-describe('StoryblokClient', () => {
+/**
+ * Smoke tests against the real Storyblok CDN API.
+ *
+ * These tests are intentionally minimal — they exist to catch real API
+ * regressions (e.g. auth, response shape changes, content structure) that
+ * MSW-based tests cannot detect.
+ *
+ * They are skipped automatically when VITE_ACCESS_TOKEN is not set, so
+ * they never block CI for external contributors. They run when a valid
+ * token is available (e.g. internal PRs or scheduled workflows).
+ *
+ * Required env vars (in .env.test):
+ *   VITE_ACCESS_TOKEN  — CDN access token
+ *   VITE_SPACE_ID      — numeric space ID
+ */
+describe.skipIf(!process.env.VITE_ACCESS_TOKEN)('StoryblokClient (smoke tests)', () => {
   let client: StoryblokClient;
 
   beforeEach(() => {
-    // Setup default mocks
     client = new StoryblokClient({
       accessToken: process.env.VITE_ACCESS_TOKEN,
       cache: { type: 'memory', clear: 'auto' },
     });
   });
-  // TODO: Uncomment when we have a valid token
-  /* if (process.env.VITE_OAUTH_TOKEN) {
-      describe('management API', () => {
-        const spaceId = process.env.VITE_SPACE_ID
-        describe('should return all spaces', async () => {
-          const StoryblokManagement = new StoryblokClient({
-            oauthToken: process.env.VITE_OAUTH_TOKEN,
-          })
-          const result = await StoryblokManagement.getAll(
-            `spaces/${spaceId}/stories`
-          )
-          expect(result.length).toBeGreaterThan(0)
-        })
-      })
-  } */
 
-  describe('get function', () => {
-    it('get(\'cdn/spaces/me\') should return the space information', async () => {
-      const { data } = await client.get('cdn/spaces/me');
-      expect(data.space.id).toBe(Number(process.env.VITE_SPACE_ID));
-    });
-
-    it('get(\'cdn/stories\') should return all stories', async () => {
-      const { data } = await client.get('cdn/stories');
-      expect(data.stories.length).toBeGreaterThan(0);
-    });
-
-    it('get(\'cdn/stories/testcontent-0\' should return the specific story', async () => {
-      const { data } = await client.get('cdn/stories/testcontent-0');
-      expect(data.story.slug).toBe('testcontent-0');
-    });
-
-    it('get(\'cdn/stories\' { starts_with: testcontent-0 } should return the specific story', async () => {
-      const { data } = await client.get('cdn/stories', {
-        starts_with: 'testcontent-0',
-      });
-      expect(data.stories.length).toBe(1);
-    });
-
-    it('get(\'cdn/stories/testcontent-draft\', { version: \'draft\' }) should return the specific story draft', async () => {
-      const { data } = await client.get('cdn/stories/testcontent-draft', {
-        version: 'draft',
-      });
-      expect(data.story.slug).toBe('testcontent-draft');
-    });
-
-    it('get(\'cdn/stories/testcontent-0\', { version: \'published\' }) should return the specific story published', async () => {
-      const { data } = await client.get('cdn/stories/testcontent-0', {
-        version: 'published',
-      });
-      expect(data.story.slug).toBe('testcontent-0');
-    });
-
-    it('cdn/stories/testcontent-0 should resolve author relations', async () => {
-      const { data } = await client.get('cdn/stories/testcontent-0', {
-        resolve_relations: 'root.author',
-      });
-
-      expect(data.story.content.author[0].slug).toBe('edgar-allan-poe');
-    });
-
-    it('get(\'cdn/stories\', { by_slugs: \'folder/*\' }) should return the specific story', async () => {
-      const { data } = await client.get('cdn/stories', {
-        by_slugs: 'folder/*',
-      });
-      expect(data.stories.length).toBeGreaterThan(0);
-    });
+  it('authenticates and returns space information', async () => {
+    const { data } = await client.get('cdn/spaces/me');
+    expect(data.space.id).toBe(Number(process.env.VITE_SPACE_ID));
   });
 
-  describe('getAll function', () => {
-    it('getAll(\'cdn/stories\') should return all stories', async () => {
-      const result = await client.getAll('cdn/stories', {});
-      expect(result.length).toBeGreaterThan(0);
-    });
-
-    it('getAll(\'cdn/stories\') should return all stories with filtered results', async () => {
-      const result = await client.getAll('cdn/stories', {
-        starts_with: 'testcontent-0',
-      });
-      expect(result.length).toBe(1);
-    });
-
-    it('getAll(\'cdn/stories\', filter_query: { __or: [{ category: { any_in_array: \'Category 1\' } }, { category: { any_in_array: \'Category 2\' } }]}) should return all stories with the specific filter applied', async () => {
-      const result = await client.getAll('cdn/stories', {
-        filter_query: {
-          __or: [
-            { category: { any_in_array: 'Category 1' } },
-            { category: { any_in_array: 'Category 2' } },
-          ],
-        },
-      });
-      expect(result.length).toBeGreaterThan(0);
-    });
-
-    it('getAll(\'cdn/stories\', {by_slugs: \'folder/*\'}) should return all stories with the specific filter applied', async () => {
-      const result = await client.getAll('cdn/stories', {
-        by_slugs: 'folder/*',
-      });
-      expect(result.length).toBeGreaterThan(0);
-    });
-
-    it('getAll(\'cdn/links\') should return all links', async () => {
-      const result = await client.getAll('cdn/links', {});
-      expect(result.length).toBeGreaterThan(0);
-    });
+  it('returns at least one published story', async () => {
+    const { data } = await client.get('cdn/stories');
+    expect(data.stories.length).toBeGreaterThan(0);
   });
 
-  describe('caching', () => {
-    it('get(\'cdn/spaces/me\') should not be cached', async () => {
-      const provider = client.cacheProvider();
-      await provider.flush();
-      await client.get('cdn/spaces/me');
-      expect(Object.values(provider.getAll()).length).toBe(0);
+  it('returns a specific story by slug', async () => {
+    const { data } = await client.get('cdn/stories/testcontent-0');
+    expect(data.story.slug).toBe('testcontent-0');
+  });
+
+  it('resolves relations against real content', async () => {
+    const { data } = await client.get('cdn/stories/testcontent-0', {
+      resolve_relations: 'root.author',
     });
+    expect(data.story.content.author[0].slug).toBe('edgar-allan-poe');
+  });
 
-    it('get(\'cdn/stories\') should be cached when is a published version', async () => {
-      const cacheVersion = client.cacheVersion();
+  it('returns stories matching a by_slugs wildcard', async () => {
+    const { data } = await client.get('cdn/stories', { by_slugs: 'folder/*' });
+    expect(data.stories.length).toBeGreaterThan(0);
+  });
 
-      await client.get('cdn/stories');
-
-      expect(cacheVersion).not.toBe(undefined);
-
-      const newCacheVersion = client.cacheVersion();
-
-      await client.get('cdn/stories');
-
-      expect(newCacheVersion).toBe(client.cacheVersion());
-
-      await client.get('cdn/stories');
-
-      expect(newCacheVersion).toBe(client.cacheVersion());
-    });
+  it('paginates through all stories with getAll', async () => {
+    const result = await client.getAll('cdn/stories', {});
+    expect(result.length).toBeGreaterThan(0);
   });
 });

--- a/packages/js-client/tests/api/index.test.ts
+++ b/packages/js-client/tests/api/index.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import StoryblokClient from 'storyblok-js-client';
+
+const ACCESS_TOKEN = 'test-token';
+const BASE_URL = 'https://api.storyblok.com/v2';
+
+const makeStory = (overrides: Record<string, unknown> = {}) => ({
+  id: Math.floor(Math.random() * 100000),
+  uuid: `uuid-${Math.random()}`,
+  name: 'Test Story',
+  slug: 'test-story',
+  full_slug: 'test-story',
+  content: { _uid: 'uid-1', component: 'page' },
+  ...overrides,
+});
+
+let _linkCounter = 0;
+const makeLink = (overrides: Record<string, unknown> = {}) => {
+  const n = ++_linkCounter;
+  return {
+    id: n,
+    uuid: `uuid-link-${n}`,
+    slug: `test-link-${n}`,
+    name: `Test Link ${n}`,
+    is_folder: false,
+    parent_id: 0,
+    published: true,
+    position: 0,
+    ...overrides,
+  };
+};
+
+const server = setupServer();
+
+const preconditions = {
+  canFetchSpaceInfo() {
+    server.use(
+      http.get(`${BASE_URL}/cdn/spaces/me`, () =>
+        HttpResponse.json({ space: { id: 12345 } })),
+    );
+  },
+  canFetchStories(stories: ReturnType<typeof makeStory>[], params: Record<string, string> = {}, cv = 12345678) {
+    server.use(
+      http.get(`${BASE_URL}/cdn/stories`, ({ request }) => {
+        const url = new URL(request.url);
+        const matchesParams = Object.entries(params).every(
+          ([key, value]) => url.searchParams.get(key) === value,
+        );
+        const page = Number(url.searchParams.get('page') ?? 1);
+        const perPage = Number(url.searchParams.get('per_page') ?? 25);
+        const items = matchesParams ? stories : [];
+        const pageItems = items.slice((page - 1) * perPage, page * perPage);
+        return HttpResponse.json(
+          { stories: pageItems, cv },
+          {
+            headers: {
+              'Total': String(items.length),
+              'Per-Page': String(perPage),
+            },
+          },
+        );
+      }),
+    );
+  },
+  canFetchLinks(links: ReturnType<typeof makeLink>[]) {
+    server.use(
+      http.get(`${BASE_URL}/cdn/links`, ({ request }) => {
+        const url = new URL(request.url);
+        const page = Number(url.searchParams.get('page') ?? 1);
+        const perPage = Number(url.searchParams.get('per_page') ?? 25);
+        const pageItems = links.slice((page - 1) * perPage, page * perPage);
+        const linksMap = Object.fromEntries(pageItems.map(l => [l.slug, l]));
+        return HttpResponse.json(
+          { links: linksMap },
+          {
+            headers: {
+              'Total': String(links.length),
+              'Per-Page': String(perPage),
+            },
+          },
+        );
+      }),
+    );
+  },
+};
+
+describe('storyblokClient (MSW)', () => {
+  let client: StoryblokClient;
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  beforeEach(() => {
+    client = new StoryblokClient({
+      accessToken: ACCESS_TOKEN,
+      cache: { type: 'memory', clear: 'auto' },
+    });
+  });
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  describe('get()', () => {
+    it('passes starts_with as a query param to the API', async () => {
+      // The handler only returns stories when the param is present in the URL.
+      // If the client fails to serialize the param, it gets back 0 stories.
+      const matching = makeStory({ slug: 'testcontent-0' });
+      const other = makeStory({ slug: 'other-story' });
+      preconditions.canFetchStories([matching, other], { starts_with: 'testcontent-0' });
+
+      const { data } = await client.get('cdn/stories', { starts_with: 'testcontent-0' });
+
+      expect(data.stories.length).toBe(2);
+    });
+
+    it('passes by_slugs as a query param to the API', async () => {
+      // Same principle: handler only matches when by_slugs arrives in the URL.
+      const folderStories = [
+        makeStory({ slug: 'folder/story-1', full_slug: 'folder/story-1' }),
+        makeStory({ slug: 'folder/story-2', full_slug: 'folder/story-2' }),
+      ];
+      preconditions.canFetchStories(folderStories, { by_slugs: 'folder/*' });
+
+      const { data } = await client.get('cdn/stories', { by_slugs: 'folder/*' });
+
+      expect(data.stories.length).toBeGreaterThan(0);
+    });
+
+    it('runs the full multi-request relation resolution pipeline', async () => {
+      // This test exercises: initial story fetch → rel_uuids in response →
+      // second fetch with by_uuids → resolved objects replacing UUIDs in content.
+      // Unit tests mock at client.client.get level; here the real SbFetch HTTP
+      // stack runs end-to-end through MSW.
+      const author = makeStory({ slug: 'edgar-allan-poe', uuid: 'author-uuid' });
+      const story = makeStory({
+        slug: 'testcontent-0',
+        content: {
+          _uid: 'uid-1',
+          component: 'root',
+          author: ['author-uuid'],
+        },
+      });
+
+      server.use(
+        http.get(`${BASE_URL}/cdn/stories/testcontent-0`, () =>
+          HttpResponse.json({ story, rel_uuids: ['author-uuid'] })),
+        http.get(`${BASE_URL}/cdn/stories`, ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get('by_uuids')) {
+            return HttpResponse.json({ stories: [author], cv: 12345678 });
+          }
+          return HttpResponse.json({ stories: [], cv: 12345678 });
+        }),
+      );
+
+      const { data } = await client.get('cdn/stories/testcontent-0', {
+        resolve_relations: 'root.author',
+      });
+
+      expect(data.story.content.author[0].slug).toBe('edgar-allan-poe');
+    });
+  });
+
+  describe('getAll()', () => {
+    it('fetches all pages by reading Total and Per-Page response headers', async () => {
+      // Unit tests mock makeRequest directly; this validates that the real
+      // HTTP header parsing (res.headers['per-page'], res.headers.total) drives
+      // pagination correctly through the full SbFetch stack.
+      const stories = Array.from({ length: 5 }, () => makeStory());
+      preconditions.canFetchStories(stories);
+
+      const result = await client.getAll('cdn/stories', { per_page: 2 });
+
+      expect(result.length).toBe(5);
+    });
+
+    it('extracts link objects from the links map returned by the API', async () => {
+      // The CDN /cdn/links endpoint returns links as an object map keyed by slug,
+      // not an array. This validates that getAll correctly calls Object.values()
+      // after the full HTTP response flows through SbFetch.
+      const links = [makeLink(), makeLink(), makeLink()];
+      preconditions.canFetchLinks(links);
+
+      const result = await client.getAll('cdn/links', {});
+
+      expect(result.length).toBe(3);
+    });
+  });
+
+  describe('caching', () => {
+    it('does not cache cdn/spaces/me responses', async () => {
+      preconditions.canFetchSpaceInfo();
+
+      const provider = client.cacheProvider();
+      await provider.flush();
+      await client.get('cdn/spaces/me');
+
+      expect(Object.values(provider.getAll()).length).toBe(0);
+    });
+
+    it('reads the cv value from the response and reuses it on subsequent requests', async () => {
+      // Validates that the cv field in the JSON body is parsed correctly through
+      // SbFetch and used to maintain the cache version across calls.
+      const stories = [makeStory()];
+      preconditions.canFetchStories(stories);
+
+      const cvBefore = client.cacheVersion();
+
+      await client.get('cdn/stories');
+      const cvAfterFirst = client.cacheVersion();
+
+      await client.get('cdn/stories');
+      const cvAfterSecond = client.cacheVersion();
+
+      expect(cvBefore).not.toBe(undefined);
+      expect(cvAfterFirst).toBe(cvAfterSecond);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,9 @@ importers:
       eslint:
         specifier: ^9.26.0
         version: 9.39.3(jiti@2.6.1)
+      msw:
+        specifier: ^2.10.2
+        version: 2.12.10(@types/node@24.11.0)(typescript@5.8.3)
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.8.3)


### PR DESCRIPTION
- Add MSW-based integration tests (tests/api/index.test.ts) using the preconditions pattern, covering query param serialization, relation resolution pipeline, pagination via HTTP headers, links map extraction, and client-side caching behaviour
- Trim e2e suite to 6 high-value smoke tests wrapped in describe.skipIf so they skip cleanly in CI when VITE_ACCESS_TOKEN is absent, fixing the external contributor CI failure
- Add msw as a devDependency to storyblok-js-client

Fixes WDX-307