### PR TITLE
fix(cli): stop pushing empty content and give verbose errors request context

### DIFF
--- a/packages/cli/src/commands/stories/push/index.ts
+++ b/packages/cli/src/commands/stories/push/index.ts
@@ -233,13 +233,16 @@ pushCmd
        * We need to run the second pass in a separate pipeline because we need a
        * complete map of all stories.
        */
+      const uuidByFilename = new Map(storyIndex.map(entry => [entry.filename, entry.uuid]));
+
       await pipeline(
         // Read local stories from `.json` files.
         readLocalStoriesStream({
           directoryPath: storiesDirectoryPath,
-          fileFilter({ uuid }) {
+          fileFilter({ filename }) {
             // Only load files that were successfully created and mapped.
-            return Boolean(maps.stories.get(uuid));
+            const uuid = uuidByFilename.get(filename);
+            return uuid != null && Boolean(maps.stories.get(uuid));
           },
           setTotalStories(total) {
             summary.processResults.total = total;

--- a/packages/cli/src/commands/stories/streams.test.ts
+++ b/packages/cli/src/commands/stories/streams.test.ts
@@ -247,6 +247,35 @@ describe('scanLocalStoryIndex', () => {
 
     expect(entries).toHaveLength(1);
   });
+
+  it('should report an error for stories missing a uuid', async () => {
+    // Story JSON with no `uuid` field — multiple such stories would otherwise
+    // collide on an empty-string key when the push command builds its maps.
+    vol.fromJSON({
+      [join(STORIES_DIR, 'no-uuid_unknown.json')]: JSON.stringify({
+        id: 50,
+        slug: 'no-uuid',
+        name: 'No UUID',
+        full_slug: 'no-uuid',
+        is_folder: false,
+        parent_id: 0,
+        content: { _uid: '1', component: 'page' },
+      }),
+    });
+
+    const errors: Array<{ filename: string; message: string }> = [];
+    const entries = await scanLocalStoryIndex({
+      directoryPath: STORIES_DIR,
+      onError(error, filename) {
+        errors.push({ filename, message: error.message });
+      },
+    });
+
+    expect(entries).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].filename).toBe('no-uuid_unknown.json');
+    expect(errors[0].message).toMatch(/uuid/i);
+  });
 });
 
 describe('groupStoriesByDepth', () => {

--- a/packages/cli/src/commands/stories/streams.test.ts
+++ b/packages/cli/src/commands/stories/streams.test.ts
@@ -77,6 +77,66 @@ describe('readLocalStoriesStream', () => {
     expect(results[0].id).toBe(1);
     expect(errors).toHaveLength(1);
   });
+
+  it('should yield a story whose uuid contains underscores when its filename passes the filter', async () => {
+    const uuidWithUnderscore = 'legacy_id_123';
+    const storyA = {
+      name: 'Story A',
+      id: 100,
+      uuid: uuidWithUnderscore,
+      parent_id: 0,
+      is_folder: false,
+      slug: 'story-a',
+      content: { _uid: 'x', component: 'page', title: 'real content' },
+    };
+    writeStory(storyA);
+
+    const stream = readLocalStoriesStream({
+      directoryPath: STORIES_DIR,
+      fileFilter: () => true,
+    });
+    const results = await collectStream(stream);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].uuid).toBe(uuidWithUnderscore);
+    expect(results[0].content.title).toBe('real content');
+  });
+
+  it('should not read files rejected by fileFilter', async () => {
+    const keepUuid = randomUUID();
+    const dropUuid = randomUUID();
+    writeStory({
+      name: 'Keep',
+      id: 1,
+      uuid: keepUuid,
+      parent_id: 0,
+      is_folder: false,
+      slug: 'keep',
+    });
+    writeStory({
+      name: 'Drop',
+      id: 2,
+      uuid: dropUuid,
+      parent_id: 0,
+      is_folder: false,
+      slug: 'drop',
+    });
+    // Overwrite the "drop" file with invalid JSON; if the filter works,
+    // the stream must never attempt to parse it.
+    vol.fromJSON({ [join(STORIES_DIR, `drop_${dropUuid}.json`)]: '{not json' });
+
+    const errors: string[] = [];
+    const stream = readLocalStoriesStream({
+      directoryPath: STORIES_DIR,
+      fileFilter: ({ filename }) => filename.startsWith('keep_'),
+      onStoryError: (_err, filename) => { errors.push(filename); },
+    });
+    const results = await collectStream(stream);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].uuid).toBe(keepUuid);
+    expect(errors).toEqual([]);
+  });
 });
 
 describe('normalizeFullSlug', () => {

--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -244,10 +244,15 @@ export const scanLocalStoryIndex = async ({
       const filePath = join(directoryPath, file);
       const fileContent = await readFile(filePath, 'utf-8');
       const story = JSON.parse(fileContent) as Story;
+      if (!story.uuid) {
+        // A missing uuid would otherwise collapse multiple stories onto the
+        // same empty-string key in downstream maps and silently lose content.
+        throw new Error(`Story "${file}" is missing a uuid and cannot be pushed.`);
+      }
       entries.push({
         filename: file,
         id: story.id,
-        uuid: story.uuid ?? '',
+        uuid: story.uuid,
         slug: story.slug ?? '',
         name: story.name ?? '',
         full_slug: story.full_slug ?? '',

--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -1,5 +1,5 @@
 import { readFile, unlink } from 'node:fs/promises';
-import { basename, extname, join, resolve } from 'pathe';
+import { extname, join, resolve } from 'pathe';
 import { Readable, Transform, Writable } from 'node:stream';
 import { Sema } from 'async-sema';
 import { createStory, fetchStories, fetchStory, updateStory } from './actions';
@@ -123,14 +123,6 @@ export const fetchStoryStream = ({
   });
 };
 
-const getUUIDFromFilename = (filename: string) => {
-  const uuid = basename(filename, extname(filename)).split('_').at(-1);
-  if (!uuid) {
-    throw new Error(`Unable to extract UUID from local story "${filename}"`);
-  }
-  return uuid;
-};
-
 export const readLocalStoriesStream = ({
   directoryPath,
   fileFilter = () => true,
@@ -140,7 +132,14 @@ export const readLocalStoriesStream = ({
   onStoryError,
 }: {
   directoryPath: string;
-  fileFilter?: (options: { uuid: string }) => boolean;
+  /**
+   * Decides whether a local story file should flow into the pipeline.
+   * Receives the `filename` only — callers that need to resolve to a uuid
+   * should rely on an external index (e.g. the scan index from pass 1),
+   * because filenames `${slug}_${uuid}.json` can't be parsed reliably when
+   * either segment contains underscores.
+   */
+  fileFilter?: (options: { filename: string }) => boolean;
   setTotalStories?: (total: number) => void;
   onIncrement?: () => void;
   onStorySuccess?: (story: Story) => void;
@@ -148,7 +147,7 @@ export const readLocalStoriesStream = ({
 }) => {
   const listGenerator = async function* localStoryIterator() {
     const files = (await readDirectory(directoryPath))
-      .filter(f => extname(f) === '.json' && fileFilter({ uuid: getUUIDFromFilename(f) }));
+      .filter(f => extname(f) === '.json' && fileFilter({ filename: f }));
     setTotalStories?.(files.length);
 
     for (const file of files) {

--- a/packages/cli/src/utils/error/api-error.test.ts
+++ b/packages/cli/src/utils/error/api-error.test.ts
@@ -144,4 +144,53 @@ describe('handleAPIError', () => {
       expect((e as APIError).errorId).toBe('generic');
     }
   });
+
+  it('should forward request url and method from FetchError into APIError.getInfo()', () => {
+    const error = new FetchError(
+      'HTTP error! status: 404',
+      { status: 404, statusText: 'Not Found', data: { message: 'Missing' } },
+      { url: 'https://api.test.com/v1/spaces/1/stories', method: 'POST' },
+    );
+
+    try {
+      handleAPIError('create_story', error);
+    }
+    catch (e) {
+      const info = (e as APIError).getInfo();
+      expect(info.request).toEqual({
+        url: 'https://api.test.com/v1/spaces/1/stories',
+        method: 'POST',
+      });
+    }
+  });
+
+  it('should forward request context when a non-FetchError carries a request field', () => {
+    const error = Object.assign(new Error('Not found'), {
+      response: { status: 404, statusText: 'Not Found', data: null },
+      request: { url: 'https://api.test.com/v1/spaces/1/stories/42', method: 'PUT' },
+    });
+
+    try {
+      handleAPIError('update_story', error);
+    }
+    catch (e) {
+      const info = (e as APIError).getInfo();
+      expect(info.request).toEqual({
+        url: 'https://api.test.com/v1/spaces/1/stories/42',
+        method: 'PUT',
+      });
+    }
+  });
+
+  it('should omit request from APIError.getInfo() when no url or method is available', () => {
+    const error = new ClientError('Not Found', { status: 404, statusText: 'Not Found', data: null });
+
+    try {
+      handleAPIError('create_story', error);
+    }
+    catch (e) {
+      const info = (e as APIError).getInfo() as Record<string, unknown>;
+      expect('request' in info).toBe(false);
+    }
+  });
 });

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -71,12 +71,19 @@ export function handleAPIError(action: keyof typeof API_ACTIONS, error: unknown,
     throw new APIError(errorId, action, error, customMessage);
   }
 
-  // Handle non-FetchError objects that have a response property (e.g. mapi-client ClientError)
+  // Handle non-FetchError objects that have a response property (e.g. mapi-client ClientError).
+  // ClientError itself doesn't carry request context, but some wrappers attach
+  // a `request` field — forward it best-effort so verbose output can show it.
   const response = (error as any)?.response;
   if (response?.status) {
+    const reqCandidate = (error as any)?.request;
     const wrappedError = new FetchError(
       response.statusText ?? (error as Error).message,
       { status: response.status, statusText: response.statusText ?? '', data: response.data },
+      {
+        url: typeof reqCandidate?.url === 'string' ? reqCandidate.url : undefined,
+        method: typeof reqCandidate?.method === 'string' ? reqCandidate.method : undefined,
+      },
     );
     const errorId = getErrorId(response.status);
     throw new APIError(errorId, action, wrappedError, customMessage);
@@ -123,6 +130,8 @@ export class APIError extends Error {
   }
 
   getInfo() {
+    const request = this.error?.request;
+    const hasRequestContext = Boolean(request && (request.url || request.method));
     return {
       name: this.name,
       message: this.message,
@@ -131,6 +140,7 @@ export class APIError extends Error {
       errorId: this.errorId,
       stack: this.stack,
       responseData: this.response?.data,
+      ...(hasRequestContext ? { request: { url: request!.url, method: request!.method } } : {}),
     };
   }
 }

--- a/packages/cli/src/utils/fetch.test.ts
+++ b/packages/cli/src/utils/fetch.test.ts
@@ -122,6 +122,22 @@ describe('customFetch', () => {
     });
   });
 
+  it('should attach url and method to FetchError for HTTP errors', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ message: 'Not Found' }),
+    });
+
+    await expect(
+      customFetch('https://api.test.com/spaces/1/stories', { method: 'POST', body: {} }),
+    ).rejects.toMatchObject({
+      request: { url: 'https://api.test.com/spaces/1/stories', method: 'POST' },
+    });
+  });
+
   it('should handle network errors', async () => {
     mockFetch.mockRejectedValue(new Error('Network Error'));
 
@@ -132,6 +148,7 @@ describe('customFetch', () => {
         statusText: 'Network Error',
         data: null,
       },
+      request: { url: 'https://api.test.com', method: 'GET' },
     });
   });
 

--- a/packages/cli/src/utils/fetch.ts
+++ b/packages/cli/src/utils/fetch.ts
@@ -1,5 +1,10 @@
 import { getActiveConfig } from '../lib/config';
 
+export interface FetchErrorRequest {
+  url?: string;
+  method?: string;
+}
+
 export class FetchError extends Error {
   response: {
     status: number;
@@ -7,10 +12,17 @@ export class FetchError extends Error {
     data?: Record<string, unknown> | null;
   };
 
-  constructor(message: string, response: { status: number; statusText: string; data?: Record<string, unknown> | null }) {
+  request: FetchErrorRequest;
+
+  constructor(
+    message: string,
+    response: { status: number; statusText: string; data?: Record<string, unknown> | null },
+    request: FetchErrorRequest = {},
+  ) {
     super(message);
     this.name = 'FetchError';
     this.response = response;
+    this.request = request;
   }
 }
 
@@ -28,6 +40,7 @@ export async function customFetch<T>(url: string, options: FetchOptions = {}): P
   const { api } = getActiveConfig(); // live config includes CLI overrides (maxRetries, maxConcurrency, etc.)
   const maxRetries = options.maxRetries ?? api.maxRetries;
   const baseDelay = options.baseDelay ?? 500; // 500ms base delay
+  const requestContext: FetchErrorRequest = { url, method: options.method ?? 'GET' };
   let attempt = 0;
 
   while (attempt <= maxRetries) {
@@ -61,7 +74,7 @@ export async function customFetch<T>(url: string, options: FetchOptions = {}): P
           status: response.status,
           statusText: response.statusText,
           data: null,
-        });
+        }, requestContext);
       }
 
       if (!response.ok) {
@@ -77,7 +90,7 @@ export async function customFetch<T>(url: string, options: FetchOptions = {}): P
           status: response.status,
           statusText: response.statusText,
           data,
-        });
+        }, requestContext);
       }
 
       return {
@@ -95,7 +108,7 @@ export async function customFetch<T>(url: string, options: FetchOptions = {}): P
         status: 0,
         statusText: 'Network Error',
         data: null,
-      });
+      }, requestContext);
     }
   }
 
@@ -103,5 +116,5 @@ export async function customFetch<T>(url: string, options: FetchOptions = {}): P
     status: 429,
     statusText: 'Rate Limit Exceeded',
     data: null,
-  });
+  }, requestContext);
 }


### PR DESCRIPTION
## Summary
- Fixes the push bug where stories whose `uuid` contains an underscore were created in Storyblok with empty placeholder content. `readLocalStoriesStream` no longer reconstructs uuids from filenames; the push command resolves `filename → uuid` through the scan index (which reads uuids from file contents).
- Makes missing-uuid local stories fail loudly in the scan instead of collapsing onto an empty-string key in `maps.stories` and silently producing empty remote content.
- Adds request context (`url`, `method`) to `FetchError` and surfaces it in `APIError.getInfo()`, so `--verbose` finally tells you which request produced a 404.

## Context
Customer report: migrating content via `storyblok stories push` created stories with empty content and surfaced no error. Reproduced locally — root cause was `basename(filename).split('_').at(-1)` in `streams.ts`, which returns only the last fragment when the uuid itself contains underscores. Pass 2's filter then missed the uuid in `maps.stories` and silently dropped the file before the real content was uploaded.

The three commits map to the three issues from the report and are independently revertible:
1. `fix(cli): push uploads content for stories whose uuid contains underscores` — primary bug.
2. `fix(cli): fail loudly when a local story is missing a uuid` — the "missing ID" case the customer also sent.
3. `feat(cli): include request url and method in verbose api errors` — better `--verbose` output.

## Overlap with WDX-391
`bugfix/WDX-391-push-stories-missing-story-identification` touches the same callback sites in `push/index.ts`. This PR was written against `main`; if WDX-391 lands first, this will need a small rebase around `push/index.ts`.

## Caveats
- The upstream `ClientError` in `@storyblok/management-api-client` does not currently carry request metadata, so stories-push errors still fall back to the existing `action` message ("Failed to create story") for the URL/method portion. `FetchError`-based paths (login/signup/assets) get the full `request` payload immediately. Extending the mapi-client is tracked separately.

## Test plan
- [x] `pnpm test` in `packages/cli` — 634 tests pass, 1 todo.
- [x] `pnpm test:types` in `packages/cli` — clean.
- [x] `pnpm lint:fix` in `packages/cli` — clean.
- [ ] Manual push against a real space:
  - [x] Story with `"uuid": "legacy_id_123"` lands with full content (not the placeholder).
  - [x] Story missing `uuid` is reported as a failed story and not created.
  - [x] A forced 404 in `--verbose` shows `request: { url, method }` in the error output (for direct-fetch commands; stories-push will still show the action name).