### PR TITLE
fix(js-client): fallback to space.version for cache version

### DIFF
--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -737,14 +737,17 @@ export class Storyblok {
         const isCacheClearable = (this.cache.clear === 'onpreview' && params.version === 'draft')
           || this.cache.clear === 'auto';
 
-        if (params.token && response.data.cv) {
+        // Get cv from story or space
+        const cv = response.data.cv ?? response.data.space?.version;
+
+        if (params.token && cv) {
           if (isCacheClearable
             && cacheVersions[params.token] // there is a cache
-            && cacheVersions[params.token] !== response.data.cv // a new cv is incoming
+            && cacheVersions[params.token] !== cv // a new cv is incoming
           ) {
             await this.flushCache();
           }
-          cacheVersions[params.token] = response.data.cv;
+          cacheVersions[params.token] = cv;
         }
 
         return resolve(response);


### PR DESCRIPTION
The way that new versions are discovered today, is that it checks for data.cv and saves it in-memory. The problem is, the only way that data.cv is available, is through heavily cached endpoints. The cdn/spaces/me endpoint is only cached for 2 seconds and has a small response and includes the latest known version, but it's not used at all, until this PR.

With this change it'll allow me to poll the cdn/spaces/me endpoint every 60 seconds and switch back to querying for published content using the SDK. 

Addressed the findings from this comment: https://github.com/storyblok/monoblok/issues/105#issuecomment-4060334565