### PR TITLE
fix(richtext): add grouped marks in order to render

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,13 @@ Always use linting and type-checking scripts for affected packages after making 
   2. Internal/Workspace dependencies (e.g., `@storyblok/...`).
   3. Local imports (relative paths).
 
+### JSDoc
+
+- Add JSDoc to exported functions and non-trivial internal helpers.
+- Use concise one-liners (`/** Does X. */`) for simple functions.
+- Use multi-line JSDoc with `@param`, `@returns`, and `@example` only for public-facing utilities where the signature isn't self-explanatory.
+- Skip JSDoc on trivial code where the name and types already tell the full story.
+
 ## General
 
 - **IMPORTANT:** Never stage or commit any code yourself unless explicitly told so!

--- a/packages/richtext/src/richtext-segment.ts
+++ b/packages/richtext/src/richtext-segment.ts
@@ -1,7 +1,7 @@
 import { ComponentBlok, getStoryblokExtensions } from './extensions';
 import type { Attributes, Mark as TiptapMark, Node as TiptapNode } from '@tiptap/core';
-import type { BlockAttributes, StoryblokRichTextNode, TextNode } from './types';
-import { SELF_CLOSING_TAGS } from './utils';
+import type { BlockAttributes, MarkNode, StoryblokRichTextNode, TextNode } from './types';
+import { collectMarkedTextGroup, getUniqueMarks, SELF_CLOSING_TAGS } from './utils';
 
 /**
  * ProseMirror DOMOutputSpec returned by renderHTML
@@ -82,6 +82,62 @@ export function getRichTextSegments(richText: StoryblokRichTextNode, options: St
     }
   }
 
+  // --- Mark merging (ProseMirror-style adjacent text node grouping) ---
+
+  /** Renders a group of text nodes with shared marks wrapped once around unique-mark content. */
+  function renderMergedTextNodes(group: TextNode<string>[], shared: MarkNode<string>[]): SBRichTextSegment[] {
+    const innerSegments: SBRichTextSegment[] = group.flatMap((node) => {
+      return renderText({ ...node, marks: getUniqueMarks(node.marks || [], shared) } as TextNode<string>);
+    });
+
+    // Reverse: matches renderText's [...marks].reverse() iteration order,
+    // where the last mark in the array becomes the outermost segment wrapper.
+    let segments: SBRichTextSegment[] = innerSegments;
+    for (let i = shared.length - 1; i >= 0; i--) {
+      const mark = shared[i];
+      const ext = markExtMap.get(mark.type);
+      if (!ext?.config?.renderHTML) {
+        continue;
+      }
+      const attrs = mark.attrs ?? {};
+      const spec = callExtensionRenderHTML(ext, attrs);
+      const tag = getTagFromSpec(spec);
+      segments = [{
+        kind: 'mark' as const,
+        type: mark.type,
+        tag,
+        attrs,
+        content: segments,
+      }];
+    }
+
+    return segments;
+  }
+
+  /** Groups adjacent text nodes with shared marks and renders them merged. */
+  function groupAndFlatMapChildren(children: StoryblokRichTextNode[]): SBRichTextSegment[] {
+    const result: SBRichTextSegment[] = [];
+    let i = 0;
+    while (i < children.length) {
+      const match = collectMarkedTextGroup<string>(children, i);
+      if (!match) {
+        result.push(...renderNode(children[i]));
+        i++;
+        continue;
+      }
+      if (match.group.length === 1) {
+        result.push(...renderText(match.group[0]));
+      }
+      else {
+        result.push(...renderMergedTextNodes(match.group, match.shared));
+      }
+      i = match.endIndex;
+    }
+    return result;
+  }
+
+  // --- End mark merging helpers ---
+
   function renderNode(node: StoryblokRichTextNode): SBRichTextSegment[] {
     if (node.type === 'text') {
       return renderText(node as TextNode<string>);
@@ -90,7 +146,7 @@ export function getRichTextSegments(richText: StoryblokRichTextNode, options: St
       return node.content?.flatMap(renderNode) ?? [];
     }
 
-    const children = node.content?.flatMap(renderNode) ?? [];
+    const children = node.content ? groupAndFlatMapChildren(node.content) : [];
     const ext = nodeExtMap.get(node.type);
 
     if (!ext?.config?.renderHTML) {

--- a/packages/richtext/src/richtext.test.ts
+++ b/packages/richtext/src/richtext.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { richTextResolver } from './richtext';
+import { getRichTextSegments } from './richtext-segment';
+import { renderSegments } from './render-segments';
+import type { RendererAdapter } from './render-segments';
 import { createTextVNode, h } from 'vue';
 import type { VNode } from 'vue';
 import type { StoryblokRichTextNode } from './types';
@@ -1905,5 +1908,227 @@ describe('renderComponent (blok extension option)', () => {
       'textStyle',
       'underline',
     ].sort());
+  });
+
+  describe('mark merging (adjacent text nodes with shared marks)', () => {
+    it('should merge link with bold and italic inner marks', () => {
+      const { render } = richTextResolver({});
+      const doc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'normal ', marks: [{ type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+            { type: 'text', text: 'bold', marks: [{ type: 'bold' }, { type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+            { type: 'text', text: ' and ', marks: [{ type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+            { type: 'text', text: 'italic', marks: [{ type: 'italic' }, { type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+            { type: 'text', text: ' end', marks: [{ type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+          ],
+        }],
+      };
+
+      const html = render(doc as StoryblokRichTextNode<string>);
+      expect(html).toBe('<p><a href="/url">normal <strong>bold</strong> and <em>italic</em> end</a></p>');
+    });
+
+    it('should handle non-text node breaking a link group', () => {
+      const { render } = richTextResolver({});
+      const doc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Before ', marks: [{ type: 'link', attrs: { href: '/x', linktype: 'url' } }] },
+            { type: 'hard_break' },
+            { type: 'text', text: 'After', marks: [{ type: 'link', attrs: { href: '/x', linktype: 'url' } }] },
+          ],
+        }],
+      };
+
+      const html = render(doc as StoryblokRichTextNode<string>);
+      expect(html).toBe('<p><a href="/x">Before </a><br><a href="/x">After</a></p>');
+    });
+
+    it('should separate groups when any link attr differs', () => {
+      const { render } = richTextResolver({});
+      const doc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            // Group 1: href /a
+            { type: 'text', text: 'A', marks: [{ type: 'link', attrs: { href: '/a', linktype: 'url' } }] },
+            { type: 'text', text: 'B', marks: [{ type: 'bold' }, { type: 'link', attrs: { href: '/a', linktype: 'url' } }] },
+            // Group 2: same href, different target → separate group
+            { type: 'text', text: 'C', marks: [{ type: 'link', attrs: { href: '/a', linktype: 'url', target: '_blank' } }] },
+            { type: 'text', text: 'D', marks: [{ type: 'italic' }, { type: 'link', attrs: { href: '/a', linktype: 'url', target: '_blank' } }] },
+          ],
+        }],
+      };
+
+      const html = render(doc as StoryblokRichTextNode<string>);
+      expect(html).toBe('<p><a href="/a">A<strong>B</strong></a><a href="/a" target="_blank">C<em>D</em></a></p>');
+    });
+
+    it('should merge adjacent links into a single VNode with Vue renderFn', () => {
+      const { render } = richTextResolver<VNode | VNode[]>({
+        renderFn: h,
+        textFn: createTextVNode,
+        keyedResolvers: true,
+      });
+      const doc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Visit our ', marks: [{ type: 'link', attrs: { href: '/page', linktype: 'url' } }] },
+            { type: 'text', text: 'awesome', marks: [{ type: 'bold' }, { type: 'link', attrs: { href: '/page', linktype: 'url' } }] },
+            { type: 'text', text: ' page', marks: [{ type: 'link', attrs: { href: '/page', linktype: 'url' } }] },
+          ],
+        }],
+      };
+
+      const vnodes = render(doc as StoryblokRichTextNode<VNode | VNode[]>);
+      const result = Array.isArray(vnodes) ? vnodes : [vnodes];
+      expect(result).toHaveLength(1);
+      const p = result[0] as VNode;
+      expect(p.type).toBe('p');
+      const pChildren = p.children as VNode[];
+      const linkNodes = (Array.isArray(pChildren) ? pChildren : [pChildren]).filter(
+        (c: any) => typeof c === 'object' && c?.type === 'a',
+      );
+      expect(linkNodes).toHaveLength(1);
+    });
+
+    it('should merge marks when using a custom link extension (Vue router-link)', () => {
+      const CustomLink = Mark.create({
+        name: 'link',
+        renderHTML({ mark }) {
+          return ['router-link', { to: mark.attrs.href }, 0];
+        },
+      });
+
+      const { render } = richTextResolver({
+        tiptapExtensions: { link: CustomLink },
+      });
+
+      const doc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Go to ', marks: [{ type: 'link', attrs: { href: '/about' } }] },
+            { type: 'text', text: 'about', marks: [{ type: 'bold' }, { type: 'link', attrs: { href: '/about' } }] },
+          ],
+        }],
+      };
+
+      const html = render(doc as StoryblokRichTextNode<string>);
+      expect(html).toBe('<p><router-link to="/about">Go to <strong>about</strong></router-link></p>');
+    });
+
+    it('should merge marks with a renderFn that intercepts link tags (Next.js pattern)', () => {
+      interface MockElement { tag: string; attrs: Record<string, any>; children: any }
+      const el = (tag: string, attrs: Record<string, any>, children?: any): MockElement =>
+        ({ tag, attrs, children });
+
+      const { render } = richTextResolver<MockElement>({
+        renderFn: (tag, attrs = {}, children) => {
+          // Simulate Next.js pattern: replace <a> with <Link>
+          if (tag === 'a') {
+            return el('Link', { href: attrs.href }, children);
+          }
+          return el(tag, attrs, children);
+        },
+        textFn: text => text as any,
+      });
+
+      const doc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Visit ', marks: [{ type: 'link', attrs: { href: '/about', linktype: 'url' } }] },
+            { type: 'text', text: 'about', marks: [{ type: 'bold' }, { type: 'link', attrs: { href: '/about', linktype: 'url' } }] },
+            { type: 'text', text: ' page', marks: [{ type: 'link', attrs: { href: '/about', linktype: 'url' } }] },
+          ],
+        }],
+      };
+
+      const result = render(doc as any) as unknown as MockElement[];
+      const p = result[0];
+      expect(p.tag).toBe('p');
+      const pChildren = Array.isArray(p.children) ? p.children : [p.children];
+      const linkNodes = pChildren.filter((c: any) => c?.tag === 'Link');
+      expect(linkNodes).toHaveLength(1);
+      expect(linkNodes[0].attrs.href).toBe('/about');
+    });
+  });
+});
+
+describe('getRichTextSegments mark merging', () => {
+  function segmentsToHtml(segments: any[]): string {
+    const adapter: RendererAdapter<string> = {
+      createElement: (tag, attrs, children) => {
+        const attrStr = attrs
+          ? Object.entries(attrs)
+              .filter(([k, v]) => k !== 'key' && v != null)
+              .map(([k, v]) => ` ${k}="${v}"`)
+              .join('')
+          : '';
+        const inner = children ? children.join('') : '';
+        return `<${tag}${attrStr}>${inner}</${tag}>`;
+      },
+      createText: text => text,
+    };
+    return renderSegments(segments, adapter, []).join('');
+  }
+
+  it('should merge link with bold and italic inner marks', () => {
+    const doc = {
+      type: 'doc',
+      content: [{
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'normal ', marks: [{ type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+          { type: 'text', text: 'bold', marks: [{ type: 'bold' }, { type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+          { type: 'text', text: ' and ', marks: [{ type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+          { type: 'text', text: 'italic', marks: [{ type: 'italic' }, { type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+          { type: 'text', text: ' end', marks: [{ type: 'link', attrs: { href: '/url', linktype: 'url' } }] },
+        ],
+      }],
+    };
+
+    const segments = getRichTextSegments(doc as StoryblokRichTextNode);
+    const html = segmentsToHtml(segments);
+    expect(html.match(/<a /g)?.length).toBe(1);
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<em>italic</em>');
+  });
+
+  it('should produce correct segment structure for merged marks', () => {
+    const doc = {
+      type: 'doc',
+      content: [{
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'A ', marks: [{ type: 'link', attrs: { href: '/x', linktype: 'url' } }] },
+          { type: 'text', text: 'B', marks: [{ type: 'bold' }, { type: 'link', attrs: { href: '/x', linktype: 'url' } }] },
+        ],
+      }],
+    };
+
+    const segments = getRichTextSegments(doc as StoryblokRichTextNode);
+    expect(segments).toHaveLength(1);
+    const paragraph = segments[0] as any;
+    expect(paragraph.kind).toBe('node');
+    expect(paragraph.tag).toBe('p');
+    const linkSegments = paragraph.content.filter((s: any) => s.kind === 'mark' && s.type === 'link');
+    expect(linkSegments).toHaveLength(1);
+    const linkContent = linkSegments[0].content;
+    expect(linkContent).toHaveLength(2);
+    expect(linkContent[0]).toEqual({ kind: 'text', text: 'A ' });
+    expect(linkContent[1].kind).toBe('mark');
+    expect(linkContent[1].type).toBe('bold');
   });
 });

--- a/packages/richtext/src/richtext.ts
+++ b/packages/richtext/src/richtext.ts
@@ -1,6 +1,6 @@
 import { getStoryblokExtensions } from './extensions';
 import type { BlockAttributes, MarkNode, StoryblokRichTextDocumentNode, StoryblokRichTextNode, StoryblokRichTextOptions, TextNode } from './types';
-import { attrsToString, escapeHtml, SELF_CLOSING_TAGS } from './utils';
+import { attrsToString, collectMarkedTextGroup, escapeHtml, getUniqueMarks, SELF_CLOSING_TAGS } from './utils';
 
 /**
  * Default render function that creates an HTML string for a given tag, attributes, and children.
@@ -132,6 +132,55 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
     return renderFn(tag, attrs, children);
   };
 
+  // --- Mark merging (ProseMirror-style adjacent text node grouping) ---
+
+  /** Renders a group of text nodes with shared marks wrapped once around unique-mark content. */
+  function renderMergedTextNodes(group: TextNode<T>[], shared: MarkNode<T>[]): T {
+    const innerRendered = group.map((node) => {
+      return renderText({ ...node, marks: getUniqueMarks(node.marks || [], shared) } as TextNode<T>);
+    });
+
+    let content: T = isExternalRenderFn
+      ? innerRendered as unknown as T
+      : innerRendered.join('') as unknown as T;
+
+    // Forward order: matches renderText's marks.reduce() where marks[0] wraps first
+    // (innermost) and marks[last] wraps last (outermost).
+    for (const mark of shared) {
+      const ext = markExtMap.get(mark.type);
+      if (!ext?.config?.renderHTML) {
+        continue;
+      }
+      const markAttrs = mark.attrs || {};
+      const spec = callExtensionRenderHTML(ext, 'mark', markAttrs);
+      content = specToRender(spec, contextRenderFn, content);
+    }
+
+    return content;
+  }
+
+  /** Groups adjacent text nodes with shared marks and renders them merged. */
+  function groupAndRenderChildren(children: StoryblokRichTextNode<T>[]): T[] {
+    const result: T[] = [];
+    let i = 0;
+    while (i < children.length) {
+      const match = collectMarkedTextGroup(children, i);
+      if (!match) {
+        result.push(render(children[i]));
+        i++;
+        continue;
+      }
+      if (match.group.length === 1) {
+        result.push(renderText(match.group[0]));
+      }
+      else {
+        result.push(renderMergedTextNodes(match.group, match.shared));
+      }
+      i = match.endIndex;
+    }
+    return result;
+  }
+
   function renderNode(node: StoryblokRichTextNode<T>): T {
     // Text nodes — apply marks via reduce
     if (node.type === 'text') {
@@ -187,7 +236,7 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
       return specToRender(spec, contextRenderFn, parts as T | undefined) as T;
     }
 
-    const children = node.content ? node.content.map(render) : undefined;
+    const children = node.content ? groupAndRenderChildren(node.content) : undefined;
 
     const nodeAttrs = node.attrs || {};
     const spec = callExtensionRenderHTML(ext, 'node', nodeAttrs);

--- a/packages/richtext/src/utils/index.ts
+++ b/packages/richtext/src/utils/index.ts
@@ -1,4 +1,94 @@
-import type { BlockAttributes } from '../types';
+import type { BlockAttributes, MarkNode, StoryblokRichTextNode, TextNode } from '../types';
+
+/**
+ * Deep equality comparison for plain objects, arrays, and primitives.
+ */
+export function deepEqual(a: any, b: any): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || a === undefined || b === null || b === undefined) {
+    return a === b;
+  }
+  if (typeof a !== typeof b) {
+    return false;
+  }
+  if (typeof a !== 'object') {
+    return false;
+  }
+  if (Array.isArray(a) !== Array.isArray(b)) {
+    return false;
+  }
+  if (Array.isArray(a)) {
+    if (a.length !== (b as any[]).length) {
+      return false;
+    }
+    return a.every((v: any, i: number) => deepEqual(v, (b as any[])[i]));
+  }
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  return aKeys.every(k => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
+}
+
+/** Checks if two marks are equal by comparing their type and attrs. */
+export function markEquals<T>(a: MarkNode<T>, b: MarkNode<T>): boolean {
+  return a.type === b.type && deepEqual(a.attrs, b.attrs);
+}
+
+/** Type guard: checks if a node is a text node with at least one mark. */
+export function isMarkedTextNode<T>(node: StoryblokRichTextNode<T>): node is TextNode<T> {
+  return node.type === 'text' && !!(node as TextNode<T>).marks?.length;
+}
+
+/** Returns marks unique to a node (not in the shared set), or undefined if all marks are shared. */
+export function getUniqueMarks<T>(marks: MarkNode<T>[], shared: MarkNode<T>[]): MarkNode<T>[] | undefined {
+  const unique = marks.filter(m => !shared.some(s => markEquals(s, m)));
+  return unique.length ? unique : undefined;
+}
+
+export interface MarkedTextGroup<T> {
+  group: TextNode<T>[];
+  shared: MarkNode<T>[];
+  endIndex: number;
+}
+
+/**
+ * Starting at `fromIndex`, collects adjacent marked text nodes that share at least one common mark.
+ * Returns null if the node at `fromIndex` is not a marked text node.
+ */
+export function collectMarkedTextGroup<T>(
+  children: StoryblokRichTextNode<T>[],
+  fromIndex: number,
+): MarkedTextGroup<T> | null {
+  const child = children[fromIndex];
+  if (!isMarkedTextNode(child)) {
+    return null;
+  }
+
+  const group: TextNode<T>[] = [child];
+  let shared: MarkNode<T>[] = child.marks!;
+  let j = fromIndex + 1;
+  while (j < children.length) {
+    const next = children[j];
+    if (!isMarkedTextNode(next)) {
+      break;
+    }
+    const nextShared = shared.filter(m =>
+      next.marks!.some(n => markEquals(m, n)),
+    );
+    if (nextShared.length === 0) {
+      break;
+    }
+    shared = nextShared;
+    group.push(next);
+    j++;
+  }
+
+  return { group, shared, endIndex: j };
+}
 
 export const SELF_CLOSING_TAGS = [
   'area',


### PR DESCRIPTION
## The problem

When a linked phrase contains styled text (bold, italic), the Storyblok API returns separate text nodes each carrying the `link` mark independently. The resolver rendered each node in isolation, producing multiple `<a>` tags instead of one:

```
Before: <a href="/url">normal </a><a href="/url"><strong>bold</strong></a><a href="/url"> end</a>
After:  <a href="/url">normal <strong>bold</strong> end</a>
```

## Solution

Adjacent text nodes sharing common marks (by type + deep-equal attrs) are grouped and rendered with the shared marks wrapping once around the unique-mark content — mirroring how ProseMirror's `DOMSerializer` tracks "active marks" across siblings.

**Both rendering paths are covered:**
- `richTextResolver` (Vue, React, Astro) — `richtext.ts`
- `getRichTextSegments` (Angular) — `richtext-segment.ts`

The grouping algorithm lives in a shared utility (`collectMarkedTextGroup`) to avoid duplication.

## Custom links and Framework SDKs support

No changes needed in Frameworks renderers, works transparently out of the box, including custom link overrides:

**Vue** — `tiptapExtensions` with `router-link`:
```typescript
const { render } = useStoryblokRichText({
  tiptapExtensions: {
    link: Mark.create({
      name: 'link',
      renderHTML: ({ mark }) => ['router-link', { to: mark.attrs.href }, 0],
    }),
  },
})
```

Closes #525
