### PR TITLE
refactor(cli): remove change detection from assets push

### DIFF
--- a/adr/0003-remove-change-detection-from-assets-push.md
+++ b/adr/0003-remove-change-detection-from-assets-push.md
@@ -1,0 +1,29 @@
+# ADR-0003: Remove Change Detection from `assets push`
+
+**Status:** Accepted  
+**Date:** 2026-04-15
+
+## Context
+
+The `storyblok assets push` command performed change detection before uploading each asset: it fetched the remote asset's metadata, downloaded the full remote binary, computed SHA-256 hashes of both local and remote files, and compared metadata fields. Only when a difference was detected would it proceed with the upload.
+
+While this avoided unnecessary uploads, it introduced significant bandwidth overhead. Pushing a single 5 MB asset required downloading the same 5 MB file just to compare hashes — doubling the minimum bandwidth to 10 MB even when the asset had changed and needed uploading anyway. At scale, this overhead compounds.
+
+Investigation confirmed that re-uploading an asset preserves its URL, so there is no risk of orphaned URLs in stories.
+
+## Decision
+
+Remove all change detection from `assets push`. Every invocation unconditionally uploads all assets it encounters — creating new assets or replacing existing ones — without downloading or comparing remote content.
+
+This also removes the `--asset-token` CLI option from the push command, which was only needed to download private assets for comparison.
+
+## Alternatives Considered
+
+- **Metadata-only comparison** — Compare only the lightweight GET response (no binary download). Rejected because it cannot detect binary-only changes (e.g. a resized image with identical metadata), making the detection unreliable.
+- **Manifest-cached SHA-256 hashes** — Store the hash of each pushed file in the manifest and compare on subsequent pushes. Rejected because it cannot detect changes made through the Storyblok UI (the user may edit an asset via the editor without re-pulling), leading to stale hashes and missed updates.
+
+## Consequences
+
+- Simpler implementation with fewer network calls per asset (no GET + download for comparison).
+- Every push re-uploads all targeted assets regardless of whether they changed. Users who want selective uploads must manage that externally (e.g. by only placing changed files in the assets directory).
+- The `--asset-token` option is no longer available on push (it remains available on pull where it is needed to download private assets).

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -1,11 +1,9 @@
-import { Buffer } from 'node:buffer';
 import Storyblok from 'storyblok-js-client';
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { toError } from '../../utils/error/error';
 import type { RegionCode } from '../../constants';
 import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetListQuery, AssetUpdate, AssetUpload } from './types';
-import { createHash } from 'node:crypto';
 
 /**
  * Fetches a single page of assets from Storyblok Management API.
@@ -143,19 +141,7 @@ export const updateAssetFolder = async (id: number, folder: AssetFolderUpdate, {
   }
 };
 
-/**
- * Computes the SHA-256 hash of a file buffer.
- * Used for comparing local and remote file contents.
- */
-export const sha256 = (data: ArrayBuffer | Buffer) => {
-  const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
-  return createHash('sha256').update(buffer).digest('hex');
-};
-
-/**
- * Downloads a remote asset file for comparison purposes.
- * Handles both public and private assets.
- */
+/** Downloads a remote asset file. Handles both public and private assets. */
 export const downloadAssetFile = async (
   asset: { filename: string; is_private?: boolean },
   options: { assetToken?: string; region?: RegionCode },

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -14,7 +14,6 @@ import type {
   CleanupAssetTransport,
   CreateAssetFolderTransport,
   CreateAssetTransport,
-  DownloadAssetFileTransport,
   GetAssetFolderTransport,
   GetAssetTransport,
   UpdateAssetFolderTransport,
@@ -98,14 +97,13 @@ export const upsertAssetsPipeline = async ({
     getAsset: GetAssetTransport;
     createAsset: CreateAssetTransport;
     updateAsset: UpdateAssetTransport;
-    downloadAssetFile: DownloadAssetFileTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset: CleanupAssetTransport;
   };
   ui: UI;
 }): Promise<Summaries> => {
   const assetProgress = ui.createProgressBar({ title: 'Assets...'.padEnd(PROGRESS_BAR_PADDING) });
-  const summary = { total: 0, succeeded: 0, failed: 0, skipped: 0 };
+  const summary = { total: 0, succeeded: 0, failed: 0 };
 
   const steps = [];
   // Use the asset provided via the CLI.
@@ -157,21 +155,6 @@ export const upsertAssetsPipeline = async ({
 
       summary.succeeded += 1;
       logger.info('Uploaded asset', { assetId: remoteAsset.id });
-    },
-    onAssetSkipped: (localAssetResult, remoteAsset) => {
-      if ('id' in localAssetResult && localAssetResult.id) {
-        maps.assets.set(localAssetResult.id, {
-          old: localAssetResult,
-          new: {
-            id: remoteAsset.id,
-            filename: remoteAsset.filename,
-            meta_data: remoteAsset.meta_data,
-          },
-        });
-      }
-
-      summary.skipped += 1;
-      logger.debug('Skipped asset (unchanged)', { assetId: remoteAsset.id });
     },
     onAssetError: (error, asset) => {
       summary.failed += 1;

--- a/packages/cli/src/commands/assets/push/README.md
+++ b/packages/cli/src/commands/assets/push/README.md
@@ -74,4 +74,3 @@ storyblok assets push --space YOUR_SPACE_ID ./path/to/image.png \
 | `--folder <folderId>` | Destination asset folder ID | - |
 | `--cleanup` | Delete local assets and metadata after a successful push | `false` |
 | `--update-stories` | Update file references in stories if necessary | `false` |
-| `--asset-token <token>` | Asset token for accessing private assets | - |

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -320,21 +320,6 @@ const preconditions = {
       return HttpResponse.arrayBuffer(content.buffer as ArrayBuffer);
     }));
   },
-  canDownloadAssets(assets: MockAsset[], { content = 'binary-content' }: { content?: string } = {}) {
-    for (const asset of assets) {
-      server.use(http.get(asset.filename, () => HttpResponse.text(content)));
-    }
-  },
-  canDownloadPrivateAsset(signedUrl: string, content = 'private-binary-content') {
-    server.use(http.get(signedUrl, () => HttpResponse.text(content)));
-  },
-  canFetchSignedUrl(signedUrl: string) {
-    server.use(
-      http.get('https://api.storyblok.com/v2/cdn/assets/me', () => {
-        return HttpResponse.json({ asset: { signed_url: signedUrl } });
-      }),
-    );
-  },
   canFetchRemoteStoryPages(storyPages: MockStory[][]) {
     server.use(
       http.get(
@@ -458,7 +443,6 @@ describe('assets push command', () => {
         assetResults: {
           total: 1,
           succeeded: 1,
-          skipped: 0,
           failed: 0,
         },
       },
@@ -469,11 +453,11 @@ describe('assets push command', () => {
     expect(logFile).toMatch(/Uploaded asset/);
     expect(logFile).toContain('Pushing assets finished');
     expect(logFile).toContain('"assetFolderResults":{"total":1,"succeeded":1,"failed":0}');
-    expect(logFile).toContain('"assetResults":{"total":1,"succeeded":1,"failed":0,"skipped":0}');
+    expect(logFile).toContain('"assetResults":{"total":1,"succeeded":1,"failed":0}');
     // UI
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Push results: 1 processed, 0 assets failed'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Folders: 1/1 succeeded, 0 failed.'));
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Assets: 1/1 succeeded, 0 skipped, 0 failed.'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Assets: 1/1 succeeded, 0 failed.'));
     expect(process.exitCode).toBe(0);
   });
 
@@ -571,7 +555,7 @@ describe('assets push command', () => {
       meta: expect.any(Object),
       summary: {
         assetFolderResults: { total: 0, succeeded: 0, failed: 0 },
-        assetResults: { total: 1, succeeded: 1, skipped: 0, failed: 0 },
+        assetResults: { total: 1, succeeded: 1, failed: 0 },
         fetchStoryPages: { total: 1, succeeded: 1, failed: 0 },
         fetchStories: { total: 1, succeeded: 1, failed: 0 },
         storyProcessResults: { total: 1, succeeded: 1, failed: 0 },
@@ -581,7 +565,7 @@ describe('assets push command', () => {
     // UI
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Push results: 1 processed, 0 assets failed'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Folders: 0/0 succeeded, 0 failed.'));
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Assets: 1/1 succeeded, 0 skipped, 0 failed.'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Assets: 1/1 succeeded, 0 failed.'));
     expect(process.exitCode).toBe(0);
   });
 
@@ -719,7 +703,7 @@ describe('assets push command', () => {
       meta: expect.any(Object),
       summary: {
         assetFolderResults: { total: 0, succeeded: 0, failed: 0 },
-        assetResults: { total: 1, succeeded: 1, skipped: 0, failed: 0 },
+        assetResults: { total: 1, succeeded: 1, failed: 0 },
       },
     });
     // UI
@@ -727,7 +711,7 @@ describe('assets push command', () => {
     expect(console.error).not.toHaveBeenCalled();
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Push results: 1 processed, 0 assets failed'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Folders: 0/0 succeeded, 0 failed.'));
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Assets: 1/1 succeeded, 0 skipped, 0 failed.'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Assets: 1/1 succeeded, 0 failed.'));
     expect(process.exitCode).toBe(0);
   });
 
@@ -839,7 +823,7 @@ describe('assets push command', () => {
       expect.stringContaining('Folders: 0/0 succeeded, 0 failed.'),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Assets: 0/1 succeeded, 0 skipped, 1 failed.'),
+      expect.stringContaining('Assets: 0/1 succeeded, 1 failed.'),
     );
     expect(process.exitCode).toBe(1);
   });
@@ -883,7 +867,7 @@ describe('assets push command', () => {
       expect.stringContaining('Folders: 0/0 succeeded, 0 failed.'),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Assets: 0/1 succeeded, 0 skipped, 1 failed.'),
+      expect.stringContaining('Assets: 0/1 succeeded, 1 failed.'),
     );
     expect(process.exitCode).toBe(1);
   });
@@ -963,31 +947,17 @@ describe('assets push command', () => {
       expect.stringContaining('Folders: 0/0 succeeded, 0 failed.'),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Assets: 0/1 succeeded, 0 skipped, 1 failed.'),
+      expect.stringContaining('Assets: 0/1 succeeded, 1 failed.'),
     );
     expect(process.exitCode).toBe(1);
   });
 
   it('should handle errors when updating assets fails', async () => {
-    const localAsset = makeMockAsset({
-      meta_data: {
-        alt: 'New alt',
-        title: 'New title',
-        copyright: 'New copyright',
-      },
-    });
+    const localAsset = makeMockAsset();
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([localAsset]);
-    const [remoteAsset] = preconditions.canUpsertRemoteAssets([{
-      ...localAsset,
-      meta_data: {
-        alt: 'Old alt',
-        title: 'Old title',
-        copyright: 'Old copyright',
-      },
-    }]);
+    const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset]);
     preconditions.canFetchRemoteAssets([remoteAsset]);
-    preconditions.canDownloadAssets([remoteAsset]);
     preconditions.canLoadAssetsManifest([{ old_id: localAsset.id, new_id: remoteAsset.id }]);
     preconditions.failsToUpdateRemoteAssets();
 
@@ -1008,7 +978,7 @@ describe('assets push command', () => {
       expect.stringContaining('Folders: 0/0 succeeded, 0 failed.'),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Assets: 0/1 succeeded, 0 skipped, 1 failed.'),
+      expect.stringContaining('Assets: 0/1 succeeded, 1 failed.'),
     );
     expect(process.exitCode).toBe(1);
   });
@@ -1036,7 +1006,7 @@ describe('assets push command', () => {
       expect.stringContaining('Folders: 0/0 succeeded, 0 failed.'),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Assets: 0/1 succeeded, 0 skipped, 1 failed.'),
+      expect.stringContaining('Assets: 0/1 succeeded, 1 failed.'),
     );
     expect(process.exitCode).toBe(1);
   });
@@ -1062,31 +1032,13 @@ describe('assets push command', () => {
     }));
   });
 
-  it('should skip update when both file and metadata are unchanged', async () => {
-    const localAsset = makeMockAsset();
-    preconditions.canLoadFolders([]);
-    preconditions.canLoadAssets([localAsset]);
-    const finishUploadSpy = vi.fn();
-    const updateSpy = vi.fn();
-    const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset], { finishUploadSpy, updateSpy });
-    preconditions.canFetchRemoteAssets([remoteAsset]);
-    preconditions.canDownloadAssets([remoteAsset]);
-    preconditions.canLoadAssetsManifest([{ old_id: localAsset.id, new_id: remoteAsset.id }]);
-
-    await assetsCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
-
-    expect(finishUploadSpy).not.toHaveBeenCalled();
-    expect(updateSpy).not.toHaveBeenCalled();
-  });
-
-  it('should upload a new asset file when updating an existing asset with a different binary hash', async () => {
+  it('should always upload when updating an existing asset', async () => {
     const localAsset = makeMockAsset();
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([localAsset]);
     const finishUploadSpy = vi.fn();
     const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset], { finishUploadSpy });
     preconditions.canFetchRemoteAssets([remoteAsset]);
-    preconditions.canDownloadAssets([remoteAsset], { content: 'new-binary-content' });
 
     await assetsCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
 
@@ -1102,39 +1054,13 @@ describe('assets push command', () => {
     ]);
   });
 
-  it('should upload a new private asset file when updating an existing asset with a different binary hash', async () => {
-    const localAsset = makeMockAsset({ is_private: true });
-    preconditions.canLoadFolders([]);
-    preconditions.canLoadAssets([localAsset]);
-    const finishUploadSpy = vi.fn();
-    const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset], { finishUploadSpy });
-    preconditions.canFetchRemoteAssets([remoteAsset]);
-    const signedUrl = 'https://signed-download-url.s3.amazonaws.com/asset.png?signature=xyz';
-    preconditions.canFetchSignedUrl(signedUrl);
-    preconditions.canDownloadPrivateAsset(signedUrl);
-
-    await assetsCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE, '--asset-token', 'test-asset-token']);
-
-    expect(finishUploadSpy).toHaveBeenCalled();
-    expect(await parseManifest()).toEqual([
-      {
-        old_id: localAsset.id,
-        old_filename: localAsset.filename,
-        new_id: remoteAsset.id,
-        new_filename: remoteAsset.filename,
-        created_at: expect.any(String),
-      },
-    ]);
-  });
-
-  it('should upload a new asset file when updating an existing asset with a different binary hash when resuming from manifest', async () => {
+  it('should upload when resuming from manifest', async () => {
     const localAsset = makeMockAsset();
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([localAsset]);
     const finishUploadSpy = vi.fn();
     const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset], { finishUploadSpy });
     preconditions.canFetchRemoteAssets([remoteAsset]);
-    preconditions.canDownloadAssets([remoteAsset], { content: 'new-binary-content' });
     preconditions.canLoadAssetsManifest([{
       old_id: localAsset.id,
       old_filename: localAsset.filename,
@@ -1155,25 +1081,11 @@ describe('assets push command', () => {
   });
 
   it('should update existing remote assets even when no manifest exists', async () => {
-    const localAsset = makeMockAsset({
-      meta_data: {
-        alt: 'New alt',
-        title: 'New title',
-        copyright: 'New copyright',
-      },
-    });
+    const localAsset = makeMockAsset();
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([localAsset]);
-    const [remoteAsset] = preconditions.canUpsertRemoteAssets([{
-      ...localAsset,
-      meta_data: {
-        alt: 'Old alt',
-        title: 'Old title',
-        copyright: 'Old copyright',
-      },
-    }]);
+    const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset]);
     preconditions.canFetchRemoteAssets([remoteAsset]);
-    preconditions.canDownloadAssets([remoteAsset]);
 
     await assetsCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
 
@@ -1188,27 +1100,6 @@ describe('assets push command', () => {
         created_at: expect.any(String),
       },
     ]);
-  });
-
-  it('should not skip update when top-level metadata changed but meta_data object is empty', async () => {
-    const localAsset = makeMockAsset({
-      alt: 'New alt',
-      meta_data: {},
-    });
-    preconditions.canLoadFolders([]);
-    preconditions.canLoadAssets([localAsset]);
-    const [remoteAsset] = preconditions.canUpsertRemoteAssets([{
-      ...localAsset,
-      alt: 'Old alt',
-      meta_data: {},
-    }]);
-    preconditions.canFetchRemoteAssets([remoteAsset]);
-    preconditions.canDownloadAssets([remoteAsset]);
-    preconditions.canLoadAssetsManifest([{ old_id: localAsset.id, new_id: remoteAsset.id }]);
-
-    await assetsCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
-
-    expect(actions.updateAsset).toHaveBeenCalled();
   });
 
   it('should use sidecar json data when pushing a single local asset without --data', async () => {
@@ -1304,7 +1195,6 @@ describe('assets push command', () => {
     preconditions.canLoadAssets([asset]);
     const [remoteAsset] = preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
     preconditions.canFetchRemoteAssets([remoteAsset], { space: targetSpace });
-    preconditions.canDownloadAssets([remoteAsset]);
 
     await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
     await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
@@ -1479,7 +1369,6 @@ describe('assets push command', () => {
     });
     preconditions.canLoadComponents([pageComponent]);
     const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset]);
-    preconditions.canDownloadAssets([remoteAsset]);
     preconditions.canFetchRemoteAssets([remoteAsset]);
     preconditions.canFetchRemoteStoryPages([]);
 

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -16,7 +16,6 @@ import {
   makeCleanupAssetFSTransport,
   makeCreateAssetAPITransport,
   makeCreateAssetFolderAPITransport,
-  makeDownloadAssetFileTransport,
   makeGetAssetAPITransport,
   makeGetAssetFolderAPITransport,
   makeUpdateAssetAPITransport,
@@ -40,7 +39,6 @@ const pushCmd = assetsCommand
   .option('--folder <folderId>', 'destination asset folder ID')
   .option('--cleanup', 'delete local assets and metadata after a successful push (note: does not cleanup manifests)')
   .option('--update-stories', 'update file references in stories if necessary', false)
-  .option('--asset-token <token>', 'asset token for accessing private assets')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
   .description(`Push local assets to a Storyblok space.`);
 
@@ -60,7 +58,6 @@ pushCmd
 
     const { space: targetSpace, path: basePath, verbose } = command.optsWithGlobals();
     const fromSpace = (options.from as string | undefined) || targetSpace;
-    const assetToken = options.assetToken as string | undefined;
     const { state } = session();
 
     if (!requireAuthentication(state, verbose)) {
@@ -72,8 +69,6 @@ pushCmd
       process.exitCode = 2;
       return;
     }
-
-    const { region } = state;
 
     const summaries: [string, Report['summary'][string]][] = [];
     let fatalError = false;
@@ -152,10 +147,6 @@ pushCmd
       const updateAssetTransport = options.dryRun
         ? async () => {}
         : makeUpdateAssetAPITransport({ spaceId: targetSpace });
-      const downloadAssetFileTransport = makeDownloadAssetFileTransport({
-        assetToken,
-        region,
-      });
       const assetManifestTransport = options.dryRun
         ? () => Promise.resolve()
         : makeAppendAssetManifestFSTransport({ manifestFile });
@@ -173,7 +164,6 @@ pushCmd
           getAsset: getAssetTransport,
           createAsset: createAssetTransport,
           updateAsset: updateAssetTransport,
-          downloadAssetFile: downloadAssetFileTransport,
           appendAssetManifest: assetManifestTransport,
           cleanupAsset: cleanupAssetTransport,
         },
@@ -221,13 +211,12 @@ pushCmd
       logger.info('Pushing assets finished', { summary });
       const assetsTotal = summary.assetResults?.total ?? 0;
       const assetsSucceeded = summary.assetResults?.succeeded ?? 0;
-      const assetsSkipped = summary.assetResults?.skipped ?? 0;
       const assetsFailed = summary.assetResults?.failed ?? 0;
 
       ui.info(`Push results: ${assetsTotal} processed, ${assetsFailed} assets failed`);
       ui.list([
         `Folders: ${summary.assetFolderResults?.succeeded ?? 0}/${summary.assetFolderResults?.total ?? 0} succeeded, ${summary.assetFolderResults?.failed ?? 0} failed.`,
-        `Assets: ${assetsSucceeded}/${assetsTotal} succeeded, ${assetsSkipped} skipped, ${assetsFailed} failed.`,
+        `Assets: ${assetsSucceeded}/${assetsTotal} succeeded, ${assetsFailed} failed.`,
       ]);
       for (const [name, reportSummary] of summaries) {
         reporter.addSummary(name, reportSummary);

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -7,7 +7,7 @@ import { appendToFile, fileExists, saveToFile } from '../../utils/filesystem';
 import { toError } from '../../utils/error/error';
 import type { RegionCode } from '../../constants';
 import { SUPPORTED_ASSET_EXTENSIONS } from '../../constants';
-import { createAsset, createAssetFolder, downloadAssetFile, downloadFile, fetchAssetFolders, fetchAssets, sha256, updateAsset, updateAssetFolder } from './actions';
+import { createAsset, createAssetFolder, downloadAssetFile, downloadFile, fetchAssetFolders, fetchAssets, updateAsset, updateAssetFolder } from './actions';
 import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolderUpdate, AssetListQuery, AssetMap, AssetUpdate, AssetUpload } from './types';
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
@@ -611,41 +611,6 @@ const hasShortFilename = (a: unknown): a is { short_filename: string } => {
   return !!a && typeof a === 'object' && 'short_filename' in a && typeof (a as any).short_filename === 'string';
 };
 
-/**
- * Compares data (metadata and folder id) between local and remote assets.
- * Returns true if the data is identical (no update needed).
- *
- * Iterates over every key in the update payload so that newly added
- * AssetUpdate fields are automatically covered without manual changes.
- */
-const isDataUnchanged = (localAsset: AssetUpdate, remoteAsset: Asset): boolean => {
-  for (const key of Object.keys(localAsset) as Array<keyof AssetUpdate>) {
-    const local = localAsset[key];
-    const remote = remoteAsset[key as keyof Asset];
-
-    if (typeof local === 'object' || typeof remote === 'object') {
-      if (JSON.stringify(local) !== JSON.stringify(remote)) {
-        return false;
-      }
-    }
-    else if (local !== remote) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
-export type DownloadAssetFileTransport = (asset: { filename: string; is_private?: boolean }) => Promise<ArrayBuffer>;
-
-export const makeDownloadAssetFileTransport = ({
-  assetToken,
-  region,
-}: {
-  assetToken?: string;
-  region?: RegionCode;
-}): DownloadAssetFileTransport => asset => downloadAssetFile(asset, { assetToken, region });
-
 const processAsset = async ({
   localAsset,
   fileBuffer,
@@ -662,12 +627,11 @@ const processAsset = async ({
     getAsset: GetAssetTransport;
     createAsset: CreateAssetTransport;
     updateAsset: UpdateAssetTransport;
-    downloadAssetFile: DownloadAssetFileTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
   };
   maps: { assets: AssetMap; assetFolders: AssetFolderMap };
-}): Promise<{ status: 'skipped' | 'created' | 'updated'; remoteAsset: Asset }> => {
+}): Promise<{ status: 'created' | 'updated'; remoteAsset: Asset }> => {
   const remoteFolderId = localAsset.asset_folder_id
     && (maps.assetFolders.get(localAsset.asset_folder_id) || localAsset.asset_folder_id);
   const remoteAssetId = hasId(localAsset)
@@ -676,9 +640,9 @@ const processAsset = async ({
   const remoteAsset = remoteAssetId ? await transports.getAsset(remoteAssetId) : null;
 
   let newRemoteAsset: Asset;
-  let status: 'skipped' | 'created' | 'updated';
+  let status: 'created' | 'updated';
   if (remoteAsset) {
-    // Build only the writable metadata fields for comparison and API update.
+    // Build only the writable metadata fields for the API update.
     // Read-only fields (filename, short_filename, etc.) are intentionally excluded.
     const updatePayload: AssetUpdate = {
       asset_folder_id: remoteFolderId,
@@ -694,26 +658,16 @@ const processAsset = async ({
       meta_data: 'meta_data' in localAsset ? localAsset.meta_data : remoteAsset.meta_data,
     };
 
-    const remoteFileBuffer = await transports.downloadAssetFile(remoteAsset);
-    const isFileUnchanged = sha256(fileBuffer) === sha256(remoteFileBuffer);
-
-    if (isFileUnchanged && isDataUnchanged(updatePayload, remoteAsset)) {
-      newRemoteAsset = remoteAsset;
-      status = 'skipped';
-    }
-    else {
-      // Pass fileBuffer when the file changed so mapi-client performs the
-      // full replace flow (sign → S3 upload → finalize) before updating metadata.
-      // short_filename is required alongside fileBuffer for the sign request.
-      await transports.updateAsset(
-        remoteAsset.id,
-        { ...updatePayload, short_filename: remoteAsset.short_filename },
-        isFileUnchanged ? undefined : fileBuffer,
-      );
-      // updateAsset returns void; the remote asset's readonly fields are unchanged.
-      newRemoteAsset = { ...remoteAsset, ...updatePayload };
-      status = 'updated';
-    }
+    // Always perform the full replace flow (sign → S3 upload → finalize)
+    // and update metadata. No change detection — see ADR-0003.
+    await transports.updateAsset(
+      remoteAsset.id,
+      { ...updatePayload, short_filename: remoteAsset.short_filename },
+      fileBuffer,
+    );
+    // updateAsset returns void; the remote asset's readonly fields are unchanged.
+    newRemoteAsset = { ...remoteAsset, ...updatePayload };
+    status = 'updated';
   }
   else if (hasShortFilename(localAsset)) {
     const createPayload = {
@@ -744,21 +698,18 @@ export const upsertAssetStream = ({
   maps,
   onIncrement,
   onAssetSuccess,
-  onAssetSkipped,
   onAssetError,
 }: {
   transports: {
     getAsset: GetAssetTransport;
     createAsset: CreateAssetTransport;
     updateAsset: UpdateAssetTransport;
-    downloadAssetFile: DownloadAssetFileTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
   };
   maps: { assets: AssetMap; assetFolders: AssetFolderMap };
   onIncrement?: () => void;
   onAssetSuccess?: (localAsset: Asset | AssetUpload, remoteAsset: Asset) => void;
-  onAssetSkipped?: (localAsset: Asset | AssetUpload, remoteAsset: Asset) => void;
   onAssetError?: (error: Error, asset: Asset | AssetUpload) => void;
 }) => {
   const processing = new Set<Promise<void>>();
@@ -769,7 +720,7 @@ export const upsertAssetStream = ({
       await apiConcurrencyLock.acquire();
       const task = (async () => {
         try {
-          const { status, remoteAsset } = await processAsset({
+          const { remoteAsset } = await processAsset({
             localAsset,
             fileBuffer: context.fileBuffer,
             assetBinaryPath: context.assetBinaryPath,
@@ -778,12 +729,7 @@ export const upsertAssetStream = ({
             maps,
           });
 
-          if (status === 'skipped') {
-            onAssetSkipped?.(localAsset, remoteAsset);
-          }
-          else {
-            onAssetSuccess?.(localAsset, remoteAsset);
-          }
+          onAssetSuccess?.(localAsset, remoteAsset);
         }
         catch (maybeError) {
           onAssetError?.(toError(maybeError), localAsset);


### PR DESCRIPTION
## Summary

- Remove SHA-256 hash comparison and remote binary download from `assets push` — always upload unconditionally
- Remove `--asset-token` option from push (was only needed to download private assets for comparison)
- Remove skipped-asset tracking and reporting (assets are never skipped)
- Add ADR-0003 documenting the decision and alternatives considered

## Context

`assets push` previously downloaded the full remote binary for every asset to SHA-256-compare it against the local file. For a 5 MB asset this meant downloading 5 MB just to decide whether to upload 5 MB. Investigation confirmed that re-uploading preserves the asset URL, so there is no orphan-URL risk.

## Test plan

- [x] All 34 existing push tests pass (3 removed, 3 simplified, rest updated for removed `skipped` state)
- [x] Type checking passes (`pnpm test:types`)
- [x] Lint passes (`pnpm lint:fix`)
- [ ] Manual: push a single asset and verify it uploads without downloading the remote binary
- [ ] Manual: push an asset that already exists remotely and verify it gets re-uploaded

Fixes WDX-300