### PR TITLE
chore(angular): prepare SDK packaging for release

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,7 @@
   },
   "release": {
     "projectsRelationship": "independent",
-    "projects": ["packages/*", "packages/angular/projects/*"],
+    "projects": ["packages/*", "packages/angular/projects/sdk", "!packages/angular"],
     "version": {
       "conventionalCommits": true,
       "fallbackCurrentVersionResolver": "disk",

--- a/packages/angular/LICENSE
+++ b/packages/angular/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Storyblok GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "playground:ssr:start": "ng serve ssr-playground --ssl",
     "playground:app:start": "ng serve app-playground --ssl",
-    "build": "ng build @storyblok/angular",
+    "build": "ng build @storyblok/angular && cp README.md LICENSE dist/",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },

--- a/packages/angular/projects/sdk/project.json
+++ b/packages/angular/projects/sdk/project.json
@@ -1,6 +1,13 @@
 {
   "name": "@storyblok/angular",
   "targets": {
+    "build": {
+      "dependsOn": ["^build"],
+      "command": "pnpm build",
+      "options": {
+        "cwd": "packages/angular"
+      }
+    },
     "nx-release-publish": {
       "options": {
         "packageRoot": "packages/angular/dist"


### PR DESCRIPTION
* Exclude root Angular folder from Nx
* Target `angular/projects/sdk` as the Angular SDK project
* Add `LICENSE` file to the project
* Update build script to copy `README` and `LICENSE` to `dist`
* Update `project.json` so the build runs from the project root
