### PR TITLE
feat(nuxt): Add reactivity to useAsyncStoryblok composable https://git…

### DIFF
--- a/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
+++ b/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
@@ -1,7 +1,7 @@
+import type { AsyncData, AsyncDataOptions, NuxtError } from '#app';
+import { useAsyncData } from '#app';
 import { type ISbResult, type ISbStoriesParams, type StoryblokBridgeConfigV2, useStoryblokApi, useStoryblokBridge } from '@storyblok/vue';
 import { computed, type ComputedRef, type Ref, watch } from 'vue';
-import { useAsyncData } from '#app';
-import type { AsyncData, AsyncDataOptions, NuxtError } from '#app';
 
 /**
  * Options for the useAsyncStoryblok composable.
@@ -9,7 +9,7 @@ import type { AsyncData, AsyncDataOptions, NuxtError } from '#app';
  */
 export interface UseAsyncStoryblokOptions extends AsyncDataOptions<ISbResult> {
   /** Storyblok API parameters for fetching stories */
-  api: ISbStoriesParams;
+  api: MaybeRefOrGetter<ISbStoriesParams>;
   /** Storyblok Bridge configuration for live preview */
   bridge: StoryblokBridgeConfigV2;
 }
@@ -97,63 +97,59 @@ export async function useAsyncStoryblok(
 ): Promise<UseAsyncStoryblokResult> {
   const storyblokApiInstance = useStoryblokApi();
   const { api, bridge = {}, ...rest } = options;
-  const uniqueKey = `${stableStringify(api)}${url}`;
+  const uniqueKey = (): string => `${stableStringify(toValue(api))}${url}`;
 
   // Copy resolve_relations and resolve_links from API options to bridge options
   // This ensures the bridge resolves the same relations during live preview updates
   const bridgeOptions: StoryblokBridgeConfigV2 = {
-    ...bridge,
-    resolveRelations: bridge.resolveRelations ?? api.resolve_relations,
-    resolveLinks: bridge.resolveLinks ?? api.resolve_links,
+      ...bridge,
+      resolveRelations: bridge.resolveRelations ?? toValue(api).resolve_relations,
+      resolveLinks: bridge.resolveLinks ?? toValue(api).resolve_links,
   };
 
-  const result = await useAsyncData(uniqueKey, () => storyblokApiInstance.get(`cdn/stories/${url}`, api), rest) as AsyncData<ISbResult, NuxtError<unknown>>;
+  const result = (await useAsyncData(uniqueKey, () => storyblokApiInstance.get(`cdn/stories/${url}`, { ...toValue(api) }), rest)) as AsyncData<
+      ISbResult,
+      NuxtError<unknown>
+  >;
 
   // Register bridge for live preview updates (client-side only)
   // Use watch instead of onMounted because lifecycle hooks must be registered before the first await
   // in async setup functions, but we can't as we need the story.id
   if (import.meta.client) {
-    const registerBridge = (storyId: number) => {
-      useStoryblokBridge(storyId, (evStory) => {
-        // In Nuxt 4, data is a shallowRef - we must replace the entire object
-        // to trigger reactivity instead of mutating nested properties
-        if (result.data.value) {
-          result.data.value = {
-            ...result.data.value,
-            data: {
-              ...result.data.value.data,
-              story: evStory,
-            },
-          };
-        }
-      }, bridgeOptions);
-    };
+      let registeredId: number | undefined;
 
-    const id = result.data.value?.data?.story?.id;
-    if (id) {
-      registerBridge(id);
-    }
-    else {
-      // Wait for data to become available, then register bridge once
-      const stopWatch = watch(
-        () => result.data.value?.data?.story?.id,
-        (storyId) => {
-          if (storyId) {
-            stopWatch();
-            registerBridge(storyId);
-          }
-        },
+      watch(
+          () => result.data.value?.data?.story?.id,
+          storyId => {
+              if (storyId && storyId !== registeredId) {
+                  registeredId = storyId;
+                  useStoryblokBridge(
+                      storyId,
+                      evStory => {
+                          // In Nuxt 4, data is a shallowRef - we must replace the entire object
+                          // to trigger reactivity instead of mutating nested properties
+                          if (result.data.value) {
+                              result.data.value = {
+                                  ...result.data.value,
+                                  data: { ...result.data.value.data, story: evStory },
+                              };
+                          }
+                      },
+                      bridgeOptions
+                  );
+              }
+          },
+          { immediate: true }
       );
-    }
   }
 
   return {
-    data: result.data,
-    pending: result.pending,
-    error: result.error,
-    refresh: result.refresh,
-    execute: result.execute,
-    clear: result.clear,
-    story: computed(() => result.data.value?.data.story),
+      data: result.data,
+      pending: result.pending,
+      error: result.error,
+      refresh: result.refresh,
+      execute: result.execute,
+      clear: result.clear,
+      story: computed(() => result.data.value?.data.story),
   };
 }

--- a/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
+++ b/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
@@ -1,7 +1,7 @@
 import type { AsyncData, AsyncDataOptions, NuxtError } from '#app';
 import { useAsyncData } from '#app';
 import { type ISbResult, type ISbStoriesParams, type StoryblokBridgeConfigV2, useStoryblokApi, useStoryblokBridge } from '@storyblok/vue';
-import { computed, type ComputedRef, type Ref, watch } from 'vue';
+import { computed, type ComputedRef, type MaybeRefOrGetter, type Ref, toValue, watch } from 'vue';
 
 /**
  * Options for the useAsyncStoryblok composable.
@@ -102,54 +102,54 @@ export async function useAsyncStoryblok(
   // Copy resolve_relations and resolve_links from API options to bridge options
   // This ensures the bridge resolves the same relations during live preview updates
   const bridgeOptions: StoryblokBridgeConfigV2 = {
-      ...bridge,
-      resolveRelations: bridge.resolveRelations ?? toValue(api).resolve_relations,
-      resolveLinks: bridge.resolveLinks ?? toValue(api).resolve_links,
+    ...bridge,
+    resolveRelations: bridge.resolveRelations ?? toValue(api).resolve_relations,
+    resolveLinks: bridge.resolveLinks ?? toValue(api).resolve_links,
   };
 
   const result = (await useAsyncData(uniqueKey, () => storyblokApiInstance.get(`cdn/stories/${url}`, { ...toValue(api) }), rest)) as AsyncData<
-      ISbResult,
-      NuxtError<unknown>
+    ISbResult,
+    NuxtError<unknown>
   >;
 
   // Register bridge for live preview updates (client-side only)
   // Use watch instead of onMounted because lifecycle hooks must be registered before the first await
   // in async setup functions, but we can't as we need the story.id
   if (import.meta.client) {
-      let registeredId: number | undefined;
+    let registeredId: number | undefined;
 
-      watch(
-          () => result.data.value?.data?.story?.id,
-          storyId => {
-              if (storyId && storyId !== registeredId) {
-                  registeredId = storyId;
-                  useStoryblokBridge(
-                      storyId,
-                      evStory => {
-                          // In Nuxt 4, data is a shallowRef - we must replace the entire object
-                          // to trigger reactivity instead of mutating nested properties
-                          if (result.data.value) {
-                              result.data.value = {
-                                  ...result.data.value,
-                                  data: { ...result.data.value.data, story: evStory },
-                              };
-                          }
-                      },
-                      bridgeOptions
-                  );
+    watch(
+      () => result.data.value?.data?.story?.id,
+      (storyId) => {
+        if (storyId && storyId !== registeredId) {
+          registeredId = storyId;
+          useStoryblokBridge(
+            storyId,
+            (evStory) => {
+              // In Nuxt 4, data is a shallowRef - we must replace the entire object
+              // to trigger reactivity instead of mutating nested properties
+              if (result.data.value) {
+                result.data.value = {
+                  ...result.data.value,
+                  data: { ...result.data.value.data, story: evStory },
+                };
               }
-          },
-          { immediate: true }
-      );
+            },
+            bridgeOptions,
+          );
+        }
+      },
+      { immediate: true },
+    );
   }
 
   return {
-      data: result.data,
-      pending: result.pending,
-      error: result.error,
-      refresh: result.refresh,
-      execute: result.execute,
-      clear: result.clear,
-      story: computed(() => result.data.value?.data.story),
+    data: result.data,
+    pending: result.pending,
+    error: result.error,
+    refresh: result.refresh,
+    execute: result.execute,
+    clear: result.clear,
+    story: computed(() => result.data.value?.data.story),
   };
 }

--- a/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
+++ b/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
@@ -8,7 +8,15 @@ import { computed, type ComputedRef, type MaybeRefOrGetter, type Ref, toValue, w
  * Extends Nuxt's AsyncDataOptions with Storyblok-specific configuration.
  */
 export interface UseAsyncStoryblokOptions extends AsyncDataOptions<ISbResult> {
-  /** Storyblok API parameters for fetching stories */
+  /**
+   * Storyblok API parameters for fetching stories.
+   *
+   * Accepts a plain object, a ref, a computed, or a getter. The current value
+   * is read (via `toValue`) on every fetch, so reactive params stay in sync.
+   * Note that changing a reactive value does not auto-refetch on its own —
+   * trigger a re-fetch by calling `refresh()` or by passing a `watch` option
+   * (e.g. `watch: [version]`), which Nuxt's `useAsyncData` re-runs on.
+   */
   api: MaybeRefOrGetter<ISbStoriesParams>;
   /** Storyblok Bridge configuration for live preview */
   bridge: StoryblokBridgeConfigV2;
@@ -90,6 +98,20 @@ const stableStringify = (obj: Record<string, any>): string => {
  * </template>
  * ```
  *
+ * @example
+ * Reactive params: pass a getter/computed and refetch when it changes.
+ * ```vue
+ * <script setup>
+ * const version = ref('draft')
+ * const { story, refresh } = await useAsyncStoryblok('home', {
+ *   api: () => ({ version: version.value }),
+ *   bridge: {},
+ *   // re-fetch automatically when `version` changes
+ *   watch: [version],
+ * })
+ * // ...or trigger manually: version.value = 'published'; await refresh()
+ * </script>
+ * ```
  */
 export async function useAsyncStoryblok(
   url: string,

--- a/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
+++ b/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
@@ -121,23 +121,21 @@ export async function useAsyncStoryblok(
     watch(
       () => result.data.value?.data?.story?.id,
       (storyId) => {
-        if (storyId && storyId !== registeredId) {
-          registeredId = storyId;
-          useStoryblokBridge(
-            storyId,
-            (evStory) => {
-              // In Nuxt 4, data is a shallowRef - we must replace the entire object
-              // to trigger reactivity instead of mutating nested properties
-              if (result.data.value) {
-                result.data.value = {
-                  ...result.data.value,
-                  data: { ...result.data.value.data, story: evStory },
-                };
-              }
-            },
-            bridgeOptions,
-          );
+        if (!storyId || storyId === registeredId) {
+          return;
         }
+        registeredId = storyId;
+        useStoryblokBridge(storyId, (evStory) => {
+          // In Nuxt 4, data is a shallowRef - we must replace the entire object
+          // to trigger reactivity instead of mutating nested properties
+          if (!result.data.value) {
+            return;
+          }
+          result.data.value = {
+            ...result.data.value,
+            data: { ...result.data.value.data, story: evStory },
+          };
+        }, bridgeOptions);
       },
       { immediate: true },
     );


### PR DESCRIPTION
Closes https://github.com/storyblok/monoblok/discussions/586

**What changed**
The api option in UseAsyncStoryblokOptions now accepts MaybeRefOrGetter<ISbStoriesParams> instead of a plain ISbStoriesParams object. This allows passing reactive values (ref, computed, or getter functions) as API parameters, so the composable can read the latest params at fetch time.

**How it works**
toValue(api) is used wherever the params are consumed — in the fetch call, the uniqueKey function, and when deriving bridgeOptions — so all three read the current value of the reactive source.
uniqueKey is now a function (instead of a pre-computed string) so useAsyncData derives a fresh key from the current params on each execution.
bridgeOptions still reads toValue(api) for resolveRelations / resolveLinks, but it is evaluated once when the composable runs (it is not reactive); the bridge is registered once per story id.

Note on refetching: useAsyncData does not watch the key getter, so changing a reactive api value alone does not auto-refetch. Trigger a re-fetch by calling refresh() or by passing a watch option (e.g. watch: [version]). This is documented in the composable's JSDoc with a reactive usage example.

The bridge watcher was simplified: a single watch with { immediate: true } replaces the previous split between an eager check and a lazy watcher, and a registeredId guard prevents re-registering the bridge for the same story. The registration block was further flattened with guard clauses.

**Breaking change**
UseAsyncStoryblokOptions.api now has type MaybeRefOrGetter<ISbStoriesParams>. Passing a plain object continues to work as before (it is a valid MaybeRefOrGetter), so existing usage is unaffected.
