### PR TITLE
fix(richtext): export StoryblokRichTextDocumentNode from markdown parser

### DIFF
--- a/packages/richtext/src/markdown-parser.ts
+++ b/packages/richtext/src/markdown-parser.ts
@@ -1,5 +1,6 @@
 import MarkdownIt from 'markdown-it';
 import { type HTMLParserOptions, htmlToStoryblokRichtext } from './html-parser';
+import type { StoryblokRichTextDocumentNode } from './types';
 
 export interface MarkdownParserOptions {
   tiptapExtensions?: HTMLParserOptions['tiptapExtensions'];
@@ -12,3 +13,5 @@ export function markdownToStoryblokRichtext(
   const html = new MarkdownIt({ html: false, linkify: true, typographer: true, breaks: true }).render(md);
   return htmlToStoryblokRichtext(html, options);
 }
+
+export type { StoryblokRichTextDocumentNode };


### PR DESCRIPTION
Summary

Expose `StoryblokRichTextDocumentNode` as part of the public API of
`@storyblok/richtext/markdown-parser`.

Problem

`markdownToStoryblokRichtext` returns a structured rich text document,
but its return type is not exported.

This makes it difficult to use in strongly typed environments, especially when:

- defining component APIs (for example Vue `defineEmits` / `defineProps`)
- writing reusable utilities
- using strict TypeScript + ESLint rules

Consumers are currently forced to rely on workarounds such as:

```ts
type Doc = ReturnType<typeof markdownToStoryblokRichtext>
```

or unsafe casts.

### Solution

* Export `StoryblokRichTextDocumentNode` from the types module
* Re-export it from `markdown-parser`
* Add an explicit return type to `markdownToStoryblokRichtext`

### Result

Consumers can now write:

```ts
import {
  markdownToStoryblokRichtext,
  type StoryblokRichTextDocumentNode,
} from '@storyblok/richtext/markdown-parser'
```

### Notes

This change does not affect runtime behavior. It only improves type accessibility and developer experience.

````
