### PR TITLE
fix: change storyblokEditable to have narrow type

### DIFF
--- a/packages/js/src/editable.ts
+++ b/packages/js/src/editable.ts
@@ -1,6 +1,4 @@
-import type { SbBlokData } from './types';
-
-export default (blok: SbBlokData) => {
+export default (blok: { _editable?: string }) => {
   if (typeof blok !== 'object' || typeof blok._editable === 'undefined') {
     return {};
   }


### PR DESCRIPTION
The current type for storyblokEditable() says that it needs SbBlokData which has a very broad index type:
```ts
export interface SbBlokData extends ISbComponentType<string> {
    [index: string]: SbBlokKeyDataTypes;
}
```

This means that in order to satisfy the storyblokEditable function, I need my components to extend a type that breaks type safety.

This function ONLY needs 1x property, so just give it that