### PR TITLE
fix: support encoded resolve_relations values automatically across clients

### DIFF
--- a/packages/capi-client/src/utils/inline-relations.test.ts
+++ b/packages/capi-client/src/utils/inline-relations.test.ts
@@ -55,6 +55,34 @@ describe('parseResolveRelations', () => {
 
     expect(relationPaths).toEqual(['page.author', 'page.categories']);
   });
+
+  it('should handle URL-encoded resolve_relations strings', () => {
+    const relationPaths = parseResolveRelations({
+      resolve_relations: 'dodoNewsItem.tags%2CgooseProductMetadata.systemGenerationRef%2CgooseProductMetadata.productGroupRef',
+    });
+
+    expect(relationPaths).toEqual([
+      'dodoNewsItem.tags',
+      'gooseProductMetadata.systemGenerationRef',
+      'gooseProductMetadata.productGroupRef',
+    ]);
+  });
+
+  it('should handle URL-encoded strings with spaces', () => {
+    const relationPaths = parseResolveRelations({
+      resolve_relations: 'page.author%2C%20page.categories',
+    });
+
+    expect(relationPaths).toEqual(['page.author', 'page.categories']);
+  });
+
+  it('should handle non-encoded strings normally', () => {
+    const relationPaths = parseResolveRelations({
+      resolve_relations: 'page.author,page.categories',
+    });
+
+    expect(relationPaths).toEqual(['page.author', 'page.categories']);
+  });
 });
 
 describe('inlineStoryContent', () => {

--- a/packages/capi-client/src/utils/inline-relations.ts
+++ b/packages/capi-client/src/utils/inline-relations.ts
@@ -18,6 +18,24 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isComponentNode = (value: Record<string, unknown>): value is ComponentNode =>
   typeof value.component === 'string' && typeof value._uid === 'string';
 
+/**
+ * Decodes a string if it appears to be URL-encoded.
+ * Detects common encoded characters (%2C for comma, %20 for space, etc.)
+ */
+const decodeIfEncoded = (value: string): string => {
+  // Check if the string contains URL-encoded characters (% followed by hex digits)
+  if (/%[0-9A-F]{2}/i.test(value)) {
+    try {
+      return decodeURIComponent(value);
+    }
+    catch {
+      // If decoding fails (malformed encoding), return original
+      return value;
+    }
+  }
+  return value;
+};
+
 const inlineStoryContentInternal = <TStory extends StoryCapi | StoryWithInlinedRelations>(
   story: TStory,
   relationPaths: ReadonlySet<RelationPath>,
@@ -77,7 +95,10 @@ export const parseResolveRelations = (query: Record<string, unknown>): RelationP
     return [];
   }
 
-  return query.resolve_relations
+  // Decode URL-encoded strings to handle pre-encoded input
+  const resolveRelations = decodeIfEncoded(query.resolve_relations);
+
+  return resolveRelations
     .split(',')
     .map(path => path.trim())
     .filter((path): path is RelationPath => {

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -1537,6 +1537,92 @@ describe('storyblokClient', () => {
         undefined,
       );
     });
+
+    it('should decode URL-encoded resolve_relations string', async () => {
+      const storySlug = 'test-story';
+      const mockStoryResponse = {
+        data: {
+          story: {
+            id: 123,
+            uuid: 'test-uuid',
+            name: 'Test Story',
+            content: {
+              _uid: 'test-uid',
+              component: 'test',
+              title: 'Test Title',
+            },
+          },
+        },
+        headers: {},
+        status: 200,
+      };
+
+      const mockGet = vi.fn().mockResolvedValue(mockStoryResponse);
+
+      // Replace the client's internal fetch instance to capture actual params
+      client.client = {
+        get: mockGet,
+        post: vi.fn(),
+        setFetchOptions: vi.fn(),
+      };
+
+      // Call get with URL-encoded resolve_relations
+      await client.get(`cdn/stories/${storySlug}`, {
+        version: 'published',
+        resolve_relations: 'page.author%2Cpage.categories',
+      });
+
+      // Verify that the internal client received decoded resolve_relations
+      expect(mockGet).toHaveBeenCalledWith(
+        `/cdn/stories/${storySlug}`,
+        expect.objectContaining({
+          resolve_relations: 'page.author,page.categories',
+        }),
+      );
+    });
+
+    it('should decode URL-encoded strings in resolve_relations array', async () => {
+      const storySlug = 'test-story';
+      const mockStoryResponse = {
+        data: {
+          story: {
+            id: 123,
+            uuid: 'test-uuid',
+            name: 'Test Story',
+            content: {
+              _uid: 'test-uid',
+              component: 'test',
+              title: 'Test Title',
+            },
+          },
+        },
+        headers: {},
+        status: 200,
+      };
+
+      const mockGet = vi.fn().mockResolvedValue(mockStoryResponse);
+
+      // Replace the client's internal fetch instance to capture actual params
+      client.client = {
+        get: mockGet,
+        post: vi.fn(),
+        setFetchOptions: vi.fn(),
+      };
+
+      // Call get with URL-encoded items in resolve_relations array
+      await client.get(`cdn/stories/${storySlug}`, {
+        version: 'published',
+        resolve_relations: ['page.author', 'page.categories%2Ftags'],
+      });
+
+      // Verify that the internal client received decoded and joined resolve_relations
+      expect(mockGet).toHaveBeenCalledWith(
+        `/cdn/stories/${storySlug}`,
+        expect.objectContaining({
+          resolve_relations: 'page.author,page.categories/tags',
+        }),
+      );
+    });
   });
 
   describe('dynamic Rate Limiting', () => {

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -1,5 +1,6 @@
 import {
   asyncMap,
+  decodeIfEncoded,
   delay,
   flatMap,
   getOptionsPage,
@@ -177,7 +178,12 @@ export class Storyblok {
     }
 
     if (Array.isArray(params.resolve_relations)) {
-      params.resolve_relations = params.resolve_relations.join(',');
+      // Decode URL-encoded strings in array before joining
+      params.resolve_relations = params.resolve_relations.map(decodeIfEncoded).join(',');
+    }
+    else if (typeof params.resolve_relations === 'string') {
+      // Decode URL-encoded strings to prevent double-encoding
+      params.resolve_relations = decodeIfEncoded(params.resolve_relations);
     }
 
     if (typeof params.resolve_relations !== 'undefined') {

--- a/packages/js-client/src/utils.test.ts
+++ b/packages/js-client/src/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   arrayFrom,
   asyncMap,
+  decodeIfEncoded,
   delay,
   escapeHTML,
   flatMap,
@@ -183,6 +184,42 @@ describe('utils', () => {
       expect(escaped).toBe(
         '&lt;div&gt;Test &amp; &quot;more&quot; test&lt;/div&gt;',
       );
+    });
+  });
+
+  describe('decodeIfEncoded', () => {
+    it('decodes URL-encoded commas in resolve_relations string', () => {
+      const encoded = 'dodoNewsItem.tags%2CgooseProductMetadata.systemGenerationRef';
+      expect(decodeIfEncoded(encoded)).toBe('dodoNewsItem.tags,gooseProductMetadata.systemGenerationRef');
+    });
+
+    it('decodes fully URL-encoded resolve_relations string', () => {
+      const encoded = 'dodoNewsItem.tags%2CgooseProductMetadata.systemGenerationRef%2CgooseProductMetadata.productGroupRef';
+      expect(decodeIfEncoded(encoded)).toBe('dodoNewsItem.tags,gooseProductMetadata.systemGenerationRef,gooseProductMetadata.productGroupRef');
+    });
+
+    it('returns original string when not URL-encoded', () => {
+      const plain = 'dodoNewsItem.tags,gooseProductMetadata.systemGenerationRef';
+      expect(decodeIfEncoded(plain)).toBe(plain);
+    });
+
+    it('returns original string for empty input', () => {
+      expect(decodeIfEncoded('')).toBe('');
+    });
+
+    it('handles mixed encoded characters', () => {
+      const encoded = 'component.field%20with%20spaces%2Cother.field';
+      expect(decodeIfEncoded(encoded)).toBe('component.field with spaces,other.field');
+    });
+
+    it('returns original string for malformed encoding', () => {
+      const malformed = 'component.field%2';
+      expect(decodeIfEncoded(malformed)).toBe(malformed);
+    });
+
+    it('does not double-decode already decoded strings', () => {
+      const plain = 'component.field,other.field';
+      expect(decodeIfEncoded(plain)).toBe(plain);
     });
   });
 });

--- a/packages/js-client/src/utils.ts
+++ b/packages/js-client/src/utils.ts
@@ -86,6 +86,26 @@ export const flatMap = (arr: ISbResult[] = [], func: FlatMapFn) =>
   arr.map(func).reduce((xs, ys) => [...xs, ...ys], []);
 
 /**
+ * Decodes a string if it appears to be URL-encoded.
+ * Detects common encoded characters (%2C for comma, %20 for space, etc.)
+ * @param value - The string to potentially decode
+ * @returns The decoded string, or the original if not encoded
+ */
+export const decodeIfEncoded = (value: string): string => {
+  // Check if the string contains URL-encoded characters (% followed by hex digits)
+  if (/%[0-9A-F]{2}/i.test(value)) {
+    try {
+      return decodeURIComponent(value);
+    }
+    catch {
+      // If decoding fails (malformed encoding), return original
+      return value;
+    }
+  }
+  return value;
+};
+
+/**
  * Stringifies an object into a URL query string
  * @param params - Parameters to stringify
  * @param prefix - Prefix for nested keys


### PR DESCRIPTION
This PR improves `resolve_relations` handling by automatically decoding encoded relation strings before processing.

Users can now pass encoded strings directly, and the client will handle them without requiring manual `decodeURIComponent()` calls.

## Changes

- Automatically handle encoded `resolve_relations` values
- Support `%2C`-encoded comma-separated relation strings
- Remove the need for users to manually decode relation strings before passing them to the client
- Added test coverage for encoded relation inputs

## Example

Before:
```ts
const relationString =
  "dodoNewsItem.tags%2CgooseProductMetadata.systemGenerationRef%2CgooseProductMetadata.productGroupRef";

const resolve_relations = decodeURIComponent(relationString);

await storyblok.get("cdn/stories", {
  resolve_relations,
});
```
After:
```ts
const resolve_relations =
  "dodoNewsItem.tags%2CgooseProductMetadata.systemGenerationRef%2CgooseProductMetadata.productGroupRef";

await storyblok.get("cdn/stories", {
  resolve_relations,
});
```
## Why

This improves developer experience by making the client more forgiving and reducing unnecessary manual preprocessing for encoded relation strings.