### PR TITLE
fix(cli): validate story content against local schemas before pushing

### DIFF
--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -4,6 +4,7 @@ import type { Story } from '../stories/constants';
 import type { UI } from '../../utils/ui';
 import type { WriteStoryTransport } from '../stories/streams';
 import { fetchStoriesStream, fetchStoryStream, mapReferencesStream, writeStoryStream } from '../stories/streams';
+import { validateStoryAgainstSchemas } from '../stories/validate-story';
 import type { Logger } from '../../lib/logger/logger';
 import type { Report } from '../../lib/reporter/reporter';
 import { logOnlyError } from '../../utils/error/error';
@@ -271,7 +272,8 @@ export const mapAssetReferencesInStoriesPipeline = async ({
       onIncrement() {
         processProgress.increment();
       },
-      onStorySuccess(localStory, _, missingSchemas) {
+      onStorySuccess(localStory) {
+        const { missingSchemas } = validateStoryAgainstSchemas(localStory, schemas);
         warnAboutMissingSchemas(missingSchemas, localStory);
         logger.info('Processed story', { storyId: localStory.uuid });
         summaries.storyProcessResults.succeeded += 1;

--- a/packages/cli/src/commands/stories/__tests__/helpers.ts
+++ b/packages/cli/src/commands/stories/__tests__/helpers.ts
@@ -35,7 +35,6 @@ export const makeMockStory = (overrides: Partial<MockStory> = {}): MockStory => 
     content: overrides.content ?? {
       _uid: randomUUID(),
       component: 'page',
-      references: [],
     },
     is_folder: overrides.is_folder ?? false,
     parent_id: overrides.parent_id ?? 0,

--- a/packages/cli/src/commands/stories/push/index.test.ts
+++ b/packages/cli/src/commands/stories/push/index.test.ts
@@ -962,7 +962,7 @@ describe('stories push command', () => {
     it('should not end up with duplicate entries in the manifest after multiple runs', async () => {
       const storyA = makeMockStory();
       preconditions.canLoadStories([storyA]);
-      preconditions.canLoadComponents([makeMockComponent()]);
+      preconditions.canLoadComponents([makeMockComponent({ name: 'page' })]);
       const remoteStories = preconditions.canCreateStories([storyA]);
       preconditions.canUpdateStories(remoteStories);
 
@@ -1217,17 +1217,376 @@ describe('stories push command', () => {
       expect(actions.updateStory).not.toHaveBeenCalled();
     });
 
-    it('should show a helpful warning when a component schema is missing', async () => {
+    it('should abort with a hard error when a story references a missing component schema', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: { _uid: randomUUID(), component: 'page' },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'article' }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      expect(actions.createStory).not.toHaveBeenCalled();
+      expect(actions.updateStory).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Missing component schemas:'),
+        expect.anything(),
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('- page (in stories: story-a)'),
+        expect.anything(),
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('run `storyblok components pull` to sync them locally'),
+        expect.anything(),
+      );
+      const report = getReport();
+      expect(report?.status).toBe('FAILURE');
+      const logFile = getLogFileContents(LOG_PREFIX);
+      expect(logFile).toContain('Schema validation failed');
+    });
+
+    it('should abort with a hard error when a story has a field not declared in the component schema', async () => {
       const storyA = makeMockStory({
         slug: 'story-a',
         content: {
+          _uid: randomUUID(),
           component: 'page',
+          color: {
+            _uid: randomUUID(),
+            plugin: 'official-colorpicker',
+            color: '#4c1130',
+          },
         },
       });
       preconditions.canLoadStories([storyA]);
       preconditions.canLoadComponents([
         makeMockComponent({
-          name: 'article',
+          name: 'page',
+          schema: { headline: { type: 'text' } },
+        }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      expect(actions.createStory).not.toHaveBeenCalled();
+      expect(actions.updateStory).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('- page.color (in stories: story-a)'),
+        expect.anything(),
+      );
+      const report = getReport();
+      expect(report?.status).toBe('FAILURE');
+    });
+
+    it('should report every drift field across multiple components in a single aggregated error', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          color: '#4c1130',
+          extra_page_field: 'x',
+        },
+      });
+      const storyB = makeMockStory({
+        slug: 'story-b',
+        content: {
+          _uid: randomUUID(),
+          component: 'article',
+          orphan: 'y',
+          leftover: 'z',
+        },
+      });
+      preconditions.canLoadStories([storyA, storyB]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'page', schema: {} }),
+        makeMockComponent({ name: 'article', schema: {} }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      expect(actions.createStory).not.toHaveBeenCalled();
+      expect(actions.updateStory).not.toHaveBeenCalled();
+      const errorCalls = (console.error as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      const message = errorCalls.map(call => call[0]).join('\n');
+      expect(message).toContain('- article.leftover (in stories: story-b)');
+      expect(message).toContain('- article.orphan (in stories: story-b)');
+      expect(message).toContain('- page.color (in stories: story-a)');
+      expect(message).toContain('- page.extra_page_field (in stories: story-a)');
+    });
+
+    it('should abort when a drift field lives inside a nested blok', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          body: [
+            {
+              _uid: randomUUID(),
+              component: 'hero',
+              title: 'Ok',
+              bg_color: '#ff0000',
+            },
+          ],
+        },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'page', schema: { body: { type: 'bloks' } } }),
+        makeMockComponent({ name: 'hero', schema: { title: { type: 'text' } } }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      expect(actions.createStory).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('- hero.bg_color (in stories: story-a)'),
+        expect.anything(),
+      );
+    });
+
+    it('should abort when a drift field lives inside a blok embedded in a richtext field', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          rt: {
+            type: 'doc',
+            content: [
+              {
+                type: 'blok',
+                attrs: {
+                  id: randomUUID(),
+                  body: [
+                    {
+                      _uid: randomUUID(),
+                      component: 'hero',
+                      title: 'Ok',
+                      undeclared: 42,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'page', schema: { rt: { type: 'richtext' } } }),
+        makeMockComponent({ name: 'hero', schema: { title: { type: 'text' } } }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      expect(actions.createStory).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('- hero.undeclared (in stories: story-a)'),
+        expect.anything(),
+      );
+    });
+
+    it('should report both missing schemas and drift fields together', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          stray: 'x',
+        },
+      });
+      const storyB = makeMockStory({
+        slug: 'story-b',
+        content: { _uid: randomUUID(), component: 'unknown_component' },
+      });
+      preconditions.canLoadStories([storyA, storyB]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'page', schema: {} }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      const errorCalls = (console.error as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      const message = errorCalls.map(call => call[0]).join('\n');
+      expect(message).toContain('Missing component schemas:');
+      expect(message).toContain('- unknown_component (in stories: story-b)');
+      expect(message).toContain('- page.stray (in stories: story-a)');
+    });
+
+    it('should validate before dry-run and abort on drift', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: { _uid: randomUUID(), component: 'page', stray: 1 },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'page', schema: {} }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE, '--dry-run']);
+
+      expect(actions.createStory).not.toHaveBeenCalled();
+      expect(actions.updateStory).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('- page.stray (in stories: story-a)'),
+        expect.anything(),
+      );
+    });
+
+    it('should not delete local stories when validation fails even if --cleanup is passed', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: { _uid: randomUUID(), component: 'page', stray: 1 },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'page', schema: {} }),
+      ]);
+      const storyFilePath = join(
+        resolveCommandPath(directories.stories, DEFAULT_SPACE),
+        `${storyA.slug}_${storyA.uuid}.json`,
+      );
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE, '--cleanup']);
+
+      const files = vol.toJSON();
+      const hasStoryFile = Object.keys(files).some(f => stripDriveLetter(f) === stripDriveLetter(storyFilePath));
+      expect(hasStoryFile).toBe(true);
+    });
+
+    it('should emit a FAILURE report with failed creation counts when validation fails', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: { _uid: randomUUID(), component: 'page', stray: 1 },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({ name: 'page', schema: {} }),
+      ]);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      const report = getReport();
+      expect(report?.status).toBe('FAILURE');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Creating stories: 0/1 succeeded, 1 failed.'),
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Processing stories: 0/0 succeeded, 0 failed.'),
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Updating stories: 0/0 succeeded, 0 failed.'),
+      );
+    });
+
+    it('should proceed with the push when every content field is declared in its schema', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          headline: 'Hi',
+          color: {
+            _uid: randomUUID(),
+            plugin: 'official-colorpicker',
+            color: '#4c1130',
+          },
+        },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({
+          name: 'page',
+          schema: {
+            headline: { type: 'text' },
+            color: { type: 'custom', field_type: 'official-colorpicker' },
+          },
+        }),
+      ]);
+      const remoteStories = preconditions.canCreateStories([storyA]);
+      preconditions.canUpdateStories(remoteStories);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      expect(actions.createStory).toHaveBeenCalled();
+      expect(console.error).not.toHaveBeenCalled();
+      const report = getReport();
+      expect(report?.status).toBe('SUCCESS');
+    });
+
+    it('should warn once per plugin name when story content carries a custom plugin payload', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          color: {
+            _uid: randomUUID(),
+            plugin: 'official-colorpicker',
+            color: '#4c1130',
+          },
+          secondary_color: {
+            _uid: randomUUID(),
+            plugin: 'official-colorpicker',
+            color: '#ffffff',
+          },
+        },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({
+          name: 'page',
+          schema: {
+            color: { type: 'custom', field_type: 'official-colorpicker' },
+            secondary_color: { type: 'custom', field_type: 'official-colorpicker' },
+          },
+        }),
+      ]);
+      const remoteStories = preconditions.canCreateStories([storyA]);
+      preconditions.canUpdateStories(remoteStories);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
+
+      const warnCalls = (console.warn as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(call => typeof call[0] === 'string' && call[0].includes('official-colorpicker'));
+      expect(warnCalls).toHaveLength(1);
+      const logFile = getLogFileContents(LOG_PREFIX);
+      expect(logFile).toContain('The custom plugin \\"official-colorpicker\\" may contain references that require manual updates.');
+    });
+
+    it('should warn about plugin content nested inside a bloks field', async () => {
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          body: [
+            {
+              _uid: randomUUID(),
+              component: 'hero',
+              bg_color: {
+                _uid: randomUUID(),
+                plugin: 'official-colorpicker',
+                color: '#aabbcc',
+              },
+            },
+          ],
+        },
+      });
+      preconditions.canLoadStories([storyA]);
+      preconditions.canLoadComponents([
+        makeMockComponent({
+          name: 'page',
+          schema: { body: { type: 'bloks' } },
+        }),
+        makeMockComponent({
+          name: 'hero',
+          schema: { bg_color: { type: 'custom', field_type: 'official-colorpicker' } },
         }),
       ]);
       const remoteStories = preconditions.canCreateStories([storyA]);
@@ -1236,49 +1595,7 @@ describe('stories push command', () => {
       await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
 
       expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('The component "page" was not found. Please run `storyblok components pull` to fetch the latest components.'),
-      );
-    });
-
-    it('should warn the user that references in custom plugin fields can\'t be processed', async () => {
-      const storyA = makeMockStory({
-        uuid: randomUUID(),
-        slug: 'story-a',
-        content: {
-          _uid: randomUUID(),
-          component: 'page',
-          plugin: {
-            type: 'custom',
-            field_type: 'my_custom_field',
-          },
-        },
-      });
-      preconditions.canLoadStories([storyA]);
-      preconditions.canListStories([storyA]);
-      const pageComponent = makeMockComponent({
-        name: 'page',
-        schema: {
-          plugin: {
-            type: 'custom',
-            field_type: 'my_custom_field',
-          },
-        },
-      });
-      preconditions.canLoadComponents([pageComponent]);
-      preconditions.canUpdateStories([storyA]);
-
-      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE]);
-
-      expect(actions.createStory).not.toHaveBeenCalled();
-      expect(actions.updateStory).toHaveBeenCalledWith(DEFAULT_SPACE, storyA.id, expect.objectContaining({
-        story: { ...storyA, parent_id: 0 },
-      }));
-      // Logging
-      const logFile = getLogFileContents(LOG_PREFIX);
-      expect(logFile).toMatch(new RegExp(`The custom plugin \\\\"my_custom_field\\\\" may contain references that require manual updates.*?"storyId":"${storyA.uuid}"`));
-      // UI
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('The custom plugin "my_custom_field" may contain references that require manual updates.'),
+        expect.stringContaining('The custom plugin "official-colorpicker" may contain references that require manual updates.'),
       );
     });
 

--- a/packages/cli/src/commands/stories/push/index.ts
+++ b/packages/cli/src/commands/stories/push/index.ts
@@ -1,6 +1,5 @@
 import { pipeline } from 'node:stream/promises';
 import { join } from 'pathe';
-import type { Component } from '../../components/constants';
 import type { Story } from '../constants';
 import { colorPalette, commands, directories } from '../../../constants';
 import { CommandError, handleError, requireAuthentication, toError } from '../../../utils';
@@ -14,6 +13,7 @@ import { createStoriesForLevel, groupStoriesByDepth, makeAppendToManifestFSTrans
 import { findComponentSchemas } from '../utils';
 import { loadAssetMap } from '../../assets/utils';
 import { prefetchTargetStories } from '../actions';
+import { collectSchemaIssues, formatSchemaIssues, hasSchemaIssues } from '../validate-story';
 
 const pushCmd = storiesCommand
   .command('push')
@@ -52,33 +52,6 @@ pushCmd
 
     const pendingWarnings: string[] = [];
 
-    const warnedPlugins = new Set<string>();
-    const warnAboutCustomPlugins = (fields: Set<Component['schema']>, story: Story) => {
-      for (const field of fields) {
-        if (field.type === 'custom' && typeof field.field_type === 'string') {
-          if (warnedPlugins.has(field.field_type)) {
-            continue;
-          }
-          warnedPlugins.add(field.field_type);
-          const message = `The custom plugin "${field.field_type}" may contain references that require manual updates.`;
-          pendingWarnings.push(message);
-          logger.warn(message, { storyId: story.uuid });
-        }
-      }
-    };
-    const missingSchemaWarnings = new Set<string>();
-    const warnAboutMissingSchemas = (missingSchemas: Set<Component['name']>, story: Story) => {
-      for (const schemaName of missingSchemas) {
-        if (missingSchemaWarnings.has(schemaName)) {
-          continue;
-        }
-        const message = `The component "${schemaName}" was not found. Please run \`storyblok components pull\` to fetch the latest components.`;
-        pendingWarnings.push(message);
-        logger.warn(message, { storyId: story.uuid });
-        missingSchemaWarnings.add(schemaName);
-      }
-    };
-
     const summary = {
       creationResults: { total: 0, succeeded: 0, skipped: 0, failed: 0 },
       processResults: { total: 0, succeeded: 0, failed: 0 },
@@ -101,14 +74,56 @@ pushCmd
         return;
       }
 
+      const storiesDirectoryPath = resolveCommandPath(directories.stories, fromSpace, basePath);
+
+      // Pre-flight schema validation. Aborts before any API call if a story's
+      // content references a missing component, or has fields that the local
+      // schema does not declare (schema drift).
+      const schemaIssues = await collectSchemaIssues({ directoryPath: storiesDirectoryPath, schemas });
+      if (hasSchemaIssues(schemaIssues)) {
+        const message = formatSchemaIssues(schemaIssues);
+        ui.error(message);
+        logger.error(message);
+        // Surface the failure in the run summary so the report status is
+        // FAILURE rather than a trivial zero-counts SUCCESS.
+        const total = Math.max(schemaIssues.total, 1);
+        summary.creationResults.total = total;
+        summary.creationResults.failed = total;
+        return;
+      }
+
+      // Warn when story content includes custom plugin payloads. References
+      // embedded inside a plugin's opaque JSON can't be auto-remapped, so the
+      // user may need to update them manually. Emitted once per plugin name
+      // per story during Pass 2, after schema validation has confirmed the
+      // content shape is trustworthy.
+      const warnAboutCustomPlugins = (story: Story) => {
+        const warned = new Set<string>();
+        const visit = (node: unknown): void => {
+          if (Array.isArray(node)) {
+            for (const item of node) { visit(item); }
+            return;
+          }
+          if (!node || typeof node !== 'object') { return; }
+          const obj = node as Record<string, unknown>;
+          const plugin = obj.plugin;
+          if (typeof plugin === 'string' && !warned.has(plugin)) {
+            warned.add(plugin);
+            const message = `The custom plugin "${plugin}" may contain references that require manual updates.`;
+            pendingWarnings.push(message);
+            logger.warn(message, { storyId: story.uuid });
+          }
+          for (const value of Object.values(obj)) { visit(value); }
+        };
+        visit(story.content);
+      };
+
       const fetchProgress = ui.createProgressBar({ title: 'Matching Stories...'.padEnd(21) });
       const existingTargetStories = await prefetchTargetStories(space, {
         onTotal: total => fetchProgress.setTotal(total),
         onIncrement: count => fetchProgress.increment(count),
       });
       fetchProgress.stop();
-
-      const storiesDirectoryPath = resolveCommandPath(directories.stories, fromSpace, basePath);
 
       /**
        * Pass 1: Scan local stories, group by depth, and create remote
@@ -236,9 +251,8 @@ pushCmd
           onIncrement() {
             processProgress.increment();
           },
-          onStorySuccess(localStory, processedFields, missingSchemas) {
-            warnAboutCustomPlugins(processedFields, localStory);
-            warnAboutMissingSchemas(missingSchemas, localStory);
+          onStorySuccess(localStory) {
+            warnAboutCustomPlugins(localStory);
             logger.info('Processed story', { storyId: localStory.uuid });
             summary.processResults.succeeded += 1;
           },

--- a/packages/cli/src/commands/stories/ref-mapper.test.ts
+++ b/packages/cli/src/commands/stories/ref-mapper.test.ts
@@ -25,7 +25,7 @@ describe('storyRefMapper', () => {
     const maps = { assets: new Map(), stories: storyMap };
 
     // @ts-expect-error Our types are wrong.
-    const { mappedStory } = storyRefMapper(story, { schemas: componentSchemas, maps });
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
 
     expect(mappedStory.id).toBe(storyMap.get(story.id));
     expect(mappedStory.uuid).toBe(storyMap.get(story.uuid));
@@ -68,7 +68,7 @@ describe('storyRefMapper', () => {
     const maps = { assets: assetMap, stories: storyMap };
 
     // @ts-expect-error Our types are wrong.
-    const { mappedStory } = storyRefMapper(story, { schemas: componentSchemas, maps });
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
 
     // Bloks > multilink
     expect(mappedStory.content.bloks[0].link.id).toBe(storyMap.get(story.content.bloks[0].link.id));
@@ -107,47 +107,9 @@ describe('storyRefMapper', () => {
     const maps = { assets: assetMap, stories: new Map() };
 
     // @ts-expect-error Our types are wrong.
-    const { mappedStory } = storyRefMapper(story, { schemas: componentSchemas, maps });
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
 
     expect(mappedStory.content.asset.filename).toBe(expectedCdnFilename);
-  });
-
-  it('should track all the components it processed', () => {
-    const story = makeStoryWithAllFieldTypes();
-    const maps = { assets: new Map(), stories: new Map() };
-
-    // @ts-expect-error Our types are wrong.
-    const { processedFields } = storyRefMapper(story, { schemas: componentSchemas, maps });
-
-    expect(Array.from(processedFields)).toEqual([
-      expect.objectContaining({ type: 'datetime' }),
-      expect.objectContaining({ type: 'multilink' }),
-      expect.objectContaining({ type: 'text' }),
-      expect.objectContaining({ type: 'asset' }),
-      expect.objectContaining({ type: 'table' }),
-      expect.objectContaining({ type: 'bloks' }),
-      expect.objectContaining({ type: 'number' }),
-      expect.objectContaining({ type: 'custom' }),
-      expect.objectContaining({ type: 'boolean' }),
-      expect.objectContaining({ type: 'markdown' }),
-      expect.objectContaining({ type: 'richtext' }),
-      expect.objectContaining({ type: 'textarea' }),
-      expect.objectContaining({ type: 'options' }),
-      expect.objectContaining({ type: 'multiasset' }),
-      expect.objectContaining({ type: 'options' }),
-      expect.objectContaining({ type: 'option' }),
-    ]);
-  });
-
-  it('should track missing component schemas', () => {
-    const story = makeStoryWithAllFieldTypes();
-    const maps = { assets: new Map(), stories: new Map() };
-    const schemasWithoutPage = {};
-
-    // @ts-expect-error Our types are wrong.
-    const { missingSchemas } = storyRefMapper(story, { schemas: schemasWithoutPage, maps });
-
-    expect(Array.from(missingSchemas)).toEqual(['page_with_everything']);
   });
 
   it('should handle null parent_id for root-level stories', () => {
@@ -163,7 +125,7 @@ describe('storyRefMapper', () => {
     const maps = { assets: new Map(), stories: new Map() };
 
     // @ts-expect-error Partial story for testing
-    const { mappedStory } = storyRefMapper(story, { schemas: componentSchemas, maps });
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
 
     expect(mappedStory.parent_id).toBe(0);
   });
@@ -181,7 +143,7 @@ describe('storyRefMapper', () => {
     const maps = { assets: new Map(), stories: new Map() };
 
     // @ts-expect-error Partial story for testing
-    const { mappedStory } = storyRefMapper(story, { schemas: componentSchemas, maps });
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
 
     expect(mappedStory.parent_id).toBe(0);
   });
@@ -198,7 +160,7 @@ describe('storyRefMapper', () => {
     const maps = { assets: new Map(), stories: new Map() };
 
     // @ts-expect-error Our types are wrong.
-    const { mappedStory } = storyRefMapper(story, { schemas: componentSchemas, maps });
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
 
     expect(mappedStory.content).toBeUndefined();
     expect(mappedStory.id).toBe(story.id);
@@ -218,10 +180,9 @@ describe('storyRefMapper', () => {
     const maps = { assets: new Map(), stories: new Map() };
 
     // @ts-expect-error Our types are wrong.
-    const { mappedStory, missingSchemas } = storyRefMapper(story, { schemas: componentSchemas, maps });
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
 
     expect(mappedStory.content).toEqual(story.content);
-    expect(Array.from(missingSchemas)).toEqual([]);
   });
 
   it('should handle richtext with missing attrs on link nodes', () => {

--- a/packages/cli/src/commands/stories/ref-mapper.ts
+++ b/packages/cli/src/commands/stories/ref-mapper.ts
@@ -9,16 +9,12 @@ export interface RefMaps {
 }
 
 export type ComponentSchemas = Record<Component['name'], Component['schema']>;
-type ProcessedFields = Set<Component['schema']>;
-type MissingSchemas = Set<Component['name']>;
 
 type RefMapper = <const T extends Record<string, unknown>>(data: T, options: {
   schema: Component['schema'];
   schemas: ComponentSchemas;
   maps: RefMaps;
   fieldRefMappers: FieldRefMappers;
-  processedFields: ProcessedFields;
-  missingSchemas: MissingSchemas;
 }) => T;
 
 type FieldRefMappers = Record<string, RefMapper>;
@@ -29,14 +25,10 @@ const traverseAndMapBySchema = (
     schemas,
     maps,
     fieldRefMappers,
-    processedFields,
-    missingSchemas,
   }: {
     schemas: ComponentSchemas;
     maps: RefMaps;
     fieldRefMappers: FieldRefMappers;
-    processedFields: ProcessedFields;
-    missingSchemas: MissingSchemas;
   },
 ): any => {
   if (!data?.component) {
@@ -44,7 +36,6 @@ const traverseAndMapBySchema = (
   }
   const schema = schemas[data.component];
   if (!schema) {
-    missingSchemas.add(data.component);
     return data;
   }
   const dataNew = { ...data };
@@ -54,18 +45,12 @@ const traverseAndMapBySchema = (
     const fieldType = fieldSchema && typeof fieldSchema === 'object' && 'type' in fieldSchema && fieldSchema.type;
     const fieldRefMapper = typeof fieldType === 'string' && fieldRefMappers[fieldType];
 
-    if (fieldSchema) {
-      processedFields.add(fieldSchema);
-    }
-
     if (fieldRefMapper) {
       dataNew[fieldName] = fieldRefMapper(fieldValue as any, {
         schema: fieldSchema,
         schemas,
         maps,
         fieldRefMappers,
-        processedFields,
-        missingSchemas,
       });
     }
   }
@@ -79,14 +64,10 @@ const traverseAndMapRichtextDoc = (
     schemas,
     maps,
     fieldRefMappers,
-    processedFields,
-    missingSchemas,
   }: {
     schemas: ComponentSchemas;
     maps: RefMaps;
     fieldRefMappers: FieldRefMappers;
-    processedFields: ProcessedFields;
-    missingSchemas: MissingSchemas;
   },
 ): any => {
   if (Array.isArray(data)) {
@@ -94,8 +75,6 @@ const traverseAndMapRichtextDoc = (
       schemas,
       maps,
       fieldRefMappers,
-      processedFields,
-      missingSchemas,
     }));
   }
 
@@ -118,8 +97,6 @@ const traverseAndMapRichtextDoc = (
             schemas,
             maps,
             fieldRefMappers,
-            processedFields,
-            missingSchemas,
           })),
         },
       };
@@ -131,8 +108,6 @@ const traverseAndMapRichtextDoc = (
         schemas,
         maps,
         fieldRefMappers,
-        processedFields,
-        missingSchemas,
       });
     }
     return newData;
@@ -144,12 +119,10 @@ const traverseAndMapRichtextDoc = (
 /**
  * Richtext field reference mapper.
  */
-const richtextFieldRefMapper: RefMapper = (data, { schemas, maps, fieldRefMappers, processedFields, missingSchemas }) => traverseAndMapRichtextDoc(data, {
+const richtextFieldRefMapper: RefMapper = (data, { schemas, maps, fieldRefMappers }) => traverseAndMapRichtextDoc(data, {
   schemas,
   maps,
   fieldRefMappers,
-  processedFields,
-  missingSchemas,
 });
 
 /**
@@ -169,7 +142,7 @@ const multilinkFieldRefMapper: RefMapper = (data, { maps }) => {
 /**
  * Bloks field reference mapper.
  */
-const bloksFieldRefMapper: RefMapper = (data, { schemas, maps, fieldRefMappers, processedFields, missingSchemas }) => {
+const bloksFieldRefMapper: RefMapper = (data, { schemas, maps, fieldRefMappers }) => {
   if (!Array.isArray(data)) {
     throw new TypeError(`Invalid bloks field: expected an array, but received ${JSON.stringify(data)}. Please make sure your bloks field value is an array of components (e.g. [{ component: "my_blok", ... }]).`);
   }
@@ -178,8 +151,6 @@ const bloksFieldRefMapper: RefMapper = (data, { schemas, maps, fieldRefMappers, 
     schemas,
     maps,
     fieldRefMappers,
-    processedFields,
-    missingSchemas,
   })) as any;
 };
 
@@ -243,9 +214,6 @@ export const storyRefMapper = (story: Story, { schemas, maps }: {
   schemas: ComponentSchemas;
   maps: RefMaps;
 }) => {
-  const processedFields: ProcessedFields = new Set();
-  const missingSchemas: MissingSchemas = new Set();
-
   const alternates = story.alternates
     ? (story.alternates as Required<Story>['alternates']).map((a: any) => ({
         ...a,
@@ -255,15 +223,13 @@ export const storyRefMapper = (story: Story, { schemas, maps }: {
     : story.alternates;
 
   const parentId = maps.stories?.get(story.parent_id) ?? story.parent_id;
-  const mappedStory = {
+  return {
     ...story,
     content: story.content?.component
       ? traverseAndMapBySchema(story.content, {
           schemas,
           maps,
           fieldRefMappers,
-          processedFields,
-          missingSchemas,
         })
       : story.content,
     id: Number(maps.stories?.get(story.id) ?? story.id),
@@ -271,10 +237,4 @@ export const storyRefMapper = (story: Story, { schemas, maps }: {
     parent_id: parentId != null ? Number(parentId) : 0,
     alternates,
   } satisfies Story;
-
-  return {
-    mappedStory,
-    processedFields,
-    missingSchemas,
-  };
 };

--- a/packages/cli/src/commands/stories/richtext.ts
+++ b/packages/cli/src/commands/stories/richtext.ts
@@ -1,0 +1,24 @@
+/**
+ * Walks a richtext AST and invokes `onBlok` for every content node embedded in
+ * a `type: 'blok'` attrs.body array. Read-only: does not reconstruct the tree.
+ *
+ * Ref-mapper has its own richtext traversal because it also remaps `type: 'link'`
+ * story uuids and must return a new tree with mapped references. Extract a
+ * shared map-with-rebuild helper only once that walker grows a second consumer.
+ */
+export const walkRichtextBloks = (node: unknown, onBlok: (blok: unknown) => void): void => {
+  if (Array.isArray(node)) {
+    for (const item of node) { walkRichtextBloks(item, onBlok); }
+    return;
+  }
+  if (!node || typeof node !== 'object') { return; }
+
+  const obj = node as Record<string, unknown>;
+  if (obj.type === 'blok' && obj.attrs && typeof obj.attrs === 'object') {
+    const body = (obj.attrs as Record<string, unknown>).body;
+    if (Array.isArray(body)) {
+      for (const blok of body) { onBlok(blok); }
+    }
+  }
+  for (const value of Object.values(obj)) { walkRichtextBloks(value, onBlok); }
+};

--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -2,7 +2,6 @@ import { readFile, unlink } from 'node:fs/promises';
 import { basename, extname, join, resolve } from 'pathe';
 import { Readable, Transform, Writable } from 'node:stream';
 import { Sema } from 'async-sema';
-import type { Component } from '../components/constants';
 import { createStory, fetchStories, fetchStory, updateStory } from './actions';
 import type { ExistingTargetStories, StoriesQueryParams, Story, StoryIndexEntry, TargetStoryRef } from './constants';
 import { normalizeFullSlug } from './constants';
@@ -182,15 +181,15 @@ export const mapReferencesStream = ({
   schemas: ComponentSchemas;
   maps: RefMaps;
   onIncrement?: () => void;
-  onStorySuccess?: (localStory: Story, processedFields: Set<Component['schema']>, missingSchemas: Set<Component['name']>) => void;
+  onStorySuccess?: (localStory: Story) => void;
   onStoryError?: (error: Error, story: Story) => void;
 }) => {
   return new Transform({
     objectMode: true,
     transform(localStory: Story, _encoding, callback) {
       try {
-        const { mappedStory, processedFields, missingSchemas } = storyRefMapper(localStory, { schemas, maps });
-        onStorySuccess?.(mappedStory, processedFields, missingSchemas);
+        const mappedStory = storyRefMapper(localStory, { schemas, maps });
+        onStorySuccess?.(mappedStory);
         this.push(mappedStory);
       }
       catch (maybeError) {

--- a/packages/cli/src/commands/stories/validate-story.test.ts
+++ b/packages/cli/src/commands/stories/validate-story.test.ts
@@ -1,0 +1,551 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { join } from 'pathe';
+import { vol } from 'memfs';
+import type { Story } from './constants';
+import type { ComponentSchemas } from './ref-mapper';
+import {
+  collectSchemaIssues,
+  formatSchemaIssues,
+  hasSchemaIssues,
+  validateStoryAgainstSchemas,
+} from './validate-story';
+import { makeStoryWithAllFieldTypes, pageWithEverythingBlok } from './__tests__/story-with-all-field-types';
+
+const makeStory = (content: Record<string, unknown>): Story => ({
+  name: 'Test',
+  id: 1,
+  uuid: randomUUID(),
+  parent_id: 0,
+  is_folder: false,
+  slug: 'test',
+  content,
+} as unknown as Story);
+
+describe('validateStoryAgainstSchemas', () => {
+  it('should return empty sets when content matches schema', () => {
+    const schemas: ComponentSchemas = {
+      page: {
+        headline: { type: 'text' },
+        body: { type: 'textarea' },
+      } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      headline: 'Hi',
+      body: 'Lorem',
+    });
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.size).toBe(0);
+    expect(missingSchemas.size).toBe(0);
+  });
+
+  it('should ignore reserved keys (_uid, _editable, _shared, component)', () => {
+    const schemas: ComponentSchemas = {
+      page: {} as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      _editable: '<!--#storyblok#-->',
+      _shared: 'shared-id',
+      _isolated: false,
+      _locked: false,
+      component: 'page',
+    });
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.size).toBe(0);
+    expect(missingSchemas.size).toBe(0);
+  });
+
+  it('should report root-level fields not declared in schema', () => {
+    const schemas: ComponentSchemas = {
+      page: {
+        headline: { type: 'text' },
+      } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      headline: 'Hi',
+      color: '#ff0000',
+    });
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('page')).toEqual(new Set(['color']));
+    expect(driftByComponent.size).toBe(1);
+    expect(missingSchemas.size).toBe(0);
+  });
+
+  it('should report every undeclared field on a single component', () => {
+    const schemas: ComponentSchemas = {
+      page: {
+        headline: { type: 'text' },
+      } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      headline: 'Hi',
+      color: '#ff0000',
+      extra: 'something',
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('page')).toEqual(new Set(['color', 'extra']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should report plugin-shaped drift (value is an object carrying a `plugin` property)', () => {
+    const schemas: ComponentSchemas = {
+      page: {
+        headline: { type: 'text' },
+      } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      headline: 'Hi',
+      color: {
+        _uid: randomUUID(),
+        plugin: 'official-colorpicker',
+        color: '#4c1130',
+      },
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('page')).toEqual(new Set(['color']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should report drift inside a declared `bloks` field', () => {
+    const schemas: ComponentSchemas = {
+      page: {
+        body: { type: 'bloks' },
+      } as never,
+      hero: {
+        title: { type: 'text' },
+      } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      body: [
+        {
+          _uid: randomUUID(),
+          component: 'hero',
+          title: 'Hello',
+          bg_color: '#ff0000',
+        },
+      ],
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('hero')).toEqual(new Set(['bg_color']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should dedupe drift across repeated instances of the same blok', () => {
+    const schemas: ComponentSchemas = {
+      page: { body: { type: 'bloks' } } as never,
+      hero: { title: { type: 'text' } } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      body: [
+        { _uid: randomUUID(), component: 'hero', title: 'A', bg_color: '#fff' },
+        { _uid: randomUUID(), component: 'hero', title: 'B', bg_color: '#000' },
+        { _uid: randomUUID(), component: 'hero', title: 'C', bg_color: '#abc' },
+      ],
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('hero')).toEqual(new Set(['bg_color']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should report drift two levels deep in nested bloks', () => {
+    const schemas: ComponentSchemas = {
+      page: { body: { type: 'bloks' } } as never,
+      section: { items: { type: 'bloks' } } as never,
+      card: { title: { type: 'text' } } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      body: [
+        {
+          _uid: randomUUID(),
+          component: 'section',
+          items: [
+            {
+              _uid: randomUUID(),
+              component: 'card',
+              title: 'Ok',
+              unknown_field: 'drift',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('card')).toEqual(new Set(['unknown_field']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should report drift inside a blok embedded in a richtext field', () => {
+    const schemas: ComponentSchemas = {
+      page: { rt: { type: 'richtext' } } as never,
+      hero: { title: { type: 'text' } } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      rt: {
+        type: 'doc',
+        content: [
+          {
+            type: 'blok',
+            attrs: {
+              id: randomUUID(),
+              body: [
+                {
+                  _uid: randomUUID(),
+                  component: 'hero',
+                  title: 'Ok',
+                  undeclared: 42,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('hero')).toEqual(new Set(['undeclared']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should report the missing component when content references an unknown schema', () => {
+    const schemas: ComponentSchemas = {};
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'unknown',
+      anything: 'goes',
+    });
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(Array.from(missingSchemas)).toEqual(['unknown']);
+    expect(driftByComponent.size).toBe(0);
+  });
+
+  it('should record a missing nested component but keep validating its siblings', () => {
+    const schemas: ComponentSchemas = {
+      page: { body: { type: 'bloks' } } as never,
+      hero: { title: { type: 'text' } } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      body: [
+        {
+          _uid: randomUUID(),
+          component: 'unknown_block',
+          title: 'ignored',
+        },
+        {
+          _uid: randomUUID(),
+          component: 'hero',
+          title: 'Ok',
+          undeclared: true,
+        },
+      ],
+    });
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(Array.from(missingSchemas)).toEqual(['unknown_block']);
+    expect(driftByComponent.get('hero')).toEqual(new Set(['undeclared']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should normalize the __i18n__ suffix when looking up fields', () => {
+    const schemas: ComponentSchemas = {
+      page: {
+        headline: { type: 'text' },
+      } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      headline: 'Hello',
+      headline__i18n__de: 'Hallo',
+      color__i18n__de: '#4c1130',
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('page')).toEqual(new Set(['color']));
+    expect(driftByComponent.size).toBe(1);
+  });
+
+  it('should skip content without a component field', () => {
+    const schemas: ComponentSchemas = {};
+    const story = makeStory({ headline: 'Hi' });
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.size).toBe(0);
+    expect(missingSchemas.size).toBe(0);
+  });
+
+  it('should not crash or report drift for null or undefined field values', () => {
+    const schemas: ComponentSchemas = {
+      page: {
+        body: { type: 'bloks' },
+        headline: { type: 'text' },
+      } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      body: null,
+      headline: undefined,
+    });
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.size).toBe(0);
+    expect(missingSchemas.size).toBe(0);
+  });
+
+  it('should validate every sibling when one of them has drift', () => {
+    const schemas: ComponentSchemas = {
+      page: { body: { type: 'bloks' } } as never,
+      hero: { title: { type: 'text' } } as never,
+      cta: { label: { type: 'text' } } as never,
+    };
+    const story = makeStory({
+      _uid: randomUUID(),
+      component: 'page',
+      body: [
+        { _uid: randomUUID(), component: 'hero', title: 'A', stray: 1 },
+        { _uid: randomUUID(), component: 'cta', label: 'B', extra: 2 },
+      ],
+    });
+
+    const { driftByComponent } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.get('hero')).toEqual(new Set(['stray']));
+    expect(driftByComponent.get('cta')).toEqual(new Set(['extra']));
+    expect(driftByComponent.size).toBe(2);
+  });
+
+  it('should report zero issues for the realistic makeStoryWithAllFieldTypes fixture', () => {
+    const schemas: ComponentSchemas = {
+      page_with_everything: pageWithEverythingBlok.schema as never,
+    };
+    const story = makeStoryWithAllFieldTypes() as unknown as Story;
+
+    const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+    expect(driftByComponent.size).toBe(0);
+    expect(missingSchemas.size).toBe(0);
+  });
+});
+
+describe('collectSchemaIssues', () => {
+  afterEach(() => { vol.reset(); });
+
+  const writeStory = (dir: string, story: Story) => {
+    vol.fromJSON({ [join(dir, `${story.slug}_${story.uuid}.json`)]: JSON.stringify(story) });
+  };
+
+  it('should return zeroed issues when no story files exist', async () => {
+    const issues = await collectSchemaIssues({ directoryPath: '/nowhere', schemas: {} });
+
+    expect(issues.total).toBe(0);
+    expect(issues.driftByComponent.size).toBe(0);
+    expect(issues.missingSchemas.size).toBe(0);
+  });
+
+  it('should aggregate drift and missing schemas across every story in the directory', async () => {
+    const directoryPath = '/stories';
+    const schemas: ComponentSchemas = {
+      page: { headline: { type: 'text' } } as never,
+    };
+    const driftStory: Story = {
+      name: 'Drift',
+      id: 1,
+      uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      parent_id: 0,
+      is_folder: false,
+      slug: 'drift',
+      content: {
+        _uid: randomUUID(),
+        component: 'page',
+        headline: 'Hi',
+        color: '#4c1130',
+      },
+    } as unknown as Story;
+    const missingStory: Story = {
+      name: 'Missing',
+      id: 2,
+      uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      parent_id: 0,
+      is_folder: false,
+      slug: 'missing',
+      content: { _uid: randomUUID(), component: 'article' },
+    } as unknown as Story;
+    writeStory(directoryPath, driftStory);
+    writeStory(directoryPath, missingStory);
+
+    const issues = await collectSchemaIssues({ directoryPath, schemas });
+
+    expect(issues.total).toBe(2);
+    expect(issues.missingSchemas.get('article')).toEqual(new Set(['missing']));
+    expect(issues.driftByComponent.get('page')?.get('color')).toEqual(new Set(['drift']));
+  });
+
+  it('should dedupe drift and missing across many stories', async () => {
+    const directoryPath = '/stories';
+    const schemas: ComponentSchemas = {
+      page: { headline: { type: 'text' } } as never,
+    };
+    for (let i = 0; i < 3; i += 1) {
+      const story: Story = {
+        name: `Story ${i}`,
+        id: i,
+        uuid: `${i}${i}${i}${i}${i}${i}${i}${i}-${i}${i}${i}${i}-${i}${i}${i}${i}-${i}${i}${i}${i}-${i}${i}${i}${i}${i}${i}${i}${i}${i}${i}${i}${i}`,
+        parent_id: 0,
+        is_folder: false,
+        slug: `story-${i}`,
+        content: { _uid: randomUUID(), component: 'page', color: '#fff' },
+      } as unknown as Story;
+      writeStory(directoryPath, story);
+    }
+
+    const issues = await collectSchemaIssues({ directoryPath, schemas });
+
+    expect(issues.total).toBe(3);
+    const drift = issues.driftByComponent.get('page')?.get('color');
+    expect(drift).toEqual(new Set(['story-0', 'story-1', 'story-2']));
+  });
+});
+
+describe('formatSchemaIssues', () => {
+  it('should render both sections with alphabetically sorted entries and story lists', () => {
+    const driftByComponent = new Map<string, Map<string, Set<string>>>([
+      ['page', new Map([
+        ['color', new Set(['home/landing'])],
+        ['another', new Set(['home/about'])],
+      ])],
+      ['article', new Map([
+        ['leftover', new Set(['blog/first'])],
+        ['orphan', new Set(['blog/second', 'blog/first'])],
+      ])],
+    ]);
+    const missingSchemas = new Map<string, Set<string>>([
+      ['zz_missing', new Set(['home/index'])],
+      ['aa_missing', new Set(['home/about'])],
+    ]);
+
+    const message = formatSchemaIssues({
+      driftByComponent,
+      missingSchemas,
+      total: 5,
+    });
+
+    expect(message).toContain('Schema validation failed. Push aborted.');
+    expect(message).toContain('Missing component schemas:');
+    expect(message).toContain('- aa_missing (in stories: home/about)');
+    expect(message).toContain('- zz_missing (in stories: home/index)');
+    expect(message).toContain('Fields not declared in local schemas:');
+    expect(message).toContain('- article.leftover (in stories: blog/first)');
+    expect(message).toContain('- article.orphan (in stories: blog/first, blog/second)');
+    expect(message).toContain('- page.another (in stories: home/about)');
+    expect(message).toContain('- page.color (in stories: home/landing)');
+    // Different remedies for each section
+    expect(message).toContain('If these components exist in Storyblok, run `storyblok components pull` to sync them locally.');
+    expect(message).toContain('Otherwise, create them in Storyblok first, or remove the references from the affected stories.');
+    expect(message).toContain('These fields will be lost when the stories are pushed. To fix, either:');
+    expect(message).toContain('Add the field to the component in Storyblok, then run `storyblok components pull`');
+    expect(message).toContain('Or remove the field from the affected story JSON files');
+    // Missing section appears before drift section
+    expect(message.indexOf('Missing component schemas')).toBeLessThan(message.indexOf('Fields not declared'));
+    // Alphabetical ordering of components
+    expect(message.indexOf('- aa_missing')).toBeLessThan(message.indexOf('- zz_missing'));
+    expect(message.indexOf('- article')).toBeLessThan(message.indexOf('- page'));
+  });
+
+  it('should omit the drift section when no fields drifted', () => {
+    const message = formatSchemaIssues({
+      driftByComponent: new Map(),
+      missingSchemas: new Map([['foo', new Set(['home'])]]),
+      total: 1,
+    });
+
+    expect(message).toContain('- foo (in stories: home)');
+    expect(message).not.toContain('Fields not declared');
+    expect(message).not.toContain('These fields will be lost');
+  });
+
+  it('should omit the missing section when no components are missing', () => {
+    const message = formatSchemaIssues({
+      driftByComponent: new Map([['page', new Map([['color', new Set(['home'])]])]]),
+      missingSchemas: new Map(),
+      total: 1,
+    });
+
+    expect(message).not.toContain('Missing component schemas');
+    expect(message).toContain('- page.color (in stories: home)');
+  });
+
+  it('should truncate long story lists with a summary count', () => {
+    const stories = new Set(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    const message = formatSchemaIssues({
+      driftByComponent: new Map([['page', new Map([['color', stories]])]]),
+      missingSchemas: new Map(),
+      total: 7,
+    });
+
+    expect(message).toContain('(in stories: a, b, c, d, e, and 2 more)');
+  });
+});
+
+describe('hasSchemaIssues', () => {
+  it('should return false when both drift and missing sets are empty', () => {
+    expect(hasSchemaIssues({ driftByComponent: new Map(), missingSchemas: new Map(), total: 3 })).toBe(false);
+  });
+
+  it('should return true when any component has drift fields', () => {
+    expect(hasSchemaIssues({
+      driftByComponent: new Map([['page', new Map([['color', new Set(['home'])]])]]),
+      missingSchemas: new Map(),
+      total: 1,
+    })).toBe(true);
+  });
+
+  it('should return true when any component schema is missing', () => {
+    expect(hasSchemaIssues({
+      driftByComponent: new Map(),
+      missingSchemas: new Map([['foo', new Set(['home'])]]),
+      total: 1,
+    })).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/stories/validate-story.ts
+++ b/packages/cli/src/commands/stories/validate-story.ts
@@ -1,0 +1,209 @@
+import { pipeline } from 'node:stream/promises';
+import { Writable } from 'node:stream';
+import type { Component } from '../components/constants';
+import type { Story } from './constants';
+import type { ComponentSchemas } from './ref-mapper';
+import { walkRichtextBloks } from './richtext';
+import { readLocalStoriesStream } from './streams';
+
+export interface SchemaIssues {
+  driftByComponent: Map<Component['name'], Set<string>>;
+  missingSchemas: Set<Component['name']>;
+}
+
+/**
+ * Aggregated schema-validation result across every local story in a directory.
+ * Every drift field and missing component is paired with the set of affected
+ * story `full_slug`s so the error message can point users at the files to fix.
+ */
+export interface AggregatedSchemaIssues {
+  driftByComponent: Map<Component['name'], Map<string, Set<string>>>;
+  missingSchemas: Map<Component['name'], Set<string>>;
+  total: number;
+}
+
+const RESERVED_KEYS = new Set(['component']);
+const isReservedKey = (key: string) => RESERVED_KEYS.has(key) || key.startsWith('_');
+
+const MAX_STORIES_PER_ENTRY = 5;
+
+const addDrift = (
+  driftByComponent: Map<string, Set<string>>,
+  component: string,
+  field: string,
+): void => {
+  const existing = driftByComponent.get(component) ?? new Set<string>();
+  existing.add(field);
+  driftByComponent.set(component, existing);
+};
+
+/**
+ * Validates a story's content against local component schemas without mutating
+ * either input. Records two kinds of issues:
+ *
+ * - `missingSchemas`: the content references a component whose schema is not
+ *   available locally. Descent into that subtree stops.
+ * - `driftByComponent`: for each known component, the set of content fields
+ *   the component's schema does not declare (schema drift).
+ *
+ * Descends into fields declared as `bloks` (array of bloks) and `richtext`
+ * (traverses the AST, recursing into `type: 'blok'` nodes).
+ */
+export const validateStoryAgainstSchemas = (
+  story: Story,
+  schemas: ComponentSchemas,
+): SchemaIssues => {
+  const driftByComponent = new Map<string, Set<string>>();
+  const missingSchemas = new Set<Component['name']>();
+
+  const visit = (data: unknown): void => {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) { return; }
+    const node = data as Record<string, unknown>;
+    const componentName = node.component;
+    if (typeof componentName !== 'string' || componentName.length === 0) { return; }
+
+    const schema = schemas[componentName];
+    if (!schema) {
+      missingSchemas.add(componentName);
+      return;
+    }
+
+    for (const [fieldName, fieldValue] of Object.entries(node)) {
+      if (isReservedKey(fieldName)) { continue; }
+
+      const normalized = fieldName.replace(/__i18n__.*/, '');
+      const fieldSchema = (schema as Record<string, unknown>)[normalized] as
+        | Record<string, unknown>
+        | undefined;
+
+      if (!fieldSchema) {
+        addDrift(driftByComponent, componentName, normalized);
+        continue;
+      }
+
+      const fieldType = typeof fieldSchema.type === 'string' ? fieldSchema.type : undefined;
+
+      if (fieldType === 'bloks' && Array.isArray(fieldValue)) {
+        for (const item of fieldValue) { visit(item); }
+      }
+      else if (fieldType === 'richtext' && fieldValue && typeof fieldValue === 'object') {
+        walkRichtextBloks(fieldValue, blok => visit(blok));
+      }
+    }
+  };
+
+  visit(story.content);
+
+  return { driftByComponent, missingSchemas };
+};
+
+const addStoryToSet = (bag: Map<string, Set<string>>, key: string, storySlug: string): void => {
+  const existing = bag.get(key) ?? new Set<string>();
+  existing.add(storySlug);
+  bag.set(key, existing);
+};
+
+/**
+ * Streams every local story from `directoryPath` through
+ * `validateStoryAgainstSchemas`, aggregating drift fields and missing component
+ * schemas across the whole push and recording which stories are affected.
+ * Resolves with an empty result when the directory does not exist — the
+ * downstream pipeline reports that separately.
+ */
+export const collectSchemaIssues = async ({
+  directoryPath,
+  schemas,
+}: {
+  directoryPath: string;
+  schemas: ComponentSchemas;
+}): Promise<AggregatedSchemaIssues> => {
+  const issues: AggregatedSchemaIssues = {
+    driftByComponent: new Map(),
+    missingSchemas: new Map(),
+    total: 0,
+  };
+
+  try {
+    await pipeline(
+      readLocalStoriesStream({ directoryPath }),
+      new Writable({
+        objectMode: true,
+        write(story: Story, _encoding, callback) {
+          issues.total += 1;
+          const storyIdentifier = story.full_slug || story.slug;
+          const { driftByComponent, missingSchemas } = validateStoryAgainstSchemas(story, schemas);
+
+          for (const component of missingSchemas) {
+            addStoryToSet(issues.missingSchemas, component, storyIdentifier);
+          }
+          for (const [component, fields] of driftByComponent) {
+            const fieldMap = issues.driftByComponent.get(component) ?? new Map<string, Set<string>>();
+            for (const field of fields) { addStoryToSet(fieldMap, field, storyIdentifier); }
+            issues.driftByComponent.set(component, fieldMap);
+          }
+          callback();
+        },
+      }),
+    );
+  }
+  catch (error) {
+    // Missing directory is surfaced by the downstream read stream during Pass 1;
+    // pre-flight has nothing to add. Other errors propagate to the caller.
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') { throw error; }
+  }
+
+  return issues;
+};
+
+const formatStoryList = (stories: Set<string>): string => {
+  const sorted = [...stories].sort();
+  if (sorted.length <= MAX_STORIES_PER_ENTRY) { return sorted.join(', '); }
+  const shown = sorted.slice(0, MAX_STORIES_PER_ENTRY).join(', ');
+  return `${shown}, and ${sorted.length - MAX_STORIES_PER_ENTRY} more`;
+};
+
+/**
+ * Builds the multi-line error message shown to the user when
+ * `collectSchemaIssues` finds at least one problem. Splits the two kinds of
+ * issues into separate sections with tailored remedies: the fix for a missing
+ * component schema is different from the fix for an undeclared field, and
+ * running `storyblok components pull` is not always the right answer.
+ */
+export const formatSchemaIssues = (issues: AggregatedSchemaIssues): string => {
+  const lines: string[] = ['Schema validation failed. Push aborted.'];
+
+  if (issues.missingSchemas.size > 0) {
+    lines.push('');
+    lines.push('Missing component schemas:');
+    const sortedMissing = [...issues.missingSchemas.entries()]
+      .sort(([a], [b]) => a.localeCompare(b));
+    for (const [component, stories] of sortedMissing) {
+      lines.push(`  - ${component} (in stories: ${formatStoryList(stories)})`);
+    }
+    lines.push('');
+    lines.push('If these components exist in Storyblok, run `storyblok components pull` to sync them locally.');
+    lines.push('Otherwise, create them in Storyblok first, or remove the references from the affected stories.');
+  }
+
+  if (issues.driftByComponent.size > 0) {
+    lines.push('');
+    lines.push('Fields not declared in local schemas:');
+    const sortedComponents = [...issues.driftByComponent.entries()]
+      .sort(([a], [b]) => a.localeCompare(b));
+    for (const [component, fieldMap] of sortedComponents) {
+      const sortedFields = [...fieldMap.entries()].sort(([a], [b]) => a.localeCompare(b));
+      for (const [field, stories] of sortedFields) {
+        lines.push(`  - ${component}.${field} (in stories: ${formatStoryList(stories)})`);
+      }
+    }
+    lines.push('');
+    lines.push('These fields will be lost when the stories are pushed. To fix, either:');
+    lines.push('  - Add the field to the component in Storyblok, then run `storyblok components pull`');
+    lines.push('  - Or remove the field from the affected story JSON files');
+  }
+
+  return lines.join('\n');
+};
+
+export const hasSchemaIssues = (issues: AggregatedSchemaIssues): boolean =>
+  issues.missingSchemas.size > 0 || issues.driftByComponent.size > 0;


### PR DESCRIPTION
## Summary

Replaces the soft custom-plugin warning from #564 with a hard pre-flight schema validation pass. Manual QA confirmed the original warning was silent when a story's content contained fields the local component schema did not declare (schema drift) — stories pushed successfully with no indication.

- New `validate-story.ts` module with three helpers:
  - `validateStoryAgainstSchemas` — per-story traversal, records drift fields and missing component schemas.
  - `collectSchemaIssues` — streams every local story file through the validator using `readLocalStoriesStream`, aggregates issues.
  - `formatSchemaIssues` — builds the user-facing multi-line error message.
- `stories push` runs the validator after `findComponentSchemas` and aborts before any API call if issues are found. Error shape matches the existing "No components found" path; the run reports `FAILURE`.
- Restored the *"may contain references that require manual updates"* warning, now emitted during Pass 2 via a content walk (looks for `plugin: string` on any node). Schema conformance has already been verified pre-flight, so no false-positive guard is needed.
- Removed the now-unused `processedFields` / `missingSchemas` channel from `ref-mapper.ts`, `mapReferencesStream`, and `storyRefMapper`.
- `assets push` pipeline sources the missing-schema warning from `validateStoryAgainstSchemas` directly.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Schema declares field used in content | soft warning fires for custom plugins | validation passes, plugin warning still fires during Pass 2 |
| Schema drift (content field not declared) | silent, story pushed | **hard abort**, clear error, no API call |
| Unknown component in content | soft warning, continues | **hard abort**, clear error |
| No local components at all | hard error (unchanged) | hard error (unchanged) |

## Test plan

- [x] Unit: `validate-story.test.ts` — 24 cases covering drift detection (root, nested bloks, richtext bloks, i18n suffix, reserved keys, deduplication) plus the streaming `collectSchemaIssues`, `formatSchemaIssues`, and `hasSchemaIssues` helpers.
- [x] Integration: `push/index.test.ts` — hard-error cases for missing schemas, drift at root, drift in nested bloks, drift in richtext bloks, aggregated output for multiple drift fields, dry-run and cleanup respect the abort, `FAILURE` report status; plus restored plugin warning happy-path and nested-blok cases.
- [x] Full CLI suite green: 658 tests passing.
- [x] `pnpm test:types` clean.
- [x] `pnpm lint:fix` clean.
- [x] Manual QA against real Storyblok spaces:
  - Aligned schema, root-level plugin → push succeeds, warning fires.
  - Aligned schema, plugin nested in bloks → push succeeds, warning fires.
  - Schema drift → push aborts, target unchanged.
  - Missing component schema → push aborts, target unchanged.