### PR TITLE
fix(cli): make --path a global option and fix path resolution

### DIFF
--- a/packages/cli/src/commands/assets/pull/index.ts
+++ b/packages/cli/src/commands/assets/pull/index.ts
@@ -22,7 +22,6 @@ import {
 const pullCmd = assetsCommand
   .command('pull')
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
   .option('-q, --query <query>', 'Filter assets using Storyblok filter query syntax. Example: --query="search=my-file.jpg&with_tags=tag1,tag2"')
   .option('--asset-token <token>', 'Asset token for accessing private assets')

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -17,6 +17,7 @@ import { getAssetBinaryFilename, getAssetFilename, getFolderFilename } from '../
 import * as actions from '../actions';
 import * as storyActions from '../../stories/actions';
 import { normalizeAssetUrl } from '@storyblok/management-api-client';
+import { getProgram } from '../../../program';
 import {
   DEFAULT_SPACE,
   getID,
@@ -401,6 +402,7 @@ describe('assets push command', () => {
     vol.reset();
     server.resetHandlers();
     resetReporter();
+    getProgram().setOptionValueWithSource('path', undefined, 'default');
     process.exitCode = undefined;
   });
   afterAll(() => server.close());
@@ -741,7 +743,9 @@ describe('assets push command', () => {
     const folderMap = new Map<number, number>([[folder.id, remoteFolder.id]]);
     const [remoteAsset] = preconditions.canUpsertRemoteAssets([asset], { folderMap });
 
-    await assetsCommand.parseAsync(['node', 'test', 'push', '--path', customPath, '--space', DEFAULT_SPACE]);
+    const program = getProgram();
+    program.setOptionValueWithSource('path', customPath, 'cli');
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
 
     expect(actions.createAssetFolder).toHaveBeenCalled();
     expect(actions.createAsset).toHaveBeenCalled();

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -33,7 +33,6 @@ const pushCmd = assetsCommand
   .command('push')
   .argument('[asset]', 'path or URL of a single asset to push')
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage')
   .option('-f, --from <from>', 'source space id')
   .option('--data <data>', 'inline asset data as JSON')
   .option('--short-filename <short-filename>', 'override the asset filename')

--- a/packages/cli/src/commands/components/pull/index.test.ts
+++ b/packages/cli/src/commands/components/pull/index.test.ts
@@ -9,6 +9,7 @@ import '../index';
 import { componentsCommand } from '../command';
 import { loggedOutSessionState } from '../../../../test/setup';
 import { getUI } from '../../../utils/ui';
+import { getProgram } from '../../../program';
 
 vi.mock('./actions', () => ({
   fetchComponents: vi.fn(),
@@ -41,6 +42,7 @@ describe('pull', () => {
     vi.spyOn(ui, 'br');
     vi.spyOn(ui, 'title');
     // Reset the option values
+    getProgram().setOptionValueWithSource('path', undefined, 'default');
     (componentsCommand as any)._optionValues = {};
     (componentsCommand as any)._optionValueSources = {};
     for (const command of componentsCommand.commands) {
@@ -160,7 +162,9 @@ describe('pull', () => {
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
 
-      await componentsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345', '--path', '/path/to/components']);
+      const program = getProgram();
+      program.setOptionValueWithSource('path', '/path/to/components', 'cli');
+      await componentsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
       expect(fetchComponents).toHaveBeenCalledWith('12345');
       expect(saveComponentsToFiles).toHaveBeenCalledWith('12345', {
         components: mockResponse,

--- a/packages/cli/src/commands/components/pull/index.ts
+++ b/packages/cli/src/commands/components/pull/index.ts
@@ -19,7 +19,6 @@ const pullCmd = componentsCommand
   .option('--sf, --separate-files', 'Argument to create a single file for each component')
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. components.<suffix>.json)')
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage')
   .description(`Download your space's components schema as json. Optionally specify a component name to pull a single component.`);
 
 pullCmd

--- a/packages/cli/src/commands/components/push/index.ts
+++ b/packages/cli/src/commands/components/push/index.ts
@@ -22,8 +22,7 @@ const pushCmd = componentsCommand
   .option('--fi, --filter <filter>', 'glob filter to apply to the components before pushing')
   .option('--sf, --separate-files', 'Read from separate files instead of consolidated files', false)
   .option('--su, --suffix <suffix>', 'Suffix to add to the component name')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 pushCmd
   .action(async (componentName: string | undefined, options: PushComponentsOptions, command: Command) => {

--- a/packages/cli/src/commands/datasources/delete/index.ts
+++ b/packages/cli/src/commands/datasources/delete/index.ts
@@ -17,8 +17,7 @@ const deleteCmd = datasourcesCommand
   .description('Delete a datasource from your space by name or id')
   .option('--id <id>', 'Delete by datasource id instead of name')
   .option('--force', 'Skip confirmation prompt for deletion (useful for CI)')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 deleteCmd
   .action(async (name: string, options: DeleteDatasourceOptions, command: Command) => {

--- a/packages/cli/src/commands/datasources/pull/index.ts
+++ b/packages/cli/src/commands/datasources/pull/index.ts
@@ -19,7 +19,6 @@ const pullCmd = datasourcesCommand
   .option('--sf, --separate-files', 'Argument to create a single file for each datasource')
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. datasources.<suffix>.json)')
   .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage')
   .description('Pull datasources from your space');
 
 pullCmd

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -18,8 +18,7 @@ const pushCmd = datasourcesCommand
   .option('--fi, --filter <filter>', 'glob filter to apply to the datasources before pushing')
   .option('--sf, --separate-files', 'Read from separate files instead of consolidated files')
   .option('--su, --suffix <suffix>', 'Suffix to add to the datasource name')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 pushCmd
   .action(async (datasourceName: string | undefined, options: PushDatasourcesOptions, command: Command) => {

--- a/packages/cli/src/commands/languages/index.test.ts
+++ b/packages/cli/src/commands/languages/index.test.ts
@@ -8,11 +8,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { loggedOutSessionState } from '../../../test/setup';
 import { join, relative } from 'pathe';
 import { resolveCommandPath } from '../../utils/filesystem';
+import { getProgram } from '../../program';
 
 vi.mock('./actions', () => ({
   fetchLanguages: vi.fn(),
   saveLanguagesToFile: vi.fn(),
 }));
+
+beforeEach(() => {
+  getProgram().setOptionValueWithSource('path', undefined, 'default');
+});
 
 vi.mock('../../creds', () => ({
   getCredentials: vi.fn(),
@@ -118,7 +123,9 @@ describe('languagesCommand', () => {
         };
 
         vi.mocked(fetchLanguages).mockResolvedValue(mockResponse);
-        await languagesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345', '--path', '/tmp']);
+        const program = getProgram();
+        program.setOptionValueWithSource('path', '/tmp', 'cli');
+        await languagesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
         expect(fetchLanguages).toHaveBeenCalledWith('12345');
         expect(saveLanguagesToFile).toHaveBeenCalledWith('12345', mockResponse, expect.objectContaining({
           path: '/tmp',

--- a/packages/cli/src/commands/languages/index.ts
+++ b/packages/cli/src/commands/languages/index.ts
@@ -22,8 +22,7 @@ const pullCmd = languagesCommand
   .description(`Download your space's languages schema as json`)
   .option('-f, --filename <filename>', 'filename to save the file as <filename>.<suffix>.json')
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. languages.<suffix>.json). By default, the space ID is used.')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 pullCmd
   .action(async (options: PullLanguagesOptions, command: Command) => {

--- a/packages/cli/src/commands/logs/list/index.ts
+++ b/packages/cli/src/commands/logs/list/index.ts
@@ -7,8 +7,7 @@ import { directories } from '../../../constants';
 
 const listCmd = logsCommand.command('list')
   .description('List logs')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 listCmd
   .action(async (_options: unknown, command: Command) => {

--- a/packages/cli/src/commands/logs/prune/index.ts
+++ b/packages/cli/src/commands/logs/prune/index.ts
@@ -8,8 +8,7 @@ import { directories } from '../../../constants';
 const pruneCmd = logsCommand.command('prune')
   .description('Prune logs')
   .option('--keep <number>', 'Max number of log files to keep (default `0`, meaning remove all)', Number.parseInt, 0)
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 pruneCmd
   .action(async (options: { keep: number }, command: Command) => {

--- a/packages/cli/src/commands/migrations/generate/actions.test.ts
+++ b/packages/cli/src/commands/migrations/generate/actions.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateMigration } from './actions';
 import { resolvePath, saveToFile } from '../../../utils/filesystem';
-import { join, resolve } from 'pathe';
+import { join } from 'pathe';
 import { handleFileSystemError } from '../../../utils';
 import type { Component } from '../../components';
 
@@ -80,18 +80,15 @@ describe('generateMigration', () => {
   it('should use custom path when provided', async () => {
     // Arrange
     const customPath = '/custom/path';
-    const expectedPath = resolve(process.cwd(), customPath, 'migrations', mockSpace);
+    const expectedPath = join(process.cwd(), '.storyblok', `migrations/${mockSpace}`);
     const expectedFilePath = join(expectedPath, `${mockComponent.name}.js`);
 
     // Act
     await generateMigration(mockSpace, customPath, mockComponent);
 
     // Assert
-    expect(saveToFile).toHaveBeenCalledTimes(1);
-    expect(saveToFile).toHaveBeenCalledWith(
-      expectedFilePath,
-      expect.any(String),
-    );
+    expect(resolvePath).toHaveBeenCalledWith(customPath, `migrations/${mockSpace}`);
+    expect(saveToFile).toHaveBeenCalledWith(expectedFilePath, expect.any(String));
   });
 
   it('should handle filesystem errors properly', async () => {

--- a/packages/cli/src/commands/migrations/generate/actions.ts
+++ b/packages/cli/src/commands/migrations/generate/actions.ts
@@ -1,6 +1,6 @@
 import { resolvePath, saveToFile } from '../../../utils/filesystem';
 import type { Component } from '../../components/constants';
-import { join, resolve } from 'pathe';
+import { join } from 'pathe';
 import { handleFileSystemError } from '../../../utils';
 
 const getMigrationTemplate = () => {
@@ -20,9 +20,7 @@ const getMigrationTemplate = () => {
 };
 
 export const generateMigration = async (space: string, path: string | undefined, component: Component, suffix?: string) => {
-  const resolvedPath = path
-    ? resolve(process.cwd(), path, 'migrations', space)
-    : resolvePath(path, `migrations/${space}`);
+  const resolvedPath = resolvePath(path, `migrations/${space}`);
 
   const fileName = suffix ? `${component.name}.${suffix}.js` : `${component.name}.js`;
   const migrationPath = join(resolvedPath, fileName);

--- a/packages/cli/src/commands/migrations/generate/index.test.ts
+++ b/packages/cli/src/commands/migrations/generate/index.test.ts
@@ -6,6 +6,7 @@ import '../index';
 import { migrationsCommand } from '../command';
 import { fetchComponent } from '../../../commands/components';
 import { getLogFileContents } from '../../__tests__/helpers';
+import { getProgram } from '../../../program';
 
 vi.mock('../../../commands/components', () => ({
   fetchComponent: vi.fn(),
@@ -49,6 +50,7 @@ describe('migrations generate command', () => {
     vi.resetAllMocks();
     vi.clearAllMocks();
     vol.reset();
+    getProgram().setOptionValueWithSource('path', undefined, 'default');
   });
 
   it('should generate a migration using default path', async () => {
@@ -68,7 +70,10 @@ describe('migrations generate command', () => {
   it('should generate a migration using custom path', async () => {
     preconditions.componentExists();
 
-    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--space', '12345', '--path', 'custom']);
+    const program = getProgram();
+    program.setOptionValueWithSource('path', 'custom', 'cli');
+
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--space', '12345']);
 
     expect(generateMigration).toHaveBeenCalledWith('12345', 'custom', expect.objectContaining({ name: 'component-name' }), undefined);
     const logFile = getLogFileContents(LOG_PREFIX);

--- a/packages/cli/src/commands/migrations/generate/index.ts
+++ b/packages/cli/src/commands/migrations/generate/index.ts
@@ -15,8 +15,7 @@ const generateCmd = migrationsCommand
   .command('generate [componentName]')
   .description('Generate a migration file')
   .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. {component-name}.<suffix>.js)')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 generateCmd
   .action(async (componentName: string | undefined, options: MigrationsGenerateOptions, command: Command) => {

--- a/packages/cli/src/commands/migrations/rollback/index.test.ts
+++ b/packages/cli/src/commands/migrations/rollback/index.test.ts
@@ -10,6 +10,7 @@ import type { StoryContent } from '../../stories/constants';
 import { getLogFileContents } from '../../__tests__/helpers';
 import { session } from '../../../session';
 import { loggedOutSessionState } from '../../../../test/setup';
+import { getProgram } from '../../../program';
 
 vi.mock('./actions', () => ({
   readRollbackFile: vi.fn(),
@@ -73,6 +74,7 @@ describe('migrations rollback command', () => {
     vi.resetAllMocks();
     vi.clearAllMocks();
     vol.reset();
+    getProgram().setOptionValueWithSource('path', undefined, 'default');
   });
 
   it('should rollback a migration successfully', async () => {
@@ -210,6 +212,9 @@ describe('migrations rollback command', () => {
   it('should handle custom path option', async () => {
     preconditions.canRollback();
 
+    const program = getProgram();
+    program.setOptionValueWithSource('path', '/custom/path', 'cli');
+
     await migrationsCommand.parseAsync([
       'node',
       'test',
@@ -217,8 +222,6 @@ describe('migrations rollback command', () => {
       'test-migration',
       '--space',
       '12345',
-      '--path',
-      '/custom/path',
     ]);
 
     expect(readRollbackFile).toHaveBeenCalledWith({

--- a/packages/cli/src/commands/migrations/rollback/index.ts
+++ b/packages/cli/src/commands/migrations/rollback/index.ts
@@ -12,8 +12,7 @@ import chalk from 'chalk';
 
 const rollbackCmd = migrationsCommand.command('rollback [migrationFile]')
   .description('Rollback a migration')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 rollbackCmd
   .action(async (migrationFile: string, _options: unknown, command: Command) => {

--- a/packages/cli/src/commands/migrations/run/index.ts
+++ b/packages/cli/src/commands/migrations/run/index.ts
@@ -20,8 +20,7 @@ const runCmd = migrationsCommand.command('run [componentName]')
   .option('-q, --query <query>', 'Filter stories by content attributes using Storyblok filter query syntax. Example: --query="[highlighted][in]=true"')
   .option('--starts-with <path>', 'Filter stories by path. Example: --starts-with="/en/blog/"')
   .option('--publish <publish>', 'Options for publication mode: all | published | published-with-changes')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 runCmd
   .action(async (componentName: string | undefined, options: MigrationsRunOptions, command: Command) => {

--- a/packages/cli/src/commands/reports/list/index.ts
+++ b/packages/cli/src/commands/reports/list/index.ts
@@ -7,8 +7,7 @@ import { reportsCommand } from '../command';
 
 const listCmd = reportsCommand.command('list')
   .description('List reports')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 listCmd
   .action(async (_options: unknown, command: Command) => {

--- a/packages/cli/src/commands/reports/prune/index.ts
+++ b/packages/cli/src/commands/reports/prune/index.ts
@@ -8,8 +8,7 @@ import { directories } from '../../../constants';
 const pruneCmd = reportsCommand.command('prune')
   .description('Prune reports')
   .option('--keep <number>', 'Max number of report files to keep (default `0`, meaning remove all)', Number.parseInt, 0)
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 pruneCmd
   .action(async (options: { keep: number }, command: Command) => {

--- a/packages/cli/src/commands/stories/pull/index.ts
+++ b/packages/cli/src/commands/stories/pull/index.ts
@@ -16,7 +16,6 @@ const pullCmd = storiesCommand
   .command('pull')
   .option('-s, --space <space>', 'space ID')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
-  .option('-p, --path <path>', 'base path to store stories (default .storyblok)')
   .option('-q, --query <query>', 'Filter stories by content attributes using Storyblok filter query syntax. Example: --query="[highlighted][in]=true"')
   .option('--starts-with <path>', 'Filter stories by path. Example: --starts-with="/en/blog/"')
   .description(`Download your space's stories as separate json files.`);

--- a/packages/cli/src/commands/stories/push/index.test.ts
+++ b/packages/cli/src/commands/stories/push/index.test.ts
@@ -12,6 +12,7 @@ import { directories } from '../../../constants';
 import { loadManifest, resolveCommandPath } from '../../../utils/filesystem';
 import * as actions from '../actions';
 import { resetReporter } from '../../../lib/reporter/reporter';
+import { getProgram } from '../../../program';
 import {
   DEFAULT_SPACE,
   getID,
@@ -158,6 +159,7 @@ describe('stories push command', () => {
     vi.clearAllMocks();
     vol.reset();
     server.resetHandlers();
+    getProgram().setOptionValueWithSource('path', undefined, 'default');
     resetReporter();
   });
   afterAll(() => server.close());
@@ -1010,7 +1012,9 @@ describe('stories push command', () => {
       const remoteStories = preconditions.canCreateStories([storyA]);
       preconditions.canUpdateStories(remoteStories);
 
-      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE, '--path', customPath]);
+      const program = getProgram();
+      program.setOptionValueWithSource('path', customPath, 'cli');
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
 
       const [remoteStory] = remoteStories;
       expect(actions.updateStory).toHaveBeenCalledWith(DEFAULT_SPACE, remoteStory.id, expect.anything());

--- a/packages/cli/src/commands/stories/push/index.ts
+++ b/packages/cli/src/commands/stories/push/index.ts
@@ -19,7 +19,6 @@ const pushCmd = storiesCommand
   .command('push')
   .option('-s, --space <space>', 'space ID')
   .option('-f, --from <from>', 'source space id')
-  .option('-p, --path <path>', 'base path for stories and components (default .storyblok)')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
   .option('--publish', 'Publish stories after pushing')
   .option('--cleanup', 'delete local stories after a successful push (note: does not cleanup manifests)')

--- a/packages/cli/src/commands/types/generate/index.ts
+++ b/packages/cli/src/commands/types/generate/index.ts
@@ -23,8 +23,7 @@ const generateCmd = typesCommand
   .option('--suffix <suffix>', 'Components suffix')
   .option('--custom-fields-parser <path>', 'Path to the parser file for Custom Field Types')
   .option('--compiler-options <options>', 'path to the compiler options from json-schema-to-typescript')
-  .option('-s, --space <space>', 'space ID')
-  .option('-p, --path <path>', 'path for file storage');
+  .option('-s, --space <space>', 'space ID');
 
 generateCmd
   .action(async (options: GenerateTypesOptions, command: Command) => {

--- a/packages/cli/src/lib/config/commander.ts
+++ b/packages/cli/src/lib/config/commander.ts
@@ -47,6 +47,9 @@ export function applyCliOverrides(commandChain: CommanderCommand[], globalResolv
       const value = command.getOptionValue(attrName);
       if (isRoot) {
         setValueAtPath(globalResolved, getOptionPath(option), value);
+        // Global CLI overrides must also win over module-level config that may have
+        // set the same key in localResolved (e.g. --path overriding modules.*.path).
+        delete localResolved[attrName];
       }
       else {
         localResolved[attrName] = value;

--- a/packages/cli/src/lib/config/index.test.ts
+++ b/packages/cli/src/lib/config/index.test.ts
@@ -44,14 +44,12 @@ function createCommandHierarchy(): CommandHierarchy {
     .option('--separate-files', 'Separate output per component', false)
     .option('--filename <filename>', 'Filename used for exports', 'components')
     .option('--suffix <suffix>', 'Optional filename suffix')
-    .option('-s, --space <space>', 'space ID')
-    .option('-p, --path <path>', 'path for file storage');
+    .option('-s, --space <space>', 'space ID');
 
   const push = components
     .command('push')
     .option('--dry-run', 'Preview component push', false)
-    .option('-s, --space <space>', 'space ID')
-    .option('-p, --path <path>', 'path for file storage');
+    .option('-s, --space <space>', 'space ID');
 
   return { root, components, pull, push };
 }
@@ -125,6 +123,24 @@ describe('config resolver', () => {
     expect(resolved.dryRun).toBe(true);
   });
 
+  it('module-level path overrides global path from config', async () => {
+    loadConfigLayersSpy.mockResolvedValue([
+      {
+        path: 'global-path',
+        modules: {
+          components: {
+            path: 'module-path',
+          },
+        },
+      },
+    ]);
+
+    const { root, components, pull } = createCommandHierarchy();
+    const resolved = await resolveConfig(pull, [root, components, pull]);
+
+    expect(resolved.path).toBe('module-path');
+  });
+
   it('prefers specific config layers but leaves CLI overrides as the final word', async () => {
     loadConfigLayersSpy.mockResolvedValue([
       {
@@ -149,7 +165,7 @@ describe('config resolver', () => {
 
     const { root, components, pull } = createCommandHierarchy();
     root.setOptionValueWithSource('region', 'cn', 'cli');
-    pull.setOptionValueWithSource('path', './from-cli', 'cli');
+    root.setOptionValueWithSource('path', './from-cli', 'cli');
     pull.setOptionValueWithSource('separateFiles', true, 'cli');
 
     const resolved = await resolveConfig(pull, [root, components, pull]);
@@ -201,13 +217,13 @@ describe('config resolver', () => {
 
     const defaultConfig = createDefaultResolvedConfig();
     expect(root.getOptionValue('region')).toBe(defaultConfig.region);
-    expect(pull.getOptionValue('path')).toBeUndefined();
+    expect(root.getOptionValue('path')).toBeUndefined();
     expect(pull.getOptionValue('suffix')).toBeUndefined();
 
     applyConfigToCommander(ancestry, resolved);
 
     expect(root.getOptionValue('region')).toBe('us');
-    expect(pull.getOptionValue('path')).toBe('.storyblok');
+    expect(root.getOptionValue('path')).toBe('.storyblok');
     expect(pull.getOptionValue('suffix')).toBe('resolved');
   });
 
@@ -454,8 +470,7 @@ describe('deeply nested command structures', () => {
     const pull = components
       .command('pull')
       .option('--filename <filename>', 'Filename', 'components')
-      .option('-s, --space <space>', 'space ID')
-      .option('-p, --path <path>', 'path for file storage');
+      .option('-s, --space <space>', 'space ID');
 
     const show = pull
       .command('show')

--- a/packages/cli/src/lib/config/options.ts
+++ b/packages/cli/src/lib/config/options.ts
@@ -11,6 +11,11 @@ export function parseNumber(value: string): number {
 
 export const GLOBAL_OPTION_DEFINITIONS: GlobalOptionDefinition[] = [
   {
+    flags: '-p, --path <path>',
+    description: 'Base directory for file storage (default: .storyblok)',
+    defaultValue: DEFAULT_GLOBAL_CONFIG.path,
+  },
+  {
     flags: '--verbose',
     description: 'Enable verbose output',
     defaultValue: DEFAULT_GLOBAL_CONFIG.verbose,

--- a/packages/cli/src/utils/filesystem.test.ts
+++ b/packages/cli/src/utils/filesystem.test.ts
@@ -156,6 +156,18 @@ describe('filesystem utils', async () => {
       const resolvedPathWithoutPath = resolvePath(undefined, folder);
       expect(resolvedPathWithoutPath).toBe(resolve(process.cwd(), '.storyblok', folder));
     });
+
+    it('should preserve dot-prefixed directory names', async () => {
+      const resolvedPath = resolvePath('.storyblok', 'migrations/12345');
+      expect(resolvedPath).toBe(resolve(process.cwd(), '.storyblok', 'migrations/12345'));
+    });
+
+    it('should not duplicate migrations when path does not include it', async () => {
+      const resolvedPath = resolvePath('.storyblok', 'migrations/12345');
+      const parts = resolvedPath.split('/');
+      const migrationsCount = parts.filter(p => p === 'migrations').length;
+      expect(migrationsCount).toBe(1);
+    });
   });
 
   describe('getComponentNameFromFilename', async () => {


### PR DESCRIPTION
## Summary

- Promote `--path` from a per-command option (duplicated across 18 commands) to a single global option, ensuring it consistently appears in CLI help
- Fix inconsistent path resolution in `migrations generate` that used raw `resolve()` instead of `resolvePath()`
- Improve `--path` description to clarify it is a base directory (not the full path)
- Ensure CLI `--path` overrides always take precedence over module-level config values

Fixes WDX-250
Fixes #414

## Test plan

- [x] All 625 CLI tests pass (`pnpm vitest run`)
- [x] Type checking passes (`pnpm test:types`)
- [x] Linting passes (`pnpm lint:fix`)
- [x] Manual: `storyblok migrations run --help` shows `--path` in global options
- [x] Manual: `storyblok migrations run <name> --space <id> --path .custom-dir` resolves path with dot preserved