### PR TITLE
fix(cli): allow single generated file from multiple components

### DIFF
--- a/packages/cli/src/commands/components/push/actions.ts
+++ b/packages/cli/src/commands/components/push/actions.ts
@@ -4,7 +4,7 @@ import { DEFAULT_COMPONENTS_FILENAME, DEFAULT_GROUPS_FILENAME, DEFAULT_PRESETS_F
 import type { ReadComponentsOptions } from './constants';
 import { join } from 'pathe';
 import { readdir } from 'node:fs/promises';
-import { readJsonFile, resolvePath } from '../../../utils/filesystem';
+import { readJsonFile, resolvePath, shouldUseSeparateFiles } from '../../../utils/filesystem';
 import chalk from 'chalk';
 import { getMapiClient } from '../../../api';
 
@@ -251,7 +251,7 @@ export const upsertComponentInternalTag = async (
 
 export const readComponentsFiles = async (
   options: ReadComponentsOptions): Promise<ComponentsData> => {
-  const { from, path, separateFiles = false, suffix } = options;
+  const { from, path, separateFiles, suffix } = options;
   const resolvedPath = resolvePath(path, `components/${from}`);
 
   // Check if directory exists first
@@ -275,7 +275,8 @@ export const readComponentsFiles = async (
     );
   }
 
-  if (separateFiles) {
+  // Determine read mode: explicit flag takes precedence, otherwise auto-detect
+  if (await shouldUseSeparateFiles(resolvedPath, DEFAULT_COMPONENTS_FILENAME, separateFiles, suffix)) {
     return await readSeparateFiles(resolvedPath, suffix);
   }
 

--- a/packages/cli/src/commands/datasources/push/actions.ts
+++ b/packages/cli/src/commands/datasources/push/actions.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import type { SpaceDatasource, SpaceDatasourceEntry, SpaceDatasourcesData } from '../constants';
 import { DEFAULT_DATASOURCES_FILENAME } from '../constants';
 import type { ReadDatasourcesOptions } from './constants';
-import { readJsonFile, resolvePath } from '../../../utils/filesystem';
+import { readJsonFile, resolvePath, shouldUseSeparateFiles } from '../../../utils/filesystem';
 import { getMapiClient } from '../../../api';
 import { handleAPIError } from '../../../utils/error/api-error';
 import { FileSystemError, handleFileSystemError } from '../../../utils/error/filesystem-error';
@@ -168,7 +168,7 @@ export const deleteDatasourceEntry = async (spaceId: string, entryId: number): P
 };
 
 export const readDatasourcesFiles = async (options: ReadDatasourcesOptions): Promise<SpaceDatasourcesData> => {
-  const { from, path, separateFiles = false, suffix } = options;
+  const { from, path, separateFiles, suffix } = options;
   const resolvedPath = resolvePath(path, `datasources/${from}`);
 
   // Check if directory exists first
@@ -192,7 +192,8 @@ export const readDatasourcesFiles = async (options: ReadDatasourcesOptions): Pro
     );
   }
 
-  if (separateFiles) {
+  // Determine read mode: explicit flag takes precedence, otherwise auto-detect
+  if (await shouldUseSeparateFiles(resolvedPath, DEFAULT_DATASOURCES_FILENAME, separateFiles, suffix)) {
     return await readSeparateFiles(resolvedPath, suffix);
   }
 

--- a/packages/cli/src/commands/types/generate/index.test.ts
+++ b/packages/cli/src/commands/types/generate/index.test.ts
@@ -147,14 +147,14 @@ describe('types generate', () => {
       }));
     });
 
-    it('should pass separateFiles to readComponentsFiles when --separate-files flag is used', async () => {
+    it('should not pass separateFiles to readComponentsFiles even when --separate-files flag is used (auto-detect input)', async () => {
       vi.mocked(readComponentsFiles).mockResolvedValue(mockSpaceData);
       vi.mocked(generateStoryblokTypes).mockResolvedValue(true);
       vi.mocked(generateTypes).mockResolvedValue('// Generated types');
 
       await typesCommand.parseAsync(['node', 'test', 'generate', '--space', '12345', '--separate-files']);
 
-      expect(readComponentsFiles).toHaveBeenCalledWith(expect.objectContaining({
+      expect(readComponentsFiles).toHaveBeenCalledWith(expect.not.objectContaining({
         separateFiles: true,
       }));
     });
@@ -166,8 +166,8 @@ describe('types generate', () => {
 
       await typesCommand.parseAsync(['node', 'test', 'generate', '--space', '12345']);
 
-      expect(readComponentsFiles).toHaveBeenCalledWith(expect.objectContaining({
-        separateFiles: undefined,
+      expect(readComponentsFiles).toHaveBeenCalledWith(expect.not.objectContaining({
+        separateFiles: expect.anything(),
       }));
     });
 

--- a/packages/cli/src/commands/types/generate/index.ts
+++ b/packages/cli/src/commands/types/generate/index.ts
@@ -38,10 +38,10 @@ generateCmd
 
     try {
       spinner.start(`Generating types...`);
+      // Input format is auto-detected based on files on disk
       const componentsData = await readComponentsFiles({
         from: space,
         path,
-        separateFiles,
         suffix,
         verbose,
       });
@@ -51,7 +51,6 @@ generateCmd
         dataSourceData = await readDatasourcesFiles({
           from: space,
           path,
-          separateFiles,
           suffix,
           verbose,
         });

--- a/packages/cli/src/commands/types/generate/integration.test.ts
+++ b/packages/cli/src/commands/types/generate/integration.test.ts
@@ -101,9 +101,8 @@ describe('types generate integration', () => {
       expect(result).toContain('export interface Feature');
     });
 
-    it('should fail when using consolidated mode on separate files', async () => {
-      // This is the exact scenario from issue #432:
-      // Components pulled with --sf, but types generate called without --sf
+    it('should fail when explicitly using consolidated mode on separate files', async () => {
+      // Passing separateFiles: false explicitly should NOT auto-detect
       vol.fromJSON({
         '/project/components/12345/hero.json': JSON.stringify([mockComponent1]),
         '/project/components/12345/feature.json': JSON.stringify([mockComponent2]),
@@ -117,6 +116,84 @@ describe('types generate integration', () => {
           verbose: false,
         }),
       ).rejects.toThrow('No components found');
+    });
+  });
+
+  describe('auto-detecting input format', () => {
+    it('should auto-detect separate files when components.json is absent', async () => {
+      vol.fromJSON({
+        '/project/components/12345/hero.json': JSON.stringify([mockComponent1]),
+        '/project/components/12345/feature.json': JSON.stringify([mockComponent2]),
+      });
+
+      const componentsData = await readComponentsFiles({
+        from: '12345',
+        path: '/project',
+        // separateFiles not specified - auto-detect
+        verbose: false,
+      });
+
+      expect(componentsData.components).toHaveLength(2);
+    });
+
+    it('should auto-detect consolidated mode when components.json exists', async () => {
+      vol.fromJSON({
+        '/project/components/12345/components.json': JSON.stringify([mockComponent1, mockComponent2]),
+      });
+
+      const componentsData = await readComponentsFiles({
+        from: '12345',
+        path: '/project',
+        // separateFiles not specified - auto-detect
+        verbose: false,
+      });
+
+      expect(componentsData.components).toHaveLength(2);
+    });
+
+    it('should auto-detect separate files with suffix', async () => {
+      vol.fromJSON({
+        '/project/components/12345/hero.dev.json': JSON.stringify([mockComponent1]),
+        '/project/components/12345/feature.dev.json': JSON.stringify([mockComponent2]),
+      });
+
+      const componentsData = await readComponentsFiles({
+        from: '12345',
+        path: '/project',
+        suffix: 'dev',
+        verbose: false,
+      });
+
+      expect(componentsData.components).toHaveLength(2);
+    });
+
+    it('should generate a single type file from auto-detected separate component files (#530)', async () => {
+      // This is the exact scenario from issue #530:
+      // Components pulled with --sf (separate JSON files), but user wants single .d.ts output
+      vol.fromJSON({
+        '/project/components/12345/hero.json': JSON.stringify([mockComponent1]),
+        '/project/components/12345/feature.json': JSON.stringify([mockComponent2]),
+      });
+
+      // Read without separateFiles - auto-detect picks separate files mode
+      const componentsData = await readComponentsFiles({
+        from: '12345',
+        path: '/project',
+        verbose: false,
+      });
+
+      expect(componentsData.components).toHaveLength(2);
+
+      // Generate a single combined output (no separateFiles in options)
+      const result = await generateTypes(
+        { ...componentsData, datasources: [] },
+        { strict: false },
+      );
+
+      // Should be a single string, not an array of files
+      expect(typeof result).toBe('string');
+      expect(result).toContain('export interface Hero');
+      expect(result).toContain('export interface Feature');
     });
   });
 

--- a/packages/cli/src/utils/filesystem.test.ts
+++ b/packages/cli/src/utils/filesystem.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { vol } from 'memfs';
-import { appendToFile, getComponentNameFromFilename, getStoryblokGlobalPath, resolvePath, sanitizeFilename, saveToFile } from './filesystem';
+import { appendToFile, consolidatedFilename, getComponentNameFromFilename, getStoryblokGlobalPath, resolvePath, sanitizeFilename, saveToFile, shouldUseSeparateFiles } from './filesystem';
 import { join, resolve } from 'pathe';
 
 beforeEach(() => {
@@ -175,6 +175,52 @@ describe('filesystem utils', async () => {
 
     it('should handle filenames with paths', () => {
       expect(getComponentNameFromFilename('/path/to/my_component.js')).toBe('/path/to/my_component');
+    });
+  });
+
+  describe('consolidatedFilename', () => {
+    it('should return filename with .json when no suffix', () => {
+      expect(consolidatedFilename('components')).toBe('components.json');
+    });
+
+    it('should return filename with suffix and .json', () => {
+      expect(consolidatedFilename('components', 'v2')).toBe('components.v2.json');
+    });
+  });
+
+  describe('shouldUseSeparateFiles', () => {
+    it('should return true when separateFiles is explicitly true', async () => {
+      const result = await shouldUseSeparateFiles('/some/path', 'components', true);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when separateFiles is explicitly false', async () => {
+      const result = await shouldUseSeparateFiles('/some/path', 'components', false);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when consolidated file exists', async () => {
+      vol.fromJSON({ '/space/components.json': '[]' });
+      const result = await shouldUseSeparateFiles('/space', 'components');
+      expect(result).toBe(false);
+    });
+
+    it('should return true when consolidated file does not exist', async () => {
+      vol.fromJSON({ '/space/other.json': '[]' });
+      const result = await shouldUseSeparateFiles('/space', 'components');
+      expect(result).toBe(true);
+    });
+
+    it('should check suffixed consolidated file when suffix is provided', async () => {
+      vol.fromJSON({ '/space/components.v2.json': '[]' });
+      const result = await shouldUseSeparateFiles('/space', 'components', undefined, 'v2');
+      expect(result).toBe(false);
+    });
+
+    it('should return true when suffixed consolidated file does not exist', async () => {
+      vol.fromJSON({ '/space/components.json': '[]' });
+      const result = await shouldUseSeparateFiles('/space', 'components', undefined, 'v2');
+      expect(result).toBe(true);
     });
   });
 

--- a/packages/cli/src/utils/filesystem.ts
+++ b/packages/cli/src/utils/filesystem.ts
@@ -247,3 +247,16 @@ export async function fileExists(path: string) {
     return false;
   }
 }
+
+export function consolidatedFilename(defaultFilename: string, suffix?: string): string {
+  return suffix
+    ? `${defaultFilename}.${suffix}.json`
+    : `${defaultFilename}.json`;
+}
+
+export async function shouldUseSeparateFiles(resolvedPath: string, defaultFilename: string, separateFiles?: boolean, suffix?: string): Promise<boolean> {
+  if (separateFiles !== undefined) {
+    return separateFiles;
+  }
+  return !(await fileExists(join(resolvedPath, consolidatedFilename(defaultFilename, suffix))));
+}


### PR DESCRIPTION
Fix `types generate` failing when components were pulled with `--sf` (separate files) but types were generated without it.

Previously, `readComponentsFiles` and `readDatasourcesFiles` required the caller to explicitly pass `separateFiles` to match the on-disk format. This meant `types generate` had to know how components were originally pulled, creating an unnecessary coupling between the two commands. If a user pulled with `--sf` but ran `types generate` without it, the command would fail because it looked for a consolidated `components.json` that didn't exist.

Now both read functions auto-detect the input format by checking whether the consolidated file exists on disk. The `--sf` flag on `types generate` controls only the output format (single `.d.ts` vs one file per component), which is its actual responsibility. The explicit `separateFiles` parameter still works as an override when passed from `components push` or `datasources push`.

Fixes WDX-344