### PR TITLE
fix(astro): lazy-load Storyblok components to prevent circular dependency

### DIFF
--- a/packages/astro/src/components/StoryblokComponent.astro
+++ b/packages/astro/src/components/StoryblokComponent.astro
@@ -11,34 +11,25 @@ export interface Props {
 const { blok, ...props } = Astro.props;
 
 if (!blok) {
-  throw new Error(
-    "Cannot render StoryblokComponent. 'blok' prop is undefined."
-  );
+  throw new Error("Cannot render StoryblokComponent. 'blok' prop is undefined.");
 }
 /**
  * convert blok components to camel case to match vite-plugin-import-storyblok-components
  */
 let key = toCamelCase(blok.component as string);
 
-const componentFound: boolean = key in storyblokComponents;
+const loader = storyblokComponents[key] || storyblokComponents['FallbackComponent'];
 
-let Component: AstroComponentFactory;
-
-if (!componentFound) {
-  if (!options.enableFallbackComponent)
-    throw new Error(
-      `No component found for blok "${blok.component}". 
+if (!loader) {
+  throw new Error(
+    `No component found for blok "${blok.component}". 
       Make sure the component is:
       • Registered in your astro.config.mjs, or
       • Placed in the "/${options.componentsDir}/storyblok" folder, or
-      • Enable the "fallbackComponent" option to handle missing components.`
-    );
-  else {
-    Component = storyblokComponents['FallbackComponent'];
-  }
-} else {
-  Component = storyblokComponents[key];
+      • Enable the "fallbackComponent" option to handle missing components.`,
+  );
 }
+const Component: AstroComponentFactory = await loader();
 ---
 
 <Component blok={blok} {...props} />

--- a/packages/astro/src/internal.d.ts
+++ b/packages/astro/src/internal.d.ts
@@ -21,7 +21,10 @@ declare namespace App {
 declare module 'virtual:import-storyblok-components' {
   import type { AstroComponentFactory } from 'astro/runtime/server/index.js';
 
-  export const storyblokComponents: Record<string, AstroComponentFactory>;
+  export const storyblokComponents: Record<
+    string,
+    () => Promise<AstroComponentFactory>
+  >;
 }
 
 /** Integration options provided to the Astro SDK. */

--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -90,40 +90,31 @@ function generateModuleCode(
   return `
     // Import utilities and fallback component
     import { toCamelCase } from '@storyblok/astro';
-    ${fallbackImport}
-    ${manualImports.join('\n')}
 
     // Dynamically import all Storyblok components using Vite's glob import
-    const modules = import.meta.glob('${globPattern}', { eager: true });
+    const modules = import.meta.glob('${globPattern}');
     // Process imported modules into a components object
     const storyblokComponents = {};
-    
     for (const filePath in modules) {
       // Extract component name from file path (remove extension)
       const fileName = filePath.split('/').pop();
       const componentName = fileName?.replace(/\\.[^/.]+$/, '');
       
       if (componentName) {
-        // Get the component (handle both default and named exports)
-        const component = modules[filePath].default || modules[filePath];
-        
         // Convert filename to camelCase for Storyblok component naming
         const camelCaseName = toCamelCase(componentName);
-        storyblokComponents[camelCaseName] = component;
+
+        storyblokComponents[camelCaseName] = async () => {
+        const module = await modules[filePath]();
+        return module.default || module;
+        };
       }
     }
     
-    // Manual imports (overwrite auto if same key exists)
-    ${manualImports
-      .map((imp) => {
-        const varName = imp.match(/import\s+(\w+)\s+from/)?.[1];
-        return `storyblokComponents['${varName}'] = ${varName};`;
-      })
-      .join('\n')}
-
+    // Manual components
+    ${manualImports.join('\n')}
     // Add fallback component if enabled
-    ${fallbackImport ? `storyblokComponents['FallbackComponent'] = FallbackComponent;` : ''}
-    
+    ${fallbackImport}    
     // Export the components object for use in Storyblok initialization
     export { storyblokComponents };
   `.trim();
@@ -150,10 +141,19 @@ async function resolveFallbackComponent(
         `Custom fallback component could not be found. Does "${customPath}" exist?`,
       );
     }
-    return `import FallbackComponent from '${customPath}';`;
+
+    return `
+      storyblokComponents['FallbackComponent'] = async () => {
+        const module = await import('${resolved.id}');
+        return module.default || module;
+      };`;
   }
 
-  return `import FallbackComponent from '@storyblok/astro/FallbackComponent.astro';`;
+  return `
+    storyblokComponents['FallbackComponent'] = async () => {
+      const module = await import('@storyblok/astro/FallbackComponent.astro');
+      return module.default || module;
+    };`;
 }
 /**
  * Resolves user-provided Storyblok components into import statements.
@@ -184,7 +184,13 @@ async function resolveUserComponents(
       }
     }
     else {
-      imports.push(`import ${toCamelCase(key)} from "${resolvedId.id}"`);
+      const camelCaseName = toCamelCase(key);
+
+      imports.push(`
+      storyblokComponents['${camelCaseName}'] = async () => {
+        const module = await import('${resolvedId.id}');
+        return module.default || module;
+      };`);
     }
   }
 

--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -99,14 +99,14 @@ function generateModuleCode(
       // Extract component name from file path (remove extension)
       const fileName = filePath.split('/').pop();
       const componentName = fileName?.replace(/\\.[^/.]+$/, '');
-      
-      if (componentName) {
-        // Convert filename to camelCase for Storyblok component naming
-        const camelCaseName = toCamelCase(componentName);
 
-        storyblokComponents[camelCaseName] = async () => {
-        const module = await modules[filePath]();
-        return module.default || module;
+        if (componentName) {
+          // Convert filename to camelCase for Storyblok component naming
+          const camelCaseName = toCamelCase(componentName);
+
+          storyblokComponents[camelCaseName] = async () => {
+          const module = await modules[filePath]();
+          return module.default || module;
         };
       }
     }


### PR DESCRIPTION
This PR switches Storyblok component imports to lazy loading to prevent circular dependency issues and improve build stability.

Previously, components were imported using `eager` imports, which could cause runtime errors like:

`ReferenceError: Cannot access '$$Component' before initialization`

This change introduces async component loaders and updates the runtime to resolve components lazily.

Fixes #547

## Changes

- Convert auto-imported Storyblok components to lazy imports
- Convert manual component imports to lazy imports
- Convert fallback component to lazy import
- Update runtime to resolve components asynchronously