### PR TITLE
feat(cli): add --from flag to migrations run

### DIFF
--- a/.claude/skills/qa-engineer-manual/SKILL.md
+++ b/.claude/skills/qa-engineer-manual/SKILL.md
@@ -151,7 +151,12 @@ Paths are relative to this `SKILL.md`.
 - When running `.mjs` test files, env vars must be **exported** (`set -a && source ./.env.qa-engineer-manual && set +a`) — plain `source` does not propagate to `node` subprocesses.
 
 **MAPI:**
+- **Auth uses `personalAccessToken`** — The MAPI client config property is `personalAccessToken` (or `oauthToken` for OAuth).
+  ```js
+  createManagementApiClient({ personalAccessToken: process.env.STORYBLOK_TOKEN, spaceId })
+  ```
 - **Assets list does NOT support `sort_by`** — passing `sort_by: 'id:asc'` returns HTTP 422 and `data: undefined`.
+- **Story `content.body` is not always an array** — `body` can be a string or other type depending on the component schema. Never spread it directly (e.g., `...content.body`). Use `Array.isArray(content.body)` or walk content recursively to find nested blocks.
 
 **CLI:**
 - **`--asset-token` requires an `asset`-type API key** — Only a token with access type `asset` works. Use `STORYBLOK_ASSET_TOKEN` or `STORYBLOK_ASSET_TOKEN_TARGET` environment variables.

--- a/packages/cli/src/commands/migrations/run/README.md
+++ b/packages/cli/src/commands/migrations/run/README.md
@@ -42,7 +42,8 @@ This will run migrations for the specified component:
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-s, --space <space>` | (Required) The ID of the space to run migrations in | - |
+| `-s, --space <space>` | (Required) The ID of the space to run migrations on | - |
+| `-f, --from <from>` | Source space ID to read migration files from (useful for multi-space workflows where migrations are created in one space and applied to others) | Same as `--space` |
 | `--fi, --filter <filter>` | Glob pattern to filter migration filenames (e.g., "hero*" will match all migration files starting with "hero") | - |
 | `-d, --dry-run` | Preview changes without applying them to Storyblok | `false` |
 | `-q, --query <query>` | Filter stories by content attributes using Storyblok filter query syntax (e.g., `--query="[highlighted][in]=true"`) | - |
@@ -97,6 +98,18 @@ storyblok migrations run --space 12345 --starts-with "/en/blog/"
 storyblok migrations run --space 12345 --query "[highlighted][in]=true"
 ```
 
+10. Run migrations from a different space (cross-space workflow):
+```bash
+# Generate migrations against your DEV space
+storyblok migrations generate hero --space 11111
+
+# Apply those same migrations to STAGING
+storyblok migrations run hero --space 22222 --from 11111
+
+# Apply to PRODUCTION
+storyblok migrations run hero --space 33333 --from 11111
+```
+
 ## File Structure
 
 The command reads from the following file structure:
@@ -123,6 +136,7 @@ Where:
   - Apply the migrations to the stories
   - Update the stories in Storyblok (unless `--dry-run` is used)
   - Create a snapshot of each story's content in `.storyblok/migrations/{spaceId}/rollbacks` with a timestamp for potential rollbacks
+- Use `--from` to read migration files from a different space's directory — this is useful for DEV/STAGING/PRODUCTION workflows where you create migrations once and apply them across spaces
 - Use `--dry-run` to preview changes before applying them
 - Use `--publish` to control which stories are affected
 - Use `--starts-with` and `--query` to filter which stories are affected

--- a/packages/cli/src/commands/migrations/run/constants.ts
+++ b/packages/cli/src/commands/migrations/run/constants.ts
@@ -4,6 +4,10 @@ import type { StoryContent } from '../../stories/constants';
 export interface MigrationsRunOptions extends CommandOptions {
   dryRun?: boolean;
   filter?: string;
+  /**
+   * The source space id to read migration files from.
+   */
+  from?: string;
   query?: string;
   startsWith?: string;
   publish?: 'all' | 'published' | 'published-with-changes';

--- a/packages/cli/src/commands/migrations/run/index.test.ts
+++ b/packages/cli/src/commands/migrations/run/index.test.ts
@@ -62,6 +62,7 @@ const createMockStory = (overrides: Partial<Story> = {}): Story => ({
 const mockStory = createMockStory();
 
 const MIGRATION_FUNCTION_FILE_PATH = './.storyblok/migrations/12345/migration-component.js';
+const FROM_SPACE_MIGRATION_FILE_PATH = './.storyblok/migrations/67890/migration-component.js';
 const LOG_PREFIX = 'storyblok-migrations-run-';
 
 const preconditions = {
@@ -111,6 +112,16 @@ const preconditions = {
     this.canFetchStory();
     this.canUpdateStory();
     this.canLoadMigrationFunction((block: any) => block);
+  },
+  canMigrateFromSpace() {
+    this.canFetchStories();
+    this.canFetchStory();
+    this.canUpdateStory();
+    vol.fromJSON({
+      [FROM_SPACE_MIGRATION_FILE_PATH]: 'only the filename matters!',
+    });
+    const importModuleSpy = vi.spyOn(filesystem, 'importModule');
+    importModuleSpy.mockImplementation(() => Promise.resolve({ default: (block: any) => ({ ...block, migrated: true }) }));
   },
 };
 
@@ -312,5 +323,63 @@ describe('migrations run command', () => {
       }),
     );
     expect(fetchStory).toHaveBeenCalledWith('12345', '517473243');
+  });
+
+  it('should read migration files from --from space and apply to --space', async () => {
+    preconditions.canMigrateFromSpace();
+
+    resetLogger();
+
+    await migrationsCommand.parseAsync(['node', 'test', 'run', '--space', '12345', '--from', '67890']);
+
+    // Stories should be fetched from the target space (--space)
+    expect(fetchStories).toHaveBeenCalledWith(
+      '12345',
+      expect.objectContaining({
+        per_page: 500,
+        page: 1,
+        story_only: true,
+      }),
+    );
+    expect(fetchStory).toHaveBeenCalledWith('12345', '517473243');
+
+    // Migration module should be loaded from the --from space directory, not --space
+    expect(filesystem.importModule).toHaveBeenCalledWith(
+      expect.stringContaining('/migrations/67890/'),
+    );
+    expect(filesystem.importModule).not.toHaveBeenCalledWith(
+      expect.stringContaining('/migrations/12345/'),
+    );
+
+    // Migration should be applied successfully
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('Migration Results:'),
+    );
+  });
+
+  it('should show info message when --from is provided', async () => {
+    preconditions.canMigrateFromSpace();
+
+    resetLogger();
+
+    await migrationsCommand.parseAsync(['node', 'test', 'run', '--space', '12345', '--from', '67890']);
+
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('from'),
+    );
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('67890'),
+    );
+  });
+
+  it('should reference --from space in error when migration directory does not exist', async () => {
+    preconditions.migrationDirectoryDoesNotExist();
+
+    resetLogger();
+
+    await migrationsCommand.parseAsync(['node', 'test', 'run', '--space', '12345', '--from', '67890']);
+
+    const logFile = getLogFileContents(LOG_PREFIX);
+    expect(logFile).toContain('No directory found for space \\"67890\\".');
   });
 });

--- a/packages/cli/src/commands/migrations/run/index.ts
+++ b/packages/cli/src/commands/migrations/run/index.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import chalk from 'chalk';
 import { getUI } from '../../../utils/ui';
 import { getLogger } from '../../../lib/logger/logger';
 import { getReporter } from '../../../lib/reporter/reporter';
@@ -20,6 +21,7 @@ const runCmd = migrationsCommand.command('run [componentName]')
   .option('-q, --query <query>', 'Filter stories by content attributes using Storyblok filter query syntax. Example: --query="[highlighted][in]=true"')
   .option('--starts-with <path>', 'Filter stories by path. Example: --starts-with="/en/blog/"')
   .option('--publish <publish>', 'Options for publication mode: all | published | published-with-changes')
+  .option('-f, --from <from>', 'source space id')
   .option('-s, --space <space>', 'space ID');
 
 runCmd
@@ -47,13 +49,19 @@ runCmd
       return;
     }
 
-    const { filter, dryRun = false, query, startsWith, publish } = options;
+    const { filter, from, dryRun = false, query, startsWith, publish } = options;
+    const fromSpace = from || space;
+
+    if (from) {
+      ui.info(`Running migrations ${chalk.bold('from')} space ${chalk.hex(colorPalette.MIGRATIONS)(fromSpace)} ${chalk.bold('on')} space ${chalk.hex(colorPalette.MIGRATIONS)(space)}`);
+      ui.br();
+    }
 
     try {
       const spinner = ui.createSpinner(`Fetching migration files and stories...`);
 
       const migrationFiles = await readMigrationFiles({
-        space,
+        space: fromSpace,
         path,
         filter,
       });
@@ -66,7 +74,7 @@ runCmd
         : migrationFiles;
 
       if (filteredMigrations.length === 0) {
-        spinner.failed(`No migration files found${componentName ? ` for component "${componentName}"` : ''}${filter ? ` matching filter "${filter}"` : ''} in space "${space}".`);
+        spinner.failed(`No migration files found${componentName ? ` for component "${componentName}"` : ''}${filter ? ` matching filter "${filter}"` : ''} in space "${fromSpace}".`);
         logger.warn('No migration files found');
         logger.info('Migration finished');
         return;
@@ -98,6 +106,7 @@ runCmd
       const migrationStream = new MigrationStream({
         migrationFiles: filteredMigrations,
         space,
+        sourceSpace: fromSpace,
         path,
         componentName,
         onTotal: (total) => {

--- a/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
+++ b/packages/cli/src/commands/migrations/run/streams/migrations-transform.ts
@@ -11,6 +11,8 @@ import { toError } from '../../../../utils/error';
 export interface MigrationStreamOptions {
   migrationFiles: MigrationFile[];
   space: string;
+  /** Space id to read migration files from. Defaults to `space` when not set. */
+  sourceSpace: string;
   path: string;
   componentName?: string;
   onProgress: (current: number) => void;
@@ -77,7 +79,7 @@ export class MigrationStream extends Transform {
 
     const migrationFunction = await getMigrationFunction(
       migrationFile.name,
-      this.options.space,
+      this.options.sourceSpace,
       this.options.path,
     );
     this.migrationFunctions.set(migrationFile.name, migrationFunction);

--- a/packages/cli/test/GUIDE.md
+++ b/packages/cli/test/GUIDE.md
@@ -22,6 +22,7 @@ bash .claude/skills/qa-engineer-manual/scripts/seed-scenario.sh \
 ## Known quirks
 
 - **Progress bar titles show `{title}` literally** — all progress bars render the raw `{title}` placeholder instead of the actual label. This is a known rendering issue and does not affect functionality. Ignore it when reading command output.
+- **Spinner continues after error in `migrations run`** — when `readMigrationFiles` throws (e.g., missing directory), the spinner is not stopped before the error handler runs. The error message is still displayed correctly.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add `-f, --from <from>` option to `migrations run`, enabling cross-space migration workflows
- Migration files are read from the `--from` space directory while stories are fetched/updated on the `--space` target
- Consistent with existing `--from` flag on `components push` and `datasources push`

Closes https://github.com/storyblok/monoblok/discussions/221#discussioncomment-15495048

## Test plan

- [x] Existing migrations run tests still pass (9/9)
- [x] New test: migration files loaded from `--from` space path, not `--space`
- [x] New test: info message displayed when `--from` is provided
- [x] New test: error message references `--from` space when directory is missing
- [x] Type check passes
- [x] Lint passes