### PR TITLE
fix(react): use story ids for RSC preview cache handoff

### DIFF
--- a/packages/react/src/__tests__/live-edit-update-action.test.ts
+++ b/packages/react/src/__tests__/live-edit-update-action.test.ts
@@ -44,6 +44,22 @@ describe('liveEditUpdateAction', () => {
     expect(globalThis.storyCache.get('123')).not.toBe(oldStory);
   });
 
+  it('should cache under the provided cacheKey when given', async () => {
+    const story = { id: 42, content: { headline: 'historic' } };
+    await liveEditUpdateAction({ story, pathToRevalidate: '/path', cacheKey: 'id:42' });
+    expect(globalThis.storyCache.get('id:42')).toBe(story);
+    // uuid is undefined, so it must not be written under the uuid
+    expect(globalThis.storyCache.has('undefined')).toBe(false);
+  });
+
+  it('should skip caching when both cacheKey and story.uuid are missing', async () => {
+    const story = { id: 99, content: {} };
+    const before = globalThis.storyCache.size;
+    await liveEditUpdateAction({ story, pathToRevalidate: '/path' });
+    expect(globalThis.storyCache.size).toBe(before);
+    expect(globalThis.storyCache.has('undefined')).toBe(false);
+  });
+
   it('should attempt to revalidate path when in Next.js environment', async () => {
     // Mock Next.js environment
     process.env.NEXT_RUNTIME = 'nodejs';
@@ -60,6 +76,22 @@ describe('liveEditUpdateAction', () => {
     await actionWithMocks({ story, pathToRevalidate: '/test-path' });
 
     expect(mockRevalidatePath).toHaveBeenCalledWith('/test-path');
+  });
+
+  it('should revalidate path for history events keyed by cacheKey', async () => {
+    process.env.NEXT_RUNTIME = 'nodejs';
+
+    vi.doMock('next/cache', async () => {
+      return { revalidatePath: mockRevalidatePath };
+    });
+
+    const { liveEditUpdateAction: actionWithMocks } = await import('../rsc/live-edit-update-action');
+
+    const story = { id: 7, content: { headline: 'history' } };
+    await actionWithMocks({ story, pathToRevalidate: '/vh-path', cacheKey: 'id:7' });
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/vh-path');
+    expect(globalThis.storyCache.get('id:7')).toBe(story);
   });
 
   it('should catch and log errors during revalidation', async () => {

--- a/packages/react/src/__tests__/live-edit-update-action.test.ts
+++ b/packages/react/src/__tests__/live-edit-update-action.test.ts
@@ -27,14 +27,14 @@ describe('liveEditUpdateAction', () => {
   });
 
   it('should set the story in the global storyCache', async () => {
-    const story = { uuid: '123' };
+    const story = { id: 123 };
     await liveEditUpdateAction({ story, pathToRevalidate: '/path' });
     expect(globalThis.storyCache.get('123')).toBe(story);
   });
 
   it('should replace existing story in the cache if it already exists', async () => {
-    const oldStory = { uuid: '123', content: { old: true } };
-    const newStory = { uuid: '123', content: { new: true } };
+    const oldStory = { id: 123, content: { old: true } };
+    const newStory = { id: 123, content: { new: true } };
 
     globalThis.storyCache.set('123', oldStory);
     expect(globalThis.storyCache.get('123')).toBe(oldStory);
@@ -44,16 +44,15 @@ describe('liveEditUpdateAction', () => {
     expect(globalThis.storyCache.get('123')).not.toBe(oldStory);
   });
 
-  it('should cache under the provided cacheKey when given', async () => {
+  it('should cache id-only history payloads under the story id', async () => {
     const story = { id: 42, content: { headline: 'historic' } };
-    await liveEditUpdateAction({ story, pathToRevalidate: '/path', cacheKey: 'id:42' });
-    expect(globalThis.storyCache.get('id:42')).toBe(story);
-    // uuid is undefined, so it must not be written under the uuid
+    await liveEditUpdateAction({ story, pathToRevalidate: '/path' });
+    expect(globalThis.storyCache.get('42')).toBe(story);
     expect(globalThis.storyCache.has('undefined')).toBe(false);
   });
 
-  it('should skip caching when both cacheKey and story.uuid are missing', async () => {
-    const story = { id: 99, content: {} };
+  it('should skip caching when story.id is missing', async () => {
+    const story = { uuid: 'uuid-only', content: {} };
     const before = globalThis.storyCache.size;
     await liveEditUpdateAction({ story, pathToRevalidate: '/path' });
     expect(globalThis.storyCache.size).toBe(before);
@@ -72,13 +71,13 @@ describe('liveEditUpdateAction', () => {
     // Re-import the module to use the mocked version
     const { liveEditUpdateAction: actionWithMocks } = await import('../rsc/live-edit-update-action');
 
-    const story = { uuid: '123' };
+    const story = { id: 123 };
     await actionWithMocks({ story, pathToRevalidate: '/test-path' });
 
     expect(mockRevalidatePath).toHaveBeenCalledWith('/test-path');
   });
 
-  it('should revalidate path for history events keyed by cacheKey', async () => {
+  it('should revalidate path for id-only history payloads', async () => {
     process.env.NEXT_RUNTIME = 'nodejs';
 
     vi.doMock('next/cache', async () => {
@@ -88,10 +87,10 @@ describe('liveEditUpdateAction', () => {
     const { liveEditUpdateAction: actionWithMocks } = await import('../rsc/live-edit-update-action');
 
     const story = { id: 7, content: { headline: 'history' } };
-    await actionWithMocks({ story, pathToRevalidate: '/vh-path', cacheKey: 'id:7' });
+    await actionWithMocks({ story, pathToRevalidate: '/vh-path' });
 
     expect(mockRevalidatePath).toHaveBeenCalledWith('/vh-path');
-    expect(globalThis.storyCache.get('id:7')).toBe(story);
+    expect(globalThis.storyCache.get('7')).toBe(story);
   });
 
   it('should catch and log errors during revalidation', async () => {
@@ -110,7 +109,7 @@ describe('liveEditUpdateAction', () => {
     // Re-import the module to use the mocked version
     const { liveEditUpdateAction: actionWithMocks } = await import('../rsc/live-edit-update-action');
 
-    const story = { uuid: '456' };
+    const story = { id: 456 };
     await actionWithMocks({ story, pathToRevalidate: '/path' });
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(

--- a/packages/react/src/__tests__/live-editing.test.ts
+++ b/packages/react/src/__tests__/live-editing.test.ts
@@ -111,7 +111,7 @@ describe('storyblokLiveEditing', () => {
     expect(loadStoryblokBridge).not.toHaveBeenCalled();
   });
 
-  it('should call liveEditUpdateAction without cacheKey for regular live-edit events', async () => {
+  it('should call liveEditUpdateAction for regular live-edit events', async () => {
     vi.mocked(isVisualEditor).mockReturnValue(true);
     vi.mocked(isBridgeLoaded).mockReturnValue(true);
 
@@ -135,12 +135,12 @@ describe('storyblokLiveEditing', () => {
     expect(liveEditUpdateAction).toHaveBeenCalledWith(
       expect.objectContaining({
         story: expect.objectContaining({ uuid: 'uuid-10' }),
-        cacheKey: undefined,
+        pathToRevalidate: '/',
       }),
     );
   });
 
-  it('should call liveEditUpdateAction with id cacheKey for Visual History events', async () => {
+  it('should call liveEditUpdateAction with the same payload shape for Visual History events', async () => {
     vi.mocked(isVisualEditor).mockReturnValue(true);
     vi.mocked(isBridgeLoaded).mockReturnValue(true);
 
@@ -165,7 +165,7 @@ describe('storyblokLiveEditing', () => {
     expect(liveEditUpdateAction).toHaveBeenCalledWith(
       expect.objectContaining({
         story: expect.objectContaining({ id: 42 }),
-        cacheKey: 'id:42',
+        pathToRevalidate: '/',
       }),
     );
   });

--- a/packages/react/src/__tests__/live-editing.test.ts
+++ b/packages/react/src/__tests__/live-editing.test.ts
@@ -6,7 +6,8 @@ import type { ISbStoryData } from '@storyblok/js';
 // Import after mocks
 import StoryblokLiveEditing from '../rsc/live-editing';
 import { isBridgeLoaded, isVisualEditor } from '../utils';
-import { loadStoryblokBridge } from '@storyblok/js';
+import { loadStoryblokBridge, registerStoryblokBridge } from '@storyblok/js';
+import { liveEditUpdateAction } from '../rsc/live-edit-update-action';
 
 // Mock dependencies - need to define functions inline to avoid hoisting issues
 vi.mock('../rsc/live-edit-update-action', () => ({
@@ -108,5 +109,64 @@ describe('storyblokLiveEditing', () => {
 
     // Since bridge is already loaded, we should not call loadStoryblokBridge
     expect(loadStoryblokBridge).not.toHaveBeenCalled();
+  });
+
+  it('should call liveEditUpdateAction without cacheKey for regular live-edit events', async () => {
+    vi.mocked(isVisualEditor).mockReturnValue(true);
+    vi.mocked(isBridgeLoaded).mockReturnValue(true);
+
+    let captured: ((story: ISbStoryData) => void) | null = null;
+    vi.mocked(registerStoryblokBridge).mockImplementation((_id, cb) => {
+      captured = cb as (story: ISbStoryData) => void;
+    });
+
+    render(
+      React.createElement(StoryblokLiveEditing, {
+        story: { id: 10, uuid: 'uuid-10' } as ISbStoryData,
+        bridgeOptions: {},
+      }),
+    );
+
+    await vi.waitFor(() => expect(captured).not.toBeNull());
+
+    captured!({ id: 10, uuid: 'uuid-10', content: { _uid: 'x' } } as ISbStoryData);
+
+    await vi.waitFor(() => expect(liveEditUpdateAction).toHaveBeenCalled());
+    expect(liveEditUpdateAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        story: expect.objectContaining({ uuid: 'uuid-10' }),
+        cacheKey: undefined,
+      }),
+    );
+  });
+
+  it('should call liveEditUpdateAction with id cacheKey for Visual History events', async () => {
+    vi.mocked(isVisualEditor).mockReturnValue(true);
+    vi.mocked(isBridgeLoaded).mockReturnValue(true);
+
+    let captured: ((story: ISbStoryData) => void) | null = null;
+    vi.mocked(registerStoryblokBridge).mockImplementation((_id, cb) => {
+      captured = cb as (story: ISbStoryData) => void;
+    });
+
+    render(
+      React.createElement(StoryblokLiveEditing, {
+        story: { id: 42, uuid: 'uuid-42' } as ISbStoryData,
+        bridgeOptions: {},
+      }),
+    );
+
+    await vi.waitFor(() => expect(captured).not.toBeNull());
+
+    // Visual History payload: minimal, no uuid
+    captured!({ id: 42, content: { _uid: 'hist' } } as unknown as ISbStoryData);
+
+    await vi.waitFor(() => expect(liveEditUpdateAction).toHaveBeenCalled());
+    expect(liveEditUpdateAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        story: expect.objectContaining({ id: 42 }),
+        cacheKey: 'id:42',
+      }),
+    );
   });
 });

--- a/packages/react/src/__tests__/rsc-story.test.tsx
+++ b/packages/react/src/__tests__/rsc-story.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import type { ISbStoryData } from '@storyblok/js';
+
+import StoryblokStory from '../rsc/story';
+import { setComponents } from '../core/state';
+
+// StoryblokLiveEditing registers the bridge on mount; for rendering tests we
+// keep `isVisualEditor` falsy so it short-circuits to `return null`.
+vi.mock('../utils', async () => {
+  const actual = await vi.importActual<typeof import('../utils')>('../utils');
+  return {
+    ...actual,
+    isVisualEditor: vi.fn(() => false),
+    isBridgeLoaded: vi.fn(() => false),
+  };
+});
+
+vi.mock('@storyblok/js', () => ({
+  registerStoryblokBridge: vi.fn(),
+  loadStoryblokBridge: vi.fn(() => Promise.resolve()),
+}));
+
+function Marker({ blok }: { blok: { label?: string } }) {
+  return <span data-testid="marker">{blok?.label ?? 'no-label'}</span>;
+}
+
+describe('storyblokStory cache lookup', () => {
+  beforeEach(() => {
+    globalThis.storyCache = new Map();
+    setComponents({ marker: Marker });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the uuid-keyed cached story and clears the uuid entry', () => {
+    const server = { id: 1, uuid: 'u-1', content: { component: 'marker', label: 'server' } } as unknown as ISbStoryData;
+    const cached = { id: 1, uuid: 'u-1', content: { component: 'marker', label: 'cached' } } as unknown as ISbStoryData;
+    globalThis.storyCache.set('u-1', cached);
+
+    const { getByTestId } = render(<StoryblokStory story={server} />);
+
+    expect(getByTestId('marker').textContent).toBe('cached');
+    expect(globalThis.storyCache.has('u-1')).toBe(false);
+  });
+
+  it('falls back to the id-index when uuid miss, merging payload onto server story', () => {
+    const server = {
+      id: 42,
+      uuid: 'u-draft',
+      slug: 'home',
+      full_slug: 'home',
+      content: { component: 'marker', label: 'draft' },
+    } as unknown as ISbStoryData;
+    const historyPayload = {
+      id: 42,
+      content: { component: 'marker', label: 'history' },
+    } as unknown as ISbStoryData;
+    globalThis.storyCache.set('id:42', historyPayload);
+
+    const { getByTestId } = render(<StoryblokStory story={server} />);
+
+    expect(getByTestId('marker').textContent).toBe('history');
+    expect(globalThis.storyCache.has('id:42')).toBe(false);
+  });
+
+  it('renders the server story when no cache entry matches', () => {
+    const server = { id: 7, uuid: 'u-7', content: { component: 'marker', label: 'only-draft' } } as unknown as ISbStoryData;
+
+    const { getByTestId } = render(<StoryblokStory story={server} />);
+
+    expect(getByTestId('marker').textContent).toBe('only-draft');
+  });
+
+  it('prefers the uuid entry over an id-index entry when both exist', () => {
+    const server = { id: 9, uuid: 'u-9', content: { component: 'marker', label: 'draft' } } as unknown as ISbStoryData;
+    const uuidHit = { id: 9, uuid: 'u-9', content: { component: 'marker', label: 'by-uuid' } } as unknown as ISbStoryData;
+    const idHit = { id: 9, content: { component: 'marker', label: 'by-id' } } as unknown as ISbStoryData;
+    globalThis.storyCache.set('u-9', uuidHit);
+    globalThis.storyCache.set('id:9', idHit);
+
+    const { getByTestId } = render(<StoryblokStory story={server} />);
+
+    expect(getByTestId('marker').textContent).toBe('by-uuid');
+    // Both entries are cleared so a stale id-index payload can't replay later.
+    expect(globalThis.storyCache.has('u-9')).toBe(false);
+    expect(globalThis.storyCache.has('id:9')).toBe(false);
+  });
+
+  it('clears a stale id-index entry even when no cache hit occurs', () => {
+    // Simulates a later render (no fresh bridge event) where a previous uuid
+    // consumption left an older Visual History payload behind.
+    const server = { id: 11, uuid: 'u-11', content: { component: 'marker', label: 'draft' } } as unknown as ISbStoryData;
+    const staleHistory = { id: 11, content: { component: 'marker', label: 'stale-history' } } as unknown as ISbStoryData;
+    globalThis.storyCache.set('id:11', staleHistory);
+
+    const { getByTestId, rerender } = render(<StoryblokStory story={server} />);
+    // First render merges the stale history payload but consumes the entry.
+    expect(getByTestId('marker').textContent).toBe('stale-history');
+    expect(globalThis.storyCache.has('id:11')).toBe(false);
+
+    // Second render without any fresh cache entry renders the server story.
+    rerender(<StoryblokStory story={server} />);
+    expect(getByTestId('marker').textContent).toBe('draft');
+  });
+});

--- a/packages/react/src/__tests__/rsc-story.test.tsx
+++ b/packages/react/src/__tests__/rsc-story.test.tsx
@@ -36,18 +36,18 @@ describe('storyblokStory cache lookup', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the uuid-keyed cached story and clears the uuid entry', () => {
+  it('renders the id-keyed cached story and clears the id entry', () => {
     const server = { id: 1, uuid: 'u-1', content: { component: 'marker', label: 'server' } } as unknown as ISbStoryData;
     const cached = { id: 1, uuid: 'u-1', content: { component: 'marker', label: 'cached' } } as unknown as ISbStoryData;
-    globalThis.storyCache.set('u-1', cached);
+    globalThis.storyCache.set('1', cached);
 
     const { getByTestId } = render(<StoryblokStory story={server} />);
 
     expect(getByTestId('marker').textContent).toBe('cached');
-    expect(globalThis.storyCache.has('u-1')).toBe(false);
+    expect(globalThis.storyCache.has('1')).toBe(false);
   });
 
-  it('falls back to the id-index when uuid miss, merging payload onto server story', () => {
+  it('merges the id-keyed payload onto the server story', () => {
     const server = {
       id: 42,
       uuid: 'u-draft',
@@ -59,12 +59,12 @@ describe('storyblokStory cache lookup', () => {
       id: 42,
       content: { component: 'marker', label: 'history' },
     } as unknown as ISbStoryData;
-    globalThis.storyCache.set('id:42', historyPayload);
+    globalThis.storyCache.set('42', historyPayload);
 
     const { getByTestId } = render(<StoryblokStory story={server} />);
 
     expect(getByTestId('marker').textContent).toBe('history');
-    expect(globalThis.storyCache.has('id:42')).toBe(false);
+    expect(globalThis.storyCache.has('42')).toBe(false);
   });
 
   it('renders the server story when no cache entry matches', () => {
@@ -75,32 +75,15 @@ describe('storyblokStory cache lookup', () => {
     expect(getByTestId('marker').textContent).toBe('only-draft');
   });
 
-  it('prefers the uuid entry over an id-index entry when both exist', () => {
-    const server = { id: 9, uuid: 'u-9', content: { component: 'marker', label: 'draft' } } as unknown as ISbStoryData;
-    const uuidHit = { id: 9, uuid: 'u-9', content: { component: 'marker', label: 'by-uuid' } } as unknown as ISbStoryData;
-    const idHit = { id: 9, content: { component: 'marker', label: 'by-id' } } as unknown as ISbStoryData;
-    globalThis.storyCache.set('u-9', uuidHit);
-    globalThis.storyCache.set('id:9', idHit);
-
-    const { getByTestId } = render(<StoryblokStory story={server} />);
-
-    expect(getByTestId('marker').textContent).toBe('by-uuid');
-    // Both entries are cleared so a stale id-index payload can't replay later.
-    expect(globalThis.storyCache.has('u-9')).toBe(false);
-    expect(globalThis.storyCache.has('id:9')).toBe(false);
-  });
-
-  it('clears a stale id-index entry even when no cache hit occurs', () => {
-    // Simulates a later render (no fresh bridge event) where a previous uuid
-    // consumption left an older Visual History payload behind.
+  it('clears a stale id entry even when no fresh cache hit occurs later', () => {
     const server = { id: 11, uuid: 'u-11', content: { component: 'marker', label: 'draft' } } as unknown as ISbStoryData;
     const staleHistory = { id: 11, content: { component: 'marker', label: 'stale-history' } } as unknown as ISbStoryData;
-    globalThis.storyCache.set('id:11', staleHistory);
+    globalThis.storyCache.set('11', staleHistory);
 
     const { getByTestId, rerender } = render(<StoryblokStory story={server} />);
     // First render merges the stale history payload but consumes the entry.
     expect(getByTestId('marker').textContent).toBe('stale-history');
-    expect(globalThis.storyCache.has('id:11')).toBe(false);
+    expect(globalThis.storyCache.has('11')).toBe(false);
 
     // Second render without any fresh cache entry renders the server story.
     rerender(<StoryblokStory story={server} />);

--- a/packages/react/src/core/state.ts
+++ b/packages/react/src/core/state.ts
@@ -1,5 +1,4 @@
 import type {
-  ISbStoryData,
   SbReactComponentsMap,
   StoryblokClient,
 } from '@/types';
@@ -9,13 +8,6 @@ let storyblokApiInstance: StoryblokClient = null;
 const componentsMap: Map<string, React.ElementType> = new Map<string, React.ElementType>();
 let enableFallbackComponent: boolean = false;
 let customFallbackComponent: React.ElementType = null;
-
-declare global {
-  // eslint-disable-next-line vars-on-top
-  var storyCache: Map<string, ISbStoryData>;
-}
-
-globalThis.storyCache = globalThis.storyCache || new Map<string, ISbStoryData>();
 
 // State accessors
 export const getStoryblokApiInstance = (): StoryblokClient => storyblokApiInstance;

--- a/packages/react/src/core/story-cache.ts
+++ b/packages/react/src/core/story-cache.ts
@@ -1,0 +1,31 @@
+import type { ISbStoryData } from '@/types';
+
+declare global {
+  // eslint-disable-next-line vars-on-top
+  var storyCache: Map<string, ISbStoryData>;
+}
+
+globalThis.storyCache = globalThis.storyCache || new Map<string, ISbStoryData>();
+
+/** Returns the shared cache key for a Storyblok story. */
+export const getStoryCacheKey = (story: Pick<ISbStoryData, 'id'> | null | undefined): string | null => {
+  if (typeof story?.id !== 'number') {
+    return null;
+  }
+
+  return String(story.id);
+};
+
+/** Merges and consumes a cached live-edit update for a story id. */
+export const consumeCachedStory = (story: ISbStoryData): ISbStoryData => {
+  const cacheKey = getStoryCacheKey(story);
+
+  if (!cacheKey) {
+    return story;
+  }
+
+  const cached = globalThis.storyCache.get(cacheKey);
+  globalThis.storyCache.delete(cacheKey);
+
+  return cached ? { ...story, ...cached } : story;
+};

--- a/packages/react/src/rsc/live-edit-update-action.ts
+++ b/packages/react/src/rsc/live-edit-update-action.ts
@@ -1,12 +1,26 @@
 'use server';
 import type { ISbStoryData } from '@storyblok/js';
 
-export async function liveEditUpdateAction({ story, pathToRevalidate }: { story: ISbStoryData; pathToRevalidate: string }) {
+export async function liveEditUpdateAction({
+  story,
+  pathToRevalidate,
+  cacheKey,
+}: {
+  story: ISbStoryData;
+  pathToRevalidate: string;
+  cacheKey?: string;
+}) {
   if (!story || !pathToRevalidate) {
     return console.error('liveEditUpdateAction: story or pathToRevalidate is not provided');
   }
 
-  globalThis.storyCache?.set(story.uuid, story);
+  // Visual History events ship minimal `{ id, content }` payloads without a uuid.
+  // Callers pass `cacheKey` (e.g. `id:<id>`) so the cache entry is retrievable
+  // after revalidation, since the server-fetched draft has a different uuid.
+  const key = cacheKey ?? story.uuid;
+  if (key) {
+    globalThis.storyCache?.set(key, story);
+  }
 
   // Revalidate path in Next.js SDKs only
   if (process.env.NEXT_RUNTIME) {

--- a/packages/react/src/rsc/live-edit-update-action.ts
+++ b/packages/react/src/rsc/live-edit-update-action.ts
@@ -1,25 +1,21 @@
 'use server';
 import type { ISbStoryData } from '@storyblok/js';
+import { getStoryCacheKey } from '../core/story-cache';
 
 export async function liveEditUpdateAction({
   story,
   pathToRevalidate,
-  cacheKey,
 }: {
   story: ISbStoryData;
   pathToRevalidate: string;
-  cacheKey?: string;
 }) {
   if (!story || !pathToRevalidate) {
     return console.error('liveEditUpdateAction: story or pathToRevalidate is not provided');
   }
 
-  // Visual History events ship minimal `{ id, content }` payloads without a uuid.
-  // Callers pass `cacheKey` (e.g. `id:<id>`) so the cache entry is retrievable
-  // after revalidation, since the server-fetched draft has a different uuid.
-  const key = cacheKey ?? story.uuid;
-  if (key) {
-    globalThis.storyCache?.set(key, story);
+  const cacheKey = getStoryCacheKey(story);
+  if (cacheKey) {
+    globalThis.storyCache?.set(cacheKey, story);
   }
 
   // Revalidate path in Next.js SDKs only

--- a/packages/react/src/rsc/live-editing.tsx
+++ b/packages/react/src/rsc/live-editing.tsx
@@ -21,23 +21,35 @@ const StoryblokLiveEditing = ({ story = null, bridgeOptions = {} }: { story: ISb
         await loadStoryblokBridge();
       }
 
-      const handleInput = async (story: ISbStoryData) => {
-        if (!story) {
+      const handleInput = async (incoming: ISbStoryData) => {
+        if (!incoming) {
           return;
         }
+
+        // Visual History picks arrive as minimal `{ id, content }` payloads
+        // without a uuid. Key the cache by id so the server re-render can find
+        // them after revalidatePath returns the draft (which has a different
+        // uuid).
+        const isHistoryEvent = !incoming.uuid && typeof incoming.id === 'number';
+        const cacheKey = isHistoryEvent ? `id:${incoming.id}` : undefined;
 
         try {
           const { liveEditUpdateAction } = await import('./live-edit-update-action');
 
           startTransition(() => {
-            liveEditUpdateAction({ story, pathToRevalidate: window.location.pathname });
+            liveEditUpdateAction({
+              story: incoming,
+              pathToRevalidate: window.location.pathname,
+              cacheKey,
+            });
           });
         }
         catch (error) {
           // Fallback: just cache the story if server action is not available
           console.warn('Server action not available, caching story locally:', error);
-          if (story.uuid) {
-            globalThis.storyCache?.set(story.uuid, story);
+          const fallbackKey = cacheKey ?? incoming.uuid;
+          if (fallbackKey) {
+            globalThis.storyCache?.set(fallbackKey, incoming);
           }
         }
       };

--- a/packages/react/src/rsc/live-editing.tsx
+++ b/packages/react/src/rsc/live-editing.tsx
@@ -2,6 +2,7 @@
 
 import { type ISbStoryData, loadStoryblokBridge, registerStoryblokBridge, type StoryblokBridgeConfigV2 } from '@storyblok/js';
 import { startTransition, useEffect } from 'react';
+import { getStoryCacheKey } from '../core/story-cache';
 import { isBridgeLoaded, isVisualEditor } from '../utils';
 
 const StoryblokLiveEditing = ({ story = null, bridgeOptions = {} }: { story: ISbStoryData; bridgeOptions?: StoryblokBridgeConfigV2 }) => {
@@ -11,8 +12,12 @@ const StoryblokLiveEditing = ({ story = null, bridgeOptions = {} }: { story: ISb
     return null;
   }
 
-  const storyId = story?.id ?? 0;
+  const storyId = typeof story?.id === 'number' ? story.id : null;
   useEffect(() => {
+    if (storyId === null) {
+      return;
+    }
+
     (async () => {
       // In RSC environments, Storyblok components are server-side rendered,
       // so the bridge script is never automatically loaded on the client.
@@ -26,13 +31,6 @@ const StoryblokLiveEditing = ({ story = null, bridgeOptions = {} }: { story: ISb
           return;
         }
 
-        // Visual History picks arrive as minimal `{ id, content }` payloads
-        // without a uuid. Key the cache by id so the server re-render can find
-        // them after revalidatePath returns the draft (which has a different
-        // uuid).
-        const isHistoryEvent = !incoming.uuid && typeof incoming.id === 'number';
-        const cacheKey = isHistoryEvent ? `id:${incoming.id}` : undefined;
-
         try {
           const { liveEditUpdateAction } = await import('./live-edit-update-action');
 
@@ -40,14 +38,13 @@ const StoryblokLiveEditing = ({ story = null, bridgeOptions = {} }: { story: ISb
             liveEditUpdateAction({
               story: incoming,
               pathToRevalidate: window.location.pathname,
-              cacheKey,
             });
           });
         }
         catch (error) {
           // Fallback: just cache the story if server action is not available
           console.warn('Server action not available, caching story locally:', error);
-          const fallbackKey = cacheKey ?? incoming.uuid;
+          const fallbackKey = getStoryCacheKey(incoming);
           if (fallbackKey) {
             globalThis.storyCache?.set(fallbackKey, incoming);
           }

--- a/packages/react/src/rsc/story.tsx
+++ b/packages/react/src/rsc/story.tsx
@@ -17,10 +17,25 @@ const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
       return null;
     }
 
-    if (globalThis?.storyCache.has(story.uuid)) {
-      story = globalThis.storyCache.get(story.uuid);
-      // Delete the story from the cache to avoid draft content leaking
-      globalThis.storyCache.delete(story.uuid);
+    const uuidKey = story.uuid;
+    const idKey = typeof story.id === 'number' ? `id:${story.id}` : null;
+
+    if (globalThis?.storyCache.has(uuidKey)) {
+      story = globalThis.storyCache.get(uuidKey);
+    }
+    else if (idKey && globalThis?.storyCache.has(idKey)) {
+      // Visual History fallback: the cached payload is minimal (`{ id, content }`),
+      // so merge it on top of the server-fetched story to keep slug/full_slug/etc.
+      const cached = globalThis.storyCache.get(idKey);
+      story = { ...story, ...cached };
+    }
+
+    // Clear both possible keys for this story so a stale Visual History payload
+    // can't replay on a later render (e.g. after a subsequent live-edit consumes
+    // the uuid entry but leaves an older id-keyed entry behind).
+    globalThis?.storyCache.delete(uuidKey);
+    if (idKey) {
+      globalThis?.storyCache.delete(idKey);
     }
 
     if (typeof story.content === 'string') {

--- a/packages/react/src/rsc/story.tsx
+++ b/packages/react/src/rsc/story.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import type { ISbStoryData, StoryblokBridgeConfigV2 } from '@/types';
+import { consumeCachedStory } from '../core/story-cache';
 import StoryblokServerComponent from '../server/server-component';
 import StoryblokLiveEditing from './live-editing';
 
@@ -17,26 +18,7 @@ const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
       return null;
     }
 
-    const uuidKey = story.uuid;
-    const idKey = typeof story.id === 'number' ? `id:${story.id}` : null;
-
-    if (globalThis?.storyCache.has(uuidKey)) {
-      story = globalThis.storyCache.get(uuidKey);
-    }
-    else if (idKey && globalThis?.storyCache.has(idKey)) {
-      // Visual History fallback: the cached payload is minimal (`{ id, content }`),
-      // so merge it on top of the server-fetched story to keep slug/full_slug/etc.
-      const cached = globalThis.storyCache.get(idKey);
-      story = { ...story, ...cached };
-    }
-
-    // Clear both possible keys for this story so a stale Visual History payload
-    // can't replay on a later render (e.g. after a subsequent live-edit consumes
-    // the uuid entry but leaves an older id-keyed entry behind).
-    globalThis?.storyCache.delete(uuidKey);
-    if (idKey) {
-      globalThis?.storyCache.delete(idKey);
-    }
+    story = consumeCachedStory(story);
 
     if (typeof story.content === 'string') {
       try {

--- a/packages/react/src/server/server-story.tsx
+++ b/packages/react/src/server/server-story.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import type { ISbStoryData } from '@/types';
+import { consumeCachedStory } from '../core/story-cache';
 import StoryblokServerComponent from './server-component';
 
 interface StoryblokServerStoryProps extends Omit<Record<string, unknown>, 'story'> {
@@ -20,11 +21,7 @@ const StoryblokServerStory = forwardRef<HTMLElement, StoryblokServerStoryProps>(
     }
 
     // Handle cached story updates (for revalidation scenarios)
-    if (globalThis?.storyCache.has(story.uuid)) {
-      story = globalThis.storyCache.get(story.uuid);
-      // Delete the story from the cache to avoid draft content leaking
-      globalThis.storyCache.delete(story.uuid);
-    }
+    story = consumeCachedStory(story);
 
     // Parse story content if it's a string
     if (typeof story.content === 'string') {


### PR DESCRIPTION
## Summary
- use `story.id` as the single cache key for the RSC preview handoff between bridge events and the next server render
- remove the uuid/history split so regular live-edit payloads and minimal Visual History payloads follow the same cache path
- share cache-key generation and cache consumption across the RSC renderers and cover the id-only flow in tests

Fixes WDX-397