### PR TITLE
fix(release): unblock stable releases of api-client and mapi-client

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -115,10 +115,11 @@ To release a pre-release version (e.g., for testing before stable release):
 
 Each package's `release.branches` in its `package.json` is the source of truth for which branches it may release from. Packages without a `release.branches` field release from every release branch (`main`, `alpha`, `beta`, `next`).
 
-The gate is enforced in two places:
+The gate is enforced in three places:
 
 1. `pnpm release` skips ineligible packages when creating version commits and tags.
-2. The **Publish** workflow re-computes the eligible list from `release.branches` before running `nx release publish`. This means raw flows like `pnpm nx release version` — which bypass `pnpm release` — still cannot accidentally publish an ineligible package to npm, because the workflow will filter them out.
+2. `pnpm release` also **aborts after the `nx release` step** if an ineligible package's `version` was bumped anyway. This guards against a regression where nx release version would silently bump alpha-only packages, leaving downstream `workspace:*` references pointing at versions that would never be published (see the "Alpha-only packages and downstream consumers" note below).
+3. The **Publish** workflow re-computes the eligible list from `release.branches` before running `nx release publish`. This means raw flows like `pnpm nx release version` — which bypass `pnpm release` — still cannot accidentally publish an ineligible package to npm, because the workflow will filter them out.
 
 To keep a package out of stable releases, omit `"main"` from its `release.branches`. To promote an alpha-only package to stable, add `"main"` back.
 
@@ -127,9 +128,18 @@ To keep a package out of stable releases, omit `"main"` from its `release.branch
 | `@storyblok/astro` | `main`, `alpha`, `next` |
 | `@storyblok/nuxt` | `main`, `next` |
 | `storyblok-js-client` | `main`, `beta`, `next` |
-| `@storyblok/api-client` | `alpha` only — stable disabled until promoted |
-| `@storyblok/management-api-client` | `alpha` only — stable disabled until promoted |
 | `@storyblok/migrations` | `alpha` only — stable disabled until promoted |
+
+#### Alpha-only packages and downstream consumers
+
+Marking a package alpha-only (`release.branches: [{ name: "alpha", prerelease: true }]`) freezes its stable version on npm, but does **not** prevent nx from bumping the package's `version` field on `main` if conventional commits drive a bump. Downstream consumers that reference the alpha-only package via `workspace:*` will then publish tarballs pinning the bumped — but never published — version, producing `ETARGET` failures for anyone installing them.
+
+Two mitigations are in place:
+
+1. **Keep breaking changes on the `alpha` branch.** If an alpha-only package is undergoing a breaking rewrite, do the rewrite work on `alpha` and keep `main` at the last stable state until it is ready to promote. Don't let main accumulate changes to an alpha-only package's source.
+2. **The `pnpm release` guard** (see item 2 above) catches the case where main has accidentally accumulated bump-worthy commits for an alpha-only package and aborts before the release is pushed. If the guard fires, follow the recovery instructions it prints (typically `git reset --hard <base-sha>` and reverting the offending commits).
+
+The original incident that motivated this guard is commit `f824b398e` (April 2026), which produced broken `@storyblok/angular@0.1.6` and `storyblok@4.16.9` tarballs on npm latest.
 
 #### Promoting Pre-release to Stable
 

--- a/packages/capi-client/package.json
+++ b/packages/capi-client/package.json
@@ -55,14 +55,6 @@
     "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   },
-  "release": {
-    "branches": [
-      {
-        "name": "alpha",
-        "prerelease": true
-      }
-    ]
-  },
   "nx": {
     "targets": {
       "generate": {

--- a/packages/mapi-client/package.json
+++ b/packages/mapi-client/package.json
@@ -56,14 +56,6 @@
     "tsx": "^4.20.3",
     "vitest": "^3.1.3"
   },
-  "release": {
-    "branches": [
-      {
-        "name": "alpha",
-        "prerelease": true
-      }
-    ]
-  },
   "nx": {
     "targets": {
       "generate": {

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
 import { exit, argv, stdin, stdout } from 'process';
 import * as readline from 'readline';
 
@@ -200,6 +202,13 @@ async function main() {
     for (const name of excluded) log(`   - ${name}`, YELLOW);
   }
 
+  // Snapshot the on-disk `version` of each excluded package so we can detect
+  // if `nx release` bumps one of them. See the abort check after the release
+  // command below — this prevents the regression that produced commit
+  // f824b398e and the subsequent ETARGET failures for downstream consumers.
+  const baseSha = execCommand('git rev-parse HEAD', { silent: true });
+  const excludedSnapshot = snapshotPackageVersions(excluded);
+
   let effectiveProjects;
   if (projectsArg) {
     const requested = projectsArg.split(',').map(s => s.trim()).filter(Boolean);
@@ -247,6 +256,24 @@ async function main() {
       log('\n✅ Dry run completed successfully!', GREEN);
       log('\nNo changes were made. Run without --dry-run to perform the actual release.\n', YELLOW);
     } else {
+      const mutated = detectMutatedVersions(excludedSnapshot);
+      if (mutated.length > 0) {
+        log('\n❌ Release aborted: nx release bumped package(s) that will not be', RED);
+        log(`   published on ${currentBranch} (release.branches excludes it):`, RED);
+        for (const { name, oldVersion, newVersion } of mutated) {
+          log(`   - ${name}: ${oldVersion} -> ${newVersion}`, RED);
+        }
+        log('\nPushing this release would publish downstream packages with', YELLOW);
+        log('unresolvable dependency references (see RELEASING.md for the', YELLOW);
+        log('original incident — commit f824b398e).', YELLOW);
+        log('\nRecover with:', BLUE);
+        log(`   git reset --hard ${baseSha}`, YELLOW);
+        log(`   for t in $(git tag --points-at HEAD); do git tag -d "$t"; done`, YELLOW);
+        log('\nThen either run from a branch the package(s) allow, or revert', BLUE);
+        log('the conventional-commit changes that are driving the bump.\n', BLUE);
+        exit(1);
+      }
+
       log('\n✅ Release completed successfully!', GREEN);
       log('\n📋 Next steps:', BLUE);
       log('  1. Go to the GitHub Actions tab');
@@ -260,6 +287,45 @@ async function main() {
     log('Check the error message above for details\n', YELLOW);
     exit(1);
   }
+}
+
+/**
+ * Reads the current on-disk `version` for each package name in `names`.
+ * Returns a map of `name -> { path, version }` for packages that exist under
+ * `packages/`. Packages not found are silently skipped (they may live
+ * elsewhere in the workspace, which this guard does not try to cover).
+ */
+function snapshotPackageVersions(names, packagesDir = 'packages') {
+  if (!names || names.length === 0) return new Map();
+  const wanted = new Set(names);
+  const snapshot = new Map();
+  for (const entry of readdirSync(packagesDir)) {
+    const pkgPath = join(packagesDir, entry, 'package.json');
+    let stat;
+    try { stat = statSync(pkgPath); } catch { continue; }
+    if (!stat.isFile()) continue;
+    let pkg;
+    try { pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')); } catch { continue; }
+    if (!pkg.name || !wanted.has(pkg.name)) continue;
+    snapshot.set(pkg.name, { path: pkgPath, version: pkg.version });
+  }
+  return snapshot;
+}
+
+/**
+ * Compares current on-disk `version` values against the snapshot taken before
+ * `nx release` ran. Returns the list of packages whose version changed.
+ */
+function detectMutatedVersions(snapshot) {
+  const mutated = [];
+  for (const [name, { path, version: oldVersion }] of snapshot) {
+    let pkg;
+    try { pkg = JSON.parse(readFileSync(path, 'utf-8')); } catch { continue; }
+    if (pkg.version !== oldVersion) {
+      mutated.push({ name, oldVersion, newVersion: pkg.version });
+    }
+  }
+  return mutated;
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

- Drops `release.branches` alpha-only gating from `@storyblok/api-client` and `@storyblok/management-api-client` so their current main versions (0.2.2 / 0.2.3) can be published via the existing OIDC workflow.
- Adds a detect-and-abort guard in `tools/release.mjs` that catches any future run where nx release bumps an alpha-only package on a branch that won't publish it.
- Updates RELEASING.md with the new channels table and a subsection explaining the failure mode and mitigations.

## Why

Commit `7a6da8cad` introduced per-package `release.branches` gating, but nx's version step ignored it. The next release commit (`f824b398e`) bumped `api-client` 0.2.1 → 0.2.2 and `mapi-client` 0.2.2 → 0.2.3 on main. Neither was published because the workflow filtered them out, but pnpm's publish-time `workspace:*` rewrite pinned those ghost versions into downstream tarballs:

- `@storyblok/angular@0.1.6` → `@storyblok/api-client: 0.2.2` (ETARGET)
- `storyblok@4.16.9` → `@storyblok/management-api-client: 0.2.3` (ETARGET)

Consumers installing either package currently hit `npm error code ETARGET`.

### Why not revert main to the last stable mapi-client / capi-client source?

Considered and rejected: the CLI (`packages/cli/src/api.ts`, etc.) and migrations import v1-only symbols (`createManagementApiClient`, `/resources/*` subpaths) that don't exist in the 0.2.2 published architecture. Reverting mapi-client would break the CLI build and require also reverting weeks of CLI features (`feat(cli): add --from flag`, `fix(cli): validate story content`, the assets-push refactor, etc.). The published `angular@0.1.6` / `storyblok@4.16.9` tarballs were built against the current v1 architecture and need it at runtime to function, so shipping current code at the pending versions is what actually unblocks consumers.

This is technically a semver violation — 0.2.1 → 0.2.2 is a patch by convention but the code contains breaking changes (`getAll` → `list` rename, v1 mapi rewrite). Accepted pragmatically; a proper 1.0.0 would require re-publishing every downstream consumer with corrected deps and deprecating/unpublishing the current broken versions.

## Post-merge

After this merges, trigger the **Publish** workflow on `main`. The eligible-packages filter in `.github/workflows/publish.yaml` will now include capi-client and mapi-client, so `nx release publish` will push 0.2.2 / 0.2.3 to npm latest. Already-published packages (angular, cli, etc.) are no-ops.

Migrations stays alpha-only — nothing depends on its missing 0.1.5, so there's no ETARGET to fix there.

Follow-up (not in this PR): hard-reset `origin/alpha` to `origin/main` with `--force-with-lease` after publish confirms. Validated that alpha has no unique feature work — the 4 commits unique to alpha are all `chore(release): publish` / release-config.

## Test plan

- [x] `node --check tools/release.mjs` — syntax clean.
- [x] Unit test of `snapshotPackageVersions` + `detectMutatedVersions` in isolation — detects stale-snapshot mismatches, handles empty/unknown inputs.
- [x] `pnpm nx run-many -t=lint --projects=storyblok,@storyblok/api-client,@storyblok/management-api-client` — green.
- [ ] After merge + publish: `npm view @storyblok/api-client versions --json` includes `0.2.2`; `npm view @storyblok/management-api-client versions --json` includes `0.2.3`.
- [ ] After merge + publish, in a fresh dir: `npm install @storyblok/angular@0.1.6` and `npm install storyblok@4.16.9` both succeed.

## Out of scope

- Pre-existing typecheck failures in `packages/mapi-client/src/sdk-registry.generated.ts` (`Module ... has no exported member 'Sdk'`). Reproduces on `origin/main` — this PR does not touch that path.