### PR TITLE
fix: preserve local template names and add static fallback

### DIFF
--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -451,7 +451,19 @@ describe('repositoryToTemplate', () => {
     });
   });
 
-  it('should fallback to default port if no port topic', () => {
+  it('should fallback to default port if no port topic and no static template match', () => {
+    const repo = {
+      name: 'blueprint-core-unknown',
+      topics: [],
+      clone_url: 'https://github.com/storyblok/blueprint-core-unknown.git',
+      description: 'An unknown starter',
+      updated_at: '2024-01-01T00:00:00Z',
+    };
+    const template = repositoryToTemplate(repo);
+    expect(template.location).toBe('https://localhost:3000/');
+  });
+
+  it('should use static template location when available', () => {
     const repo = {
       name: 'blueprint-core-react',
       topics: [],
@@ -460,7 +472,8 @@ describe('repositoryToTemplate', () => {
       updated_at: '2024-01-01T00:00:00Z',
     };
     const template = repositoryToTemplate(repo);
-    expect(template.location).toBe('https://localhost:3000/');
+    // React static template has location https://localhost:5173/
+    expect(template.location).toBe('https://localhost:5173/');
   });
 });
 
@@ -521,12 +534,12 @@ describe('fetchBlueprintRepositories', () => {
     expect(blueprints?.[0]?.name).toBe('React');
     expect(blueprints?.[1]?.name).toBe('Vue');
 
-    // Verify blueprint structure
+    // Verify blueprint structure (React uses static template location)
     expect(blueprints?.[0]).toEqual({
       name: 'React',
       value: 'react',
       template: 'https://github.com/storyblok/blueprint-core-react.git',
-      location: 'https://localhost:3000/',
+      location: 'https://localhost:5173/', // From static templates
       description: 'A React starter',
       updated_at: '2024-01-02T00:00:00Z',
       stars: 75,
@@ -548,5 +561,23 @@ describe('fetchBlueprintRepositories', () => {
       octokitError,
       'Failed to fetch blueprints from GitHub',
     );
+  });
+
+  it('should return static templates as fallback when GitHub API fails', async () => {
+    // Mock createOctokit to throw an error
+    const octokitError = new Error('GitHub API error');
+    mockedCreateOctokit.mockImplementation(() => {
+      throw octokitError;
+    });
+
+    const blueprints = await fetchBlueprintRepositories();
+
+    // Should return static templates as fallback
+    expect(blueprints).toBeDefined();
+    expect(blueprints.length).toBeGreaterThan(0);
+    // Check that known static templates are present
+    expect(blueprints.some(bp => bp.value === 'react')).toBe(true);
+    expect(blueprints.some(bp => bp.value === 'vue')).toBe(true);
+    expect(blueprints.some(bp => bp.value === 'nuxt')).toBe(true);
   });
 });

--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -6,7 +6,6 @@ import open from 'open';
 import { createEnvFile, extractPortFromTopics, fetchBlueprintRepositories, generateProject, generateSpaceUrl, handleEnvFileCreation, openSpaceInBrowser, repositoryToTemplate } from './actions';
 import * as filesystem from '../../utils/filesystem';
 
-// Mock external dependencies
 vi.mock('node:child_process');
 vi.mock('node:fs/promises', () => ({
   default: {
@@ -15,18 +14,19 @@ vi.mock('node:fs/promises', () => ({
 }));
 vi.mock('open');
 vi.mock('../../utils/filesystem');
-// Mock github module for fetchBlueprintRepositories tests
 vi.mock('../../github', () => ({
   createOctokit: vi.fn(),
 }));
-// Mock utils module for error handling and konsola
-vi.mock('../../utils', () => ({
-  handleAPIError: vi.fn(),
-  konsola: {
+const { mockedUI } = vi.hoisted(() => ({
+  mockedUI: {
     ok: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
   },
+}));
+
+vi.mock('../../utils/ui', () => ({
+  getUI: vi.fn(() => mockedUI),
 }));
 
 const mockedSpawn = vi.mocked(spawn);
@@ -36,10 +36,7 @@ const mockedFsAccess = vi.mocked(fs.access);
 
 // Import the mocked modules
 const { createOctokit } = await import('../../github');
-const { handleAPIError, konsola } = await import('../../utils');
 const mockedCreateOctokit = vi.mocked(createOctokit);
-const mockedHandleAPIError = vi.mocked(handleAPIError);
-const mockedKonsola = vi.mocked(konsola);
 
 describe('create actions', () => {
   beforeEach(() => {
@@ -49,16 +46,13 @@ describe('create actions', () => {
 
   describe('generateProject', () => {
     it('should generate project successfully when directory does not exist', async () => {
-      // Mock fs.access to throw ENOENT (directory doesn't exist)
       const accessError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
       accessError.code = 'ENOENT';
       mockedFsAccess.mockRejectedValueOnce(accessError);
 
-      // Mock successful spawn process
       const mockProcess = {
         on: vi.fn((event: string, callback: (code: number) => void) => {
           if (event === 'close') {
-            // Simulate successful completion
             setTimeout(() => callback(0), 0);
           }
         }),
@@ -79,7 +73,6 @@ describe('create actions', () => {
     });
 
     it('should throw FileSystemError when directory already exists', async () => {
-      // Mock fs.access to succeed (directory exists)
       mockedFsAccess.mockResolvedValueOnce(undefined);
 
       await expect(generateProject('vue', 'existing-project')).rejects.toThrow(
@@ -94,7 +87,6 @@ describe('create actions', () => {
     });
 
     it('should handle filesystem errors other than ENOENT', async () => {
-      // Mock fs.access to throw EACCES (permission denied)
       const accessError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
       accessError.code = 'EACCES';
       mockedFsAccess.mockRejectedValueOnce(accessError);
@@ -108,16 +100,13 @@ describe('create actions', () => {
     });
 
     it('should handle spawn process failure', async () => {
-      // Mock fs.access to throw ENOENT (directory doesn't exist)
       const accessError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
       accessError.code = 'ENOENT';
       mockedFsAccess.mockRejectedValueOnce(accessError);
 
-      // Mock failed spawn process
       const mockProcess = {
         on: vi.fn((event: string, callback: (code: number) => void) => {
           if (event === 'close') {
-            // Simulate failure
             setTimeout(() => callback(1), 0);
           }
         }),
@@ -130,12 +119,10 @@ describe('create actions', () => {
     });
 
     it('should handle spawn process error', async () => {
-      // Mock fs.access to throw ENOENT (directory doesn't exist)
       const accessError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
       accessError.code = 'ENOENT';
       mockedFsAccess.mockRejectedValueOnce(accessError);
 
-      // Mock spawn process error
       const mockProcess = {
         on: vi.fn((event: string, callback: (error: Error) => void) => {
           if (event === 'error') {
@@ -248,10 +235,7 @@ describe('create actions', () => {
         '/test/project/.env',
         expect.stringContaining('STORYBLOK_REGION=us'),
       );
-      expect(mockedKonsola.ok).toHaveBeenCalledWith(
-        expect.stringContaining('Created .env file with'),
-        true,
-      );
+      expect(mockedUI.ok).toHaveBeenCalledWith(expect.stringContaining('Created .env file with'), true);
     });
 
     it('should create .env file with only token', async () => {
@@ -264,7 +248,7 @@ describe('create actions', () => {
         '/test/project/.env',
         expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN=test-token-456'),
       );
-      expect(mockedKonsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Created .env file with'),
         true,
       );
@@ -280,17 +264,14 @@ describe('create actions', () => {
         '/test/project/.env',
         expect.stringContaining('STORYBLOK_REGION=ap'),
       );
-      expect(mockedKonsola.ok).toHaveBeenCalledWith(
-        expect.stringContaining('Created .env file with'),
-        true,
-      );
+      expect(mockedUI.ok).toHaveBeenCalledWith(expect.stringContaining('Created .env file with'), true);
     });
 
     it('should return true and log info when no environment variables provided', async () => {
       const result = await handleEnvFileCreation('/test/project');
 
       expect(result).toBe(true);
-      expect(mockedKonsola.info).toHaveBeenCalledWith('No environment variables to write');
+      expect(mockedUI.info).toHaveBeenCalledWith('No environment variables to write');
       expect(mockedSaveToFile).not.toHaveBeenCalled();
     });
 
@@ -301,13 +282,13 @@ describe('create actions', () => {
       const result = await handleEnvFileCreation('/test/project', 'test-token-789', 'eu');
 
       expect(result).toBe(false);
-      expect(mockedKonsola.warn).toHaveBeenCalledWith(
+      expect(mockedUI.warn).toHaveBeenCalledWith(
         expect.stringContaining('Failed to create .env file: Permission denied'),
       );
-      expect(mockedKonsola.info).toHaveBeenCalledWith(
+      expect(mockedUI.info).toHaveBeenCalledWith(
         expect.stringContaining('You can manually add STORYBLOK_DELIVERY_API_TOKEN'),
       );
-      expect(mockedKonsola.info).toHaveBeenCalledWith(
+      expect(mockedUI.info).toHaveBeenCalledWith(
         expect.stringContaining('You can manually add STORYBLOK_REGION'),
       );
     });
@@ -319,13 +300,13 @@ describe('create actions', () => {
       const result = await handleEnvFileCreation('/test/project', 'test-token');
 
       expect(result).toBe(false);
-      expect(mockedKonsola.warn).toHaveBeenCalledWith(
+      expect(mockedUI.warn).toHaveBeenCalledWith(
         expect.stringContaining('Failed to create .env file'),
       );
-      expect(mockedKonsola.info).toHaveBeenCalledWith(
+      expect(mockedUI.info).toHaveBeenCalledWith(
         expect.stringContaining('You can manually add STORYBLOK_DELIVERY_API_TOKEN'),
       );
-      expect(mockedKonsola.info).not.toHaveBeenCalledWith(
+      expect(mockedUI.info).not.toHaveBeenCalledWith(
         expect.stringContaining('You can manually add STORYBLOK_REGION'),
       );
     });
@@ -337,13 +318,13 @@ describe('create actions', () => {
       const result = await handleEnvFileCreation('/test/project', undefined, 'ca');
 
       expect(result).toBe(false);
-      expect(mockedKonsola.warn).toHaveBeenCalledWith(
+      expect(mockedUI.warn).toHaveBeenCalledWith(
         expect.stringContaining('Failed to create .env file'),
       );
-      expect(mockedKonsola.info).not.toHaveBeenCalledWith(
+      expect(mockedUI.info).not.toHaveBeenCalledWith(
         expect.stringContaining('You can manually add STORYBLOK_DELIVERY_API_TOKEN'),
       );
-      expect(mockedKonsola.info).toHaveBeenCalledWith(
+      expect(mockedUI.info).toHaveBeenCalledWith(
         expect.stringContaining('You can manually add STORYBLOK_REGION'),
       );
     });
@@ -406,25 +387,21 @@ describe('create actions', () => {
 
 describe('extractPortFromTopics', () => {
   it('should extract a valid port from topics', () => {
-    // This topic array contains a valid port topic
     const topics = ['foo', 'bar', 'port-8080', 'baz'];
     expect(extractPortFromTopics(topics)).toBe('8080');
   });
 
   it('should return default port if no port topic is found', () => {
-    // No port topic present, should fallback to 3000
     const topics = ['foo', 'bar', 'baz'];
     expect(extractPortFromTopics(topics)).toBe('3000');
   });
 
   it('should return default port if port is invalid', () => {
-    // Port topic is not a valid number
     const topics = ['port-abc', 'foo'];
     expect(extractPortFromTopics(topics)).toBe('3000');
   });
 
   it('should return default port if port is out of range', () => {
-    // Port is too high
     const topics = ['port-70000'];
     expect(extractPortFromTopics(topics)).toBe('3000');
   });
@@ -432,7 +409,6 @@ describe('extractPortFromTopics', () => {
 
 describe('repositoryToTemplate', () => {
   it('should convert a repo object to a DynamicTemplate', () => {
-    // Mock repo object with expected fields
     const repo = {
       name: 'blueprint-core-vue',
       topics: ['port-5173'],
@@ -440,7 +416,7 @@ describe('repositoryToTemplate', () => {
       description: 'A Vue starter',
       updated_at: '2024-01-01T00:00:00Z',
     };
-    const template = repositoryToTemplate(repo);
+    const template = repositoryToTemplate(repo as any);
     expect(template).toEqual({
       name: 'Vue',
       value: 'vue',
@@ -459,7 +435,7 @@ describe('repositoryToTemplate', () => {
       description: 'An unknown starter',
       updated_at: '2024-01-01T00:00:00Z',
     };
-    const template = repositoryToTemplate(repo);
+    const template = repositoryToTemplate(repo as any);
     expect(template.location).toBe('https://localhost:3000/');
   });
 
@@ -471,15 +447,13 @@ describe('repositoryToTemplate', () => {
       description: 'A React starter',
       updated_at: '2024-01-01T00:00:00Z',
     };
-    const template = repositoryToTemplate(repo);
-    // React static template has location https://localhost:5173/
+    const template = repositoryToTemplate(repo as any);
     expect(template.location).toBe('https://localhost:5173/');
   });
 });
 
 describe('fetchBlueprintRepositories', () => {
   it('should fetch and map repositories to blueprints', async () => {
-    // Mock Octokit and its response
     const mockRepos = [
       {
         name: 'blueprint-core-vue',
@@ -497,7 +471,6 @@ describe('fetchBlueprintRepositories', () => {
         updated_at: '2024-01-02T00:00:00Z',
         stargazers_count: 75,
       },
-      // Should be filtered out - not a blueprint
       {
         name: 'not-a-blueprint',
         topics: [],
@@ -515,12 +488,10 @@ describe('fetchBlueprintRepositories', () => {
       },
     };
 
-    // Mock createOctokit to return our mockOctokit
     mockedCreateOctokit.mockReturnValue(mockOctokit as any);
 
     const blueprints = await fetchBlueprintRepositories();
 
-    // Verify GitHub API was called correctly
     expect(mockedCreateOctokit).toHaveBeenCalled();
     expect(mockOctokit.rest.search.repos).toHaveBeenCalledWith({
       q: 'org:storyblok blueprint-core-',
@@ -529,12 +500,10 @@ describe('fetchBlueprintRepositories', () => {
       per_page: 100,
     });
 
-    // Only blueprint-core-* repos should be mapped and sorted alphabetically
     expect(blueprints).toHaveLength(2);
     expect(blueprints?.[0]?.name).toBe('React');
     expect(blueprints?.[1]?.name).toBe('Vue');
 
-    // Verify blueprint structure (React uses static template location)
     expect(blueprints?.[0]).toEqual({
       name: 'React',
       value: 'react',
@@ -546,25 +515,19 @@ describe('fetchBlueprintRepositories', () => {
     });
   });
 
-  it('should handle errors and call handleAPIError', async () => {
-    // Mock createOctokit to throw an error
+  it('should handle errors and call show warning', async () => {
     const octokitError = new Error('GitHub API error');
     mockedCreateOctokit.mockImplementation(() => {
       throw octokitError;
     });
 
     await fetchBlueprintRepositories();
-
-    // Verify error handling was called
-    expect(mockedHandleAPIError).toHaveBeenCalledWith(
-      'fetch_blueprints',
-      octokitError,
-      'Failed to fetch blueprints from GitHub',
+    expect(mockedUI.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch blueprints from GitHub. Using offline template list.'),
     );
   });
 
   it('should return static templates as fallback when GitHub API fails', async () => {
-    // Mock createOctokit to throw an error
     const octokitError = new Error('GitHub API error');
     mockedCreateOctokit.mockImplementation(() => {
       throw octokitError;
@@ -572,10 +535,8 @@ describe('fetchBlueprintRepositories', () => {
 
     const blueprints = await fetchBlueprintRepositories();
 
-    // Should return static templates as fallback
     expect(blueprints).toBeDefined();
     expect(blueprints.length).toBeGreaterThan(0);
-    // Check that known static templates are present
     expect(blueprints.some(bp => bp.value === 'react')).toBe(true);
     expect(blueprints.some(bp => bp.value === 'vue')).toBe(true);
     expect(blueprints.some(bp => bp.value === 'nuxt')).toBe(true);

--- a/packages/cli/src/commands/create/actions.ts
+++ b/packages/cli/src/commands/create/actions.ts
@@ -7,7 +7,11 @@ import { FileSystemError, handleFileSystemError } from '../../utils/error/filesy
 import open from 'open';
 import { createOctokit } from '../../github';
 import { handleAPIError, konsola } from '../../utils';
-import type { DynamicTemplate } from './constants';
+import { type DynamicTemplate, templates } from './constants';
+
+/** Repository item from GitHub search API response */
+type SearchReposResponse = Awaited<ReturnType<ReturnType<typeof createOctokit>['rest']['search']['repos']>>;
+type SearchRepoItem = SearchReposResponse['data']['items'][number];
 /**
  * Generates a new project from a Storyblok blueprint template
  * @param blueprint - The blueprint name (react, vue, svelte, etc.)
@@ -196,26 +200,52 @@ export const extractPortFromTopics = (topics: string[]): string => {
 };
 
 /**
+ * Finds a matching static template by value
+ * @param value - The template value to search for
+ * @returns The matching static template or undefined
+ */
+const findStaticTemplate = (value: string) => {
+  return Object.values(templates).find(t => t.value === value);
+};
+
+/**
  * Converts a GitHub repository to the format expected by the CLI
- * @param repo - GitHub repository data
+ * Uses static template name and location as priority if available
+ * @param repo - GitHub repository data from search API
  * @returns Formatted blueprint object
  */
-export const repositoryToTemplate = (repo: any): DynamicTemplate => {
+export const repositoryToTemplate = (repo: SearchRepoItem): DynamicTemplate => {
   const technology = repo.name.replace('blueprint-core-', '');
   const port = extractPortFromTopics(repo.topics || []);
+  const staticTemplate = findStaticTemplate(technology);
 
   return {
-    name: technology.charAt(0).toUpperCase() + technology.slice(1),
+    // Prioritize static template name over derived name
+    name: staticTemplate?.name || technology.charAt(0).toUpperCase() + technology.slice(1),
     value: technology,
     template: repo.clone_url,
-    location: port ? `https://localhost:${port}/` : 'https://localhost:3000/',
+    // Prioritize static template location over topic-derived port
+    location: staticTemplate?.location || (port ? `https://localhost:${port}/` : 'https://localhost:3000/'),
     description: repo.description,
     updated_at: repo.updated_at,
     stars: repo.stargazers_count,
   };
 };
 
-export const fetchBlueprintRepositories = async () => {
+/**
+ * Converts static templates to DynamicTemplate format for fallback
+ * @returns Array of DynamicTemplate objects
+ */
+const getStaticTemplatesAsFallback = (): DynamicTemplate[] => {
+  return Object.values(templates).map(t => ({
+    name: t.name,
+    value: t.value,
+    template: t.template,
+    location: t.location,
+  }));
+};
+
+export const fetchBlueprintRepositories = async (): Promise<DynamicTemplate[]> => {
   try {
     const octokit = createOctokit();
 
@@ -236,7 +266,9 @@ export const fetchBlueprintRepositories = async () => {
     return blueprints;
   }
   catch (error) {
-    // Fallback to hardcoded blueprints if GitHub search fails
+    // Fallback to static templates if GitHub search fails
     handleAPIError('fetch_blueprints', error as Error, 'Failed to fetch blueprints from GitHub');
+    konsola.warn('Using offline template list');
+    return getStaticTemplatesAsFallback();
   }
 };

--- a/packages/cli/src/commands/create/actions.ts
+++ b/packages/cli/src/commands/create/actions.ts
@@ -6,8 +6,10 @@ import { appDomains, type RegionCode } from '../../constants';
 import { FileSystemError, handleFileSystemError } from '../../utils/error/filesystem-error';
 import open from 'open';
 import { createOctokit } from '../../github';
-import { handleAPIError, konsola } from '../../utils';
-import { type DynamicTemplate, templates } from './constants';
+import { type Template, templates } from './constants';
+import { getUI } from '../../utils/ui';
+
+const ui = getUI({ enabled: true });
 
 /** Repository item from GitHub search API response */
 type SearchReposResponse = Awaited<ReturnType<ReturnType<typeof createOctokit>['rest']['search']['repos']>>;
@@ -123,24 +125,24 @@ export async function handleEnvFileCreation(resolvedPath: string, token?: string
     envVars.STORYBLOK_REGION = region;
   }
   if (Object.keys(envVars).length === 0) {
-    konsola.info('No environment variables to write');
+    ui.info('No environment variables to write');
     return true;
   }
   try {
     await createEnvFile(resolvedPath, envVars);
     const writtenKeys = Object.keys(envVars).join(', ');
-    konsola.ok(`Created .env file with: ${writtenKeys}`, true);
+    ui.ok(`Created .env file with: ${writtenKeys}`, true);
     return true;
   }
   catch (error) {
-    konsola.warn(`Failed to create .env file: ${(error as Error).message}`);
+    ui.warn(`Failed to create .env file: ${(error as Error).message}`);
     if (token) {
-      konsola.info(
+      ui.info(
         `You can manually add STORYBLOK_DELIVERY_API_TOKEN to your .env file.`,
       );
     }
     if (region) {
-      konsola.info(
+      ui.info(
         `You can manually add STORYBLOK_REGION to your .env file.`,
       );
     }
@@ -200,24 +202,15 @@ export const extractPortFromTopics = (topics: string[]): string => {
 };
 
 /**
- * Finds a matching static template by value
- * @param value - The template value to search for
- * @returns The matching static template or undefined
- */
-const findStaticTemplate = (value: string) => {
-  return Object.values(templates).find(t => t.value === value);
-};
-
-/**
  * Converts a GitHub repository to the format expected by the CLI
  * Uses static template name and location as priority if available
  * @param repo - GitHub repository data from search API
  * @returns Formatted blueprint object
  */
-export const repositoryToTemplate = (repo: SearchRepoItem): DynamicTemplate => {
+export const repositoryToTemplate = (repo: SearchRepoItem): Template => {
   const technology = repo.name.replace('blueprint-core-', '');
   const port = extractPortFromTopics(repo.topics || []);
-  const staticTemplate = findStaticTemplate(technology);
+  const staticTemplate = templates[technology.toUpperCase() as keyof typeof templates];
 
   return {
     // Prioritize static template name over derived name
@@ -232,20 +225,7 @@ export const repositoryToTemplate = (repo: SearchRepoItem): DynamicTemplate => {
   };
 };
 
-/**
- * Converts static templates to DynamicTemplate format for fallback
- * @returns Array of DynamicTemplate objects
- */
-const getStaticTemplatesAsFallback = (): DynamicTemplate[] => {
-  return Object.values(templates).map(t => ({
-    name: t.name,
-    value: t.value,
-    template: t.template,
-    location: t.location,
-  }));
-};
-
-export const fetchBlueprintRepositories = async (): Promise<DynamicTemplate[]> => {
+export const fetchBlueprintRepositories = async (): Promise<Template[]> => {
   try {
     const octokit = createOctokit();
 
@@ -265,10 +245,8 @@ export const fetchBlueprintRepositories = async (): Promise<DynamicTemplate[]> =
 
     return blueprints;
   }
-  catch (error) {
-    // Fallback to static templates if GitHub search fails
-    handleAPIError('fetch_blueprints', error as Error, 'Failed to fetch blueprints from GitHub');
-    konsola.warn('Using offline template list');
-    return getStaticTemplatesAsFallback();
+  catch {
+    ui.warn('Failed to fetch blueprints from GitHub. Using offline template list.');
+    return Object.values(templates);
   }
 };

--- a/packages/cli/src/commands/create/constants.ts
+++ b/packages/cli/src/commands/create/constants.ts
@@ -40,8 +40,8 @@ export const templates = {
     location: 'https://localhost:3000/',
   },
   NEXT: {
-    name: 'Next',
-    value: 'next',
+    name: 'Next.js',
+    value: 'nextjs',
     template: 'https://github.com/storyblok/blueprint-core-nextjs',
     location: 'https://localhost:3000/',
   },

--- a/packages/cli/src/commands/create/constants.ts
+++ b/packages/cli/src/commands/create/constants.ts
@@ -7,8 +7,18 @@ export interface CreateOptions {
   token?: string; // Access token for Storyblok
   region?: RegionCode;
 }
+type TemplateTechnology = 'REACT' | 'VUE' | 'SVELTE' | 'ASTRO' | 'NUXT' | 'NEXTJS' | 'ELEVENTY' | 'ANGULAR';
 
-export const templates = {
+export interface Template {
+  name: string;
+  value: string;
+  template: string;
+  location: string;
+  description?: string | null;
+  updated_at?: string;
+  stars?: number;
+}
+export const templates: Record<TemplateTechnology, Template> = {
   REACT: {
     name: 'React',
     value: 'react',
@@ -39,7 +49,7 @@ export const templates = {
     template: 'https://github.com/storyblok/blueprint-core-nuxt',
     location: 'https://localhost:3000/',
   },
-  NEXT: {
+  NEXTJS: {
     name: 'Next.js',
     value: 'nextjs',
     template: 'https://github.com/storyblok/blueprint-core-nextjs',
@@ -51,17 +61,10 @@ export const templates = {
     template: 'https://github.com/storyblok/blueprint-core-eleventy',
     location: 'https://localhost:8080/',
   },
+  ANGULAR: {
+    name: 'Angular',
+    value: 'angular',
+    template: 'https://github.com/storyblok/blueprint-core-angular',
+    location: 'https://localhost:4200/',
+  },
 } as const;
-
-/**
- * Interface for dynamic templates
- */
-export interface DynamicTemplate {
-  name: string;
-  value: string;
-  template: string;
-  location: string;
-  description?: string | null;
-  updated_at?: string;
-  stars?: number;
-}

--- a/packages/cli/src/commands/create/index.test.ts
+++ b/packages/cli/src/commands/create/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCommand } from './';
-import { handleError, konsola, requireAuthentication, toHumanReadable } from '../../utils';
+import { handleError, requireAuthentication, toHumanReadable } from '../../utils';
 import { confirm, input, select } from '@inquirer/prompts';
 
 import { createSpace } from '../spaces';
@@ -36,7 +36,6 @@ vi.mock('../../api', () => ({
   getMapiClient: vi.fn(),
 }));
 
-vi.mock('../../utils/konsola');
 vi.mock('../../utils', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, any>;
   return {
@@ -44,14 +43,6 @@ vi.mock('../../utils', async (importOriginal) => {
     requireAuthentication: vi.fn(),
     handleError: vi.fn(),
     toHumanReadable: vi.fn(),
-    konsola: {
-      ok: vi.fn(),
-      title: vi.fn(),
-      br: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      info: vi.fn(),
-    },
     isVitest: true,
   };
 });
@@ -61,7 +52,18 @@ vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
   confirm: vi.fn(),
 }));
+const { mockedUI } = vi.hoisted(() => ({
+  mockedUI: {
+    ok: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
+vi.mock('../../utils/ui', () => ({
+  getUI: vi.fn(() => mockedUI),
+}));
 // Helper function to create a complete Space mock object
 const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
   name: 'Test Space',
@@ -69,7 +71,6 @@ const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
   uniq_domain: 'test-uniq-domain',
   plan: 'starter',
   plan_level: 1,
-  limits: {},
   created_at: '2024-01-01T00:00:00Z',
   id: 12345,
   role: 'admin',
@@ -83,7 +84,6 @@ const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
   duplicatable: false,
   request_count_today: 0,
   exceeded_requests: 0,
-  billing_address: {},
   routes: [],
   trial: false,
   default_root: '',
@@ -91,9 +91,7 @@ const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
   has_pending_tasks: false,
   ai_translation_disabled: false,
   first_token: 'space-token-123',
-  options: {},
   collaborator: [],
-  owner: {},
   ...overrides,
 });
 
@@ -148,10 +146,10 @@ describe('createCommand', () => {
       expect(createSpace).not.toHaveBeenCalled();
       expect(openSpaceInBrowser).not.toHaveBeenCalled();
       // Should show success message
-      expect(konsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Your react project is ready 🎉 !'),
       );
-      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('Next steps:'));
+      expect(mockedUI.info).toHaveBeenCalledWith(expect.stringContaining('Next steps:'));
     });
 
     it('should work with --token even when not logged in', async () => {
@@ -228,7 +226,7 @@ describe('createCommand', () => {
 
       await createCommand.parseAsync(['node', 'test', '--template', 'invalid-template']);
 
-      expect(konsola.warn).toHaveBeenCalledWith(
+      expect(mockedUI.warn).toHaveBeenCalledWith(
         expect.stringContaining('Invalid template "invalid-template"'),
       );
       expect(select).toHaveBeenCalledWith(expect.objectContaining({
@@ -250,7 +248,7 @@ describe('createCommand', () => {
 
       await createCommand.parseAsync(['node', 'test', './my-project', '--blueprint', 'react']);
 
-      expect(konsola.warn).toHaveBeenCalledWith('The --blueprint flag is deprecated. Please use --template instead.');
+      expect(mockedUI.warn).toHaveBeenCalledWith('The --blueprint flag is deprecated. Please use --template instead.');
       expect(generateProject).toHaveBeenCalledWith('react', 'my-project', expect.any(String));
     });
 
@@ -268,7 +266,7 @@ describe('createCommand', () => {
 
       await createCommand.parseAsync(['node', 'test', './my-project', '--blueprint', 'react', '--template', 'vue']);
 
-      expect(konsola.warn).toHaveBeenCalledWith('Both --blueprint and --template provided. Using --template and ignoring --blueprint.');
+      expect(mockedUI.warn).toHaveBeenCalledWith('Both --blueprint and --template provided. Using --template and ignoring --blueprint.');
       expect(generateProject).toHaveBeenCalledWith('vue', 'my-project', expect.any(String));
     });
 
@@ -289,8 +287,8 @@ describe('createCommand', () => {
 
       await createCommand.parseAsync(['node', 'test', '--blueprint', 'invalid-blueprint']);
 
-      expect(konsola.warn).toHaveBeenCalledWith('The --blueprint flag is deprecated. Please use --template instead.');
-      expect(konsola.warn).toHaveBeenCalledWith(
+      expect(mockedUI.warn).toHaveBeenCalledWith('The --blueprint flag is deprecated. Please use --template instead.');
+      expect(mockedUI.warn).toHaveBeenCalledWith(
         expect.stringContaining('Invalid template "invalid-blueprint"'),
       );
       expect(select).toHaveBeenCalledWith(expect.objectContaining({
@@ -399,7 +397,7 @@ describe('createCommand', () => {
 
       // Verify project generation
       expect(generateProject).toHaveBeenCalledWith('react', 'my-project', expect.any(String));
-      expect(konsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Project my-project created successfully'),
         true,
       );
@@ -415,13 +413,13 @@ describe('createCommand', () => {
 
       // Verify browser opening
       expect(openSpaceInBrowser).toHaveBeenCalledWith(12345, 'eu');
-      expect(konsola.info).toHaveBeenCalledWith('Opened space in your browser');
+      expect(mockedUI.info).toHaveBeenCalledWith('Opened space in your browser');
 
       // Verify final success messages
-      expect(konsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Your react project is ready 🎉 !'),
       );
-      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('Next steps:'));
+      expect(mockedUI.info).toHaveBeenCalledWith(expect.stringContaining('Next steps:'));
     });
 
     it('should handle project generation failure', async () => {
@@ -492,9 +490,9 @@ describe('createCommand', () => {
 
       await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react']);
 
-      expect(konsola.warn).toHaveBeenCalledWith('Failed to open browser: Failed to open browser');
+      expect(mockedUI.warn).toHaveBeenCalledWith('Failed to open browser: Failed to open browser');
       expect(generateSpaceUrl).toHaveBeenCalledWith(12345, 'eu');
-      expect(konsola.info).toHaveBeenCalledWith(
+      expect(mockedUI.info).toHaveBeenCalledWith(
         expect.stringContaining('You can manually open your space at:'),
       );
     });
@@ -622,7 +620,7 @@ describe('createCommand', () => {
 
       // Verify project generation still happens
       expect(generateProject).toHaveBeenCalledWith('react', 'my-project', expect.any(String));
-      expect(konsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Project my-project created successfully'),
         true,
       );
@@ -634,7 +632,7 @@ describe('createCommand', () => {
       expect(openSpaceInBrowser).not.toHaveBeenCalled();
 
       // Verify success message still shows
-      expect(konsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Your react project is ready 🎉 !'),
       );
     });
@@ -679,22 +677,22 @@ describe('createCommand', () => {
       await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react', '--skip-space']);
 
       // Should show project creation success
-      expect(konsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Project my-project created successfully'),
         true,
       );
 
       // Should show final success message
-      expect(konsola.ok).toHaveBeenCalledWith(
+      expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Your react project is ready 🎉 !'),
       );
 
       // Should show next steps
-      expect(konsola.info).toHaveBeenCalledWith(expect.stringContaining('Next steps:'));
+      expect(mockedUI.info).toHaveBeenCalledWith(expect.stringContaining('Next steps:'));
 
       // Should NOT show space-related success messages
-      expect(konsola.ok).not.toHaveBeenCalledWith('Created .env file with Storyblok access token', true);
-      expect(konsola.info).not.toHaveBeenCalledWith('Opened space in your browser');
+      expect(mockedUI.ok).not.toHaveBeenCalledWith('Created .env file with Storyblok access token', true);
+      expect(mockedUI.info).not.toHaveBeenCalledWith('Opened space in your browser');
     });
 
     it('should handle project generation failure even when skipping space creation', async () => {
@@ -935,7 +933,7 @@ describe('createCommand', () => {
         await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react']);
 
         // Should show warning message (note: American spelling "organization")
-        expect(konsola.warn).toHaveBeenCalledWith(
+        expect(mockedUI.warn).toHaveBeenCalledWith(
           'Space creation in this region is limited to Enterprise accounts. If you\'re part of an organization, please ensure you have the required permissions. For more information about Enterprise access, contact our Sales Team.',
         );
 
@@ -969,7 +967,7 @@ describe('createCommand', () => {
         await createCommand.parseAsync(['node', 'test', 'my-project', '--blueprint', 'react']);
 
         // Should show organization-specific success message
-        expect(konsola.ok).toHaveBeenCalledWith(
+        expect(mockedUI.ok).toHaveBeenCalledWith(
           expect.stringContaining('Storyblok space created in organization Test Organization'),
         );
       });
@@ -995,7 +993,7 @@ describe('createCommand', () => {
         await createCommand.parseAsync(['node', 'test', 'my-project', '--blueprint', 'react']);
 
         // Should show partner-specific success message
-        expect(konsola.ok).toHaveBeenCalledWith(
+        expect(mockedUI.ok).toHaveBeenCalledWith(
           expect.stringContaining('Storyblok space created in partner portal'),
         );
       });
@@ -1022,13 +1020,13 @@ describe('createCommand', () => {
         await createCommand.parseAsync(['node', 'test', 'my-project', '--blueprint', 'react']);
 
         // Should show generic success message (not org or partner specific)
-        expect(konsola.ok).toHaveBeenCalledWith(
+        expect(mockedUI.ok).toHaveBeenCalledWith(
           expect.stringMatching(/^Storyblok space created, preview url and \.env configured automatically/),
         );
-        expect(konsola.ok).not.toHaveBeenCalledWith(
+        expect(mockedUI.ok).not.toHaveBeenCalledWith(
           expect.stringContaining('organization'),
         );
-        expect(konsola.ok).not.toHaveBeenCalledWith(
+        expect(mockedUI.ok).not.toHaveBeenCalledWith(
           expect.stringContaining('partner portal'),
         );
       });
@@ -1044,7 +1042,7 @@ describe('createCommand', () => {
 
         await createCommand.parseAsync(['node', 'test', 'my-project', '--blueprint', 'react']);
 
-        expect(konsola.error).toHaveBeenCalledWith('Failed to fetch user info. Your session may have expired.');
+        expect(mockedUI.error).toHaveBeenCalledWith('Failed to fetch user info. Your session may have expired.');
         expect(generateProject).toHaveBeenCalled();
         expect(createSpace).not.toHaveBeenCalled();
       });

--- a/packages/cli/src/commands/create/index.test.ts
+++ b/packages/cli/src/commands/create/index.test.ts
@@ -58,6 +58,8 @@ const { mockedUI } = vi.hoisted(() => ({
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
+    title: vi.fn(),
+    br: vi.fn(),
   },
 }));
 
@@ -541,7 +543,7 @@ describe('createCommand', () => {
       ['vue', 'VUE'],
       ['svelte', 'SVELTE'],
       ['nuxt', 'NUXT'],
-      ['next', 'NEXT'],
+      ['nextjs', 'NEXTJS'],
     ])('should handle %s template correctly', async (template, templateKey) => {
       // Use createMockSpace to ensure the mock matches the Space type
       const mockSpace = createMockSpace({ id: 12345, first_token: 'space-token-123' });
@@ -555,7 +557,7 @@ describe('createCommand', () => {
         { name: 'Vue', value: 'vue', template: '', location: 'https://localhost:5173/', description: '', updated_at: '' },
         { name: 'Svelte', value: 'svelte', template: '', location: 'https://localhost:5173/', description: '', updated_at: '' },
         { name: 'Nuxt', value: 'nuxt', template: '', location: 'https://localhost:3000/', description: '', updated_at: '' },
-        { name: 'Next', value: 'next', template: '', location: 'https://localhost:3000/', description: '', updated_at: '' },
+        { name: 'Next.js', value: 'nextjs', template: '', location: 'https://localhost:3000/', description: '', updated_at: '' },
       ]);
 
       await createCommand.parseAsync(['node', 'test', 'my-project', '--template', template]);

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -137,7 +137,7 @@ export const createCommand = program
       const templates = await fetchBlueprintRepositories();
       spinnerBlueprints.succeed('Starter templates fetched successfully');
 
-      if (!templates) {
+      if (templates.length === 0) {
         spinnerBlueprints.failed();
         konsola.warn('No starter templates found. Please contact support@storyblok.com');
         konsola.br();

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -1,4 +1,4 @@
-import { CommandError, handleError, isRegion, isVitest, konsola, requireAuthentication, toHumanReadable } from '../../utils';
+import { CommandError, handleError, isRegion, isVitest, requireAuthentication, toHumanReadable } from '../../utils';
 import { colorPalette, commands, type RegionCode, regions } from '../../constants';
 import { performInteractiveLogin } from '../login/helpers';
 import { getProgram } from '../../program';
@@ -12,34 +12,37 @@ import { createSpace, type SpaceCreate } from '../spaces';
 import { Spinner } from '@topcli/spinner';
 import type { User } from '../user/actions';
 import { getUser } from '../user/actions';
+import { getUI } from '../../utils/ui';
+
+const ui = getUI({ enabled: true });
 
 // Helper to show next steps and project ready message
 function showNextSteps(technologyTemplate: string, finalProjectPath: string) {
-  konsola.br();
-  konsola.ok(`Your ${chalk.hex(colorPalette.PRIMARY)(technologyTemplate)} project is ready 🎉 !`);
-  konsola.br();
-  konsola.info(`Next steps:\n  cd ${finalProjectPath}\n  npm install\n  npm run dev\n        `);
-  konsola.info(`Or check the dedicated guide at: ${chalk.hex(colorPalette.PRIMARY)(`https://www.storyblok.com/docs/guides/${technologyTemplate}`)}`);
+  ui.br();
+  ui.ok(`Your ${chalk.hex(colorPalette.PRIMARY)(technologyTemplate)} project is ready 🎉 !`);
+  ui.br();
+  ui.info(`Next steps:\n  cd ${finalProjectPath}\n  npm install\n  npm run dev\n        `);
+  ui.info(`Or check the dedicated guide at: ${chalk.hex(colorPalette.PRIMARY)(`https://www.storyblok.com/docs/guides/${technologyTemplate}`)}`);
 }
 
 // Helper to handle interactive login prompt
 async function promptForLogin(verbose: boolean): Promise<{ token: string; region: RegionCode } | null> {
   try {
-    konsola.br();
+    ui.br();
     const shouldLogin = await confirm({
       message: 'Would you like to login now?',
       default: true,
     });
 
     if (!shouldLogin) {
-      konsola.warn('Login cancelled. You can login later using the "storyblok login" command.');
+      ui.warn('Login cancelled. You can login later using the "storyblok login" command.');
       return null;
     }
 
     return await performInteractiveLogin({ verbose, showWelcomeMessage: true });
   }
   catch (error) {
-    konsola.br();
+    ui.br();
     handleError(error as Error, verbose);
     return null;
   }
@@ -61,7 +64,7 @@ export const createCommand = program
     `The region to apply to the generated project template (does not affect space creation).`,
   )
   .action(async (projectPath: string, options: CreateOptions) => {
-    konsola.title(`${commands.CREATE}`, colorPalette.CREATE);
+    ui.title(`${commands.CREATE}`, colorPalette.CREATE);
     // Global options
     const verbose = program.opts().verbose;
     // Command options - handle backward compatibility
@@ -74,11 +77,11 @@ export const createCommand = program
     // Handle deprecated blueprint option
     let selectedTemplate = template;
     if (blueprint && !template) {
-      konsola.warn(`The --blueprint flag is deprecated. Please use --template instead.`);
+      ui.warn(`The --blueprint flag is deprecated. Please use --template instead.`);
       selectedTemplate = blueprint;
     }
     else if (blueprint && template) {
-      konsola.warn(`Both --blueprint and --template provided. Using --template and ignoring --blueprint.`);
+      ui.warn(`Both --blueprint and --template provided. Using --template and ignoring --blueprint.`);
     }
 
     const { state, initializeSession } = session();
@@ -139,8 +142,8 @@ export const createCommand = program
 
       if (templates.length === 0) {
         spinnerBlueprints.failed();
-        konsola.warn('No starter templates found. Please contact support@storyblok.com');
-        konsola.br();
+        ui.warn('No starter templates found. Please contact support@storyblok.com');
+        ui.br();
         return;
       }
 
@@ -151,8 +154,8 @@ export const createCommand = program
         const isValidTemplate = validTemplates.find(bp => bp.value === selectedTemplate);
         if (!isValidTemplate) {
           const validOptions = validTemplates.map(bp => bp.value).join(', ');
-          konsola.warn(`Invalid template "${chalk.hex(colorPalette.CREATE)(selectedTemplate)}". Valid options are: ${chalk.hex(colorPalette.CREATE)(validOptions)}`);
-          konsola.br();
+          ui.warn(`Invalid template "${chalk.hex(colorPalette.CREATE)(selectedTemplate)}". Valid options are: ${chalk.hex(colorPalette.CREATE)(validOptions)}`);
+          ui.br();
           // Reset template to show interactive selection
           technologyTemplate = undefined;
         }
@@ -194,12 +197,12 @@ export const createCommand = program
       const targetDirectory = dirname(resolvedPath);
       const projectName = basename(resolvedPath);
 
-      konsola.br();
-      konsola.info(`Scaffolding your project using the ${chalk.hex(colorPalette.CREATE)(technologyTemplate)} template...`);
+      ui.br();
+      ui.info(`Scaffolding your project using the ${chalk.hex(colorPalette.CREATE)(technologyTemplate)} template...`);
 
       // Generate the project from the template
       await generateProject(technologyTemplate!, projectName, targetDirectory);
-      konsola.ok(`Project ${chalk.hex(colorPalette.PRIMARY)(projectName)} created successfully in ${chalk.hex(colorPalette.PRIMARY)(finalProjectPath)}`, true);
+      ui.ok(`Project ${chalk.hex(colorPalette.PRIMARY)(projectName)} created successfully in ${chalk.hex(colorPalette.PRIMARY)(finalProjectPath)}`, true);
 
       // If token is provided, use it as the access token, skip space creation, and update env
       let createdSpace;
@@ -230,10 +233,10 @@ export const createCommand = program
           userData = user;
         }
         catch {
-          konsola.error('Failed to fetch user info. Your session may have expired.');
+          ui.error('Failed to fetch user info. Your session may have expired.');
           const loginResult = await promptForLogin(verbose);
           if (!loginResult) {
-            konsola.br();
+            ui.br();
             return;
           }
           // Re-initialize session and retry fetching user
@@ -247,8 +250,8 @@ export const createCommand = program
             userData = user;
           }
           catch (retryError) {
-            konsola.error('Failed to fetch user info after login.', retryError);
-            konsola.br();
+            ui.error('Failed to fetch user info after login.', retryError);
+            ui.br();
             return;
           }
         }
@@ -274,8 +277,8 @@ export const createCommand = program
           whereToCreateSpace = 'org';
         }
         if (region !== regions.EU && !userData.has_org) {
-          konsola.warn(`Space creation in this region is limited to Enterprise accounts. If you're part of an organization, please ensure you have the required permissions. For more information about Enterprise access, contact our Sales Team.`);
-          konsola.br();
+          ui.warn(`Space creation in this region is limited to Enterprise accounts. If you're part of an organization, please ensure you have the required permissions. For more information about Enterprise access, contact our Sales Team.`);
+          ui.br();
           return;
         }
 
@@ -307,12 +310,12 @@ export const createCommand = program
         if (createdSpace?.id) {
           try {
             await openSpaceInBrowser(createdSpace.id, region!);
-            konsola.info(`Opened space in your browser`);
+            ui.info(`Opened space in your browser`);
           }
           catch (error) {
-            konsola.warn(`Failed to open browser: ${(error as Error).message}`);
+            ui.warn(`Failed to open browser: ${(error as Error).message}`);
             const spaceUrl = generateSpaceUrl(createdSpace.id, region!);
-            konsola.info(`You can manually open your space at: ${chalk.hex(colorPalette.PRIMARY)(spaceUrl)}`);
+            ui.info(`You can manually open your space at: ${chalk.hex(colorPalette.PRIMARY)(spaceUrl)}`);
           }
         }
 
@@ -320,19 +323,19 @@ export const createCommand = program
         showNextSteps(technologyTemplate!, finalProjectPath);
         if (createdSpace?.first_token) {
           if (whereToCreateSpace === 'org') {
-            konsola.ok(`Storyblok space created in organization ${chalk.hex(colorPalette.PRIMARY)(userData?.org?.name)}, preview url and .env configured automatically. You can now open your space in the browser at ${chalk.hex(colorPalette.PRIMARY)(generateSpaceUrl(createdSpace.id, region!))}`);
+            ui.ok(`Storyblok space created in organization ${chalk.hex(colorPalette.PRIMARY)(userData?.org?.name)}, preview url and .env configured automatically. You can now open your space in the browser at ${chalk.hex(colorPalette.PRIMARY)(generateSpaceUrl(createdSpace.id, region!))}`);
           }
           else if (whereToCreateSpace === 'partner') {
-            konsola.ok(`Storyblok space created in partner portal, preview url and .env configured automatically. You can now open your space in the browser at ${chalk.hex(colorPalette.PRIMARY)(generateSpaceUrl(createdSpace.id, region!))}`);
+            ui.ok(`Storyblok space created in partner portal, preview url and .env configured automatically. You can now open your space in the browser at ${chalk.hex(colorPalette.PRIMARY)(generateSpaceUrl(createdSpace.id, region!))}`);
           }
           else {
-            konsola.ok(`Storyblok space created, preview url and .env configured automatically. You can now open your space in the browser at ${chalk.hex(colorPalette.PRIMARY)(generateSpaceUrl(createdSpace.id, region!))}`);
+            ui.ok(`Storyblok space created, preview url and .env configured automatically. You can now open your space in the browser at ${chalk.hex(colorPalette.PRIMARY)(generateSpaceUrl(createdSpace.id, region!))}`);
           }
         }
       }
       catch (error) {
         spinnerSpace.failed();
-        konsola.br();
+        ui.br();
         handleError(error as Error, verbose);
         return;
       }
@@ -342,8 +345,8 @@ export const createCommand = program
     catch (error) {
       spinnerSpace.failed();
       spinnerBlueprints.failed();
-      konsola.br();
+      ui.br();
       handleError(error as Error, verbose);
     }
-    konsola.br();
+    ui.br();
   });


### PR DESCRIPTION
This PR improves template resolution in the create command by ensuring locally defined template metadata takes priority over dynamically fetched repository data.

It also adds a fallback to the static template list when fetching the dynamic template list fails, improving reliability and preventing broken template resolution.

## Changes

- Fix Next.js naming in the create command
- Preserve locally defined template names and metadata over dynamically fetched repository details
- Add fallback to static template definitions if dynamic template fetching fails
- Ensure templates like `Next.js` keep their intended naming instead of being replaced by repo names
