### PR TITLE
chore(release): gate packages by per-package release.branches

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,13 +37,12 @@ jobs:
       - name: Print Environment Info
         run: pnpm nx report
 
+      # Only publish packages that were bumped in the latest release commit.
       # Workaround for Nx bugs:
       #   - https://github.com/nrwl/nx/issues/34000
       #   - https://github.com/nrwl/nx/issues/27822
-      # For prereleases, only publish packages that were bumped in the release commit
-      - name: Detect packages to publish (prerelease)
+      - name: Detect packages to publish
         id: detect-packages
-        if: steps.npm-tag.outputs.tag != 'latest'
         run: |
           # Find the latest "chore(release): publish" commit and extract package names
           RELEASE_COMMIT=$(git log --grep='^chore(release): publish' --format=%H -1)
@@ -53,11 +52,12 @@ jobs:
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
       - name: Publish packages
+        env:
+          NPM_TAG: ${{ steps.npm-tag.outputs.tag }}
+          PACKAGES: ${{ steps.detect-packages.outputs.packages }}
         run: |
-          if [ "${{ steps.npm-tag.outputs.tag }}" = "latest" ]; then
-            pnpm nx release publish --excludeTaskDependencies --tag=latest
-          elif [ -n "${{ steps.detect-packages.outputs.packages }}" ]; then
-            pnpm nx release publish --excludeTaskDependencies --tag=${{ steps.npm-tag.outputs.tag }} --projects=${{ steps.detect-packages.outputs.packages }}
+          if [ -n "$PACKAGES" ]; then
+            pnpm nx release publish --excludeTaskDependencies --tag="$NPM_TAG" --projects="$PACKAGES"
           else
             echo "No packages to publish"
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,19 +37,45 @@ jobs:
       - name: Print Environment Info
         run: pnpm nx report
 
-      # Only publish packages that were bumped in the latest release commit.
-      # Workaround for Nx bugs:
+      # Compute the list of projects to publish. Always filter by each
+      # package's `release.branches` so alpha-only packages can never be
+      # published to `latest` from main (or to `beta`/`next` from the wrong
+      # branch), regardless of how versioning was performed.
+      #
+      # On main: publish every eligible package. `nx release publish` is a
+      # no-op for versions already on npm, so this restores catch-up semantics
+      # if a previous release cycle skipped the publish step.
+      #
+      # On prereleases: intersect eligibility with the packages bumped in the
+      # latest `chore(release): publish` commit. The intersection is needed
+      # as a workaround for nx publish bugs that would otherwise try to
+      # publish unrelated packages:
       #   - https://github.com/nrwl/nx/issues/34000
       #   - https://github.com/nrwl/nx/issues/27822
-      - name: Detect packages to publish
+      - name: Determine projects to publish
         id: detect-packages
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          # Find the latest "chore(release): publish" commit and extract package names
-          RELEASE_COMMIT=$(git log --grep='^chore(release): publish' --format=%H -1)
-          echo "Release commit: $RELEASE_COMMIT"
-          PACKAGES=$(git log -1 --format=%B "$RELEASE_COMMIT" | grep '^- project:' | awk '{print $3}' | paste -sd ',' -)
-          echo "Packages to publish: $PACKAGES"
-          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+          ELIGIBLE=$(node tools/release-branches.mjs "$BRANCH_NAME")
+          echo "Eligible on $BRANCH_NAME: $ELIGIBLE"
+
+          if [ "$BRANCH_NAME" = "main" ]; then
+            echo "packages=$ELIGIBLE" >> "$GITHUB_OUTPUT"
+          else
+            RELEASE_COMMIT=$(git log --grep='^chore(release): publish' --format=%H -1)
+            echo "Release commit: $RELEASE_COMMIT"
+            BUMPED=$(git log -1 --format=%B "$RELEASE_COMMIT" | grep '^- project:' | awk '{print $3}' | paste -sd ',' -)
+            echo "Bumped in release commit: $BUMPED"
+            PACKAGES=$(ELIGIBLE="$ELIGIBLE" BUMPED="$BUMPED" node -e '
+              const eligible = new Set((process.env.ELIGIBLE || "").split(",").filter(Boolean));
+              const bumped = (process.env.BUMPED || "").split(",").filter(Boolean);
+              process.stdout.write(bumped.filter(p => eligible.has(p)).join(","));
+            ')
+            echo "Packages to publish: $PACKAGES"
+            echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
 
       - name: Publish packages
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -113,16 +113,18 @@ To release a pre-release version (e.g., for testing before stable release):
 
 #### Supported Pre-release Channels by Package
 
-Not all packages have pre-release channels configured. Check the `release.branches` field in each package's `package.json`:
+Each package's `release.branches` in its `package.json` is the source of truth for which branches it may release from. `pnpm release` reads this field and skips any package whose list does not include the current branch. Packages without a `release.branches` field release from every release branch (`main`, `alpha`, `beta`, `next`).
+
+To keep a package out of stable releases, omit `"main"` from its `release.branches`. To promote an alpha-only package to stable, add `"main"` back.
 
 | Package | Channels |
 |---------|----------|
-| `@storyblok/astro` | `alpha`, `next` |
-| `@storyblok/nuxt` | `next` |
-| `storyblok-js-client` | `beta`, `next` |
-| `@storyblok/api-client` | `alpha` |
-| `@storyblok/management-api-client` | `alpha` |
-| `@storyblok/migrations` | `alpha` |
+| `@storyblok/astro` | `main`, `alpha`, `next` |
+| `@storyblok/nuxt` | `main`, `next` |
+| `storyblok-js-client` | `main`, `beta`, `next` |
+| `@storyblok/api-client` | `alpha` only — stable disabled until promoted |
+| `@storyblok/management-api-client` | `alpha` only — stable disabled until promoted |
+| `@storyblok/migrations` | `alpha` only — stable disabled until promoted |
 
 #### Promoting Pre-release to Stable
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -113,7 +113,12 @@ To release a pre-release version (e.g., for testing before stable release):
 
 #### Supported Pre-release Channels by Package
 
-Each package's `release.branches` in its `package.json` is the source of truth for which branches it may release from. `pnpm release` reads this field and skips any package whose list does not include the current branch. Packages without a `release.branches` field release from every release branch (`main`, `alpha`, `beta`, `next`).
+Each package's `release.branches` in its `package.json` is the source of truth for which branches it may release from. Packages without a `release.branches` field release from every release branch (`main`, `alpha`, `beta`, `next`).
+
+The gate is enforced in two places:
+
+1. `pnpm release` skips ineligible packages when creating version commits and tags.
+2. The **Publish** workflow re-computes the eligible list from `release.branches` before running `nx release publish`. This means raw flows like `pnpm nx release version` — which bypass `pnpm release` — still cannot accidentally publish an ineligible package to npm, because the workflow will filter them out.
 
 To keep a package out of stable releases, omit `"main"` from its `release.branches`. To promote an alpha-only package to stable, add `"main"` back.
 

--- a/packages/capi-client/package.json
+++ b/packages/capi-client/package.json
@@ -57,7 +57,6 @@
   },
   "release": {
     "branches": [
-      "main",
       {
         "name": "alpha",
         "prerelease": true

--- a/packages/mapi-client/package.json
+++ b/packages/mapi-client/package.json
@@ -58,7 +58,6 @@
   },
   "release": {
     "branches": [
-      "main",
       {
         "name": "alpha",
         "prerelease": true

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -71,7 +71,6 @@
   },
   "release": {
     "branches": [
-      "main",
       {
         "name": "alpha",
         "prerelease": true

--- a/tools/release-branches.mjs
+++ b/tools/release-branches.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Reads `packages/*​/package.json` and splits packages by whether their
+ * `release.branches` field allows releasing from the given branch.
+ * Packages without a `release.branches` field are eligible on every
+ * release branch.
+ */
+export function getBranchEligiblePackages(branch, packagesDir = 'packages') {
+  const eligible = [];
+  const excluded = [];
+
+  for (const entry of readdirSync(packagesDir).sort()) {
+    const pkgPath = join(packagesDir, entry, 'package.json');
+
+    let stat;
+    try {
+      stat = statSync(pkgPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    } catch (err) {
+      process.stderr.write(`⚠️  Warning: failed to parse ${pkgPath} — skipping (${err.message})\n`);
+      continue;
+    }
+
+    if (!pkg.name) continue;
+
+    const branches = pkg.release?.branches;
+    if (!Array.isArray(branches)) {
+      eligible.push(pkg.name);
+      continue;
+    }
+
+    const branchNames = branches
+      .map(b => (typeof b === 'string' ? b : b?.name))
+      .filter(Boolean);
+
+    if (branchNames.includes(branch)) {
+      eligible.push(pkg.name);
+    } else {
+      excluded.push(pkg.name);
+    }
+  }
+
+  return { eligible, excluded };
+}
+
+// CLI: `node tools/release-branches.mjs <branch>` prints eligible packages
+// as a comma-separated list on stdout. Used by .github/workflows/publish.yaml.
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const branch = process.argv[2];
+  if (!branch) {
+    process.stderr.write('Usage: node tools/release-branches.mjs <branch>\n');
+    process.exit(1);
+  }
+  const { eligible } = getBranchEligiblePackages(branch);
+  process.stdout.write(eligible.join(','));
+}

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
-import { readdirSync, readFileSync, statSync } from 'fs';
-import { join } from 'path';
 import { exit, argv, stdin, stdout } from 'process';
 import * as readline from 'readline';
+
+import { getBranchEligiblePackages } from './release-branches.mjs';
 
 const MAIN_BRANCH = 'main';
 const RELEASE_BRANCHES = ['main', 'alpha', 'beta', 'next'];
@@ -73,57 +73,6 @@ function isUpToDateWithRemote(branch) {
     log('⚠️  Warning: Could not verify if branch is up to date with remote', YELLOW);
     return true; // Assume up to date if we can't verify
   }
-}
-
-/**
- * Reads `packages/*​/package.json` and splits packages by whether their
- * `release.branches` field allows releasing from the given branch.
- * Packages without a `release.branches` field are treated as eligible on
- * every release branch (current default behaviour).
- */
-function getBranchEligiblePackages(branch) {
-  const packagesDir = join(process.cwd(), 'packages');
-  const eligible = [];
-  const excluded = [];
-
-  for (const entry of readdirSync(packagesDir).sort()) {
-    const pkgPath = join(packagesDir, entry, 'package.json');
-    let stat;
-    try {
-      stat = statSync(pkgPath);
-    } catch {
-      continue;
-    }
-    if (!stat.isFile()) continue;
-
-    let pkg;
-    try {
-      pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    } catch (err) {
-      log(`⚠️  Warning: failed to parse ${pkgPath} — skipping (${err.message})`, YELLOW);
-      continue;
-    }
-
-    if (!pkg.name) continue;
-
-    const branches = pkg.release?.branches;
-    if (!Array.isArray(branches)) {
-      eligible.push(pkg.name);
-      continue;
-    }
-
-    const branchNames = branches
-      .map(b => (typeof b === 'string' ? b : b?.name))
-      .filter(Boolean);
-
-    if (branchNames.includes(branch)) {
-      eligible.push(pkg.name);
-    } else {
-      excluded.push(pkg.name);
-    }
-  }
-
-  return { eligible, excluded };
 }
 
 function askConfirmation(question) {

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -86,13 +86,21 @@ function getBranchEligiblePackages(branch) {
   const eligible = [];
   const excluded = [];
 
-  for (const entry of readdirSync(packagesDir)) {
+  for (const entry of readdirSync(packagesDir).sort()) {
     const pkgPath = join(packagesDir, entry, 'package.json');
+    let stat;
+    try {
+      stat = statSync(pkgPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+
     let pkg;
     try {
-      if (!statSync(pkgPath).isFile()) continue;
       pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    } catch {
+    } catch (err) {
+      log(`⚠️  Warning: failed to parse ${pkgPath} — skipping (${err.message})`, YELLOW);
       continue;
     }
 

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
 import { exit, argv, stdin, stdout } from 'process';
 import * as readline from 'readline';
 
@@ -71,6 +73,49 @@ function isUpToDateWithRemote(branch) {
     log('⚠️  Warning: Could not verify if branch is up to date with remote', YELLOW);
     return true; // Assume up to date if we can't verify
   }
+}
+
+/**
+ * Reads `packages/*​/package.json` and splits packages by whether their
+ * `release.branches` field allows releasing from the given branch.
+ * Packages without a `release.branches` field are treated as eligible on
+ * every release branch (current default behaviour).
+ */
+function getBranchEligiblePackages(branch) {
+  const packagesDir = join(process.cwd(), 'packages');
+  const eligible = [];
+  const excluded = [];
+
+  for (const entry of readdirSync(packagesDir)) {
+    const pkgPath = join(packagesDir, entry, 'package.json');
+    let pkg;
+    try {
+      if (!statSync(pkgPath).isFile()) continue;
+      pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    } catch {
+      continue;
+    }
+
+    if (!pkg.name) continue;
+
+    const branches = pkg.release?.branches;
+    if (!Array.isArray(branches)) {
+      eligible.push(pkg.name);
+      continue;
+    }
+
+    const branchNames = branches
+      .map(b => (typeof b === 'string' ? b : b?.name))
+      .filter(Boolean);
+
+    if (branchNames.includes(branch)) {
+      eligible.push(pkg.name);
+    } else {
+      excluded.push(pkg.name);
+    }
+  }
+
+  return { eligible, excluded };
 }
 
 function askConfirmation(question) {
@@ -190,6 +235,39 @@ async function main() {
 
   log(`✅ Up to date with origin/${currentBranch}`, GREEN);
 
+  // Filter packages by their `release.branches` config.
+  const { eligible, excluded } = getBranchEligiblePackages(currentBranch);
+
+  if (excluded.length > 0) {
+    log(`\n⏭️  Skipping packages not configured to release from ${currentBranch}:`, YELLOW);
+    for (const name of excluded) log(`   - ${name}`, YELLOW);
+  }
+
+  let effectiveProjects;
+  if (projectsArg) {
+    const requested = projectsArg.split(',').map(s => s.trim()).filter(Boolean);
+    const droppedByBranch = requested.filter(p => excluded.includes(p));
+    const kept = requested.filter(p => !excluded.includes(p));
+
+    if (droppedByBranch.length > 0) {
+      log(`\n⚠️  Removing requested projects not eligible on ${currentBranch}: ${droppedByBranch.join(', ')}`, YELLOW);
+    }
+    if (kept.length === 0) {
+      log(`\n❌ Error: None of the requested projects are configured to release from ${currentBranch}`, RED);
+      log('\n📋 Instructions:', BLUE);
+      log(`  1. Check each package's ${YELLOW}release.branches${RESET} in its package.json`);
+      log(`  2. Switch to a branch the project(s) support, or add ${YELLOW}${currentBranch}${RESET} to their ${YELLOW}release.branches${RESET}\n`);
+      exit(1);
+    }
+    effectiveProjects = kept.join(',');
+  } else {
+    if (eligible.length === 0) {
+      log(`\n❌ Error: No packages are configured to release from ${currentBranch}`, RED);
+      exit(1);
+    }
+    effectiveProjects = eligible.join(',');
+  }
+
   // All checks passed, run the release command
   log('\n✨ All checks passed! Running release command...\n', GREEN);
   log('━'.repeat(50), BLUE);
@@ -200,7 +278,7 @@ async function main() {
     if (versionArg) releaseCommand += ` ${versionArg}`;
     releaseCommand += ' --skip-publish';
     if (isPrerelease) releaseCommand += ` --preid=${currentBranch}`;
-    if (projectsArg) releaseCommand += ` --projects=${projectsArg}`;
+    releaseCommand += ` --projects=${effectiveProjects}`;
     if (firstRelease) releaseCommand += ' --first-release';
     if (isDryRun) releaseCommand += ' --dry-run';
 


### PR DESCRIPTION
Teach tools/release.mjs to read each package's release.branches and skip packages whose list does not include the current branch. Unify the publish workflow to always derive the publish list from the release commit body, so the versioning step is the single source of truth for what gets published.

- tools/release.mjs: filter --projects by release.branches; error when every requested project is ineligible on the current branch, warn when some are dropped.
- packages/capi-client, packages/mapi-client, packages/migrations: drop "main" from release.branches so stable releases are disabled until these alpha packages are promoted.
- .github/workflows/publish.yaml: remove the main-branch shortcut that published every package; always publish only packages listed in the release commit body. Also harden by moving action outputs into env:.
- RELEASING.md: document the branch-gating rule and mark the three packages as alpha-only.