### PR TITLE
fix(js): enable tree-shaking by externalizing dependencies

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -14,6 +14,7 @@
   "bugs": {
     "url": "https://github.com/storyblok/monoblok/issues"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/js/vite.config.ts
+++ b/packages/js/vite.config.ts
@@ -27,6 +27,15 @@ export default defineConfig({
         return format === 'es' ? `${name}.mjs` : `${name}.js`;
       },
     },
+    rollupOptions: {
+      external: ['@storyblok/richtext', 'storyblok-js-client'],
+      output: {
+        globals: {
+          '@storyblok/richtext': 'StoryblokRichtext',
+          'storyblok-js-client': 'StoryblokClient',
+        },
+      },
+    },
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

- Mark `@storyblok/richtext` and `storyblok-js-client` as external in the `@storyblok/js` Vite build config
- Add `"sideEffects": false` to `package.json` so bundlers can tree-shake unused exports
- Consumers who don't use richtext features drop from **~1 MB to ~32 KB** (Vite, minified)

## Context

`@storyblok/js` v5 bundles `@storyblok/richtext` (including 20+ tiptap extensions) and `storyblok-js-client` directly into its dist file, resulting in a 1.1 MB `storyblok-js.mjs`. This means even consumers who only use `storyblokInit` and `apiPlugin` pay the full cost — bundlers cannot tree-shake the unused richtext code because everything is pre-bundled into a single blob.

This partially addresses #471 (the richtext package itself is still large when used, but consumers who don't need it are no longer affected).

### Bundle size comparison (Vite, terser-minified)

| Scenario | Before | After |
|---|---|---|
| Full import (init + richtext + js-client) | 1,087 KB | 1,284 KB |
| **Partial import (init + apiPlugin only)** | **1,080 KB** | **32 KB (-97%)** |

## Test plan

- [x] `@storyblok/js` unit tests (19/19), type-check, lint — all pass
- [x] Export parity verified: all 16 exports present, types match main
- [x] Functional tests: `storyblokInit`, `apiPlugin`, `renderRichText`, `richTextResolver`, `storyblokEditable`, `useStoryblokBridge`, enums, `StoryblokClient` — all work
- [x] Downstream packages build and pass tests: vue (1/1), react (33/33), svelte (9/9), astro (67/67 unit + 4/4 e2e)
- [x] Vite bundle test confirms tree-shaking works end-to-end

Fixes WDX-310
Fixes #476