### PR TITLE
perf(js): externalize deps and split entry points for tree shaking

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -17,12 +17,27 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/storyblok-js.mjs",
-      "require": "./dist/storyblok-js.js"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./api": {
+      "types": "./dist/api.d.ts",
+      "import": "./dist/api.mjs",
+      "require": "./dist/api.js"
+    },
+    "./bridge": {
+      "types": "./dist/bridge.d.ts",
+      "import": "./dist/bridge.mjs",
+      "require": "./dist/bridge.js"
+    },
+    "./editable": {
+      "types": "./dist/editable.d.ts",
+      "import": "./dist/editable.mjs",
+      "require": "./dist/editable.js"
     }
   },
-  "main": "./dist/storyblok-js.js",
-  "module": "./dist/storyblok-js.mjs",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/js/vite.config.ts
+++ b/packages/js/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, type Plugin } from 'vitest/config';
-import path from 'node:path';
+import { resolve } from 'node:path';
 import { lightGreen } from 'kolorist';
 import banner from 'vite-plugin-banner';
 import dts from 'vite-plugin-dts';
@@ -13,6 +13,7 @@ export default defineConfig({
   plugins: [
     dts({
       insertTypesEntry: true,
+      rollupTypes: true,
     }),
     banner({
       content: `/**\n * name: ${pkg.name}\n * (c) ${new Date().getFullYear()}\n * description: ${pkg.description}\n * author: ${pkg.author}\n */`,
@@ -20,11 +21,26 @@ export default defineConfig({
   ] as Plugin[],
   build: {
     lib: {
-      entry: path.resolve(__dirname, 'src', 'index.ts'),
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        api: resolve(__dirname, 'src/api.ts'),
+        bridge: resolve(__dirname, 'src/bridge.ts'),
+        editable: resolve(__dirname, 'src/editable.ts'),
+      },
       name: 'storyblok',
-      fileName: (format) => {
-        const name = 'storyblok-js';
-        return format === 'es' ? `${name}.mjs` : `${name}.js`;
+      fileName: (format, entry) => {
+        return format === 'es' ? `${entry}.mjs` : `${entry}.js`;
+      },
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      external: ['@storyblok/richtext', 'storyblok-js-client'],
+      output: {
+        preserveModules: true,
+        globals: {
+          '@storyblok/richtext': 'StoryblokRichtext',
+          'storyblok-js-client': 'StoryblokClient',
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Externalizes `@storyblok/richtext` and `storyblok-js-client` from the `@storyblok/js` bundle and splits the package into individual entry points — enabling proper tree shaking and code splitting for downstream bundlers.

### Problem

`@storyblok/js` was shipping as a single monolithic bundle (`storyblok-js.mjs`) with all dependencies inlined. This meant:

- `storyblok-js-client` and `@storyblok/richtext` were bundled **twice** — once inside `@storyblok/js` and again as standalone packages
- Importing any single export (e.g. `storyblokEditable`) pulled the entire bundle into the consumer's app
- No tree shaking was possible for downstream bundlers (Next.js, Vite, etc.)

### Solution

Mirrors the pattern already established in **`@storyblok/react`**, which externalizes `react`, `react-dom`, and `@storyblok/js` itself.

**`vite.config.ts` changes:**
- `@storyblok/richtext` and `storyblok-js-client` marked as `external`
- `preserveModules: true` — each source file gets its own output file
- Multiple named entry points: `index`, `api`, `bridge`, `editable`

**`package.json` changes:**
- `exports` map updated with sub-path exports for each entry point
- `main`/`module` updated from `storyblok-js.js` → `index.js`/`index.mjs`

### Before / After

| | Before | After |
|---|---|---|
| `index.mjs` | large inlined bundle | **2.18 kB** |
| `api.mjs` | inlined | **0.39 kB** |
| `bridge.mjs` | inlined | **0.81 kB** |
| `editable.mjs` | inlined | **0.37 kB** |

### Bundle analysis — Next.js application

**Before**
Huge bundle of `@storyblok/js` when using only `@storyblok/react` and  `@storyblok/richtext` packages

<img width="1376" height="1018" alt="image" src="https://github.com/user-attachments/assets/a6c62d0b-bc61-48c5-90c6-31cca4fcc388" />



**After**

<img width="1390" height="1018" alt="image" src="https://github.com/user-attachments/assets/bcee3084-45de-45d4-8ff9-260d375a0921" />



## Test plan

- [x] `pnpm build` — clean output with externalized imports verified
- [x] `pnpm test:unit` — 19/19 passing
- [x] `pnpm run test:types` — no type errors
- [x] `pnpm test:e2e` — 4/4 passing
- [x] Tested in real Next.js app via `yalc` — build succeeds, externals confirmed as `import` statements in output

