### PR TITLE
chore: ci release guard

### DIFF
--- a/.github/workflows/release-guard.yaml
+++ b/.github/workflows/release-guard.yaml
@@ -32,7 +32,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if bash tools/release-guard.sh --ci < /tmp/changed-files.txt > /tmp/touched-packages.txt; then
+          if bash tools/release-guard.sh < /tmp/changed-files.txt > /tmp/touched-packages.txt; then
             echo "cross_package=false" >> "$GITHUB_OUTPUT"
           else
             echo "cross_package=true" >> "$GITHUB_OUTPUT"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-bash tools/release-guard.sh
 pnpm exec lint-staged --relative

--- a/tools/release-guard.sh
+++ b/tools/release-guard.sh
@@ -1,48 +1,24 @@
 #!/usr/bin/env bash
 
-# Release guard — single source of truth for cross-package change detection.
+# Release guard — CI check for cross-package change detection.
 #
 # Warns when a feat/fix PR touches multiple packages/ directories.
 # In a squash-merge workflow, Nx release uses file changes (not commit scope)
 # to determine which packages to bump, so cross-package feat/fix PRs cause
 # unintended version bumps.
 #
-# Modes:
-#   (default)  Pre-commit hook. Detects branch, queries gh for PR title,
-#              uses git diff for changed files. Prints a human-readable warning.
-#   --ci       CI mode. Reads PR title from $PR_TITLE env var and changed file
-#              list from stdin. Outputs touched packages to stdout (one per line)
-#              and exits 1 when cross-package changes are detected, 0 otherwise.
+# Usage (CI):
+#   PR_TITLE="feat: ..." bash tools/release-guard.sh < changed-files.txt
+#
+# Reads PR title from $PR_TITLE env var and changed file list from stdin.
+# Outputs touched packages to stdout (one per line) and exits 1 when
+# cross-package changes are detected, 0 otherwise.
 
 BUMP_PATTERN='^(feat|fix)(\([^)]+\))?!?:'
 
-CI_MODE=false
-if [ "$1" = "--ci" ]; then
-  CI_MODE=true
-fi
-
-# ── Resolve PR title ────────────────────────────────────────────────
-
-if [ "$CI_MODE" = true ]; then
-  if [ -z "$PR_TITLE" ]; then
-    echo "Error: PR_TITLE env var not set in CI mode" >&2
-    exit 0
-  fi
-else
-  # Skip on main — nothing to compare against
-  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-  if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "HEAD" ]; then
-    exit 0
-  fi
-
-  if ! command -v gh &>/dev/null; then
-    exit 0
-  fi
-
-  PR_TITLE=$(gh pr view "$BRANCH" --json title --jq '.title' 2>/dev/null)
-  if [ -z "$PR_TITLE" ]; then
-    exit 0
-  fi
+if [ -z "$PR_TITLE" ]; then
+  echo "Error: PR_TITLE env var not set" >&2
+  exit 0
 fi
 
 # ── Check bump pattern ──────────────────────────────────────────────
@@ -53,21 +29,7 @@ fi
 
 # ── Collect changed files ───────────────────────────────────────────
 
-if [ "$CI_MODE" = true ]; then
-  CHANGED_FILES=$(cat)
-else
-  MERGE_BASE=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null)
-  if [ -z "$MERGE_BASE" ]; then
-    exit 0
-  fi
-
-  CHANGED_FILES=$(
-    {
-      git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null
-      git diff --cached --name-only 2>/dev/null
-    } | sort -u
-  )
-fi
+CHANGED_FILES=$(cat)
 
 if [ -z "$CHANGED_FILES" ]; then
   exit 0
@@ -82,32 +44,10 @@ if [ "$PACKAGE_COUNT" -le 1 ]; then
   exit 0
 fi
 
-# ── Extract commit prefix (everything before the colon) ─────────────
+# ── Output ──────────────────────────────────────────────────────────
 
 COMMIT_PREFIX=$(echo "$PR_TITLE" | sed 's/:.*//')
 
-# ── Output ──────────────────────────────────────────────────────────
-
-if [ "$CI_MODE" = true ]; then
-  echo "COMMIT_PREFIX=$COMMIT_PREFIX"
-  echo "$PACKAGES"
-  exit 1
-fi
-
-echo ""
-echo "⚠️  Cross-package changes detected"
-echo ""
-echo "PR title: $PR_TITLE"
-echo ""
-echo "Files on this branch (including staged) touch $PACKAGE_COUNT packages:"
-echo "$PACKAGES" | sed 's/^/  - /'
-echo ""
-echo "When this PR is squash-merged, Nx release uses file changes (not the"
-echo "commit scope) to determine which packages to bump, so every package"
-echo "above will get a version bump."
-echo ""
-echo "If changes to some packages are cosmetic (README, config, deps),"
-echo "split them into a separate PR with a chore: title."
-echo ""
-
-exit 0
+echo "COMMIT_PREFIX=$COMMIT_PREFIX"
+echo "$PACKAGES"
+exit 1


### PR DESCRIPTION
## Summary

- Adds a `release-guard` GitHub Actions workflow that warns when a `feat`/`fix` PR touches multiple packages
- Since we squash-merge, all file changes land in a single commit — Nx release uses file changes (not commit scope) to determine which packages to bump, so cross-package `feat`/`fix` PRs cause unintended version bumps
- The workflow posts a comment explaining the issue and suggesting to split cosmetic changes into a `chore:` PR
- Automatically cleans up stale warnings when the PR is updated to only touch one package

## How it works

1. Triggers on PR open, sync, and title edit
2. Skips non-`feat`/`fix` PRs (those don't trigger version bumps)
3. Lists changed files and groups them by `packages/*/`
4. If 2+ packages are touched, posts (or updates) a warning comment
5. If the PR is later reduced to 1 package, deletes the stale comment

## Test plan

- [ ] Open a `feat(foo):` PR touching files in 2+ packages — verify warning comment appears
- [ ] Push an update removing the extra package changes — verify comment is deleted
- [ ] Open a `chore:` PR touching multiple packages — verify no comment
- [ ] Edit a PR title from `chore:` to `feat:` — verify workflow re-runs
