### PR TITLE
fix(cli): paginate component and internal-tag list fetches

### DIFF
--- a/.claude/skills/qa-engineer-manual/SKILL.md
+++ b/.claude/skills/qa-engineer-manual/SKILL.md
@@ -53,7 +53,7 @@ bash .claude/skills/qa-engineer-manual/scripts/seed-scenario.sh \
   --scenario has-stories
 ```
 
-Seeding always cleans the space first (deletes all stories, components, assets, and asset folders), then pushes the scenario data. The space is read from `STORYBLOK_SPACE_ID` in the environment (loaded from `.env.qa-engineer-manual`). You can override it with `--space <id>`.
+Seeding always cleans the space first (deletes all stories, components, assets, asset folders, and internal tags), then pushes the scenario data. The space is read from `STORYBLOK_SPACE_ID` in the environment (loaded from `.env.qa-engineer-manual`). You can override it with `--space <id>`.
 
 Packages might define their own scenarios in `./packages/PACKAGE_NAME/test/scenarios`. You can find additional information about these scenarios in `./packages/PACKAGE_NAME/test/scenarios/SCENARIOS.md`.
 
@@ -98,7 +98,7 @@ bash .claude/skills/qa-engineer-manual/scripts/seed-scenario.sh \
 bash .claude/skills/qa-engineer-manual/scripts/cleanup-remote.sh
 ```
 
-Deletes all stories, components (except the default `page` component), assets, and asset folders in the space. Uses `STORYBLOK_SPACE_ID` from env by default (override with `--space <id>`). This runs automatically before every seed, but can also be used standalone.
+Deletes all stories, components (except the default `page` component), assets, asset folders, and internal tags in the space. Uses `STORYBLOK_SPACE_ID` from env by default (override with `--space <id>`). This runs automatically before every seed, but can also be used standalone.
 
 ### Scenario structure
 
@@ -140,7 +140,7 @@ Paths are relative to this `SKILL.md`.
 | Script | Purpose |
 | --- | --- |
 | `./scripts/cleanup-local.sh` | Deletes local QA artifacts in `.storyblok/`. |
-| `./scripts/cleanup-remote.sh` | Deletes all stories, components (except `page`), assets, and asset folders in the space. Accepts `--space <id>`. |
+| `./scripts/cleanup-remote.sh` | Deletes all stories, components (except `page`), assets, asset folders, and internal tags in the space. Accepts `--space <id>`. |
 | `./scripts/list.sh` | Lists resources in the QA space. Pass `--resource stories\|assets\|components\|datasources` and optionally `--space <id>`. |
 | `./scripts/generate-story.sh` | Writes a story JSON to stdout. All fields optional — use flags to override `--slug`, `--name`, `--component`, `--parent-id`, `--is-folder`, `--id`, `--uuid`. |
 | `./scripts/generate-asset.sh` | Writes an asset sidecar JSON to stdout. Use `--filename`, `--alt`, `--title`, `--is-private`, `--folder-id`. Pass `--copy-png <path>` to also copy the template PNG to a target path. |

--- a/.claude/skills/qa-engineer-manual/scripts/cleanup-remote.sh
+++ b/.claude/skills/qa-engineer-manual/scripts/cleanup-remote.sh
@@ -84,6 +84,7 @@ cleanup_resource "stories"
 cleanup_resource "components" "page"
 cleanup_resource "assets"
 cleanup_resource "asset_folders"
+cleanup_resource "internal_tags"
 
 if [ "${found_total}" -eq 0 ]; then
   printf "clean\n"

--- a/packages/cli/src/commands/components/pull/actions.test.ts
+++ b/packages/cli/src/commands/components/pull/actions.test.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { vol } from 'memfs';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { fetchComponent, fetchComponents, saveComponentsToFiles } from './actions';
+import { fetchComponent, fetchComponentInternalTags, fetchComponents, saveComponentsToFiles } from './actions';
 import { getMapiClient } from '../../../api';
 
 const mockedComponents = [{
@@ -76,6 +76,43 @@ describe('pull components actions', () => {
     expect(result).toEqual(mockedComponents);
   });
 
+  it('should fetch all components across multiple pages', async () => {
+    const totalComponents = 30;
+    const allComponents = Array.from({ length: totalComponents }, (_, i) => ({
+      name: `paged-${String(i + 1).padStart(2, '0')}`,
+      display_name: `Paged ${i + 1}`,
+      created_at: '2021-08-09T12:00:00Z',
+      updated_at: '2021-08-09T12:00:00Z',
+      id: 1000 + i,
+      schema: { type: 'object' },
+      color: undefined,
+      internal_tags_list: [],
+      internal_tag_ids: [],
+    }));
+    const requestedPages: number[] = [];
+
+    server.use(
+      http.get('https://mapi.storyblok.com/v1/spaces/12345/components', ({ request }) => {
+        const url = new URL(request.url);
+        const page = Number(url.searchParams.get('page') ?? '1');
+        const perPage = Number(url.searchParams.get('per_page') ?? '25');
+        requestedPages.push(page);
+        const start = (page - 1) * perPage;
+        const slice = allComponents.slice(start, start + perPage);
+        return HttpResponse.json(
+          { components: slice },
+          { headers: { total: String(totalComponents) } },
+        );
+      }),
+    );
+
+    const result = await fetchComponents('12345');
+
+    expect(result).toHaveLength(totalComponents);
+    expect(result?.map(c => c.name)).toEqual(allComponents.map(c => c.name));
+    expect(requestedPages).toEqual([1, 2]);
+  });
+
   it('should fetch a component by name', async () => {
     const mockResponse = {
       components: [{
@@ -111,6 +148,57 @@ describe('pull components actions', () => {
     // searching for 'name-2' would match both 'component-name-2' and 'name-2'
     const result = await fetchComponent('12345', 'name-2');
     expect(result).toEqual(mockResponse.components[0]);
+  });
+
+  describe('fetchComponentInternalTags', () => {
+    it('should fetch all internal tags across multiple pages', async () => {
+      const totalTags = 30;
+      const allTags = Array.from({ length: totalTags }, (_, i) => ({
+        id: i + 1,
+        name: `tag-${String(i + 1).padStart(2, '0')}`,
+        object_type: 'component',
+      }));
+      const requestedPages: number[] = [];
+      const requestedObjectTypes: (string | null)[] = [];
+
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/12345/internal_tags', ({ request }) => {
+          const url = new URL(request.url);
+          const page = Number(url.searchParams.get('page') ?? '1');
+          const perPage = Number(url.searchParams.get('per_page') ?? '25');
+          requestedPages.push(page);
+          requestedObjectTypes.push(url.searchParams.get('by_object_type'));
+          const start = (page - 1) * perPage;
+          const slice = allTags.slice(start, start + perPage);
+          return HttpResponse.json(
+            { internal_tags: slice },
+            { headers: { total: String(totalTags) } },
+          );
+        }),
+      );
+
+      const result = await fetchComponentInternalTags('12345');
+
+      expect(result).toHaveLength(totalTags);
+      expect(result?.map(t => t.name)).toEqual(allTags.map(t => t.name));
+      expect(requestedPages).toEqual([1, 2]);
+      expect(requestedObjectTypes.every(t => t === 'component')).toBe(true);
+    });
+
+    it('should return a single page when no total header is present', async () => {
+      const tags = [
+        { id: 1, name: 'only-tag', object_type: 'component' },
+      ];
+
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/12345/internal_tags', () =>
+          HttpResponse.json({ internal_tags: tags })),
+      );
+
+      const result = await fetchComponentInternalTags('12345');
+
+      expect(result).toEqual(tags);
+    });
   });
 
   // TODO: Ask team regarding resseting the mapi client options

--- a/packages/cli/src/commands/components/pull/actions.ts
+++ b/packages/cli/src/commands/components/pull/actions.ts
@@ -4,21 +4,25 @@ import { DEFAULT_COMPONENTS_FILENAME, DEFAULT_GROUPS_FILENAME, DEFAULT_PRESETS_F
 import type { SaveComponentsOptions } from './constants';
 import { handleAPIError, handleFileSystemError } from '../../../utils';
 import { resolvePath, sanitizeFilename, saveToFile } from '../../../utils/filesystem';
+import { fetchAllPages } from '../../../utils/pagination';
 import { getMapiClient } from '../../../api';
 
 // Components
 export const fetchComponents = async (spaceId: string): Promise<Component[] | undefined> => {
   try {
     const client = getMapiClient();
-
-    const { data } = await client.components.list({
-      path: {
-        space_id: Number(spaceId),
-      },
-      throwOnError: true,
-    });
-
-    return data?.components;
+    return await fetchAllPages(
+      (page: number) => client.components.list({
+        path: {
+          space_id: Number(spaceId),
+        },
+        query: {
+          page,
+        },
+        throwOnError: true,
+      }),
+      data => data?.components ?? [],
+    );
   }
   catch (error) {
     handleAPIError('pull_components', error as Error);
@@ -28,18 +32,20 @@ export const fetchComponents = async (spaceId: string): Promise<Component[] | un
 export const fetchComponent = async (spaceId: string, componentName: string): Promise<Component | undefined> => {
   try {
     const client = getMapiClient();
-
-    const { data } = await client.components.list({
-      path: {
-        space_id: Number(spaceId),
-      },
-      query: {
-        search: componentName,
-      },
-      throwOnError: true,
-    });
-
-    return data?.components?.find((c: Component) => c.name === componentName);
+    const matches = await fetchAllPages(
+      (page: number) => client.components.list({
+        path: {
+          space_id: Number(spaceId),
+        },
+        query: {
+          page,
+          search: componentName,
+        },
+        throwOnError: true,
+      }),
+      data => data?.components ?? [],
+    );
+    return matches.find((c: Component) => c.name === componentName);
   }
   catch (error) {
     handleAPIError('pull_components', error as Error, `Failed to fetch component ${componentName}`);
@@ -86,14 +92,19 @@ export const fetchComponentPresets = async (spaceId: string): Promise<Preset[] |
 export const fetchComponentInternalTags = async (spaceId: string): Promise<InternalTag[] | undefined> => {
   try {
     const client = getMapiClient();
-
-    const { data } = await client.internalTags.list({
-      path: {
-        space_id: Number(spaceId),
-      },
-    });
-
-    return data?.internal_tags?.filter((tag: InternalTag) => tag.object_type === 'component');
+    return await fetchAllPages(
+      (page: number) => client.internalTags.list({
+        path: {
+          space_id: Number(spaceId),
+        },
+        query: {
+          page,
+          by_object_type: 'component',
+        },
+        throwOnError: true,
+      }),
+      data => data?.internal_tags ?? [],
+    );
   }
   catch (error) {
     handleAPIError('pull_component_internal_tags', error as Error);

--- a/packages/cli/src/commands/datasources/pull/actions.test.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.test.ts
@@ -3,7 +3,7 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import mockedDatasources from './datasource.mock.json' assert { type: 'json' };
 import { getMapiClient } from '../../../api';
-import { fetchDatasources, saveDatasourcesToFiles } from './actions';
+import { fetchDatasource, fetchDatasources, saveDatasourcesToFiles } from './actions';
 import { vol } from 'memfs';
 
 const MAX_RETRY_DURATION = 14_000;
@@ -231,6 +231,42 @@ describe('pull datasources actions', () => {
       await vi.advanceTimersByTimeAsync(MAX_RETRY_DURATION);
       await resultPromise;
       expect(requestUrl).toBe('https://mapi.storyblok.com/v1/spaces/54321/datasources?page=1');
+    });
+  });
+
+  describe('fetchDatasource', () => {
+    it('should find a datasource whose match falls on a later page', async () => {
+      const totalDatasources = 30;
+      const allDatasources = Array.from({ length: totalDatasources }, (_, i) => ({
+        id: 1000 + i,
+        name: `match-${String(i + 1).padStart(2, '0')}`,
+        slug: `match-${i + 1}`,
+      }));
+      const requestedPages: number[] = [];
+
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/12345/datasources', ({ request }) => {
+          const url = new URL(request.url);
+          const page = Number(url.searchParams.get('page') ?? '1');
+          const perPage = Number(url.searchParams.get('per_page') ?? '25');
+          requestedPages.push(page);
+          const start = (page - 1) * perPage;
+          const slice = allDatasources.slice(start, start + perPage);
+          return HttpResponse.json(
+            { datasources: slice },
+            { headers: { total: String(totalDatasources) } },
+          );
+        }),
+        http.get('https://mapi.storyblok.com/v1/spaces/12345/datasource_entries', () =>
+          HttpResponse.json({ datasource_entries: [] })),
+      );
+
+      const resultPromise = fetchDatasource('12345', 'match-30');
+      await vi.advanceTimersByTimeAsync(MAX_RETRY_DURATION);
+      const result = await resultPromise;
+
+      expect(result?.name).toBe('match-30');
+      expect(requestedPages).toEqual([1, 2]);
     });
   });
 

--- a/packages/cli/src/commands/datasources/pull/actions.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.ts
@@ -2,41 +2,10 @@ import { handleAPIError, handleFileSystemError } from '../../../utils';
 import { getMapiClient } from '../../../api';
 import { join, resolve } from 'pathe';
 import { resolvePath, sanitizeFilename, saveToFile } from '../../../utils/filesystem';
+import { fetchAllPages } from '../../../utils/pagination';
 import type { DatasourceEntry, SpaceDatasource } from '../constants';
 import { DEFAULT_DATASOURCES_FILENAME } from '../constants';
 import type { SaveDatasourcesOptions } from './constants';
-
-/**
- * Generic pagination helper that fetches all pages of data
- * @param fetchFunction - Function that fetches a single page
- * @param extractDataFunction - Function that extracts data array from response
- * @param page - Current page number
- * @param collectedItems - Previously collected items
- * @returns Array of all items across all pages
- */
-async function fetchAllPages<T, R>(
-  fetchFunction: (page: number) => Promise<{ data: T; response: Response }>,
-  extractDataFunction: (data: T) => R[],
-  page = 1,
-  collectedItems: R[] = [],
-): Promise<R[]> {
-  const { data, response } = await fetchFunction(page);
-  const totalHeader = (response.headers.get('total'));
-  const total = Number(totalHeader);
-
-  const fetchedItems = extractDataFunction(data);
-  const allItems = [...collectedItems, ...fetchedItems];
-
-  if (!totalHeader || Number.isNaN(total)) {
-    // No valid 'total' header — assume not paginated, return all collected items plus current page
-    return allItems;
-  }
-
-  if (allItems.length < total && fetchedItems.length > 0) {
-    return fetchAllPages(fetchFunction, extractDataFunction, page + 1, allItems);
-  }
-  return allItems;
-}
 
 /**
  * Fetches entries for a given datasource id in a space.
@@ -105,16 +74,20 @@ export const fetchDatasources = async (spaceId: string): Promise<SpaceDatasource
 export const fetchDatasource = async (spaceId: string, datasourceName: string): Promise<SpaceDatasource | undefined> => {
   try {
     const client = getMapiClient();
-    const { data } = await client.datasources.list({
-      path: {
-        space_id: Number(spaceId),
-      },
-      query: {
-        search: datasourceName,
-      },
-      throwOnError: true,
-    });
-    const found = data.datasources?.find((d: SpaceDatasource) => d.name === datasourceName);
+    const matches = await fetchAllPages(
+      (page: number) => client.datasources.list({
+        path: {
+          space_id: Number(spaceId),
+        },
+        query: {
+          page,
+          search: datasourceName,
+        },
+        throwOnError: true,
+      }),
+      data => data.datasources || [],
+    );
+    const found = matches.find((d: SpaceDatasource) => d.name === datasourceName);
     if (!found) { return undefined; }
     // Fetch entries for the found datasource
     const entries = await fetchDatasourceEntries(spaceId, found.id as number);

--- a/packages/cli/src/utils/pagination.test.ts
+++ b/packages/cli/src/utils/pagination.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { fetchAllPages } from './pagination';
+
+interface Page { items: number[] }
+
+function makeResponse(items: number[], total?: number) {
+  const headers = new Headers();
+  if (total !== undefined) {
+    headers.set('total', String(total));
+  }
+  return {
+    data: { items },
+    response: new Response(null, { headers }),
+  };
+}
+
+describe('fetchAllPages', () => {
+  it('returns an empty array when the first page has no items and no total header', async () => {
+    const calls: number[] = [];
+    const result = await fetchAllPages<Page, number>(
+      (page) => {
+        calls.push(page);
+        return Promise.resolve(makeResponse([]));
+      },
+      data => data.items,
+    );
+
+    expect(result).toEqual([]);
+    expect(calls).toEqual([1]);
+  });
+
+  it('returns the single page when no total header is present', async () => {
+    const calls: number[] = [];
+    const result = await fetchAllPages<Page, number>(
+      (page) => {
+        calls.push(page);
+        return Promise.resolve(makeResponse([1, 2, 3]));
+      },
+      data => data.items,
+    );
+
+    expect(result).toEqual([1, 2, 3]);
+    expect(calls).toEqual([1]);
+  });
+
+  it('combines all pages until total is reached', async () => {
+    const total = 7;
+    const pages: Record<number, number[]> = {
+      1: [1, 2, 3],
+      2: [4, 5, 6],
+      3: [7],
+    };
+    const calls: number[] = [];
+
+    const result = await fetchAllPages<Page, number>(
+      (page) => {
+        calls.push(page);
+        return Promise.resolve(makeResponse(pages[page] ?? [], total));
+      },
+      data => data.items,
+    );
+
+    expect(result).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(calls).toEqual([1, 2, 3]);
+  });
+
+  it('stops when a page returns no items even if total has not been reached', async () => {
+    // Defends against infinite loops if the API misreports total or items get deleted mid-fetch.
+    const calls: number[] = [];
+    const result = await fetchAllPages<Page, number>(
+      (page) => {
+        calls.push(page);
+        if (page === 1) { return Promise.resolve(makeResponse([1, 2], 99)); }
+        return Promise.resolve(makeResponse([], 99));
+      },
+      data => data.items,
+    );
+
+    expect(result).toEqual([1, 2]);
+    expect(calls).toEqual([1, 2]);
+  });
+
+  it('stops when collected items already match or exceed total after the first page', async () => {
+    // Total smaller than what the first page returns — should not request a second page.
+    const calls: number[] = [];
+    const result = await fetchAllPages<Page, number>(
+      (page) => {
+        calls.push(page);
+        return Promise.resolve(makeResponse([1, 2, 3, 4, 5], 3));
+      },
+      data => data.items,
+    );
+
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+    expect(calls).toEqual([1]);
+  });
+});

--- a/packages/cli/src/utils/pagination.ts
+++ b/packages/cli/src/utils/pagination.ts
@@ -1,0 +1,32 @@
+/**
+ * Fetches every page of a list endpoint and returns the combined items.
+ * Stops when the `total` response header is reached, when a page returns
+ * no items, or immediately if the header is absent (treats the response
+ * as un-paginated).
+ *
+ * @param fetchFunction - Fetches a single page; receives the 1-based page number
+ * @param extractDataFunction - Extracts the items array from a page's response data
+ */
+export async function fetchAllPages<T, R>(
+  fetchFunction: (page: number) => Promise<{ data: T; response: Response }>,
+  extractDataFunction: (data: T) => R[],
+): Promise<R[]> {
+  const items: R[] = [];
+  let page = 1;
+
+  while (true) {
+    const { data, response } = await fetchFunction(page);
+    const totalHeader = response.headers.get('total');
+    const fetchedItems = extractDataFunction(data);
+    items.push(...fetchedItems);
+
+    if (!totalHeader) {
+      return items;
+    }
+    const total = Number(totalHeader);
+    if (Number.isNaN(total) || items.length >= total || fetchedItems.length === 0) {
+      return items;
+    }
+    page++;
+  }
+}


### PR DESCRIPTION
`storyblok components pull` silently dropped list resources past the first page because the MAPI `.list()` calls in `components/pull/actions.ts` were issued without pagination. With the default page size of 25, spaces that had more than 25 component internal tags (or >25 components) lost everything on later pages. A later `components push` then failed on any component that referenced a dropped tag with HTTP 422
`internal_tag_ids: Invalid internal_tag, there is at least one internal_tag not found in our database`.

Extract the `fetchAllPages` helper from `datasources/pull/actions.ts` into a shared `utils/pagination.ts` (iterative, single-allocation), and apply it to `fetchComponents`, `fetchComponent`, and `fetchComponentInternalTags`. The internal-tag fetch now also pushes `by_object_type: 'component'` into the MAPI query, so filtering happens server-side. Component folders and presets are left untouched because their MAPI endpoints are not paginated.

Adds direct unit tests for `fetchAllPages` and multi-page regression tests for `fetchComponents` and `fetchComponentInternalTags`.

Fixes WDX-397