### PR TITLE
chore: add CLAUDE.md symlinks and agent guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ vite.config.ts.timestamp-*
 .cursor
 .zed
 .rules
+.worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Guidelines for Storyblok monoblok
 
+> **Note:** `AGENTS.md` is the source of truth. `CLAUDE.md` is a symlink to `AGENTS.md` for Claude Code compatibility.
+
 Adhere strictly to these guidelines to ensure consistency and code quality. Use relevant skills if applicable.
 
 ## Project context
@@ -48,3 +50,5 @@ The `adr/` directory contains Architecture Decision Records (ADRs) documenting m
 ## General
 
 - **IMPORTANT:** Never stage or commit any code yourself unless explicitly told so!
+- **IMPORTANT:** Never add `Co-Authored-By` or similar AI attribution trailers to commit messages or PRs.
+- **Worktrees:** Always use the `.worktrees/` directory when creating git worktrees.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` symlinks pointing to `AGENTS.md` (root and `packages/cli/`) for Claude Code compatibility
- Add `.worktrees/` to `.gitignore`
- Add agent guidelines: no AI attribution trailers in commits/PRs, use `.worktrees/` for git worktrees

## Test plan
- [x] Verify `CLAUDE.md` symlinks resolve correctly to `AGENTS.md`
- [x] Verify `.worktrees/` is ignored by git