### PR TITLE
feat: enhance richTextRenderer with customisable renderers and options

### DIFF
--- a/packages/angular/playground/ssr/src/app/components/article/article.component.ts
+++ b/packages/angular/playground/ssr/src/app/components/article/article.component.ts
@@ -1,9 +1,9 @@
 import { Component, ChangeDetectionStrategy, input } from '@angular/core';
-import { SbRichTextComponent, type StoryblokRichTextJson } from '@storyblok/angular';
+import { SbRichTextComponent, type SbRichTextDoc } from '@storyblok/angular';
 
 export interface ArticleBlok {
   title?: string;
-  content?: StoryblokRichTextJson;
+  content?: SbRichTextDoc;
 }
 
 @Component({

--- a/packages/angular/playground/ssr/src/app/components/page/page.ts
+++ b/packages/angular/playground/ssr/src/app/components/page/page.ts
@@ -2,13 +2,13 @@ import { Component, ChangeDetectionStrategy, input, computed } from '@angular/co
 import {
   SbRichTextComponent,
   type SbBlokData,
-  type StoryblokRichTextJson,
+  type SbRichTextDoc,
   StoryblokComponent,
 } from '@storyblok/angular';
 
 export interface PageBlok {
   body?: SbBlokData[];
-  richText?: StoryblokRichTextJson;
+  richText?: SbRichTextDoc;
 }
 
 @Component({

--- a/packages/angular/playground/ssr/src/app/components/teaser/teaser.ts
+++ b/packages/angular/playground/ssr/src/app/components/teaser/teaser.ts
@@ -1,23 +1,13 @@
 import { Component, ChangeDetectionStrategy, input } from '@angular/core';
-import { type StoryblokRichTextJson } from '@storyblok/angular';
 
 export interface TeaserBlok {
   headline?: string;
-  text?: StoryblokRichTextJson;
 }
 
 @Component({
   selector: 'app-teaser',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  // imports: [SbRichTextComponent],
-  template: `
-    <div>
-      <h2>{{ blok().headline }}</h2>
-      <!-- @if (blok().text) {
-        <sb-rich-text [sbDocument]="blok().text!" />
-      } -->
-    </div>
-  `,
+  template: ` <h2>{{ blok().headline }}</h2> `,
 })
 export class TeaserComponent {
   readonly blok = input.required<TeaserBlok>();

--- a/packages/angular/src/lib/richtext/rich-text.component.spec.ts
+++ b/packages/angular/src/lib/richtext/rich-text.component.spec.ts
@@ -2,6 +2,7 @@ import { Component, input, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SbRichTextComponent } from './rich-text.component';
 import { StoryblokRichtextResolver } from './richtext.feature';
+import { SbRichTextDoc } from '@storyblok/richtext/static';
 
 /**
  * Mock custom node component
@@ -11,11 +12,11 @@ import { StoryblokRichtextResolver } from './richtext.feature';
   standalone: true,
   imports: [SbRichTextComponent],
   template: `<div class="custom-node">
-    <sb-rich-text [sbDocument]="data().content" />
+    <sb-rich-text [sbDocument]="data()?.content" />
   </div>`,
 })
 class MockCustomParagraphComponent {
-  data = input<any>();
+  data = input<SbRichTextDoc>();
 }
 
 /**
@@ -27,7 +28,7 @@ class MockCustomParagraphComponent {
   template: `<span class="custom-link"><ng-content /></span>`,
 })
 class MockCustomMarkComponent {
-  data = input<any>();
+  data = input<SbRichTextDoc>();
 }
 
 /**
@@ -65,6 +66,75 @@ function createMockResolver(componentMap: Record<string, Type<unknown>> = {}) {
     },
   };
 }
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/** Creates a text node. */
+const text = (content: string, marks?: SbRichTextDoc['marks']): SbRichTextDoc => ({
+  type: 'text',
+  text: content,
+  ...(marks && { marks }),
+});
+
+/** Creates a link mark. */
+const linkMark = (
+  href: string,
+  options: {
+    target?: '_blank' | '_self';
+    linktype?: 'url' | 'story' | 'email' | 'asset';
+    anchor?: string;
+    custom?: Record<string, unknown>;
+  } = {},
+): NonNullable<SbRichTextDoc['marks']>[number] => ({
+  type: 'link',
+  attrs: {
+    href,
+    linktype: options.linktype ?? 'url',
+    target: options.target ?? null,
+    anchor: options.anchor ?? null,
+    uuid: null,
+    ...(options.custom && { custom: options.custom }),
+  },
+});
+
+/** Creates a table cell. */
+const tableCell = (
+  content: string,
+  attrs: { colspan?: number; rowspan?: number; colwidth?: number[]; backgroundColor?: string } = {},
+): SbRichTextDoc => ({
+  type: 'tableCell',
+  content: [{ type: 'paragraph', content: [text(content)] }],
+  attrs: {
+    colspan: attrs.colspan ?? 1,
+    rowspan: attrs.rowspan ?? 1,
+    ...(attrs.colwidth && { colwidth: attrs.colwidth }),
+    ...(attrs.backgroundColor && { backgroundColor: attrs.backgroundColor }),
+  },
+});
+
+/** Creates a table header cell. */
+const tableHeader = (content: string): SbRichTextDoc => ({
+  type: 'tableHeader',
+  content: [{ type: 'paragraph', content: [text(content)] }],
+  attrs: { colspan: 1, rowspan: 1 },
+});
+
+/** Creates a table row. */
+const tableRow = (cells: SbRichTextDoc[]): SbRichTextDoc => ({
+  type: 'tableRow',
+  content: cells,
+});
+
+/** Creates a table. */
+const table = (rows: SbRichTextDoc[]): SbRichTextDoc => ({
+  type: 'table',
+  content: rows,
+});
+
+// ============================================================================
+// Tests: Input Handling
+// ============================================================================
 
 describe('SbRichTextComponent', () => {
   let fixture: ComponentFixture<SbRichTextComponent>;
@@ -85,274 +155,910 @@ describe('SbRichTextComponent', () => {
 
     fixture = TestBed.createComponent(SbRichTextComponent);
   });
-
-  it('should render normal richtext HTML nodes', async () => {
-    fixture.componentRef.setInput('sbDocument', {
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Hello World',
-            },
-          ],
-        },
-      ],
+  describe('input handling', () => {
+    it('returns empty string for null input', async () => {
+      fixture.componentRef.setInput('sbDocument', null);
+      fixture.detectChanges();
+      const textContent = fixture.nativeElement.textContent.trim();
+      expect(textContent).toBe('');
     });
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const p = fixture.nativeElement.querySelector('p');
-
-    expect(p).toBeTruthy();
-    expect(p.textContent.trim()).toBe('Hello World');
-  });
-
-  it('should render native marks like strong', async () => {
-    fixture.componentRef.setInput('sbDocument', {
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Bold Text',
-              marks: [
-                {
-                  type: 'bold',
-                },
-              ],
-            },
-          ],
-        },
-      ],
+    it('returns empty string for undefined input', async () => {
+      fixture.componentRef.setInput('sbDocument', undefined);
+      fixture.detectChanges();
+      const textContent = fixture.nativeElement.textContent.trim();
+      expect(textContent).toBe('');
     });
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const strong = fixture.nativeElement.querySelector('strong');
-
-    expect(strong).toBeTruthy();
-    expect(strong.textContent.trim()).toBe('Bold Text');
-  });
-
-  it('should render custom node component when resolver returns component', async () => {
-    // Reset TestBed with custom component registered in resolver
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      imports: [SbRichTextComponent],
-      providers: [
-        {
-          provide: StoryblokRichtextResolver,
-          useValue: createMockResolver({ paragraph: MockCustomParagraphComponent }),
-        },
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(SbRichTextComponent);
-
-    fixture.componentRef.setInput('sbDocument', {
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Custom Paragraph',
-            },
-          ],
-        },
-      ],
+    it('returns empty string for empty array', async () => {
+      fixture.componentRef.setInput('sbDocument', []);
+      fixture.detectChanges();
+      const textContent = fixture.nativeElement.textContent.trim();
+      expect(textContent).toBe('');
     });
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    it('renders array of nodes', async () => {
+      const nodes: SbRichTextDoc[] = [
+        { type: 'paragraph', content: [text('First')] },
+        { type: 'paragraph', content: [text('Second')] },
+      ];
+      fixture.componentRef.setInput('sbDocument', nodes);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
 
-    const customNode = fixture.nativeElement.querySelector('.custom-node');
+      expect(html).toBe('<p>First</p><p>Second</p>');
+    });
 
-    expect(customNode).toBeTruthy();
-    expect(customNode.textContent.trim()).toBe('Custom Paragraph');
+    it('renders doc node without wrapper', async () => {
+      const doc: SbRichTextDoc = {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [text('Hello')] }],
+      };
+      fixture.componentRef.setInput('sbDocument', doc);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p>Hello</p>');
+    });
+
+    it('renders nested doc nodes', async () => {
+      const nested: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [text('Outer')] },
+          { type: 'doc', content: [{ type: 'paragraph', content: [text('Inner')] }] },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', nested);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p>Outer</p><p>Inner</p>');
+    });
+
+    it('renders single non-doc node directly', async () => {
+      const node: SbRichTextDoc = { type: 'paragraph', content: [text('Direct')] };
+
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p>Direct</p>');
+    });
   });
 
-  it('should render custom mark component when resolver returns component', async () => {
-    // Reset TestBed with custom mark component registered in resolver
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      imports: [SbRichTextComponent],
-      providers: [
-        {
-          provide: StoryblokRichtextResolver,
-          useValue: createMockResolver({ link: MockCustomMarkComponent }),
-        },
-      ],
-    }).compileComponents();
+  // ============================================================================
+  // Tests: Block Types
+  // ============================================================================
 
-    fixture = TestBed.createComponent(SbRichTextComponent);
+  describe('block types', () => {
+    describe('paragraph', () => {
+      it('renders basic paragraph', async () => {
+        const node: SbRichTextDoc = { type: 'paragraph', content: [text('Hello')] };
+        fixture.componentRef.setInput('sbDocument', node);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
 
-    fixture.componentRef.setInput('sbDocument', {
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
+        expect(html).toBe('<p>Hello</p>');
+      });
+
+      it('renders empty paragraph', async () => {
+        const node: SbRichTextDoc = { type: 'paragraph', content: [] };
+        fixture.componentRef.setInput('sbDocument', node);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+        expect(html).toBe('<p></p>');
+      });
+    });
+
+    describe('heading', () => {
+      it.each([1, 2, 3, 4, 5, 6] as const)('renders h%i', async (level) => {
+        const heading: SbRichTextDoc = {
+          type: 'heading',
+          attrs: { level, textAlign: null },
+          content: [text(`Heading ${level}`)],
+        };
+        fixture.componentRef.setInput('sbDocument', heading);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe(`<h${level}>Heading ${level}</h${level}>`);
+      });
+    });
+
+    describe('blockquote', () => {
+      it('renders blockquote', async () => {
+        const blockquote: SbRichTextDoc = {
+          type: 'blockquote',
+          content: [{ type: 'paragraph', content: [text('Quote')] }],
+        };
+        fixture.componentRef.setInput('sbDocument', blockquote);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe('<blockquote><p>Quote</p></blockquote>');
+      });
+    });
+
+    describe('lists', () => {
+      it('renders bullet list', async () => {
+        const list: SbRichTextDoc = {
+          type: 'bullet_list',
+          content: [
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('Item 1')] }] },
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('Item 2')] }] },
+          ],
+        };
+        fixture.componentRef.setInput('sbDocument', list);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>');
+      });
+
+      it('renders ordered list', async () => {
+        const list: SbRichTextDoc = {
+          type: 'ordered_list',
+          attrs: { order: 1 },
+          content: [
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('First')] }] },
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('Second')] }] },
+          ],
+        };
+        fixture.componentRef.setInput('sbDocument', list);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe('<ol order="1"><li><p>First</p></li><li><p>Second</p></li></ol>');
+      });
+    });
+
+    describe('code block', () => {
+      it('renders code block with language class', async () => {
+        const codeBlock: SbRichTextDoc = {
+          type: 'code_block',
+          attrs: { class: 'javascript' },
+          content: [text('const x = 1;')],
+        };
+        fixture.componentRef.setInput('sbDocument', codeBlock);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe('<pre><code class="javascript">const x = 1;</code></pre>');
+      });
+
+      it('does not leak language as attribute', async () => {
+        const codeBlock: SbRichTextDoc = {
+          type: 'code_block',
+          attrs: { class: 'js' },
+          content: [text('code')],
+        };
+        fixture.componentRef.setInput('sbDocument', codeBlock);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).not.toContain('language=');
+      });
+    });
+
+    describe('horizontal rule', () => {
+      it('renders hr as self-closing', async () => {
+        fixture.componentRef.setInput('sbDocument', { type: 'horizontal_rule' });
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe('<hr>');
+      });
+    });
+
+    describe('hard break', () => {
+      it('renders br as self-closing', async () => {
+        fixture.componentRef.setInput('sbDocument', { type: 'hard_break' });
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe('<br>');
+      });
+    });
+
+    describe('emoji', () => {
+      it('renders emoji as image with fallback', async () => {
+        const emoji: SbRichTextDoc = {
+          type: 'emoji',
           attrs: {
-            textAlign: null,
+            emoji: '🚀',
+            name: 'rocket',
+            fallbackImage: 'https://cdn.example.com/rocket.png',
           },
-          content: [
-            {
-              text: 'External URL link',
-              type: 'text',
-              marks: [
-                {
-                  type: 'link',
-                  attrs: {
-                    href: 'https://www.storyblok.com/',
-                    uuid: null,
-                    anchor: null,
-                    custom: null,
-                    target: '_blank',
-                    linktype: 'url',
-                  },
-                },
-              ],
-            },
-            {
-              text: ' | ',
-              type: 'text',
-            },
-            {
-              text: 'Story link',
-              type: 'text',
-              marks: [
-                {
-                  type: 'link',
-                  attrs: {
-                    href: '/',
-                    uuid: '37af345b-3dec-4cf4-a0cd-c6ec41f325c3',
-                    anchor: null,
-                    custom: {},
-                    target: '_self',
-                    linktype: 'story',
-                  },
-                },
-              ],
-            },
-            {
-              text: ' | ',
-              type: 'text',
-            },
-            {
-              text: 'Story ',
-              type: 'text',
-              marks: [
-                {
-                  type: 'link',
-                  attrs: {
-                    href: '/',
-                    uuid: '37af345b-3dec-4cf4-a0cd-c6ec41f325c3',
-                    anchor: 'section-1',
-                    custom: {},
-                    target: '_self',
-                    linktype: 'story',
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      ],
+        };
+        fixture.componentRef.setInput('sbDocument', emoji);
+        fixture.detectChanges();
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toBe(
+          '<img data-emoji="🚀" data-name="rocket" src="https://cdn.example.com/rocket.png" draggable="false" loading="lazy" style="width: 1.25em; height: 1.25em; vertical-align: text-top;">',
+        );
+      });
     });
-
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const customMark = fixture.nativeElement.querySelector('.custom-link');
-
-    // console.log({ p: customMark.textContent.trim(), f: fixture.nativeElement.innerHTML });
-
-    expect(customMark).toBeTruthy();
-    expect(customMark.textContent.trim()).toContain('External URL link');
   });
 
-  it('should clear old content when doc changes', async () => {
-    fixture.componentRef.setInput('sbDocument', {
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'First',
-            },
-          ],
-        },
-      ],
+  // ============================================================================
+  // Tests: Tables
+  // ============================================================================
+
+  describe('tables', () => {
+    it('renders basic table with tbody', async () => {
+      const t = table([tableRow([tableCell('A'), tableCell('B')])]);
+      fixture.componentRef.setInput('sbDocument', t);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe(
+        '<table><tbody><tr><td colspan="1" rowspan="1"><p>A</p></td><td colspan="1" rowspan="1"><p>B</p></td></tr></tbody></table>',
+      );
     });
 
-    fixture.detectChanges();
-    await fixture.whenStable();
+    it('renders table with thead and tbody', async () => {
+      const t = table([
+        tableRow([tableHeader('H1'), tableHeader('H2')]),
+        tableRow([tableCell('C1'), tableCell('C2')]),
+      ]);
+      fixture.componentRef.setInput('sbDocument', t);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
 
-    fixture.componentRef.setInput('sbDocument', {
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Second',
-            },
-          ],
-        },
-      ],
+      expect(html).toBe(
+        '<table><thead><tr><th colspan="1" rowspan="1"><p>H1</p></th><th colspan="1" rowspan="1"><p>H2</p></th></tr></thead>' +
+          '<tbody><tr><td colspan="1" rowspan="1"><p>C1</p></td><td colspan="1" rowspan="1"><p>C2</p></td></tr></tbody></table>',
+      );
     });
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    it('renders colspan and rowspan', async () => {
+      const t = table([tableRow([tableCell('Merged', { colspan: 2, rowspan: 2 })])]);
+      fixture.componentRef.setInput('sbDocument', t);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
 
-    const paragraphs = fixture.nativeElement.querySelectorAll('p');
+      expect(html).toContain('colspan="2" rowspan="2"');
+    });
 
-    expect(paragraphs.length).toBe(1);
-    expect(paragraphs[0].textContent.trim()).toBe('Second');
+    it('renders colwidth as style', async () => {
+      const t = table([tableRow([tableCell('Wide', { colwidth: [200] })])]);
+      fixture.componentRef.setInput('sbDocument', t);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toContain('style="width: 200px;"');
+    });
+
+    it('renders backgroundColor as style', async () => {
+      const t = table([tableRow([tableCell('Colored', { backgroundColor: '#FF0000' })])]);
+      fixture.componentRef.setInput('sbDocument', t);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toContain('background-color: #FF0000;');
+    });
+
+    it('combines multiple styles', async () => {
+      const t = table([
+        tableRow([tableCell('Styled', { colwidth: [100], backgroundColor: '#00FF00' })]),
+      ]);
+      fixture.componentRef.setInput('sbDocument', t);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toContain('width: 100px;');
+      expect(html).toContain('background-color: #00FF00;');
+    });
   });
 
-  it('should not fail when doc is null', async () => {
-    fixture.componentRef.setInput('sbDocument', null);
+  // ============================================================================
+  // Tests: Marks (Inline Formatting)
+  // ============================================================================
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+  describe('marks', () => {
+    it('renders bold', async () => {
+      const node = text('Bold', [{ type: 'bold' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
 
-    expect(fixture.nativeElement.textContent.trim()).toBe('');
+      expect(html).toBe('<strong>Bold</strong>');
+    });
+
+    it('renders italic', async () => {
+      const node = text('Italic', [{ type: 'italic' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<em>Italic</em>');
+    });
+
+    it('renders strike', async () => {
+      const node = text('Strike', [{ type: 'strike' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<s>Strike</s>');
+    });
+
+    it('renders underline', async () => {
+      const node = text('Underline', [{ type: 'underline' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<u>Underline</u>');
+    });
+
+    it('renders code', async () => {
+      const node = text('code', [{ type: 'code' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<code>code</code>');
+    });
+
+    it('renders superscript', async () => {
+      const node = text('sup', [{ type: 'superscript' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<sup>sup</sup>');
+    });
+
+    it('renders subscript', async () => {
+      const node = text('sub', [{ type: 'subscript' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<sub>sub</sub>');
+    });
+
+    it('renders nested marks', async () => {
+      const node = text('Bold Italic', [{ type: 'bold' }, { type: 'italic' }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<em><strong>Bold Italic</strong></em>');
+    });
+
+    it('renders anchor mark as span with id', async () => {
+      const node = text('Anchored', [{ type: 'anchor', attrs: { id: 'section-1' } }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<span id="section-1">Anchored</span>');
+    });
+
+    it('renders styled mark with class', async () => {
+      const node = text('Styled', [{ type: 'styled', attrs: { class: 'highlight' } }]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<span class="highlight">Styled</span>');
+    });
+
+    it('renders textStyle with color', async () => {
+      const node = text('Red', [
+        { type: 'textStyle', attrs: { color: 'red', id: null, class: null } },
+      ]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<span style="color: red;">Red</span>');
+    });
   });
 
-  it('should render an array of documents', async () => {
-    fixture.componentRef.setInput('sbDocument', [
-      {
+  // ============================================================================
+  // Tests: Links
+  // ============================================================================
+
+  describe('links', () => {
+    it('renders external URL link', async () => {
+      const node = text('Click', [linkMark('https://example.com', { target: '_blank' })]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<a href="https://example.com" target="_blank">Click</a>');
+    });
+
+    it('renders internal story link', async () => {
+      const node = text('Page', [linkMark('/about', { linktype: 'story' })]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<a href="/about">Page</a>');
+    });
+
+    it('renders story link with anchor', async () => {
+      const node = text('Section', [linkMark('/page', { linktype: 'story', anchor: 'intro' })]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<a href="/page#intro">Section</a>');
+    });
+
+    it('renders email link with mailto:', async () => {
+      const node = text('Email', [linkMark('test@example.com', { linktype: 'email' })]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<a href="mailto:test@example.com">Email</a>');
+    });
+
+    it('does not duplicate mailto: prefix', async () => {
+      const node = text('Email', [linkMark('mailto:test@example.com', { linktype: 'email' })]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<a href="mailto:test@example.com">Email</a>');
+    });
+
+    it('renders asset link', async () => {
+      const node = text('Download', [
+        linkMark('https://assets.example.com/file.pdf', { linktype: 'asset' }),
+      ]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<a href="https://assets.example.com/file.pdf">Download</a>');
+    });
+
+    it('renders link without href when empty', async () => {
+      const node: SbRichTextDoc = {
         type: 'text',
-        text: 'First',
-      },
-      {
-        type: 'text',
-        text: ' Second',
-      },
-    ]);
+        text: 'No href',
+        marks: [
+          {
+            type: 'link',
+            attrs: { href: '', linktype: 'url', uuid: null, anchor: null, target: null },
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
 
-    expect(fixture.nativeElement.textContent).toBe('First Second');
+      expect(html).toBe('<a>No href</a>');
+    });
+
+    it('filters null attributes', async () => {
+      const node = text('Link', [linkMark('/')]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).not.toContain('target=');
+      expect(html).not.toContain('uuid=');
+      expect(html).not.toContain('anchor=');
+    });
+    it('should render a link with text, and custom attrs', async () => {
+      const node: SbRichTextDoc = {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: 'Click me',
+            marks: [
+              linkMark('https://example.com', {
+                linktype: 'url',
+                custom: { title: 'google', rel: 'noopener', 'data-custom': 'foo' },
+              }),
+            ],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+      expect(html).toBe(
+        '<p><a href="https://example.com" title="google" rel="noopener" data-custom="foo">Click me</a></p>',
+      );
+    });
+  });
+
+  // ============================================================================
+  // Tests: Link Mark Merging
+  // ============================================================================
+
+  describe('link mark merging', () => {
+    it('merges adjacent text nodes with same link', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [text('Hello ', [linkMark('/url')]), text('World', [linkMark('/url')])],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p><a href="/url">Hello World</a></p>');
+    });
+    it('merge groups when link with same custom attributes', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              text('Hello ', [linkMark('/a', { custom: { title: 'google' } })]),
+              text('Storyblok', [linkMark('/a', { custom: { title: 'google' } })]),
+            ],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+      expect(html).toBe('<p><a href="/a" title="google">Hello Storyblok</a></p>');
+    });
+    it('preserves inner marks when merging', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              text('normal ', [linkMark('/url')]),
+              text('bold', [{ type: 'bold' }, linkMark('/url')]),
+              text(' text', [linkMark('/url')]),
+            ],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p><a href="/url">normal <strong>bold</strong> text</a></p>');
+    });
+
+    it('handles multiple inner marks', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              text('start ', [linkMark('/url')]),
+              text('bold', [{ type: 'bold' }, linkMark('/url')]),
+              text(' and ', [linkMark('/url')]),
+              text('italic', [{ type: 'italic' }, linkMark('/url')]),
+              text(' end', [linkMark('/url')]),
+            ],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe(
+        '<p><a href="/url">start <strong>bold</strong> and <em>italic</em> end</a></p>',
+      );
+    });
+
+    it('breaks group on non-text node', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              text('Before ', [linkMark('/x')]),
+              { type: 'hard_break' },
+              text('After', [linkMark('/x')]),
+            ],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p><a href="/x">Before </a><br><a href="/x">After</a></p>');
+    });
+
+    it('separates groups when link attrs differ', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              text('A', [linkMark('/a')]),
+              text('B', [linkMark('/a', { target: '_blank' })]),
+            ],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p><a href="/a">A</a><a href="/a" target="_blank">B</a></p>');
+    });
+    it('separates groups when link with different custom attributes', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              text('A', [linkMark('/a', { custom: { title: 'google' } })]),
+              text('B', [linkMark('/a', { custom: { title: 'new' } })]),
+            ],
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML.trim();
+      expect(html).toBe('<p><a href="/a" title="google">A</a><a href="/a" title="new">B</a></p>');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Text Alignment
+  // ============================================================================
+
+  describe('text alignment', () => {
+    it('renders paragraph with text-align style', async () => {
+      const p: SbRichTextDoc = {
+        type: 'paragraph',
+        attrs: { textAlign: 'right' },
+        content: [text('Right')],
+      };
+      fixture.componentRef.setInput('sbDocument', p);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p style="text-align: right;">Right</p>');
+    });
+
+    it.each(['left', 'center', 'right', 'justify'] as const)(
+      'supports %s alignment',
+      async (align) => {
+        const p: SbRichTextDoc = {
+          type: 'paragraph',
+          attrs: { textAlign: align },
+          content: [text('Text')],
+        };
+        fixture.componentRef.setInput('sbDocument', p);
+        fixture.detectChanges();
+
+        const html = fixture.nativeElement.innerHTML.trim();
+
+        expect(html).toContain(`text-align: ${align};`);
+      },
+    );
+
+    it('renders heading with alignment', async () => {
+      const heading: SbRichTextDoc = {
+        type: 'heading',
+        attrs: { level: 2, textAlign: 'center' },
+        content: [text('Centered')],
+      };
+      fixture.componentRef.setInput('sbDocument', heading);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<h2 style="text-align: center;">Centered</h2>');
+    });
+
+    it('combines alignment with marks', async () => {
+      const p: SbRichTextDoc = {
+        type: 'paragraph',
+        attrs: { textAlign: 'center' },
+        content: [text('Styled', [{ type: 'bold' }])],
+      };
+      fixture.componentRef.setInput('sbDocument', p);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p style="text-align: center;"><strong>Styled</strong></p>');
+    });
+
+    it('renders empty paragraph with alignment', async () => {
+      const p: SbRichTextDoc = {
+        type: 'paragraph',
+        attrs: { textAlign: 'center' },
+        content: [],
+      };
+      fixture.componentRef.setInput('sbDocument', p);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('<p style="text-align: center;"></p>');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Custom Renderers (via Angular Components)
+  // ============================================================================
+
+  describe('custom renderers', () => {
+    it('overrides node rendering with custom component', async () => {
+      const node: SbRichTextDoc = { type: 'paragraph', content: [text('Hello')] };
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [SbRichTextComponent],
+        providers: [
+          {
+            provide: StoryblokRichtextResolver,
+            useValue: createMockResolver({ paragraph: MockCustomParagraphComponent }),
+          },
+        ],
+      }).compileComponents();
+      fixture = TestBed.createComponent(SbRichTextComponent);
+
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+      const customNode = fixture.nativeElement.querySelector('.custom-node');
+
+      expect(customNode).toBeTruthy();
+      expect(customNode.textContent.trim()).toBe('Hello');
+    });
+
+    it('overrides mark rendering with custom component', async () => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [SbRichTextComponent],
+        providers: [
+          {
+            provide: StoryblokRichtextResolver,
+            useValue: createMockResolver({ link: MockCustomMarkComponent }),
+          },
+        ],
+      }).compileComponents();
+      fixture = TestBed.createComponent(SbRichTextComponent);
+
+      const node: SbRichTextDoc = {
+        type: 'paragraph',
+        content: [text('Bold Link', [{ type: 'bold' }, linkMark('https://example.com')])],
+      };
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+
+      const customMark = fixture.nativeElement.querySelector('.custom-link');
+
+      expect(customMark).toBeTruthy();
+      expect(customMark.textContent.trim()).toContain('Bold Link');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Blok Nodes
+  // ============================================================================
+
+  describe('blok nodes', () => {
+    it('renders blok via StoryblokComponent when body has items', async () => {
+      const blokDoc: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'blok',
+            attrs: {
+              id: 'blok-123',
+              body: [
+                { _uid: '1', component: 'button', title: 'Click Me' },
+                { _uid: '2', component: 'button', title: 'Submit' },
+              ],
+            },
+          },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', blokDoc);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      // Angular renders bloks via StoryblokComponent
+      expect(html).toContain('sb-component');
+    });
+
+    it('renders nothing for empty body', async () => {
+      const emptyBlok: SbRichTextDoc = {
+        type: 'doc',
+        content: [{ type: 'blok', attrs: { id: 'x', body: [] } }],
+      };
+      fixture.componentRef.setInput('sbDocument', emptyBlok);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('');
+    });
+
+    it('renders nothing for null body', async () => {
+      const nullBlok: SbRichTextDoc = {
+        type: 'doc',
+        content: [{ type: 'blok', attrs: { id: 'x', body: null } }],
+      };
+      fixture.componentRef.setInput('sbDocument', nullBlok);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toBe('');
+    });
+
+    it('renders other content alongside blok', async () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [text('Before')] },
+          { type: 'blok', attrs: { id: 'x', body: [{ _uid: '1', component: 'test' }] } },
+          { type: 'paragraph', content: [text('After')] },
+        ],
+      };
+      fixture.componentRef.setInput('sbDocument', content);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      // Both paragraphs render, with blok component in between
+      expect(html).toContain('<p>Before</p>');
+      expect(html).toContain('<p>After</p>');
+      expect(html).toContain('sb-component');
+    });
+  });
+
+  // ============================================================================
+  // Tests: XSS Prevention
+  // ============================================================================
+
+  describe('xSS prevention', () => {
+    it('escapes HTML in text content', async () => {
+      const node = text('<script>alert("xss")</script>');
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+      expect(html).toBe('&lt;script&gt;alert("xss")&lt;/script&gt;');
+    });
+
+    it('escapes HTML in attributes', async () => {
+      const node = text('Link', [linkMark('javascript:alert("xss")')]);
+      fixture.componentRef.setInput('sbDocument', node);
+      fixture.detectChanges();
+
+      const html = fixture.nativeElement.innerHTML.trim();
+
+      expect(html).toContain('href="javascript:alert(&quot;xss&quot;)"');
+    });
   });
 });

--- a/packages/angular/src/lib/richtext/rich-text.component.spec.ts
+++ b/packages/angular/src/lib/richtext/rich-text.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SbRichTextComponent } from './rich-text.component';
 import { StoryblokRichtextResolver } from './richtext.feature';
 import { SbRichTextDoc } from '@storyblok/richtext/static';
+import type { RichTextComponentProps } from '../types';
 
 /**
  * Mock custom node component
@@ -16,7 +17,7 @@ import { SbRichTextDoc } from '@storyblok/richtext/static';
   </div>`,
 })
 class MockCustomParagraphComponent {
-  data = input<SbRichTextDoc>();
+  readonly data = input.required<RichTextComponentProps<'paragraph'>>();
 }
 
 /**
@@ -28,7 +29,7 @@ class MockCustomParagraphComponent {
   template: `<span class="custom-link"><ng-content /></span>`,
 })
 class MockCustomMarkComponent {
-  data = input<SbRichTextDoc>();
+  readonly data = input.required<RichTextComponentProps<'link'>>();
 }
 
 /**
@@ -957,6 +958,50 @@ describe('SbRichTextComponent', () => {
 
       expect(customMark).toBeTruthy();
       expect(customMark.textContent.trim()).toContain('Bold Link');
+    });
+
+    it('allows custom code_block component to control attribute placement', async () => {
+      @Component({
+        selector: 'app-custom-code-block',
+        standalone: true,
+        imports: [SbRichTextComponent],
+        template: `
+          <pre class="language-{{ lang() }}">
+          <code [attr.data-lang]="lang()">
+            <sb-rich-text [sbDocument]="data()?.content" />
+          </code>
+        </pre>
+        `,
+      })
+      class MockCustomCodeBlockComponent {
+        readonly data = input.required<RichTextComponentProps<'code_block'>>();
+        lang = () => (this.data()?.attrs?.['class'] as string) || '';
+      }
+
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [SbRichTextComponent],
+        providers: [
+          {
+            provide: StoryblokRichtextResolver,
+            useValue: createMockResolver({ code_block: MockCustomCodeBlockComponent }),
+          },
+        ],
+      }).compileComponents();
+      fixture = TestBed.createComponent(SbRichTextComponent);
+
+      const codeBlock: SbRichTextDoc = {
+        type: 'code_block',
+        attrs: { class: 'js' },
+        content: [text('const x: number = 1;')],
+      };
+      fixture.componentRef.setInput('sbDocument', codeBlock);
+      fixture.detectChanges();
+
+      const pre = fixture.nativeElement.querySelector('pre');
+      const code = fixture.nativeElement.querySelector('code');
+      expect(pre?.className).toBe('language-js');
+      expect(code?.getAttribute('data-lang')).toBe('js');
     });
   });
 

--- a/packages/angular/src/lib/richtext/rich-text.component.ts
+++ b/packages/angular/src/lib/richtext/rich-text.component.ts
@@ -119,10 +119,8 @@ export class SbRichTextComponent implements OnDestroy {
       if (this.shouldAbort(version)) return;
 
       if (group.linkMark) {
-        // Render grouped text nodes under a single link
         this.renderLinkGroup(group.nodes, group.linkMark, parent, version);
       } else {
-        // Render single node normally
         this.renderNode(group.nodes[0], parent, version);
       }
     }
@@ -150,10 +148,8 @@ export class SbRichTextComponent implements OnDestroy {
       return;
     }
 
-    // Create the link element
     const tag = resolveTag(linkMark);
     if (!tag) {
-      // No tag, render text nodes directly
       for (const node of nodes) {
         this.renderTextNode(node as SbRichTextDoc & { type: 'text' }, parent, version);
       }
@@ -170,7 +166,6 @@ export class SbRichTextComponent implements OnDestroy {
       const innerMarks = getInnerMarks(node);
       let current: Node = this.renderer.createText(node.text || '');
 
-      // Apply inner marks
       for (const mark of innerMarks) {
         const CustomMark = this.resolver.getSync(mark.type);
 
@@ -218,7 +213,6 @@ export class SbRichTextComponent implements OnDestroy {
     const syncComponent = this.resolver.getSync(node.type);
 
     if (syncComponent) {
-      // Custom component available synchronously
       const anchor = this.renderer.createComment('sb-node');
       this.renderer.appendChild(parent, anchor);
       this.mountComponent(syncComponent, { data: node }, parent, anchor);
@@ -227,7 +221,6 @@ export class SbRichTextComponent implements OnDestroy {
 
     // Check if this type has an async loader registered
     if (this.resolver.has(node.type)) {
-      // Create placeholder and resolve async
       const anchor = this.renderer.createComment('sb-node');
       this.renderer.appendChild(parent, anchor);
       this.resolveAndMount(node, parent, anchor, version);
@@ -270,7 +263,6 @@ export class SbRichTextComponent implements OnDestroy {
     }
 
     if (!isSelfClosing(tag)) {
-      // Special handling for tables: group rows into thead/tbody
       if (node.type === 'table' && node.content) {
         this.renderTableContent(node.content, el, version);
       } else {
@@ -295,7 +287,6 @@ export class SbRichTextComponent implements OnDestroy {
   private renderTableContent(rows: SbRichTextDoc[], tableEl: HTMLElement, version: number): void {
     const { headerRows, bodyRows } = splitTableRows(rows);
 
-    // Render thead if there are header rows
     if (headerRows.length > 0) {
       const thead = this.renderer.createElement('thead');
       for (const row of headerRows) {
@@ -304,7 +295,6 @@ export class SbRichTextComponent implements OnDestroy {
       this.renderer.appendChild(tableEl, thead);
     }
 
-    // Render tbody if there are body rows
     if (bodyRows.length > 0) {
       const tbody = this.renderer.createElement('tbody');
       for (const row of bodyRows) {
@@ -321,7 +311,6 @@ export class SbRichTextComponent implements OnDestroy {
     anchor: Node,
     version: number,
   ): Promise<void> {
-    // node.type is guaranteed to not be 'text' since text nodes are handled separately
     const CustomNode = await this.resolveCached(node.type as SbRichTextElement);
     if (this.shouldAbort(version, anchor)) return;
 

--- a/packages/angular/src/lib/richtext/rich-text.component.ts
+++ b/packages/angular/src/lib/richtext/rich-text.component.ts
@@ -14,15 +14,19 @@ import {
   untracked,
 } from '@angular/core';
 import {
+  getInnerMarks,
   getStaticChildren,
+  groupLinkNodes,
   isSelfClosing,
   processAttrs,
   resolveTag,
+  splitTableRows,
 } from '@storyblok/richtext/static';
 import type {
+  PMMark,
   RenderSpec,
-  StoryblokRichTextJson,
-  TiptapComponentName,
+  SbRichTextDoc,
+  SbRichTextElement,
 } from '@storyblok/richtext/static';
 import { StoryblokComponent } from '../blok/sb-component.component';
 import { StoryblokRichtextResolver } from './richtext.feature';
@@ -37,7 +41,7 @@ import { StoryblokRichtextResolver } from './richtext.feature';
 })
 export class SbRichTextComponent implements OnDestroy {
   /** Input richtext document or array of documents */
-  sbDocument = input.required<StoryblokRichTextJson | StoryblokRichTextJson[] | null | undefined>();
+  sbDocument = input.required<SbRichTextDoc | SbRichTextDoc[] | null | undefined>();
 
   private readonly renderer = inject(Renderer2);
   private readonly hostElement: HTMLElement = inject(ElementRef).nativeElement;
@@ -81,9 +85,7 @@ export class SbRichTextComponent implements OnDestroy {
   // --------------------------------------------------
   // Render entry
   // --------------------------------------------------
-  private render(
-    sbDocument: StoryblokRichTextJson | StoryblokRichTextJson[] | null | undefined,
-  ): void {
+  private render(sbDocument: SbRichTextDoc | SbRichTextDoc[] | null | undefined): void {
     const version = ++this.renderVersion;
 
     this.clearContent();
@@ -101,18 +103,110 @@ export class SbRichTextComponent implements OnDestroy {
   }
 
   /** Render a single document */
-  private renderSingleDocument(doc: StoryblokRichTextJson, version: number): void {
+  private renderSingleDocument(doc: SbRichTextDoc, version: number): void {
     const nodes = doc.type === 'doc' && doc.content ? doc.content : [doc];
+    this.renderChildren(nodes, this.hostElement, version);
+  }
 
-    for (const node of nodes) {
-      this.renderNode(node, this.hostElement, version);
+  /**
+   * Renders child nodes with link mark merging.
+   * Adjacent text nodes with the same link mark are grouped under a single anchor element.
+   */
+  private renderChildren(children: SbRichTextDoc[], parent: HTMLElement, version: number): void {
+    const groups = groupLinkNodes(children);
+
+    for (const group of groups) {
+      if (this.shouldAbort(version)) return;
+
+      if (group.linkMark) {
+        // Render grouped text nodes under a single link
+        this.renderLinkGroup(group.nodes, group.linkMark, parent, version);
+      } else {
+        // Render single node normally
+        this.renderNode(group.nodes[0], parent, version);
+      }
     }
+  }
+
+  /**
+   * Renders a group of text nodes that share the same link mark.
+   * Creates a single anchor element containing all the text nodes with their inner marks.
+   */
+  private renderLinkGroup(
+    nodes: SbRichTextDoc[],
+    linkMark: PMMark,
+    parent: HTMLElement,
+    version: number,
+  ): void {
+    // Check if link mark has a custom component
+    const CustomLink = this.resolver.getSync(linkMark.type);
+
+    if (CustomLink) {
+      // For custom link components, render each text node separately
+      // since we can't easily project multiple nodes into ng-content
+      for (const node of nodes) {
+        this.renderTextNode(node as SbRichTextDoc & { type: 'text' }, parent, version);
+      }
+      return;
+    }
+
+    // Create the link element
+    const tag = resolveTag(linkMark);
+    if (!tag) {
+      // No tag, render text nodes directly
+      for (const node of nodes) {
+        this.renderTextNode(node as SbRichTextDoc & { type: 'text' }, parent, version);
+      }
+      return;
+    }
+
+    const linkEl = this.renderer.createElement(tag);
+    this.applyAttributes(linkEl, processAttrs(linkMark.type, linkMark.attrs));
+
+    // Render each text node with only its inner marks (excluding the link mark)
+    for (const node of nodes) {
+      if (node.type !== 'text') continue;
+
+      const innerMarks = getInnerMarks(node);
+      let current: Node = this.renderer.createText(node.text || '');
+
+      // Apply inner marks
+      for (const mark of innerMarks) {
+        const CustomMark = this.resolver.getSync(mark.type);
+
+        if (CustomMark) {
+          const ref = createComponent(CustomMark, {
+            environmentInjector: this.envInjector,
+            projectableNodes: [[current]],
+          });
+
+          ref.setInput('data', mark);
+          this.appRef.attachView(ref.hostView);
+          this.componentRefs.push(ref);
+
+          current = (ref.hostView as any).rootNodes[0];
+          continue;
+        }
+
+        const markTag = resolveTag(mark);
+        if (!markTag) continue;
+
+        const el = this.renderer.createElement(markTag);
+        this.applyAttributes(el, processAttrs(mark.type, mark.attrs));
+        this.renderer.appendChild(el, current);
+        current = el;
+      }
+
+      this.renderer.appendChild(linkEl, current);
+    }
+
+    this.renderer.appendChild(parent, linkEl);
   }
 
   // --------------------------------------------------
   // Node renderer (synchronous with deferred async for custom components)
   // --------------------------------------------------
-  private renderNode(node: StoryblokRichTextJson, parent: HTMLElement, version: number): void {
+  private renderNode(node: SbRichTextDoc, parent: HTMLElement, version: number): void {
     if (this.shouldAbort(version)) return;
 
     if (node.type === 'text') {
@@ -157,7 +251,14 @@ export class SbRichTextComponent implements OnDestroy {
     // Native HTML node (synchronous)
     // -------------------------
     const tag = resolveTag(node);
-    if (!tag) return;
+
+    // No tag (e.g., nested doc): render children directly
+    if (!tag) {
+      if (node.content) {
+        this.renderChildren(node.content, parent, version);
+      }
+      return;
+    }
 
     const el = this.renderer.createElement(tag);
     const attrs = processAttrs(node.type, node.attrs);
@@ -169,13 +270,16 @@ export class SbRichTextComponent implements OnDestroy {
     }
 
     if (!isSelfClosing(tag)) {
-      const contentHost = staticChildren
-        ? this.createStaticScaffold(staticChildren, el, attrs)
-        : el;
+      // Special handling for tables: group rows into thead/tbody
+      if (node.type === 'table' && node.content) {
+        this.renderTableContent(node.content, el, version);
+      } else {
+        const contentHost = staticChildren
+          ? this.createStaticScaffold(staticChildren, el, attrs)
+          : el;
 
-      if (node.content) {
-        for (const child of node.content) {
-          this.renderNode(child, contentHost, version);
+        if (node.content) {
+          this.renderChildren(node.content, contentHost, version);
         }
       }
     }
@@ -183,15 +287,42 @@ export class SbRichTextComponent implements OnDestroy {
     this.renderer.appendChild(parent, el);
   }
 
+  /**
+   * Renders table content with proper thead/tbody grouping.
+   * Header rows (containing only tableHeader cells) go in thead,
+   * remaining rows go in tbody.
+   */
+  private renderTableContent(rows: SbRichTextDoc[], tableEl: HTMLElement, version: number): void {
+    const { headerRows, bodyRows } = splitTableRows(rows);
+
+    // Render thead if there are header rows
+    if (headerRows.length > 0) {
+      const thead = this.renderer.createElement('thead');
+      for (const row of headerRows) {
+        this.renderNode(row, thead, version);
+      }
+      this.renderer.appendChild(tableEl, thead);
+    }
+
+    // Render tbody if there are body rows
+    if (bodyRows.length > 0) {
+      const tbody = this.renderer.createElement('tbody');
+      for (const row of bodyRows) {
+        this.renderNode(row, tbody, version);
+      }
+      this.renderer.appendChild(tableEl, tbody);
+    }
+  }
+
   /** Async resolution and mounting for lazy-loaded components */
   private async resolveAndMount(
-    node: StoryblokRichTextJson,
+    node: SbRichTextDoc,
     parent: HTMLElement,
     anchor: Node,
     version: number,
   ): Promise<void> {
     // node.type is guaranteed to not be 'text' since text nodes are handled separately
-    const CustomNode = await this.resolveCached(node.type as TiptapComponentName);
+    const CustomNode = await this.resolveCached(node.type as SbRichTextElement);
     if (this.shouldAbort(version, anchor)) return;
 
     const parentNode = anchor.parentNode as HTMLElement;
@@ -208,7 +339,7 @@ export class SbRichTextComponent implements OnDestroy {
   // Text renderer (marks) - synchronous
   // --------------------------------------------------
   private renderTextNode(
-    node: StoryblokRichTextJson & { type: 'text' },
+    node: SbRichTextDoc & { type: 'text' },
     parent: HTMLElement,
     version: number,
   ): void {
@@ -263,7 +394,7 @@ export class SbRichTextComponent implements OnDestroy {
 
   /** Async text node rendering for lazy-loaded mark components */
   private async renderTextNodeAsync(
-    node: StoryblokRichTextJson & { type: 'text' },
+    node: SbRichTextDoc & { type: 'text' },
     parent: HTMLElement,
     anchor: Node,
     version: number,
@@ -322,7 +453,7 @@ export class SbRichTextComponent implements OnDestroy {
   }
 
   /** Resolve component with caching */
-  private async resolveCached(type: TiptapComponentName): Promise<any> {
+  private async resolveCached(type: SbRichTextElement): Promise<any> {
     if (this.componentCache.has(type)) {
       return this.componentCache.get(type);
     }

--- a/packages/angular/src/lib/richtext/richtext.feature.ts
+++ b/packages/angular/src/lib/richtext/richtext.feature.ts
@@ -1,12 +1,16 @@
-import { InjectionToken, Type, Injectable, inject } from '@angular/core';
-import type { TiptapComponentName } from '@storyblok/richtext/static';
+import { InjectionToken, Type, Injectable, inject, InputSignal } from '@angular/core';
+import type { SbRichTextElement } from '@storyblok/richtext/static';
 
-import {
-  type StoryblokFeature,
-  BaseComponentResolver,
-  StoryblokComponentLoader,
-} from '../components.feature';
+import { type StoryblokFeature, BaseComponentResolver } from '../components.feature';
+import { RichTextComponentProps } from '../types';
 
+export type RichTextAngularComponent<T extends SbRichTextElement> = Type<{
+  data: InputSignal<RichTextComponentProps<T>>;
+}>;
+
+type RichtextComponentLoader<T extends SbRichTextElement> = () => Promise<
+  RichTextAngularComponent<T>
+>;
 /**
  * Map of Storyblok segment types to Angular components.
  * Supports both eager (direct) and lazy (dynamic import) loading.
@@ -14,27 +18,27 @@ import {
  * @example
  * ```typescript
  * // Eager loading (bundled immediately)
- * const components: SBAngularComponentMap = {
+ * const components: SbAngularComponentMap = {
  *   link: CustomLinkComponent,
  *   image: OptimizedImageComponent,
  * };
  *
  * // Lazy loading (loaded on-demand) - recommended
- * const components: SBAngularComponentMap = {
+ * const components: SbAngularComponentMap = {
  *   link: () => import('./custom-link').then(m => m.CustomLinkComponent),
  *   image: () => import('./optimized-image').then(m => m.OptimizedImageComponent),
  * };
  * ```
  */
-export type SBAngularComponentMap = Partial<
-  Record<TiptapComponentName, Type<any> | StoryblokComponentLoader>
->;
+export type SbAngularComponentMap = {
+  [K in SbRichTextElement]?: RichtextComponentLoader<K>;
+};
 
 /**
  * Injection token for richtext component overrides.
  * Defaults to an empty map if not provided.
  */
-export const STORYBLOK_RICHTEXT_COMPONENTS = new InjectionToken<SBAngularComponentMap>(
+export const STORYBLOK_RICHTEXT_COMPONENTS = new InjectionToken<SbAngularComponentMap>(
   'STORYBLOK_RICHTEXT_COMPONENTS',
   { factory: () => ({}) },
 );
@@ -44,11 +48,11 @@ export const STORYBLOK_RICHTEXT_COMPONENTS = new InjectionToken<SBAngularCompone
  * Caches resolved components to avoid repeated dynamic imports.
  */
 @Injectable({ providedIn: 'root' })
-export class StoryblokRichtextResolver extends BaseComponentResolver<TiptapComponentName> {
+export class StoryblokRichtextResolver extends BaseComponentResolver<SbRichTextElement> {
   protected readonly registry = inject(STORYBLOK_RICHTEXT_COMPONENTS);
 
   /** Get all registered segment types (for determining which nodes become component nodes). */
-  getRegisteredTypes(): TiptapComponentName[] {
+  getRegisteredTypes(): SbRichTextElement[] {
     return this.getRegisteredKeys();
   }
 }
@@ -82,7 +86,7 @@ export class StoryblokRichtextResolver extends BaseComponentResolver<TiptapCompo
  * ```
  */
 export function withStoryblokRichtextComponents(
-  components: SBAngularComponentMap,
+  components: SbAngularComponentMap,
 ): StoryblokFeature {
   return {
     ɵkind: 'richtext',

--- a/packages/angular/src/lib/types.ts
+++ b/packages/angular/src/lib/types.ts
@@ -1,5 +1,5 @@
 import { ISbComponentType } from '@storyblok/live-preview';
-import { PMMark, PMNode, TiptapComponentName } from '@storyblok/richtext/static';
+import { SbRichTextElement, SbRichTextProps } from '@storyblok/richtext/static';
 
 export type SbBlokKeyDataTypes = string | number | object | boolean | undefined;
 
@@ -7,21 +7,4 @@ export interface SbBlokData extends ISbComponentType<string> {
   [index: string]: SbBlokKeyDataTypes;
 }
 
-//TODO: This is a temporary this should come from the rich text package
-type RichTextBaseProps<T extends TiptapComponentName> = T extends PMNode['type']
-  ? Extract<
-      PMNode,
-      {
-        type: T;
-      }
-    >
-  : T extends PMMark['type']
-    ? Extract<
-        PMMark,
-        {
-          type: T;
-        }
-      >
-    : never;
-
-export type RichTextComponentProps<T extends TiptapComponentName> = RichTextBaseProps<T>;
+export type RichTextComponentProps<T extends SbRichTextElement> = SbRichTextProps<T>;

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -22,9 +22,9 @@ export { SbBlokDirective } from './lib/blok/sb-blok.directive';
 // Rich Text (with custom component overrides)
 export { SbRichTextComponent } from './lib/richtext/rich-text.component';
 export { withStoryblokRichtextComponents } from './lib/richtext/richtext.feature';
-export type { SBAngularComponentMap } from './lib/richtext/richtext.feature';
+export type { SbAngularComponentMap } from './lib/richtext/richtext.feature';
 // Re-export richtext types for convenience
-export { type StoryblokRichTextJson } from '@storyblok/richtext/static';
+export { type SbRichTextDoc } from '@storyblok/richtext/static';
 
 export type { Story } from '@storyblok/api-client';
 export * from './lib/types';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -25,6 +25,7 @@ export { withStoryblokRichtextComponents } from './lib/richtext/richtext.feature
 export type { SbAngularComponentMap } from './lib/richtext/richtext.feature';
 // Re-export richtext types for convenience
 export { type SbRichTextDoc } from '@storyblok/richtext/static';
+export { renderRichText } from '@storyblok/richtext/static';
 
 export type { Story } from '@storyblok/api-client';
 export * from './lib/types';

--- a/packages/richtext/src/extensions/nodes.ts
+++ b/packages/richtext/src/extensions/nodes.ts
@@ -65,7 +65,6 @@ export const StoryblokOrderedList = OrderedList.extend({
   name: 'ordered_list',
   addAttributes() {
     return {
-      ...this.parent?.(),
       order: {
         default: 1,
       },
@@ -177,17 +176,15 @@ export const StoryblokImage = Image.extend<{ optimizeImages: boolean | Partial<S
 // Emoji with custom renderHTML
 export const StoryblokEmoji = Emoji.extend({
   renderHTML({ HTMLAttributes }) {
-    return ['span', {
-      'data-type': 'emoji',
-      'data-name': HTMLAttributes.name,
+    return ['img', {
       'data-emoji': HTMLAttributes.emoji,
-    }, ['img', {
-      src: HTMLAttributes.fallbackImage,
-      alt: HTMLAttributes.alt,
-      style: 'width: 1.25em; height: 1.25em; vertical-align: text-top',
-      draggable: 'false',
-      loading: 'lazy',
-    }]];
+      'data-name': HTMLAttributes.name,
+      'src': HTMLAttributes.fallbackImage,
+      'alt': HTMLAttributes.alt,
+      'style': 'width: 1.25em; height: 1.25em; vertical-align: text-top',
+      'draggable': 'false',
+      'loading': 'lazy',
+    }];
   },
 });
 

--- a/packages/richtext/src/extensions/richtext-attrs.ts
+++ b/packages/richtext/src/extensions/richtext-attrs.ts
@@ -1,0 +1,142 @@
+/** Node Attribute Types */
+
+export interface ParagraphAttrs {
+  textAlign: 'left' | 'center' | 'right' | 'justify' | null;
+  [key: string]: unknown;
+}
+
+export interface HeadingAttrs {
+  textAlign: 'left' | 'center' | 'right' | 'justify' | null;
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  [key: string]: unknown;
+}
+
+export interface CodeBlockAttrs {
+  class: string | null;
+  [key: string]: unknown;
+}
+
+export interface OrderedListAttrs {
+  order?: number;
+  [key: string]: unknown;
+}
+
+export interface TableCellAttrs {
+  colspan?: number;
+  rowspan?: number;
+  colwidth?: number[] | null;
+  backgroundColor?: string | null;
+  [key: string]: unknown;
+}
+
+export interface TableHeaderAttrs {
+  colspan?: number;
+  rowspan?: number;
+  colwidth?: number[] | null;
+  [key: string]: unknown;
+}
+
+export interface ImageAttrs {
+  id: number | null;
+  alt: string | null;
+  src: string;
+  title: string | null;
+  source: string | null;
+  copyright: string | null;
+  meta_data: {
+    alt: string | null;
+    title: string | null;
+    source: string | null;
+    copyright: string | null;
+  } | null;
+  [key: string]: unknown;
+}
+
+export interface EmojiAttrs {
+  name: string;
+  emoji: string;
+  fallbackImage: string;
+  [key: string]: unknown;
+}
+
+export interface BlokAttrs {
+  id: string | null;
+  body: Record<string, unknown>[] | null;
+  [key: string]: unknown;
+}
+
+/** Mark Attribute Types */
+
+export interface LinkAttrs {
+  href: string | null;
+  uuid: string | null;
+  anchor: string | null;
+  target: '_self' | '_blank' | '_parent' | '_top' | null;
+  linktype: 'story' | 'url' | 'email' | 'asset' | null;
+  custom?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface HighlightAttrs {
+  color: string;
+  [key: string]: unknown;
+}
+
+export interface TextStyleAttrs {
+  color?: string | null;
+  id?: string | null;
+  class?: string | null;
+  [key: string]: unknown;
+}
+
+export interface AnchorAttrs {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface StyledAttrs {
+  class: string | null;
+  [key: string]: unknown;
+}
+
+/** Maps node names to their attribute types. */
+export interface NodeAttrTypeMap {
+  paragraph: ParagraphAttrs;
+  heading: HeadingAttrs;
+  code_block: CodeBlockAttrs;
+  ordered_list: OrderedListAttrs;
+  tableCell: TableCellAttrs;
+  tableHeader: TableHeaderAttrs;
+  image: ImageAttrs;
+  emoji: EmojiAttrs;
+}
+
+/** Maps mark names to their attribute types. */
+export interface MarkAttrTypeMap {
+  link: LinkAttrs;
+  highlight: HighlightAttrs;
+  textStyle: TextStyleAttrs;
+  anchor: AnchorAttrs;
+  styled: StyledAttrs;
+}
+
+/** Runtime keys for NodeAttrTypeMap (type-checked via satisfies). */
+export const nodeAttrKeys: (keyof NodeAttrTypeMap)[] = [
+  'paragraph',
+  'heading',
+  'code_block',
+  'ordered_list',
+  'tableCell',
+  'tableHeader',
+  'image',
+  'emoji',
+];
+
+/** Runtime keys for MarkAttrTypeMap (type-checked via satisfies). */
+export const markAttrKeys: (keyof MarkAttrTypeMap)[] = [
+  'link',
+  'highlight',
+  'textStyle',
+  'anchor',
+  'styled',
+];

--- a/packages/richtext/src/richtext.test.ts
+++ b/packages/richtext/src/richtext.test.ts
@@ -185,7 +185,7 @@ describe('richtext', () => {
         },
       };
       const html = render(emoji as unknown as StoryblokRichTextNode<string>);
-      expect(html).toBe('<span data-type="emoji" data-name="smile" data-emoji="🚀"><img style="width: 1.25em; height: 1.25em; vertical-align: text-top" draggable="false" loading="lazy"></span>');
+      expect(html).toBe('<img data-emoji="🚀" data-name="smile" style="width: 1.25em; height: 1.25em; vertical-align: text-top" draggable="false" loading="lazy">');
     });
 
     it('should render a table', async () => {
@@ -914,7 +914,7 @@ describe('richtext', () => {
         },
       };
       const html = render(emoji as unknown as StoryblokRichTextNode<string>);
-      expect(html).toBe('<span data-type="emoji" data-name="smile" data-emoji="😊" key="span-0"><img src="smile.png" style="width: 1.25em; height: 1.25em; vertical-align: text-top" draggable="false" loading="lazy" key="img-0"></span>');
+      expect(html).toBe('<img data-emoji="😊" data-name="smile" src="smile.png" style="width: 1.25em; height: 1.25em; vertical-align: text-top" draggable="false" loading="lazy" key="img-0">');
     });
 
     it('should render a code block with keys', () => {

--- a/packages/richtext/src/static/attribute.test.ts
+++ b/packages/richtext/src/static/attribute.test.ts
@@ -1,150 +1,484 @@
 import { describe, expect, it } from 'vitest';
-import { EXCLUDED_ATTRS, processAttrs } from './attribute';
+import { escapeAttr, EXCLUDED_ATTRS, processAttrs } from './attribute';
+
+// ============================================================================
+// processAttrs - Basic Attribute Handling
+// ============================================================================
 
 describe('processAttrs', () => {
-  it('maps style properties correctly', () => {
-    expect(
-      processAttrs('paragraph', {
-        textAlign: 'center',
-      }),
-    ).toEqual({
-      style: {
-        textAlign: 'center',
-      },
+  describe('basic attribute handling', () => {
+    it('returns empty object for empty attrs', () => {
+      expect(processAttrs('paragraph', {})).toEqual({});
+    });
+
+    it('returns empty object when attrs is undefined', () => {
+      expect(processAttrs('paragraph')).toEqual({});
+    });
+
+    it('passes through regular attributes unchanged', () => {
+      expect(processAttrs('paragraph', { id: 'test' })).toEqual({ id: 'test' });
+    });
+
+    it('passes through multiple attributes', () => {
+      expect(processAttrs('paragraph', { id: 'test', class: 'foo' })).toEqual({
+        id: 'test',
+        class: 'foo',
+      });
+    });
+
+    it('keeps false as a value in non-style attributes', () => {
+      expect(processAttrs('paragraph', { test: false })).toEqual({ test: false });
+    });
+
+    it('keeps 0 as valid value', () => {
+      expect(processAttrs('tableCell', { colwidth: 0 })).toEqual({
+        style: { width: 0 },
+      });
     });
   });
 
-  it('skips null and undefined values', () => {
-    expect(
-      processAttrs('paragraph', {
+  // ============================================================================
+  // processAttrs - Invalid/Skipped Values
+  // ============================================================================
+
+  describe('invalid and skipped values', () => {
+    it('skips null values', () => {
+      expect(processAttrs('paragraph', { textAlign: null })).toEqual({});
+    });
+
+    it('skips undefined values', () => {
+      expect(processAttrs('paragraph', { colspan: undefined })).toEqual({});
+    });
+
+    it('skips empty string values', () => {
+      expect(processAttrs('paragraph', { textAlign: '' })).toEqual({});
+    });
+
+    it('skips null and undefined together', () => {
+      expect(processAttrs('paragraph', {
         textAlign: null,
         colspan: undefined,
-      }),
-    ).toEqual({});
-  });
+      })).toEqual({});
+    });
 
-  it('skips empty string values (important fix)', () => {
-    expect(
-      processAttrs('paragraph', {
-        textAlign: '',
-      }),
-    ).toEqual({});
-  });
+    it('excludes all attributes in EXCLUDED_ATTRS', () => {
+      const excludedAttrs = Array.from(EXCLUDED_ATTRS).reduce((acc, attr) => {
+        acc[attr] = 'test';
+        return acc;
+      }, {} as Record<string, string>);
 
-  it('keeps 0 as valid value', () => {
-    expect(
-      processAttrs('tableCell', {
-        colwidth: 0,
-      }),
-    ).toEqual({
-      style: {
-        width: 0,
-      },
+      expect(processAttrs('paragraph', excludedAttrs)).toEqual({});
+    });
+
+    it('excludes level attribute', () => {
+      expect(processAttrs('heading', { level: 2 })).toEqual({});
+    });
+
+    it('excludes linktype attribute', () => {
+      expect(processAttrs('link', { linktype: 'url', href: '/test' })).toEqual({
+        href: '/test',
+      });
+    });
+
+    it('excludes uuid attribute', () => {
+      expect(processAttrs('link', { uuid: '123-456', href: '/test' })).toEqual({
+        href: '/test',
+      });
+    });
+
+    it('excludes anchor attribute from output but uses it for story links', () => {
+      expect(processAttrs('link', {
+        linktype: 'story',
+        href: '/page',
+        anchor: 'section',
+      })).toEqual({
+        href: '/page#section',
+      });
     });
   });
 
-  it('keeps false as a value in non-style attributes', () => {
-    expect(
-      processAttrs('paragraph', {
-        test: false,
-      }),
-    ).toEqual({
-      test: false,
-    });
-  });
-  it('excludes all the attributes added in EXCLUDED_ATTRS', () => {
-    expect(
-      processAttrs('paragraph', {
-        ...Array.from(EXCLUDED_ATTRS).reduce((acc, attr) => {
-          acc[attr] = 'test';
-          return acc;
-        }, {} as Record<string, string>),
-      }),
-    ).toEqual({});
-  });
+  // ============================================================================
+  // processAttrs - Style Mapping
+  // ============================================================================
 
-  it('stringifies object values', () => {
-    expect(
-      processAttrs('paragraph', {
-        meta: { a: 1 },
-      }),
-    ).toEqual({
-      meta: '{"a":1}',
+  describe('style mapping', () => {
+    it('maps textAlign to style for paragraph', () => {
+      expect(processAttrs('paragraph', { textAlign: 'center' })).toEqual({
+        style: { textAlign: 'center' },
+      });
     });
-  });
 
-  it('applies default attribute mapping', () => {
-    expect(
-      processAttrs('heading', {
-        level: 2,
-        textAlign: 'right',
-      }),
-    ).toEqual({
-      style: {
-        textAlign: 'right',
-      },
+    it('maps textAlign to style for heading', () => {
+      expect(processAttrs('heading', { textAlign: 'right' })).toEqual({
+        style: { textAlign: 'right' },
+      });
     });
-  });
 
-  it('allows extendAttrMap to override defaults', () => {
-    expect(
-      processAttrs(
-        'paragraph',
-        {
-          test: 1,
+    it('maps color to backgroundColor for highlight', () => {
+      expect(processAttrs('highlight', { color: '#ff0000' })).toEqual({
+        style: { backgroundColor: '#ff0000' },
+      });
+    });
+
+    it('maps color to color for textStyle', () => {
+      expect(processAttrs('textStyle', { color: 'blue' })).toEqual({
+        style: { color: 'blue' },
+      });
+    });
+
+    it('maps backgroundColor for tableCell', () => {
+      expect(processAttrs('tableCell', { backgroundColor: '#eee' })).toEqual({
+        style: { backgroundColor: '#eee' },
+      });
+    });
+
+    it('maps colwidth to width for tableCell', () => {
+      expect(processAttrs('tableCell', { colwidth: 100 })).toEqual({
+        style: { width: 100 },
+      });
+    });
+
+    it('maps colwidth to width for tableHeader', () => {
+      expect(processAttrs('tableHeader', { colwidth: 150 })).toEqual({
+        style: { width: 150 },
+      });
+    });
+
+    it('handles array values with px conversion', () => {
+      expect(processAttrs('tableCell', { colwidth: [200] })).toEqual({
+        style: { width: '200px' },
+      });
+    });
+
+    it('handles array with null first element', () => {
+      expect(processAttrs('tableCell', { colwidth: [null] })).toEqual({});
+    });
+
+    it('handles array with undefined first element', () => {
+      expect(processAttrs('tableCell', { colwidth: [undefined] })).toEqual({});
+    });
+
+    it('combines multiple style properties', () => {
+      expect(processAttrs('tableCell', {
+        backgroundColor: '#fff',
+        colwidth: [100],
+      })).toEqual({
+        style: {
+          backgroundColor: '#fff',
+          width: '100px',
         },
-        {
-          test: 'data-test',
-        },
-      ),
-    ).toEqual({
-      'data-test': 1,
+      });
+    });
+
+    it('combines style and non-style attributes', () => {
+      expect(processAttrs('paragraph', {
+        textAlign: 'center',
+        id: 'intro',
+      })).toEqual({
+        id: 'intro',
+        style: { textAlign: 'center' },
+      });
     });
   });
 
-  it('applies styleMap for paragraph', () => {
-    expect(
-      processAttrs('paragraph', {
-        textAlign: 'right',
-      }),
-    ).toEqual({
-      style: {
-        textAlign: 'right',
-      },
+  // ============================================================================
+  // processAttrs - Default Attribute Mapping
+  // ============================================================================
+
+  describe('default attribute mapping', () => {
+    it('maps fallbackImage to src', () => {
+      expect(processAttrs('image', { fallbackImage: 'test.jpg' })).toEqual({
+        src: 'test.jpg',
+      });
+    });
+
+    it('maps body to data-body', () => {
+      const result = processAttrs('blok', { body: 'content' });
+      expect(result['data-body']).toBe('content');
+    });
+
+    it('maps colspan to colSpan', () => {
+      expect(processAttrs('tableCell', { colspan: 2 })).toEqual({
+        colSpan: 2,
+      });
+    });
+
+    it('maps rowspan to rowSpan', () => {
+      expect(processAttrs('tableCell', { rowspan: 3 })).toEqual({
+        rowSpan: 3,
+      });
+    });
+
+    it('maps name to data-name', () => {
+      const result = processAttrs('emoji', { name: 'smile' });
+      expect(result['data-name']).toBe('smile');
+    });
+
+    it('maps emoji to data-emoji', () => {
+      const result = processAttrs('emoji', { emoji: '😀' });
+      expect(result['data-emoji']).toBe('😀');
     });
   });
 
-  it('handles array values with px conversion', () => {
-    expect(
-      processAttrs('tableCell', {
-        colwidth: [200],
-      }),
-    ).toEqual({
-      style: {
-        width: '200px',
-      },
+  // ============================================================================
+  // processAttrs - Extended Attribute Mapping
+  // ============================================================================
+
+  describe('extended attribute mapping', () => {
+    it('allows extendAttrMap to add new mappings', () => {
+      expect(processAttrs('paragraph', { test: 'value' }, { test: 'data-test' })).toEqual({
+        'data-test': 'value',
+      });
+    });
+
+    it('allows extendAttrMap to override defaults', () => {
+      expect(processAttrs('paragraph', { body: 'content' }, { body: 'custom-body' })).toEqual({
+        'custom-body': 'content',
+      });
+    });
+
+    it('applies multiple extended mappings', () => {
+      expect(processAttrs('paragraph', { foo: 1, bar: 2 }, { foo: 'data-foo', bar: 'data-bar' })).toEqual({
+        'data-foo': 1,
+        'data-bar': 2,
+      });
     });
   });
-  it('handles story link', () => {
-    expect(
-      processAttrs('link', {
+
+  // ============================================================================
+  // processAttrs - Object Values
+  // ============================================================================
+
+  describe('object values', () => {
+    it('stringifies object values', () => {
+      expect(processAttrs('paragraph', { meta: { a: 1 } })).toEqual({
+        meta: '{"a":1}',
+      });
+    });
+
+    it('stringifies nested objects', () => {
+      expect(processAttrs('paragraph', { data: { nested: { deep: true } } })).toEqual({
+        data: '{"nested":{"deep":true}}',
+      });
+    });
+
+    it('stringifies arrays as JSON', () => {
+      expect(processAttrs('paragraph', { items: [1, 2, 3] })).toEqual({
+        items: '[1,2,3]',
+      });
+    });
+  });
+
+  // ============================================================================
+  // processAttrs - Link Custom Attributes
+  // ============================================================================
+
+  describe('link custom attributes', () => {
+    it('spreads custom attributes for links', () => {
+      expect(processAttrs('link', {
+        href: '/test',
+        custom: { title: 'My Link', rel: 'noopener' },
+      })).toEqual({
+        href: '/test',
+        title: 'My Link',
+        rel: 'noopener',
+      });
+    });
+
+    it('converts custom attribute values to strings', () => {
+      expect(processAttrs('link', {
+        href: '/test',
+        custom: { count: 42, active: true },
+      })).toEqual({
+        href: '/test',
+        count: '42',
+        active: 'true',
+      });
+    });
+
+    it('does not spread custom for non-link types', () => {
+      expect(processAttrs('paragraph', {
+        custom: { title: 'Test' },
+      })).toEqual({
+        custom: '{"title":"Test"}',
+      });
+    });
+  });
+
+  // ============================================================================
+  // processAttrs - Story Links
+  // ============================================================================
+
+  describe('story links', () => {
+    it('handles story link with href and anchor', () => {
+      expect(processAttrs('link', {
         linktype: 'story',
         href: '/story/123',
         anchor: 'section-1',
-      }),
-    ).toEqual({
-      href: '/story/123#section-1',
+      })).toEqual({
+        href: '/story/123#section-1',
+      });
     });
-  });
-  it('handles story link with null href', () => {
-    expect(
-      processAttrs('link', {
+
+    it('handles story link without anchor', () => {
+      expect(processAttrs('link', {
+        linktype: 'story',
+        href: '/story/456',
+      })).toEqual({
+        href: '/story/456',
+      });
+    });
+
+    it('handles story link with null href', () => {
+      expect(processAttrs('link', {
         linktype: 'story',
         href: null,
         anchor: 'section-1',
-      }),
-    ).toEqual({
-      href: '#section-1',
+      })).toEqual({
+        href: '#section-1',
+      });
     });
+
+    it('handles story link with empty anchor', () => {
+      expect(processAttrs('link', {
+        linktype: 'story',
+        href: '/page',
+        anchor: '',
+      })).toEqual({
+        href: '/page',
+      });
+    });
+
+    it('handles story link with undefined href', () => {
+      expect(processAttrs('link', {
+        linktype: 'story',
+        anchor: 'top',
+      })).toEqual({
+        href: '#top',
+      });
+    });
+  });
+
+  // ============================================================================
+  // processAttrs - Email Links
+  // ============================================================================
+
+  describe('email links', () => {
+    it('handles email link', () => {
+      expect(processAttrs('link', {
+        linktype: 'email',
+        href: 'test@example.com',
+      })).toEqual({
+        href: 'mailto:test@example.com',
+      });
+    });
+
+    it('does not duplicate mailto prefix', () => {
+      expect(processAttrs('link', {
+        linktype: 'email',
+        href: 'mailto:test@example.com',
+      })).toEqual({
+        href: 'mailto:test@example.com',
+      });
+    });
+
+    it('handles email with null href', () => {
+      expect(processAttrs('link', {
+        linktype: 'email',
+        href: null,
+      })).toEqual({});
+    });
+  });
+
+  // ============================================================================
+  // processAttrs - URL and Asset Links
+  // ============================================================================
+
+  describe('url and asset links', () => {
+    it('passes through url link href unchanged', () => {
+      expect(processAttrs('link', {
+        linktype: 'url',
+        href: 'https://example.com',
+      })).toEqual({
+        href: 'https://example.com',
+      });
+    });
+
+    it('passes through asset link href unchanged', () => {
+      expect(processAttrs('link', {
+        linktype: 'asset',
+        href: 'https://cdn.example.com/file.pdf',
+      })).toEqual({
+        href: 'https://cdn.example.com/file.pdf',
+      });
+    });
+
+    it('handles link with target attribute', () => {
+      expect(processAttrs('link', {
+        linktype: 'url',
+        href: 'https://example.com',
+        target: '_blank',
+      })).toEqual({
+        href: 'https://example.com',
+        target: '_blank',
+      });
+    });
+  });
+});
+
+// ============================================================================
+// escapeAttr
+// ============================================================================
+
+describe('escapeAttr', () => {
+  it('escapes ampersand', () => {
+    expect(escapeAttr('a & b')).toBe('a &amp; b');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeAttr('say "hello"')).toBe('say &quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapeAttr('it\'s')).toBe('it&#39;s');
+  });
+
+  it('escapes less than', () => {
+    expect(escapeAttr('a < b')).toBe('a &lt; b');
+  });
+
+  it('escapes greater than', () => {
+    expect(escapeAttr('a > b')).toBe('a &gt; b');
+  });
+
+  it('escapes multiple special characters', () => {
+    expect(escapeAttr('<script>"alert(\'xss\')&"</script>')).toBe(
+      '&lt;script&gt;&quot;alert(&#39;xss&#39;)&amp;&quot;&lt;/script&gt;',
+    );
+  });
+
+  it('returns string unchanged when no special characters', () => {
+    expect(escapeAttr('hello world')).toBe('hello world');
+  });
+
+  it('converts numbers to strings', () => {
+    expect(escapeAttr(42)).toBe('42');
+  });
+
+  it('converts booleans to strings', () => {
+    expect(escapeAttr(true)).toBe('true');
+    expect(escapeAttr(false)).toBe('false');
+  });
+
+  it('converts null to string', () => {
+    expect(escapeAttr(null)).toBe('null');
+  });
+
+  it('converts undefined to string', () => {
+    expect(escapeAttr(undefined)).toBe('undefined');
+  });
+
+  it('converts objects to string', () => {
+    expect(escapeAttr({ a: 1 })).toBe('[object Object]');
   });
 });

--- a/packages/richtext/src/static/attribute.ts
+++ b/packages/richtext/src/static/attribute.ts
@@ -1,12 +1,15 @@
-import { isValidStyleValue } from './style';
-import type { AttrValue } from './types';
-import type { TiptapComponentName } from './types.generated';
+import { NODE_RENDER_MAP } from './render-map.generated';
+import { isValidStyleValue, stringToStyle } from './style';
+import type { AttrValue, SbRichTextElement } from './types';
 
 type StyleMap = Partial<{
-  [K in TiptapComponentName]: Record<string, string>;
+  [K in SbRichTextElement]: Record<string, string>;
 }>;
 export type AttrMap = Record<string, string>;
 
+/**
+ * Maps Tiptap attribute names to CSS property names for specific element types.
+ */
 const STYLE_MAP: StyleMap = {
   highlight: {
     color: 'backgroundColor',
@@ -29,88 +32,199 @@ const STYLE_MAP: StyleMap = {
   },
 };
 
+/**
+ * Maps Tiptap attribute names to HTML attribute names.
+ */
 const DEFAULT_ATTR_MAP: AttrMap = {
   fallbackImage: 'src',
-  meta_data: 'data-meta_data',
   body: 'data-body',
   colspan: 'colSpan',
   rowspan: 'rowSpan',
+  name: 'data-name',
+  emoji: 'data-emoji',
 };
 
-export const EXCLUDED_ATTRS = new Set(['level', 'linktype', 'uuid', 'custom', 'anchor']);
+/**
+ * Attributes that should be excluded from the output.
+ */
+export const EXCLUDED_ATTRS = new Set(['level', 'linktype', 'uuid', 'anchor', 'meta_data', 'copyright', 'source']);
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Resolves the href for Storyblok link types (story, email).
+ * @returns The resolved href, or undefined if no special handling is needed.
+ */
+function resolveStoryblokLinkHref(attrs: Record<string, unknown>): string | undefined {
+  const { linktype, href, anchor } = attrs;
+
+  if (linktype === 'story') {
+    const base = typeof href === 'string' ? href : '';
+    const hash = typeof anchor === 'string' && anchor ? `#${anchor}` : '';
+    return `${base}${hash}`;
+  }
+
+  if (linktype === 'email' && typeof href === 'string') {
+    const email = href.replace(/^mailto:/, '');
+    return `mailto:${email}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts static attributes and styles from the render map for a given element type.
+ */
+function getStaticAttrsFromRenderMap(
+  type: SbRichTextElement,
+): { staticAttrs: Record<string, unknown>; staticStyle: Record<string, AttrValue> } {
+  const staticStyle: Record<string, AttrValue> = {};
+  let staticAttrs: Record<string, unknown> = {};
+
+  if (!(type in NODE_RENDER_MAP)) {
+    return { staticAttrs, staticStyle };
+  }
+
+  const renderMap = NODE_RENDER_MAP[type as keyof typeof NODE_RENDER_MAP];
+  if (!renderMap || !('attrs' in renderMap)) {
+    return { staticAttrs, staticStyle };
+  }
+
+  const renderAttrs = renderMap.attrs || {};
+  const rawStyle = 'style' in renderAttrs && typeof renderAttrs.style === 'string'
+    ? renderAttrs.style
+    : '';
+
+  const { style: _style, ...rest } = renderAttrs as Record<string, unknown>;
+  staticAttrs = rest;
+
+  if (rawStyle) {
+    Object.assign(staticStyle, stringToStyle(rawStyle));
+  }
+
+  return { staticAttrs, staticStyle };
+}
+
+/**
+ * Converts an attribute value to a CSS value based on the style map.
+ * Handles arrays (e.g., colwidth) and primitive values.
+ */
+function convertToStyleValue(value: unknown): AttrValue | undefined {
+  if (Array.isArray(value)) {
+    return value[0] != null ? `${value[0]}px` : undefined;
+  }
+
+  if (typeof value === 'number' || typeof value === 'string') {
+    return value;
+  }
+
+  return String(value);
+}
+
+/**
+ * Processes a single attribute and adds it to either the style or rest object.
+ */
+function processAttribute(
+  key: string,
+  value: unknown,
+  type: SbRichTextElement,
+  styleMap: Record<string, string>,
+  attrMap: AttrMap,
+  style: Record<string, AttrValue>,
+  rest: Record<string, unknown>,
+): void {
+  if (!isValidStyleValue(value) || EXCLUDED_ATTRS.has(key)) {
+    return;
+  }
+
+  // Handle style-mapped attributes
+  if (key in styleMap) {
+    const cssProp = styleMap[key]!;
+    const cssValue = convertToStyleValue(value);
+    if (cssValue !== undefined && isValidStyleValue(cssValue)) {
+      style[cssProp] = cssValue;
+    }
+    return;
+  }
+
+  const attrName = attrMap[key] ?? key;
+
+  // Handle custom attributes for links (spread them as individual attributes)
+  if (attrName === 'custom' && type === 'link' && typeof value === 'object' && value !== null) {
+    for (const [customKey, customValue] of Object.entries(value)) {
+      rest[customKey] = String(customValue);
+    }
+    return;
+  }
+
+  // Handle other object values (stringify them)
+  if (typeof value === 'object' && value !== null) {
+    rest[attrName] = JSON.stringify(value);
+    return;
+  }
+
+  // Default: pass through as-is
+  rest[attrName] = value;
+}
+
+// ============================================================================
+// Main Export
+// ============================================================================
 
 /**
  * Process Tiptap attributes into HTML attributes and inline styles.
  * Applies internal style mappings and allows extending or overriding
  * default attribute mappings via `extendAttrMap`.
  *
- * @param type - {@link TiptapComponentName}
+ * @param type - {@link SbRichTextElement}
  * @param attrs - Attributes from the node/mark
  * @param extendAttrMap - {@link AttrMap} Additional attribute mappings (overrides defaults)
  * @returns Processed attributes with optional `style` object
  */
 export function processAttrs(
-  type: TiptapComponentName,
+  type: SbRichTextElement,
   attrs: Record<string, unknown> = {},
   extendAttrMap: AttrMap = {},
-) {
-  const style: Record<string, AttrValue> = {};
+): Record<string, unknown> {
+  const { staticAttrs, staticStyle } = getStaticAttrsFromRenderMap(type);
+  const style: Record<string, AttrValue> = { ...staticStyle };
   const rest: Record<string, unknown> = {};
 
   const styleMap = STYLE_MAP[type] || {};
-  const attrMap = { ...DEFAULT_ATTR_MAP, ...extendAttrMap }; // user overrides
-  for (const [key, value] of Object.entries(attrs)) {
-    if (!isValidStyleValue(value) || EXCLUDED_ATTRS.has(key)) {
-      continue;
-    }
-    // STYLE MAP
-    if (key in styleMap) {
-      const cssProp = styleMap[key]!;
-      if (Array.isArray(value)) {
-        const cssValue = value[0] != null ? `${value[0]}px` : undefined;
-        if (cssValue && isValidStyleValue(cssValue)) {
-          style[cssProp] = cssValue;
-        }
-      }
-      else {
-        const cssValue = typeof value === 'number' || typeof value === 'string'
-          ? value
-          : String(value);
+  const attrMap = { ...DEFAULT_ATTR_MAP, ...extendAttrMap };
+  const mergedAttrs = { ...attrs, ...staticAttrs };
 
-        style[cssProp] = cssValue;
-      }
-      continue;
-    }
-
-    // Resolve attribute name first
-    const attrName = attrMap[key] ?? key;
-
-    // stringify objects
-    if (typeof value === 'object' && value !== null) {
-      rest[attrName] = JSON.stringify(value);
-      continue;
-    }
-
-    // DEFAULT PASS THROUGH
-    rest[attrName] = value;
+  for (const [key, value] of Object.entries(mergedAttrs)) {
+    processAttribute(key, value, type, styleMap, attrMap, style, rest);
   }
-  // Special handling for Storyblok links to add anchor to href
-  if (type === 'link' && attrs.linktype === 'story') {
-    rest.href = `${attrs.href ?? ''}#${attrs.anchor ?? ''}`;
+
+  // Special handling for Storyblok links
+  if (type === 'link') {
+    const linkHref = resolveStoryblokLinkHref(attrs);
+    if (linkHref !== undefined) {
+      rest.href = linkHref;
+    }
   }
+
   return {
     ...rest,
-    ...(Object.keys(style).length && { style }),
+    ...(Object.keys(style).length > 0 && { style }),
   };
 }
-export const escapeAttr = (value: unknown) =>
-  String(value).replace(/[&"'<>]/g, (s) => {
-    switch (s) {
+
+/**
+ * Escapes special HTML characters in attribute values.
+ */
+export const escapeAttr = (value: unknown): string =>
+  String(value).replace(/[&"'<>]/g, (char) => {
+    switch (char) {
       case '&': return '&amp;';
       case '"': return '&quot;';
       case '\'': return '&#39;';
       case '<': return '&lt;';
       case '>': return '&gt;';
-      default: return s;
+      default: return char;
     }
   });

--- a/packages/richtext/src/static/generate/parse-dom-spec.test.ts
+++ b/packages/richtext/src/static/generate/parse-dom-spec.test.ts
@@ -57,7 +57,7 @@ describe('parseDOMSpec', () => {
     expect(result).toEqual(
       {
         attrs: {
-          style: 'display: none',
+          style: 'display: none;',
         },
         tag: 'span',
       },
@@ -95,7 +95,7 @@ describe('parseDOMSpec', () => {
             attrs: {
               draggable: 'false',
               loading: 'lazy',
-              style: 'width: 1.25em; height: 1.25em; vertical-align: text-top',
+              style: 'width: 1.25em; height: 1.25em; vertical-align: text-top;',
             },
             tag: 'img',
           },

--- a/packages/richtext/src/static/generate/parse-dom-spec.ts
+++ b/packages/richtext/src/static/generate/parse-dom-spec.ts
@@ -14,10 +14,8 @@ interface DOMObjectSpec {
 /** Attribute object in a DOM spec */
 type AttrsObject = Record<string, AttrValue>;
 
-// Custom DOM specs for nodes that need special handling (e.g. table)
-const CUSTOM_SPECS: Record<string, ArrayDOMSpec> = {
-  table: ['table', ['tbody', 0]],
-};
+// Custom DOM specs for nodes that need special handling
+const CUSTOM_SPECS: Record<string, ArrayDOMSpec> = {};
 
 /** Parses a ProseMirror DOMOutputSpec into a RenderSpec. */
 export function parseDOMSpec(spec: DOMOutputSpec): RenderSpec | null {

--- a/packages/richtext/src/static/generate/richtext-type.ts
+++ b/packages/richtext/src/static/generate/richtext-type.ts
@@ -1,8 +1,12 @@
 import type { AnyExtension } from '@tiptap/core';
 import { getSchema } from '@tiptap/core';
 import type { AttributeSpec, MarkType, NodeType, Schema } from 'prosemirror-model';
+import { markAttrKeys, nodeAttrKeys } from '../../extensions/richtext-attrs';
 import { getStoryblokExtensions } from '../../extensions';
 import { hints } from './type-hints';
+
+const nodeAttrKeySet = new Set<string>(nodeAttrKeys);
+const markAttrKeySet = new Set<string>(markAttrKeys);
 
 /**
  * Converts a schema attrs object to a TS property string (with type from hints)
@@ -11,6 +15,7 @@ import { hints } from './type-hints';
 function getAttrType(attrName: string): string {
   return hints[attrName] || 'unknown';
 }
+
 function genAttrsType(attrs: Record<string, AttributeSpec> | undefined): string {
   if (!attrs || Object.keys(attrs).length === 0) {
     return 'Record<string, never>';
@@ -23,21 +28,33 @@ function genAttrsType(attrs: Record<string, AttributeSpec> | undefined): string 
   out += '}';
   return out;
 }
+
 /** Generate all node attribute interfaces and helpers */
 function genAttributeTypes(schema: Schema) {
   let nodeAttrs = '';
   let markAttrs = '';
 
   for (const [name, type] of Object.entries(schema.nodes) as [string, NodeType][]) {
-    nodeAttrs += `  ${name}: ${genAttrsType(type.spec.attrs)};\n`;
+    if (nodeAttrKeySet.has(name)) {
+      nodeAttrs += `  ${name}: NodeAttrTypeMap['${name}'];\n`;
+    }
+    else {
+      nodeAttrs += `  ${name}: ${genAttrsType(type.spec.attrs)};\n`;
+    }
   }
 
   for (const [name, type] of Object.entries(schema.marks) as [string, MarkType][]) {
-    markAttrs += `  ${name}: ${genAttrsType(type.spec.attrs)};\n`;
+    if (markAttrKeySet.has(name)) {
+      markAttrs += `  ${name}: MarkAttrTypeMap['${name}'];\n`;
+    }
+    else {
+      markAttrs += `  ${name}: ${genAttrsType(type.spec.attrs)};\n`;
+    }
   }
 
   return { nodeAttrs, markAttrs };
 }
+
 /** Generate PMNode discriminated union type */
 function genPMNode(schema: Schema): string {
   let out = 'export type PMNode =\n';
@@ -54,6 +71,7 @@ function genPMNode(schema: Schema): string {
 
   return `${out};`;
 }
+
 function genPMMark(schema: Schema): string {
   let out = 'export type PMMark =\n';
   for (const [name] of Object.entries(schema.marks)) {
@@ -69,9 +87,12 @@ export function generateTypes() {
   const extensions = Object.values(defaultExtensions);
   const schema = getSchema(extensions as AnyExtension[]);
   const attributeTypes = genAttributeTypes(schema);
+
   let output = '';
   output += '// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\n';
-  output += `import type { SbBlokData } from './types';\n\n`;
+  output += `import type { MarkAttrTypeMap, NodeAttrTypeMap } from '../extensions/richtext-attrs';\n`;
+  output += `import type { SbBlokData } from './types';\n`;
+  output += '\n';
   // --- Attribute types
   output += '/** Attribute types for all Tiptap node extensions */\n';
   output += 'export interface TiptapNodeAttributes {\n';
@@ -84,8 +105,6 @@ export function generateTypes() {
   // --- Node name unions
   output += 'export type TiptapNodeName = keyof TiptapNodeAttributes;\n';
   output += 'export type TiptapMarkName = keyof TiptapMarkAttributes;\n';
-  // Remove 'text' from component names since user dont need to provide a component for text nodes
-  output += `export type TiptapComponentName = Exclude<TiptapNodeName | TiptapMarkName, 'text'>;\n\n`;
   // --- PMNode/PMMark
   output += `${genPMNode(schema)}\n\n`;
   output += `${genPMMark(schema)}\n\n`;

--- a/packages/richtext/src/static/generate/type-hints.ts
+++ b/packages/richtext/src/static/generate/type-hints.ts
@@ -1,31 +1,8 @@
-// Could extend for more attributes if needed
+/**
+ * Fallback type hints for extensions without Valibot schemas.
+ * Currently only used for the `blok` extension attributes.
+ */
 export const hints: Record<string, string> = {
-  level: '1 | 2 | 3 | 4 | 5 | 6',
-  textAlign: '\'left\' | \'center\' | \'right\' | \'justify\' | null',
-  color: 'string | null',
-  class: 'string | null',
   id: 'string | null',
-  href: 'string',
-  linktype: '\'url\' | \'story\' | \'asset\' | \'email\'',
-  src: 'string',
-  alt: 'string',
-  title: 'string | null',
-  width: 'number | string | null',
-  height: 'number | string | null',
-  rel: 'string | null',
-  target: '\'_self\' | \'_blank\' | \'_parent\' | \'_top\' | null',
-  order: 'number',
-  colspan: 'number',
-  rowspan: 'number',
-  colwidth: 'number[] | null',
-  backgroundColor: 'string | null',
-  body: 'SbBlokData[]',
-  emoji: 'string | null',
-  name: 'string | null',
-  fallbackImage: 'string | null',
-  reporter: 'never',
-  custom: 'Record<string, string | null>',
-  uuid: 'string',
-  anchor: 'string',
-  // Expand as needed
+  body: 'SbBlokData[] | null',
 };

--- a/packages/richtext/src/static/index.ts
+++ b/packages/richtext/src/static/index.ts
@@ -1,6 +1,14 @@
 export { processAttrs } from './attribute';
+export {
+  areLinkMarksEqual,
+  getInnerMarks,
+  getTextNodeLinkMark,
+  groupLinkNodes,
+  isTableHeaderRow,
+  splitTableRows,
+} from './node-helpers';
 export { richTextRenderer } from './richtext-renderer';
 export { stringToStyle, styleToString } from './style';
-export type { RenderSpec, RichTextComponentProps, StoryblokRichTextComponentMap, StoryblokRichTextJson } from './types';
-export type { PMMark, PMNode, TiptapComponentName } from './types.generated';
+export type { RenderSpec, SbRichTextComponents, SbRichTextDoc, SbRichTextElement, SbRichTextProps } from './types';
+export type { PMMark, PMNode } from './types.generated';
 export { getStaticChildren, isSelfClosing, resolveComponent, resolveTag } from './util';

--- a/packages/richtext/src/static/index.ts
+++ b/packages/richtext/src/static/index.ts
@@ -7,7 +7,7 @@ export {
   isTableHeaderRow,
   splitTableRows,
 } from './node-helpers';
-export { richTextRenderer } from './richtext-renderer';
+export { renderRichText } from './render-richtext';
 export { stringToStyle, styleToString } from './style';
 export type { RenderSpec, SbRichTextComponents, SbRichTextDoc, SbRichTextElement, SbRichTextProps } from './types';
 export type { PMMark, PMNode } from './types.generated';

--- a/packages/richtext/src/static/node-helpers.test.ts
+++ b/packages/richtext/src/static/node-helpers.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest';
+import type { SbRichTextDoc } from './types';
+import {
+  areLinkMarksEqual,
+  getInnerMarks,
+  getTextNodeLinkMark,
+  groupLinkNodes,
+  isTableHeaderRow,
+  type LinkMark,
+  splitTableRows,
+} from './node-helpers';
+import type { PMMark } from './types.generated';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function linkMark(href: string, options: { uuid?: string; target?: '_blank' | '_self'; linktype?: 'url' | 'story' | 'email' | 'asset'; anchor?: string; custom?: Record<string, unknown> } = {}): LinkMark {
+  return { type: 'link' as const, attrs: { href, linktype: options.linktype ?? 'url', target: options.target ?? null, anchor: options.anchor ?? null, uuid: options.uuid ?? null, custom: options.custom ?? undefined } };
+}
+
+function textNode(text: string, marks: PMMark[] = []): SbRichTextDoc {
+  return { type: 'text', text, marks };
+}
+
+// ============================================================================
+// getTextNodeLinkMark
+// ============================================================================
+
+describe('getTextNodeLinkMark', () => {
+  it('returns null for non-text nodes', () => {
+    const node: SbRichTextDoc = { type: 'paragraph', content: [] };
+    expect(getTextNodeLinkMark(node)).toBeNull();
+  });
+
+  it('returns null for text node without marks', () => {
+    const node = textNode('hello');
+    expect(getTextNodeLinkMark(node)).toBeNull();
+  });
+
+  it('returns null for text node with non-link marks', () => {
+    const node = textNode('hello', [{ type: 'bold' }]);
+    expect(getTextNodeLinkMark(node)).toBeNull();
+  });
+
+  it('returns link mark when present', () => {
+    const mark = linkMark('/test');
+    const node = textNode('hello', [mark]);
+    expect(getTextNodeLinkMark(node)).toEqual(mark);
+  });
+
+  it('returns link mark even with other marks present', () => {
+    const mark = linkMark('/test');
+    const node = textNode('hello', [{ type: 'bold' }, mark, { type: 'italic' }]);
+    expect(getTextNodeLinkMark(node)).toEqual(mark);
+  });
+});
+
+// ============================================================================
+// areLinkMarksEqual
+// ============================================================================
+
+describe('areLinkMarksEqual', () => {
+  it('returns false when first mark is null', () => {
+    expect(areLinkMarksEqual(null, linkMark('/a'))).toBe(false);
+  });
+
+  it('returns false when second mark is null', () => {
+    expect(areLinkMarksEqual(linkMark('/a'), null)).toBe(false);
+  });
+
+  it('returns false when both marks are null', () => {
+    expect(areLinkMarksEqual(null, null)).toBe(false);
+  });
+
+  it('returns true for identical marks', () => {
+    const mark = linkMark('/test', { target: '_blank' });
+    expect(areLinkMarksEqual(mark, { ...mark })).toBe(true);
+  });
+
+  it('returns true for marks with same href', () => {
+    expect(areLinkMarksEqual(linkMark('/a'), linkMark('/a'))).toBe(true);
+  });
+
+  it('returns false for marks with different href', () => {
+    expect(areLinkMarksEqual(linkMark('/a'), linkMark('/b'))).toBe(false);
+  });
+
+  it('returns false for marks with different target', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { target: '_blank' }),
+      linkMark('/a', { target: '_self' }),
+    )).toBe(false);
+  });
+
+  it('returns false for marks with different linktype', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { linktype: 'story' }),
+      linkMark('/a', { linktype: 'url' }),
+    )).toBe(false);
+  });
+
+  it('returns false for marks with different anchor', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { anchor: 'section1' }),
+      linkMark('/a', { anchor: 'section2' }),
+    )).toBe(false);
+  });
+
+  it('returns false for marks with different uuid', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { uuid: 'uuid-1' }),
+      linkMark('/a', { uuid: 'uuid-2' }),
+    )).toBe(false);
+  });
+
+  it('returns true for marks with same custom attributes', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { custom: { title: 'hello' } }),
+      linkMark('/a', { custom: { title: 'hello' } }),
+    )).toBe(true);
+  });
+
+  it('returns false for marks with different custom attributes', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { custom: { title: 'hello' } }),
+      linkMark('/a', { custom: { title: 'world' } }),
+    )).toBe(false);
+  });
+
+  it('returns false when one mark has custom and other does not', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { custom: { title: 'hello' } }),
+      linkMark('/a'),
+    )).toBe(false);
+  });
+
+  it('returns true for marks with nested custom attributes', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { custom: { data: { nested: 'value' } } }),
+      linkMark('/a', { custom: { data: { nested: 'value' } } }),
+    )).toBe(true);
+  });
+
+  it('returns false for marks with different nested custom attributes', () => {
+    expect(areLinkMarksEqual(
+      linkMark('/a', { custom: { data: { nested: 'value1' } } }),
+      linkMark('/a', { custom: { data: { nested: 'value2' } } }),
+    )).toBe(false);
+  });
+});
+
+// ============================================================================
+// getInnerMarks
+// ============================================================================
+
+describe('getInnerMarks', () => {
+  it('returns empty array for non-text nodes', () => {
+    const node: SbRichTextDoc = { type: 'paragraph', content: [] };
+    expect(getInnerMarks(node)).toEqual([]);
+  });
+
+  it('returns empty array for text node without marks', () => {
+    const node = textNode('hello');
+    expect(getInnerMarks(node)).toEqual([]);
+  });
+
+  it('returns empty array when only link mark present', () => {
+    const node = textNode('hello', [linkMark('/test')]);
+    expect(getInnerMarks(node)).toEqual([]);
+  });
+
+  it('returns non-link marks', () => {
+    const boldMark = { type: 'bold' };
+    const italicMark = { type: 'italic' };
+    const node = textNode('hello', [{
+      type: 'bold',
+    }, linkMark('/test'), {
+      type: 'italic',
+    }]);
+    expect(getInnerMarks(node)).toEqual([boldMark, italicMark]);
+  });
+});
+
+// ============================================================================
+// groupLinkNodes
+// ============================================================================
+
+describe('groupLinkNodes', () => {
+  it('returns empty array for empty children', () => {
+    expect(groupLinkNodes([])).toEqual([]);
+  });
+
+  it('groups single non-linked text node', () => {
+    const node = textNode('hello');
+    const result = groupLinkNodes([node]);
+    expect(result).toEqual([{ nodes: [node], linkMark: null }]);
+  });
+
+  it('groups single linked text node', () => {
+    const mark = linkMark('/test');
+    const node = textNode('hello', [mark]);
+    const result = groupLinkNodes([node]);
+    expect(result).toEqual([{ nodes: [node], linkMark: mark }]);
+  });
+
+  it('merges adjacent text nodes with same link', () => {
+    const mark = linkMark('/test');
+    const node1 = textNode('hello ', [mark]);
+    const node2 = textNode('world', [mark]);
+    const result = groupLinkNodes([node1, node2]);
+    expect(result).toEqual([{ nodes: [node1, node2], linkMark: mark }]);
+  });
+
+  it('separates text nodes with different links', () => {
+    const mark1 = linkMark('/a');
+    const mark2 = linkMark('/b');
+    const node1 = textNode('hello', [mark1]);
+    const node2 = textNode('world', [mark2]);
+    const result = groupLinkNodes([node1, node2]);
+    expect(result).toEqual([
+      { nodes: [node1], linkMark: mark1 },
+      { nodes: [node2], linkMark: mark2 },
+    ]);
+  });
+
+  it('separates linked and non-linked text nodes', () => {
+    const mark = linkMark('/test');
+    const linkedNode = textNode('linked', [mark]);
+    const plainNode = textNode('plain');
+    const result = groupLinkNodes([linkedNode, plainNode]);
+    expect(result).toEqual([
+      { nodes: [linkedNode], linkMark: mark },
+      { nodes: [plainNode], linkMark: null },
+    ]);
+  });
+
+  it('handles non-text nodes', () => {
+    const mark = linkMark('/test');
+    const textNodeA = textNode('before', [mark]);
+    const brNode: SbRichTextDoc = { type: 'hard_break' };
+    const textNodeB = textNode('after', [mark]);
+    const result = groupLinkNodes([textNodeA, brNode, textNodeB]);
+    expect(result).toEqual([
+      { nodes: [textNodeA], linkMark: mark },
+      { nodes: [brNode], linkMark: null },
+      { nodes: [textNodeB], linkMark: mark },
+    ]);
+  });
+
+  it('separates nodes when custom attributes differ', () => {
+    const mark1 = linkMark('/a', { custom: { title: 'google' } });
+    const mark2 = linkMark('/a', { custom: { title: 'new' } });
+    const node1 = textNode('A', [mark1]);
+    const node2 = textNode('B', [mark2]);
+    const result = groupLinkNodes([node1, node2]);
+    expect(result).toEqual([
+      { nodes: [node1], linkMark: mark1 },
+      { nodes: [node2], linkMark: mark2 },
+    ]);
+  });
+});
+
+// ============================================================================
+// isTableHeaderRow
+// ============================================================================
+
+describe('isTableHeaderRow', () => {
+  it('returns false for row without content', () => {
+    const row: SbRichTextDoc = { type: 'tableRow' };
+    expect(isTableHeaderRow(row)).toBe(false);
+  });
+
+  it('returns false for row with empty content', () => {
+    const row: SbRichTextDoc = { type: 'tableRow', content: [] };
+    expect(isTableHeaderRow(row)).toBe(false);
+  });
+
+  it('returns false for row with tableCell', () => {
+    const row: SbRichTextDoc = {
+      type: 'tableRow',
+      content: [{ type: 'tableCell' }],
+    };
+    expect(isTableHeaderRow(row)).toBe(false);
+  });
+
+  it('returns true for row with only tableHeader cells', () => {
+    const row: SbRichTextDoc = {
+      type: 'tableRow',
+      content: [
+        { type: 'tableHeader' },
+        { type: 'tableHeader' },
+      ],
+    };
+    expect(isTableHeaderRow(row)).toBe(true);
+  });
+
+  it('returns false for mixed row', () => {
+    const row: SbRichTextDoc = {
+      type: 'tableRow',
+      content: [
+        { type: 'tableHeader' },
+        { type: 'tableCell' },
+      ],
+    };
+    expect(isTableHeaderRow(row)).toBe(false);
+  });
+});
+
+// ============================================================================
+// splitTableRows
+// ============================================================================
+
+describe('splitTableRows', () => {
+  it('returns empty arrays for undefined rows', () => {
+    expect(splitTableRows(undefined)).toEqual({ headerRows: [], bodyRows: [] });
+  });
+
+  it('returns empty arrays for empty rows', () => {
+    expect(splitTableRows([])).toEqual({ headerRows: [], bodyRows: [] });
+  });
+
+  it('returns all rows as body when no header rows', () => {
+    const rows: SbRichTextDoc[] = [
+      { type: 'tableRow', content: [{ type: 'tableCell' }] },
+      { type: 'tableRow', content: [{ type: 'tableCell' }] },
+    ];
+    expect(splitTableRows(rows)).toEqual({ headerRows: [], bodyRows: rows });
+  });
+
+  it('returns all rows as header when all are header rows', () => {
+    const rows: SbRichTextDoc[] = [
+      { type: 'tableRow', content: [{ type: 'tableHeader' }] },
+      { type: 'tableRow', content: [{ type: 'tableHeader' }] },
+    ];
+    expect(splitTableRows(rows)).toEqual({ headerRows: rows, bodyRows: [] });
+  });
+
+  it('splits header and body rows correctly', () => {
+    const headerRow: SbRichTextDoc = { type: 'tableRow', content: [{ type: 'tableHeader' }] };
+    const bodyRow1: SbRichTextDoc = { type: 'tableRow', content: [{ type: 'tableCell' }] };
+    const bodyRow2: SbRichTextDoc = { type: 'tableRow', content: [{ type: 'tableCell' }] };
+    const rows = [headerRow, bodyRow1, bodyRow2];
+    expect(splitTableRows(rows)).toEqual({
+      headerRows: [headerRow],
+      bodyRows: [bodyRow1, bodyRow2],
+    });
+  });
+
+  it('only considers contiguous header rows at start', () => {
+    const headerRow1: SbRichTextDoc = { type: 'tableRow', content: [{ type: 'tableHeader' }] };
+    const bodyRow: SbRichTextDoc = { type: 'tableRow', content: [{ type: 'tableCell' }] };
+    const headerRow2: SbRichTextDoc = { type: 'tableRow', content: [{ type: 'tableHeader' }] };
+    const rows = [headerRow1, bodyRow, headerRow2];
+    expect(splitTableRows(rows)).toEqual({
+      headerRows: [headerRow1],
+      bodyRows: [bodyRow, headerRow2],
+    });
+  });
+});

--- a/packages/richtext/src/static/node-helpers.ts
+++ b/packages/richtext/src/static/node-helpers.ts
@@ -1,0 +1,147 @@
+import type { PMMark } from './types.generated';
+import type { SbRichTextDoc } from './types';
+import { deepEqual } from '../utils';
+
+// ============================================================================
+// Link Mark Helpers
+// ============================================================================
+
+/**
+ * Gets the link mark from a text node, or null if not present.
+ * @param node - The node to check
+ * @returns The link mark if found, null otherwise
+ */
+export function getTextNodeLinkMark(node: SbRichTextDoc): LinkMark | null {
+  if (node.type !== 'text' || !node.marks) {
+    return null;
+  }
+
+  for (const mark of node.marks) {
+    if (mark.type === 'link') {
+      return mark;
+    }
+  }
+  return null;
+}
+export type LinkMark = PMMark & { type: 'link' };
+
+/**
+ * Checks if two link marks have identical attributes.
+ * Used for merging adjacent text nodes with the same link.
+ * @param markA - First link mark
+ * @param markB - Second link mark
+ * @returns True if the marks have identical attributes
+ */
+export function areLinkMarksEqual(markA: LinkMark | null, markB: LinkMark | null): boolean {
+  if (!markA || !markB) {
+    return false;
+  }
+
+  return deepEqual(markA.attrs ?? {}, markB.attrs ?? {});
+}
+
+/**
+ * Gets non-link marks from a text node.
+ * Used when rendering text inside a merged link group.
+ * @param node - The text node
+ * @returns Array of marks excluding the link mark
+ */
+export function getInnerMarks(node: SbRichTextDoc): PMMark[] {
+  if (node.type !== 'text' || !node.marks) {
+    return [];
+  }
+  return node.marks.filter(m => m.type !== 'link');
+}
+
+/**
+ * Identifies groups of adjacent text nodes that share the same link mark.
+ * Returns an array of groups where each group is either:
+ * - A single non-text node or text node without link
+ * - Multiple consecutive text nodes with identical link marks
+ *
+ * @param children - Array of child nodes to group
+ * @returns Array of node groups for rendering
+ */
+export function groupLinkNodes(children: SbRichTextDoc[]): Array<{
+  nodes: SbRichTextDoc[];
+  linkMark: LinkMark | null;
+}> {
+  const groups: Array<{ nodes: SbRichTextDoc[]; linkMark: LinkMark | null }> = [];
+  let i = 0;
+  const len = children.length;
+
+  while (i < len) {
+    const node = children[i];
+    const linkMark = getTextNodeLinkMark(node);
+
+    if (linkMark) {
+      // Find end of link group (consecutive text nodes with same link)
+      const groupNodes: SbRichTextDoc[] = [node];
+      let end = i + 1;
+
+      while (end < len && areLinkMarksEqual(linkMark, getTextNodeLinkMark(children[end]))) {
+        groupNodes.push(children[end]);
+        end++;
+      }
+
+      groups.push({ nodes: groupNodes, linkMark });
+      i = end;
+    }
+    else {
+      groups.push({ nodes: [node], linkMark: null });
+      i++;
+    }
+  }
+
+  return groups;
+}
+
+// ============================================================================
+// Table Helpers
+// ============================================================================
+
+/**
+ * Checks if a table row contains only tableHeader cells.
+ * Used to determine which rows belong in thead vs tbody.
+ * @param row - The table row node to check
+ * @returns True if all cells are tableHeader type
+ */
+export function isTableHeaderRow(row: SbRichTextDoc): boolean {
+  const cells = row.content;
+  if (!cells?.length) {
+    return false;
+  }
+
+  for (const cell of cells) {
+    if (cell.type !== 'tableHeader') {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Splits table rows into header rows and body rows.
+ * Header rows are contiguous tableHeader rows at the start.
+ * @param rows - Array of table row nodes
+ * @returns Object with headerRows and bodyRows arrays
+ */
+export function splitTableRows(rows: SbRichTextDoc[] | undefined): {
+  headerRows: SbRichTextDoc[];
+  bodyRows: SbRichTextDoc[];
+} {
+  if (!rows?.length) {
+    return { headerRows: [], bodyRows: [] };
+  }
+
+  // Find where header rows end (contiguous tableHeader rows at start)
+  let headerEnd = 0;
+  while (headerEnd < rows.length && isTableHeaderRow(rows[headerEnd])) {
+    headerEnd++;
+  }
+
+  return {
+    headerRows: rows.slice(0, headerEnd),
+    bodyRows: rows.slice(headerEnd),
+  };
+}

--- a/packages/richtext/src/static/render-richtext.test.ts
+++ b/packages/richtext/src/static/render-richtext.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { richTextRenderer } from './richtext-renderer';
+import { renderRichText } from './render-richtext';
 import type { SbRichTextDoc, SbRichTextOptions } from './types';
 
 // ============================================================================
@@ -67,18 +67,18 @@ const table = (rows: SbRichTextDoc[]): SbRichTextDoc => ({
 // Tests: Input Handling
 // ============================================================================
 
-describe('richTextRenderer', () => {
+describe('renderRichText', () => {
   describe('input handling', () => {
     it('returns empty string for null input', () => {
-      expect(richTextRenderer(null)).toBe('');
+      expect(renderRichText(null)).toBe('');
     });
 
     it('returns empty string for undefined input', () => {
-      expect(richTextRenderer(undefined)).toBe('');
+      expect(renderRichText(undefined)).toBe('');
     });
 
     it('returns empty string for empty array', () => {
-      expect(richTextRenderer([])).toBe('');
+      expect(renderRichText([])).toBe('');
     });
 
     it('renders array of nodes', () => {
@@ -86,7 +86,7 @@ describe('richTextRenderer', () => {
         { type: 'paragraph', content: [text('First')] },
         { type: 'paragraph', content: [text('Second')] },
       ];
-      expect(richTextRenderer(nodes)).toBe('<p>First</p><p>Second</p>');
+      expect(renderRichText(nodes)).toBe('<p>First</p><p>Second</p>');
     });
 
     it('renders doc node without wrapper', () => {
@@ -94,7 +94,7 @@ describe('richTextRenderer', () => {
         type: 'doc',
         content: [{ type: 'paragraph', content: [text('Hello')] }],
       };
-      expect(richTextRenderer(doc)).toBe('<p>Hello</p>');
+      expect(renderRichText(doc)).toBe('<p>Hello</p>');
     });
 
     it('renders nested doc nodes', () => {
@@ -105,12 +105,12 @@ describe('richTextRenderer', () => {
           { type: 'doc', content: [{ type: 'paragraph', content: [text('Inner')] }] },
         ],
       };
-      expect(richTextRenderer(nested)).toBe('<p>Outer</p><p>Inner</p>');
+      expect(renderRichText(nested)).toBe('<p>Outer</p><p>Inner</p>');
     });
 
     it('renders single non-doc node directly', () => {
       const node: SbRichTextDoc = { type: 'paragraph', content: [text('Direct')] };
-      expect(richTextRenderer(node)).toBe('<p>Direct</p>');
+      expect(renderRichText(node)).toBe('<p>Direct</p>');
     });
   });
 
@@ -122,12 +122,12 @@ describe('richTextRenderer', () => {
     describe('paragraph', () => {
       it('renders basic paragraph', () => {
         const node: SbRichTextDoc = { type: 'paragraph', content: [text('Hello')] };
-        expect(richTextRenderer(node)).toBe('<p>Hello</p>');
+        expect(renderRichText(node)).toBe('<p>Hello</p>');
       });
 
       it('renders empty paragraph', () => {
         const node: SbRichTextDoc = { type: 'paragraph', content: [] };
-        expect(richTextRenderer(node)).toBe('<p></p>');
+        expect(renderRichText(node)).toBe('<p></p>');
       });
     });
 
@@ -138,7 +138,7 @@ describe('richTextRenderer', () => {
           attrs: { level, textAlign: null },
           content: [text(`Heading ${level}`)],
         };
-        expect(richTextRenderer(heading)).toBe(`<h${level}>Heading ${level}</h${level}>`);
+        expect(renderRichText(heading)).toBe(`<h${level}>Heading ${level}</h${level}>`);
       });
     });
 
@@ -148,7 +148,7 @@ describe('richTextRenderer', () => {
           type: 'blockquote',
           content: [{ type: 'paragraph', content: [text('Quote')] }],
         };
-        expect(richTextRenderer(blockquote)).toBe('<blockquote><p>Quote</p></blockquote>');
+        expect(renderRichText(blockquote)).toBe('<blockquote><p>Quote</p></blockquote>');
       });
     });
 
@@ -161,7 +161,7 @@ describe('richTextRenderer', () => {
             { type: 'list_item', content: [{ type: 'paragraph', content: [text('Item 2')] }] },
           ],
         };
-        expect(richTextRenderer(list)).toBe('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>');
+        expect(renderRichText(list)).toBe('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>');
       });
 
       it('renders ordered list', () => {
@@ -173,7 +173,7 @@ describe('richTextRenderer', () => {
             { type: 'list_item', content: [{ type: 'paragraph', content: [text('Second')] }] },
           ],
         };
-        expect(richTextRenderer(list)).toBe('<ol order="1"><li><p>First</p></li><li><p>Second</p></li></ol>');
+        expect(renderRichText(list)).toBe('<ol order="1"><li><p>First</p></li><li><p>Second</p></li></ol>');
       });
     });
 
@@ -184,7 +184,7 @@ describe('richTextRenderer', () => {
           attrs: { class: 'javascript' },
           content: [text('const x = 1;')],
         };
-        expect(richTextRenderer(codeBlock)).toBe('<pre><code class="javascript">const x = 1;</code></pre>');
+        expect(renderRichText(codeBlock)).toBe('<pre><code class="javascript">const x = 1;</code></pre>');
       });
 
       it('does not leak language as attribute', () => {
@@ -193,19 +193,19 @@ describe('richTextRenderer', () => {
           attrs: { class: 'js' },
           content: [text('code')],
         };
-        expect(richTextRenderer(codeBlock)).not.toContain('language=');
+        expect(renderRichText(codeBlock)).not.toContain('language=');
       });
     });
 
     describe('horizontal rule', () => {
       it('renders hr as self-closing', () => {
-        expect(richTextRenderer({ type: 'horizontal_rule' })).toBe('<hr>');
+        expect(renderRichText({ type: 'horizontal_rule' })).toBe('<hr>');
       });
     });
 
     describe('hard break', () => {
       it('renders br as self-closing', () => {
-        expect(richTextRenderer({ type: 'hard_break' })).toBe('<br>');
+        expect(renderRichText({ type: 'hard_break' })).toBe('<br>');
       });
     });
 
@@ -223,7 +223,7 @@ describe('richTextRenderer', () => {
             meta_data: null,
           },
         };
-        expect(richTextRenderer(image)).toBe(
+        expect(renderRichText(image)).toBe(
           '<img id="123" src="https://example.com/image.jpg" alt="An image" title="Image title">',
         );
       });
@@ -241,7 +241,7 @@ describe('richTextRenderer', () => {
             meta_data: { alt: 'meta', title: null, source: null, copyright: null },
           },
         };
-        const html = richTextRenderer(image);
+        const html = renderRichText(image);
         expect(html).not.toContain('source=');
         expect(html).not.toContain('copyright=');
         expect(html).not.toContain('meta_data=');
@@ -260,7 +260,7 @@ describe('richTextRenderer', () => {
             meta_data: null,
           },
         };
-        const html = richTextRenderer(image, { optimizeImages: true });
+        const html = renderRichText(image, { optimizeImages: true });
         expect(html).toContain('src="https://a.storyblok.com/f/12345/image.jpg/m/"');
       });
 
@@ -277,7 +277,7 @@ describe('richTextRenderer', () => {
             meta_data: null,
           },
         };
-        const html = richTextRenderer(image, {
+        const html = renderRichText(image, {
           optimizeImages: { width: 800, height: 600 },
         });
         expect(html).toContain('src="https://a.storyblok.com/f/12345/image.jpg/m/800x600/"');
@@ -298,7 +298,7 @@ describe('richTextRenderer', () => {
             meta_data: null,
           },
         };
-        const html = richTextRenderer(image, {
+        const html = renderRichText(image, {
           optimizeImages: { filters: { quality: 80, format: 'webp' } },
         });
         expect(html).toContain('filters:quality(80):format(webp)');
@@ -317,7 +317,7 @@ describe('richTextRenderer', () => {
             meta_data: null,
           },
         };
-        const html = richTextRenderer(image, {
+        const html = renderRichText(image, {
           optimizeImages: { loading: 'lazy' },
         });
         expect(html).toContain('loading="lazy"');
@@ -334,7 +334,7 @@ describe('richTextRenderer', () => {
             fallbackImage: 'https://cdn.example.com/rocket.png',
           },
         };
-        const html = richTextRenderer(emoji);
+        const html = renderRichText(emoji);
         expect(html).toBe('<img data-emoji="🚀" data-name="rocket" src="https://cdn.example.com/rocket.png" draggable="false" loading="lazy" style="width: 1.25em; height: 1.25em; vertical-align: text-top;">');
       });
     });
@@ -347,7 +347,7 @@ describe('richTextRenderer', () => {
   describe('tables', () => {
     it('renders basic table with tbody', () => {
       const t = table([tableRow([tableCell('A'), tableCell('B')])]);
-      expect(richTextRenderer(t)).toBe(
+      expect(renderRichText(t)).toBe(
         '<table><tbody><tr><td colspan="1" rowspan="1"><p>A</p></td><td colspan="1" rowspan="1"><p>B</p></td></tr></tbody></table>',
       );
     });
@@ -357,7 +357,7 @@ describe('richTextRenderer', () => {
         tableRow([tableHeader('H1'), tableHeader('H2')]),
         tableRow([tableCell('C1'), tableCell('C2')]),
       ]);
-      expect(richTextRenderer(t)).toBe(
+      expect(renderRichText(t)).toBe(
         '<table><thead><tr><th colspan="1" rowspan="1"><p>H1</p></th><th colspan="1" rowspan="1"><p>H2</p></th></tr></thead>'
         + '<tbody><tr><td colspan="1" rowspan="1"><p>C1</p></td><td colspan="1" rowspan="1"><p>C2</p></td></tr></tbody></table>',
       );
@@ -365,22 +365,22 @@ describe('richTextRenderer', () => {
 
     it('renders colspan and rowspan', () => {
       const t = table([tableRow([tableCell('Merged', { colspan: 2, rowspan: 2 })])]);
-      expect(richTextRenderer(t)).toContain('colspan="2" rowspan="2"');
+      expect(renderRichText(t)).toContain('colspan="2" rowspan="2"');
     });
 
     it('renders colwidth as style', () => {
       const t = table([tableRow([tableCell('Wide', { colwidth: [200] })])]);
-      expect(richTextRenderer(t)).toContain('style="width: 200px;"');
+      expect(renderRichText(t)).toContain('style="width: 200px;"');
     });
 
     it('renders backgroundColor as style', () => {
       const t = table([tableRow([tableCell('Colored', { backgroundColor: '#FF0000' })])]);
-      expect(richTextRenderer(t)).toContain('background-color: #FF0000;');
+      expect(renderRichText(t)).toContain('background-color: #FF0000;');
     });
 
     it('combines multiple styles', () => {
       const t = table([tableRow([tableCell('Styled', { colwidth: [100], backgroundColor: '#00FF00' })])]);
-      const html = richTextRenderer(t);
+      const html = renderRichText(t);
       expect(html).toContain('width: 100px;');
       expect(html).toContain('background-color: #00FF00;');
     });
@@ -393,57 +393,57 @@ describe('richTextRenderer', () => {
   describe('marks', () => {
     it('renders bold', () => {
       const node = text('Bold', [{ type: 'bold' }]);
-      expect(richTextRenderer(node)).toBe('<strong>Bold</strong>');
+      expect(renderRichText(node)).toBe('<strong>Bold</strong>');
     });
 
     it('renders italic', () => {
       const node = text('Italic', [{ type: 'italic' }]);
-      expect(richTextRenderer(node)).toBe('<em>Italic</em>');
+      expect(renderRichText(node)).toBe('<em>Italic</em>');
     });
 
     it('renders strike', () => {
       const node = text('Strike', [{ type: 'strike' }]);
-      expect(richTextRenderer(node)).toBe('<s>Strike</s>');
+      expect(renderRichText(node)).toBe('<s>Strike</s>');
     });
 
     it('renders underline', () => {
       const node = text('Underline', [{ type: 'underline' }]);
-      expect(richTextRenderer(node)).toBe('<u>Underline</u>');
+      expect(renderRichText(node)).toBe('<u>Underline</u>');
     });
 
     it('renders code', () => {
       const node = text('code', [{ type: 'code' }]);
-      expect(richTextRenderer(node)).toBe('<code>code</code>');
+      expect(renderRichText(node)).toBe('<code>code</code>');
     });
 
     it('renders superscript', () => {
       const node = text('sup', [{ type: 'superscript' }]);
-      expect(richTextRenderer(node)).toBe('<sup>sup</sup>');
+      expect(renderRichText(node)).toBe('<sup>sup</sup>');
     });
 
     it('renders subscript', () => {
       const node = text('sub', [{ type: 'subscript' }]);
-      expect(richTextRenderer(node)).toBe('<sub>sub</sub>');
+      expect(renderRichText(node)).toBe('<sub>sub</sub>');
     });
 
     it('renders nested marks', () => {
       const node = text('Bold Italic', [{ type: 'bold' }, { type: 'italic' }]);
-      expect(richTextRenderer(node)).toBe('<em><strong>Bold Italic</strong></em>');
+      expect(renderRichText(node)).toBe('<em><strong>Bold Italic</strong></em>');
     });
 
     it('renders anchor mark as span with id', () => {
       const node = text('Anchored', [{ type: 'anchor', attrs: { id: 'section-1' } }]);
-      expect(richTextRenderer(node)).toBe('<span id="section-1">Anchored</span>');
+      expect(renderRichText(node)).toBe('<span id="section-1">Anchored</span>');
     });
 
     it('renders styled mark with class', () => {
       const node = text('Styled', [{ type: 'styled', attrs: { class: 'highlight' } }]);
-      expect(richTextRenderer(node)).toBe('<span class="highlight">Styled</span>');
+      expect(renderRichText(node)).toBe('<span class="highlight">Styled</span>');
     });
 
     it('renders textStyle with color', () => {
       const node = text('Red', [{ type: 'textStyle', attrs: { color: 'red', id: null, class: null } }]);
-      expect(richTextRenderer(node)).toBe('<span style="color: red;">Red</span>');
+      expect(renderRichText(node)).toBe('<span style="color: red;">Red</span>');
     });
   });
 
@@ -454,32 +454,32 @@ describe('richTextRenderer', () => {
   describe('links', () => {
     it('renders external URL link', () => {
       const node = text('Click', [linkMark('https://example.com', { target: '_blank' })]);
-      expect(richTextRenderer(node)).toBe('<a href="https://example.com" target="_blank">Click</a>');
+      expect(renderRichText(node)).toBe('<a href="https://example.com" target="_blank">Click</a>');
     });
 
     it('renders internal story link', () => {
       const node = text('Page', [linkMark('/about', { linktype: 'story' })]);
-      expect(richTextRenderer(node)).toBe('<a href="/about">Page</a>');
+      expect(renderRichText(node)).toBe('<a href="/about">Page</a>');
     });
 
     it('renders story link with anchor', () => {
       const node = text('Section', [linkMark('/page', { linktype: 'story', anchor: 'intro' })]);
-      expect(richTextRenderer(node)).toBe('<a href="/page#intro">Section</a>');
+      expect(renderRichText(node)).toBe('<a href="/page#intro">Section</a>');
     });
 
     it('renders email link with mailto:', () => {
       const node = text('Email', [linkMark('test@example.com', { linktype: 'email' })]);
-      expect(richTextRenderer(node)).toBe('<a href="mailto:test@example.com">Email</a>');
+      expect(renderRichText(node)).toBe('<a href="mailto:test@example.com">Email</a>');
     });
 
     it('does not duplicate mailto: prefix', () => {
       const node = text('Email', [linkMark('mailto:test@example.com', { linktype: 'email' })]);
-      expect(richTextRenderer(node)).toBe('<a href="mailto:test@example.com">Email</a>');
+      expect(renderRichText(node)).toBe('<a href="mailto:test@example.com">Email</a>');
     });
 
     it('renders asset link', () => {
       const node = text('Download', [linkMark('https://assets.example.com/file.pdf', { linktype: 'asset' })]);
-      expect(richTextRenderer(node)).toBe('<a href="https://assets.example.com/file.pdf">Download</a>');
+      expect(renderRichText(node)).toBe('<a href="https://assets.example.com/file.pdf">Download</a>');
     });
 
     it('renders link without href when empty', () => {
@@ -488,12 +488,12 @@ describe('richTextRenderer', () => {
         text: 'No href',
         marks: [{ type: 'link', attrs: { href: '', linktype: 'url', uuid: null, anchor: null, target: null } }],
       };
-      expect(richTextRenderer(node)).toBe('<a>No href</a>');
+      expect(renderRichText(node)).toBe('<a>No href</a>');
     });
 
     it('filters null attributes', () => {
       const node = text('Link', [linkMark('/')]);
-      const html = richTextRenderer(node);
+      const html = renderRichText(node);
       expect(html).not.toContain('target=');
       expect(html).not.toContain('uuid=');
       expect(html).not.toContain('anchor=');
@@ -509,7 +509,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      const html = richTextRenderer(node);
+      const html = renderRichText(node);
       expect(html).toBe('<p><a href="https://example.com" title="google" rel="noopener" data-custom="foo">Click me</a></p>');
     });
   });
@@ -530,7 +530,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      expect(richTextRenderer(content)).toBe('<p><a href="/url">Hello World</a></p>');
+      expect(renderRichText(content)).toBe('<p><a href="/url">Hello World</a></p>');
     });
     it('merge groups when link with same custom attributes', () => {
       const content: SbRichTextDoc = {
@@ -543,7 +543,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      expect(richTextRenderer(content)).toBe('<p><a href="/a" title="google">Hello Storyblok</a></p>');
+      expect(renderRichText(content)).toBe('<p><a href="/a" title="google">Hello Storyblok</a></p>');
     });
     it('preserves inner marks when merging', () => {
       const content: SbRichTextDoc = {
@@ -557,7 +557,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      expect(richTextRenderer(content)).toBe('<p><a href="/url">normal <strong>bold</strong> text</a></p>');
+      expect(renderRichText(content)).toBe('<p><a href="/url">normal <strong>bold</strong> text</a></p>');
     });
 
     it('handles multiple inner marks', () => {
@@ -574,7 +574,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      expect(richTextRenderer(content)).toBe(
+      expect(renderRichText(content)).toBe(
         '<p><a href="/url">start <strong>bold</strong> and <em>italic</em> end</a></p>',
       );
     });
@@ -591,7 +591,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      expect(richTextRenderer(content)).toBe('<p><a href="/x">Before </a><br><a href="/x">After</a></p>');
+      expect(renderRichText(content)).toBe('<p><a href="/x">Before </a><br><a href="/x">After</a></p>');
     });
 
     it('separates groups when link attrs differ', () => {
@@ -605,7 +605,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      expect(richTextRenderer(content)).toBe('<p><a href="/a">A</a><a href="/a" target="_blank">B</a></p>');
+      expect(renderRichText(content)).toBe('<p><a href="/a">A</a><a href="/a" target="_blank">B</a></p>');
     });
     it('separates groups when link with different custom attributes', () => {
       const content: SbRichTextDoc = {
@@ -618,7 +618,7 @@ describe('richTextRenderer', () => {
           ],
         }],
       };
-      expect(richTextRenderer(content)).toBe('<p><a href="/a" title="google">A</a><a href="/a" title="new">B</a></p>');
+      expect(renderRichText(content)).toBe('<p><a href="/a" title="google">A</a><a href="/a" title="new">B</a></p>');
     });
   });
 
@@ -633,7 +633,7 @@ describe('richTextRenderer', () => {
         attrs: { textAlign: 'right' },
         content: [text('Right')],
       };
-      expect(richTextRenderer(p)).toBe('<p style="text-align: right;">Right</p>');
+      expect(renderRichText(p)).toBe('<p style="text-align: right;">Right</p>');
     });
 
     it.each(['left', 'center', 'right', 'justify'] as const)('supports %s alignment', (align) => {
@@ -642,7 +642,7 @@ describe('richTextRenderer', () => {
         attrs: { textAlign: align },
         content: [text('Text')],
       };
-      expect(richTextRenderer(p)).toContain(`text-align: ${align};`);
+      expect(renderRichText(p)).toContain(`text-align: ${align};`);
     });
 
     it('renders heading with alignment', () => {
@@ -651,7 +651,7 @@ describe('richTextRenderer', () => {
         attrs: { level: 2, textAlign: 'center' },
         content: [text('Centered')],
       };
-      expect(richTextRenderer(heading)).toBe('<h2 style="text-align: center;">Centered</h2>');
+      expect(renderRichText(heading)).toBe('<h2 style="text-align: center;">Centered</h2>');
     });
 
     it('combines alignment with marks', () => {
@@ -660,7 +660,7 @@ describe('richTextRenderer', () => {
         attrs: { textAlign: 'center' },
         content: [text('Styled', [{ type: 'bold' }])],
       };
-      expect(richTextRenderer(p)).toBe('<p style="text-align: center;"><strong>Styled</strong></p>');
+      expect(renderRichText(p)).toBe('<p style="text-align: center;"><strong>Styled</strong></p>');
     });
 
     it('renders empty paragraph with alignment', () => {
@@ -669,7 +669,7 @@ describe('richTextRenderer', () => {
         attrs: { textAlign: 'center' },
         content: [],
       };
-      expect(richTextRenderer(p)).toBe('<p style="text-align: center;"></p>');
+      expect(renderRichText(p)).toBe('<p style="text-align: center;"></p>');
     });
   });
 
@@ -681,11 +681,11 @@ describe('richTextRenderer', () => {
     it('overrides node rendering', () => {
       const options: SbRichTextOptions = {
         renderers: {
-          paragraph: ({ content }) => `<div class="custom">${richTextRenderer(content, options)}</div>`,
+          paragraph: ({ content }) => `<div class="custom">${renderRichText(content, options)}</div>`,
         },
       };
       const node: SbRichTextDoc = { type: 'paragraph', content: [text('Hello')] };
-      expect(richTextRenderer(node, options)).toBe('<div class="custom">Hello</div>');
+      expect(renderRichText(node, options)).toBe('<div class="custom">Hello</div>');
     });
 
     it('overrides mark rendering', () => {
@@ -694,13 +694,13 @@ describe('richTextRenderer', () => {
           bold: ({ children }) => `<b class="heavy">${children}</b>`,
         },
       };
-      expect(richTextRenderer(text('Bold', [{ type: 'bold' }]), options)).toBe('<b class="heavy">Bold</b>');
+      expect(renderRichText(text('Bold', [{ type: 'bold' }]), options)).toBe('<b class="heavy">Bold</b>');
     });
 
     it('supports multiple custom renderers', () => {
       const options: SbRichTextOptions = {
         renderers: {
-          heading: ({ attrs, content }) => `<h${attrs?.level} class="title">${richTextRenderer(content, options)}</h${attrs?.level}>`,
+          heading: ({ attrs, content }) => `<h${attrs?.level} class="title">${renderRichText(content, options)}</h${attrs?.level}>`,
           bold: ({ children }) => `<strong class="emphasis">${children}</strong>`,
         },
       };
@@ -709,8 +709,29 @@ describe('richTextRenderer', () => {
         attrs: { level: 1, textAlign: null },
         content: [text('Title', [{ type: 'bold' }])],
       };
-      expect(richTextRenderer(heading, options)).toBe(
+      expect(renderRichText(heading, options)).toBe(
         '<h1 class="title"><strong class="emphasis">Title</strong></h1>',
+      );
+    });
+
+    it('allows custom code_block renderer to control attribute placement', () => {
+      const options: SbRichTextOptions = {
+        renderers: {
+          code_block: ({ attrs, content }) => {
+            const lang = (attrs?.class as string) || '';
+            // User decides: class on <pre>, data-lang on <code>
+            return `<pre class="language-${lang}"><code data-lang="${lang}">${renderRichText(content, options)}</code></pre>`;
+          },
+        },
+      };
+      const codeBlock: SbRichTextDoc = {
+        type: 'code_block',
+        attrs: { class: 'typescript' },
+        content: [text('const x: number = 1;')],
+      };
+      const html = renderRichText(codeBlock, options);
+      expect(html).toBe(
+        '<pre class="language-typescript"><code data-lang="typescript">const x: number = 1;</code></pre>',
       );
     });
   });
@@ -736,14 +757,14 @@ describe('richTextRenderer', () => {
 
     it('warns when no custom renderer provided', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      richTextRenderer(blokDoc);
+      renderRichText(blokDoc);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('blok'));
       warnSpy.mockRestore();
     });
 
     it('returns empty string without custom renderer', () => {
       vi.spyOn(console, 'warn').mockImplementation(() => {});
-      expect(richTextRenderer(blokDoc)).toBe('');
+      expect(renderRichText(blokDoc)).toBe('');
       vi.restoreAllMocks();
     });
 
@@ -756,7 +777,7 @@ describe('richTextRenderer', () => {
           },
         },
       };
-      expect(richTextRenderer(blokDoc, options)).toBe(
+      expect(renderRichText(blokDoc, options)).toBe(
         '<button data-uid="1">Click Me</button><button data-uid="2">Submit</button>',
       );
     });
@@ -767,7 +788,7 @@ describe('richTextRenderer', () => {
         content: [{ type: 'blok', attrs: { id: 'x', body: [] } }],
       };
       vi.spyOn(console, 'warn').mockImplementation(() => {});
-      expect(richTextRenderer(emptyBlok)).toBe('');
+      expect(renderRichText(emptyBlok)).toBe('');
       vi.restoreAllMocks();
     });
 
@@ -777,7 +798,7 @@ describe('richTextRenderer', () => {
         content: [{ type: 'blok', attrs: { id: 'x', body: null } }],
       };
       vi.spyOn(console, 'warn').mockImplementation(() => {});
-      expect(richTextRenderer(nullBlok)).toBe('');
+      expect(renderRichText(nullBlok)).toBe('');
       vi.restoreAllMocks();
     });
 
@@ -795,7 +816,7 @@ describe('richTextRenderer', () => {
           { type: 'paragraph', content: [text('After')] },
         ],
       };
-      expect(richTextRenderer(content, options)).toBe('<p>Before</p><widget /><p>After</p>');
+      expect(renderRichText(content, options)).toBe('<p>Before</p><widget /><p>After</p>');
     });
   });
 
@@ -806,12 +827,12 @@ describe('richTextRenderer', () => {
   describe('xSS prevention', () => {
     it('escapes HTML in text content', () => {
       const node = text('<script>alert("xss")</script>');
-      expect(richTextRenderer(node)).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+      expect(renderRichText(node)).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
     });
 
     it('escapes HTML in attributes', () => {
       const node = text('Link', [linkMark('javascript:alert("xss")')]);
-      expect(richTextRenderer(node)).toContain('href="javascript:alert(&quot;xss&quot;)"');
+      expect(renderRichText(node)).toContain('href="javascript:alert(&quot;xss&quot;)"');
     });
   });
 });

--- a/packages/richtext/src/static/render-richtext.ts
+++ b/packages/richtext/src/static/render-richtext.ts
@@ -18,14 +18,14 @@ type TextNode = PMNode & { type: 'text' };
  *
  * @example
  * ```ts
- * const html = richTextRenderer({
+ * const html = renderRichText({
  *   type: 'doc',
  *   content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }]
  * });
  * // => '<p>Hello</p>'
  * ```
  */
-export function richTextRenderer(
+export function renderRichText(
   document: SbRichTextDoc | SbRichTextDoc[] | null | undefined,
   options?: SbRichTextOptions,
 ): string {
@@ -43,7 +43,6 @@ export function richTextRenderer(
 
 /** Renders a single node to HTML. */
 function renderNode(node: SbRichTextDoc, options?: SbRichTextOptions): string {
-  // Text nodes: apply marks and escape content
   if (node.type === 'text') {
     return renderTextNode(node as TextNode, node.marks, options);
   }
@@ -54,7 +53,6 @@ function renderNode(node: SbRichTextDoc, options?: SbRichTextOptions): string {
     return (customRenderer as (props: typeof node) => string)(node);
   }
 
-  // Blok nodes require custom renderer
   if (node.type === 'blok') {
     console.warn('Rendering of "blok" nodes is not supported in richTextRenderer.');
     return '';
@@ -67,29 +65,25 @@ function renderNode(node: SbRichTextDoc, options?: SbRichTextOptions): string {
     return node.content ? renderChildren(node.content, options) : '';
   }
 
-  // Image nodes: apply optimization if configured
   if (node.type === 'image' && options?.optimizeImages) {
     return renderOptimizedImage(node, options);
   }
 
   const htmlAttrs = buildHtmlAttrs(node.type, node.attrs);
 
-  // Self-closing tags
   if (isSelfClosing(tag)) {
     return `<${tag}${htmlAttrs}>`;
   }
 
-  // Table: special thead/tbody grouping
   if (node.type === 'table') {
     return `<${tag}${htmlAttrs}>${renderTableRows(node.content, options)}</${tag}>`;
   }
 
   const content = node.content ? renderChildren(node.content, options) : '';
 
-  // Static children (e.g., pre > code)
   const staticChildren = getStaticChildren(node);
   if (staticChildren) {
-    const inner = renderStaticStructure(staticChildren, node.attrs, content);
+    const inner = renderStaticStructure(node.type, staticChildren, node.attrs, content);
     return `<${tag}>${inner}</${tag}>`;
   }
 
@@ -208,7 +202,6 @@ function renderLinkGroup(
   linkMark: PMMark,
   options?: SbRichTextOptions,
 ): string {
-  // Render each text node with only its non-link marks
   let inner = '';
   for (let i = start; i < end; i++) {
     const node = children[i] as TextNode;
@@ -244,7 +237,6 @@ function renderTableRows(
 
   let result = '';
 
-  // Render thead
   if (headerEnd > 0) {
     result += '<thead>';
     for (let i = 0; i < headerEnd; i++) {
@@ -253,7 +245,6 @@ function renderTableRows(
     result += '</thead>';
   }
 
-  // Render tbody
   if (headerEnd < rows.length) {
     result += '<tbody>';
     for (let i = headerEnd; i < rows.length; i++) {
@@ -269,6 +260,7 @@ function renderTableRows(
 
 /** Renders nested static structure defined in render map. */
 function renderStaticStructure(
+  type: SbRichTextElement,
   specs: readonly RenderSpec[],
   parentAttrs: Record<string, unknown> | undefined,
   content: string,
@@ -278,14 +270,14 @@ function renderStaticStructure(
   for (const spec of specs) {
     const { tag, children, attrs: specAttrs } = spec;
     const mergedAttrs = { ...specAttrs, ...parentAttrs };
-    const htmlAttrs = attrsToHtmlString(mergedAttrs);
+    const htmlAttrs = buildHtmlAttrs(type, mergedAttrs);
 
     if (isSelfClosing(tag)) {
       result += `<${tag}${htmlAttrs}>`;
     }
     else {
       const inner = children
-        ? renderStaticStructure(children, parentAttrs, content)
+        ? renderStaticStructure(type, children, parentAttrs, content)
         : content;
       result += `<${tag}${htmlAttrs}>${inner}</${tag}>`;
     }
@@ -301,7 +293,6 @@ function buildHtmlAttrs(type: SbRichTextElement, attrs: Record<string, unknown> 
     rowspan: 'rowspan',
   });
 
-  // Convert style object to string if present
   const styleObj = processed.style as Record<string, AttrValue> | undefined;
   const finalAttrs: Record<string, unknown> = { ...processed };
 

--- a/packages/richtext/src/static/richtext-renderer.test.ts
+++ b/packages/richtext/src/static/richtext-renderer.test.ts
@@ -1,475 +1,817 @@
 import { describe, expect, it, vi } from 'vitest';
 import { richTextRenderer } from './richtext-renderer';
-import type { StoryblokRichTextJson } from './types';
+import type { SbRichTextDoc, SbRichTextOptions } from './types';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/** Creates a text node. */
+const text = (content: string, marks?: SbRichTextDoc['marks']): SbRichTextDoc => ({
+  type: 'text',
+  text: content,
+  ...(marks && { marks }),
+});
+
+/** Creates a link mark. */
+const linkMark = (
+  href: string,
+  options: { target?: '_blank' | '_self'; linktype?: 'url' | 'story' | 'email' | 'asset'; anchor?: string; custom?: Record<string, unknown> } = {},
+): NonNullable<SbRichTextDoc['marks']>[number] => ({
+  type: 'link',
+  attrs: {
+    href,
+    linktype: options.linktype ?? 'url',
+    target: options.target ?? null,
+    anchor: options.anchor ?? null,
+    uuid: null,
+    custom: options.custom ?? undefined,
+  },
+});
+
+/** Creates a table cell. */
+const tableCell = (
+  content: string,
+  attrs: { colspan?: number; rowspan?: number; colwidth?: number[]; backgroundColor?: string } = {},
+): SbRichTextDoc => ({
+  type: 'tableCell',
+  content: [{ type: 'paragraph', content: [text(content)] }],
+  attrs: {
+    colspan: attrs.colspan ?? 1,
+    rowspan: attrs.rowspan ?? 1,
+    ...(attrs.colwidth && { colwidth: attrs.colwidth }),
+    ...(attrs.backgroundColor && { backgroundColor: attrs.backgroundColor }),
+  },
+});
+
+/** Creates a table header cell. */
+const tableHeader = (content: string): SbRichTextDoc => ({
+  type: 'tableHeader',
+  content: [{ type: 'paragraph', content: [text(content)] }],
+  attrs: { colspan: 1, rowspan: 1 },
+});
+
+/** Creates a table row. */
+const tableRow = (cells: SbRichTextDoc[]): SbRichTextDoc => ({
+  type: 'tableRow',
+  content: cells,
+});
+
+/** Creates a table. */
+const table = (rows: SbRichTextDoc[]): SbRichTextDoc => ({
+  type: 'table',
+  content: rows,
+});
+
+// ============================================================================
+// Tests: Input Handling
+// ============================================================================
 
 describe('richTextRenderer', () => {
-  describe('empty and null inputs', () => {
-    it('should return empty string for null input', () => {
-      const result = richTextRenderer(null as unknown as StoryblokRichTextJson);
-      expect(result).toBe('');
+  describe('input handling', () => {
+    it('returns empty string for null input', () => {
+      expect(richTextRenderer(null)).toBe('');
     });
 
-    it('should return empty string for undefined input', () => {
-      const result = richTextRenderer(
-        undefined as unknown as StoryblokRichTextJson,
-      );
-      expect(result).toBe('');
+    it('returns empty string for undefined input', () => {
+      expect(richTextRenderer(undefined)).toBe('');
     });
 
-    it('should return empty string for doc with empty content', () => {
-      const doc: StoryblokRichTextJson = {
+    it('returns empty string for empty array', () => {
+      expect(richTextRenderer([])).toBe('');
+    });
+
+    it('renders array of nodes', () => {
+      const nodes: SbRichTextDoc[] = [
+        { type: 'paragraph', content: [text('First')] },
+        { type: 'paragraph', content: [text('Second')] },
+      ];
+      expect(richTextRenderer(nodes)).toBe('<p>First</p><p>Second</p>');
+    });
+
+    it('renders doc node without wrapper', () => {
+      const doc: SbRichTextDoc = {
         type: 'doc',
+        content: [{ type: 'paragraph', content: [text('Hello')] }],
+      };
+      expect(richTextRenderer(doc)).toBe('<p>Hello</p>');
+    });
+
+    it('renders nested doc nodes', () => {
+      const nested: SbRichTextDoc = {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [text('Outer')] },
+          { type: 'doc', content: [{ type: 'paragraph', content: [text('Inner')] }] },
+        ],
+      };
+      expect(richTextRenderer(nested)).toBe('<p>Outer</p><p>Inner</p>');
+    });
+
+    it('renders single non-doc node directly', () => {
+      const node: SbRichTextDoc = { type: 'paragraph', content: [text('Direct')] };
+      expect(richTextRenderer(node)).toBe('<p>Direct</p>');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Block Types
+  // ============================================================================
+
+  describe('block types', () => {
+    describe('paragraph', () => {
+      it('renders basic paragraph', () => {
+        const node: SbRichTextDoc = { type: 'paragraph', content: [text('Hello')] };
+        expect(richTextRenderer(node)).toBe('<p>Hello</p>');
+      });
+
+      it('renders empty paragraph', () => {
+        const node: SbRichTextDoc = { type: 'paragraph', content: [] };
+        expect(richTextRenderer(node)).toBe('<p></p>');
+      });
+    });
+
+    describe('heading', () => {
+      it.each([1, 2, 3, 4, 5, 6] as const)('renders h%i', (level) => {
+        const heading: SbRichTextDoc = {
+          type: 'heading',
+          attrs: { level, textAlign: null },
+          content: [text(`Heading ${level}`)],
+        };
+        expect(richTextRenderer(heading)).toBe(`<h${level}>Heading ${level}</h${level}>`);
+      });
+    });
+
+    describe('blockquote', () => {
+      it('renders blockquote', () => {
+        const blockquote: SbRichTextDoc = {
+          type: 'blockquote',
+          content: [{ type: 'paragraph', content: [text('Quote')] }],
+        };
+        expect(richTextRenderer(blockquote)).toBe('<blockquote><p>Quote</p></blockquote>');
+      });
+    });
+
+    describe('lists', () => {
+      it('renders bullet list', () => {
+        const list: SbRichTextDoc = {
+          type: 'bullet_list',
+          content: [
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('Item 1')] }] },
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('Item 2')] }] },
+          ],
+        };
+        expect(richTextRenderer(list)).toBe('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>');
+      });
+
+      it('renders ordered list', () => {
+        const list: SbRichTextDoc = {
+          type: 'ordered_list',
+          attrs: { order: 1 },
+          content: [
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('First')] }] },
+            { type: 'list_item', content: [{ type: 'paragraph', content: [text('Second')] }] },
+          ],
+        };
+        expect(richTextRenderer(list)).toBe('<ol order="1"><li><p>First</p></li><li><p>Second</p></li></ol>');
+      });
+    });
+
+    describe('code block', () => {
+      it('renders code block with language class', () => {
+        const codeBlock: SbRichTextDoc = {
+          type: 'code_block',
+          attrs: { class: 'javascript' },
+          content: [text('const x = 1;')],
+        };
+        expect(richTextRenderer(codeBlock)).toBe('<pre><code class="javascript">const x = 1;</code></pre>');
+      });
+
+      it('does not leak language as attribute', () => {
+        const codeBlock: SbRichTextDoc = {
+          type: 'code_block',
+          attrs: { class: 'js' },
+          content: [text('code')],
+        };
+        expect(richTextRenderer(codeBlock)).not.toContain('language=');
+      });
+    });
+
+    describe('horizontal rule', () => {
+      it('renders hr as self-closing', () => {
+        expect(richTextRenderer({ type: 'horizontal_rule' })).toBe('<hr>');
+      });
+    });
+
+    describe('hard break', () => {
+      it('renders br as self-closing', () => {
+        expect(richTextRenderer({ type: 'hard_break' })).toBe('<br>');
+      });
+    });
+
+    describe('image', () => {
+      it('renders image with attributes', () => {
+        const image: SbRichTextDoc = {
+          type: 'image',
+          attrs: {
+            id: 123,
+            src: 'https://example.com/image.jpg',
+            alt: 'An image',
+            title: 'Image title',
+            source: null,
+            copyright: null,
+            meta_data: null,
+          },
+        };
+        expect(richTextRenderer(image)).toBe(
+          '<img id="123" src="https://example.com/image.jpg" alt="An image" title="Image title">',
+        );
+      });
+
+      it('filters out meta_data, source, and copyright from output', () => {
+        const image: SbRichTextDoc = {
+          type: 'image',
+          attrs: {
+            id: 1,
+            src: 'https://example.com/img.jpg',
+            alt: 'Alt',
+            title: null,
+            source: 'Source',
+            copyright: '© 2024',
+            meta_data: { alt: 'meta', title: null, source: null, copyright: null },
+          },
+        };
+        const html = richTextRenderer(image);
+        expect(html).not.toContain('source=');
+        expect(html).not.toContain('copyright=');
+        expect(html).not.toContain('meta_data=');
+      });
+
+      it('renders optimized image with optimizeImages: true', () => {
+        const image: SbRichTextDoc = {
+          type: 'image',
+          attrs: {
+            id: 1,
+            src: 'https://a.storyblok.com/f/12345/image.jpg',
+            alt: 'Test',
+            title: null,
+            source: null,
+            copyright: null,
+            meta_data: null,
+          },
+        };
+        const html = richTextRenderer(image, { optimizeImages: true });
+        expect(html).toContain('src="https://a.storyblok.com/f/12345/image.jpg/m/"');
+      });
+
+      it('renders optimized image with width and height', () => {
+        const image: SbRichTextDoc = {
+          type: 'image',
+          attrs: {
+            id: 1,
+            src: 'https://a.storyblok.com/f/12345/image.jpg',
+            alt: 'Test',
+            title: null,
+            source: null,
+            copyright: null,
+            meta_data: null,
+          },
+        };
+        const html = richTextRenderer(image, {
+          optimizeImages: { width: 800, height: 600 },
+        });
+        expect(html).toContain('src="https://a.storyblok.com/f/12345/image.jpg/m/800x600/"');
+        expect(html).toContain('width="800"');
+        expect(html).toContain('height="600"');
+      });
+
+      it('renders optimized image with filters', () => {
+        const image: SbRichTextDoc = {
+          type: 'image',
+          attrs: {
+            id: 1,
+            src: 'https://a.storyblok.com/f/12345/image.jpg',
+            alt: 'Test',
+            title: null,
+            source: null,
+            copyright: null,
+            meta_data: null,
+          },
+        };
+        const html = richTextRenderer(image, {
+          optimizeImages: { filters: { quality: 80, format: 'webp' } },
+        });
+        expect(html).toContain('filters:quality(80):format(webp)');
+      });
+
+      it('renders optimized image with loading attribute', () => {
+        const image: SbRichTextDoc = {
+          type: 'image',
+          attrs: {
+            id: 1,
+            src: 'https://a.storyblok.com/f/12345/image.jpg',
+            alt: 'Test',
+            title: null,
+            source: null,
+            copyright: null,
+            meta_data: null,
+          },
+        };
+        const html = richTextRenderer(image, {
+          optimizeImages: { loading: 'lazy' },
+        });
+        expect(html).toContain('loading="lazy"');
+      });
+    });
+
+    describe('emoji', () => {
+      it('renders emoji as image with fallback', () => {
+        const emoji: SbRichTextDoc = {
+          type: 'emoji',
+          attrs: {
+            emoji: '🚀',
+            name: 'rocket',
+            fallbackImage: 'https://cdn.example.com/rocket.png',
+          },
+        };
+        const html = richTextRenderer(emoji);
+        expect(html).toBe('<img data-emoji="🚀" data-name="rocket" src="https://cdn.example.com/rocket.png" draggable="false" loading="lazy" style="width: 1.25em; height: 1.25em; vertical-align: text-top;">');
+      });
+    });
+  });
+
+  // ============================================================================
+  // Tests: Tables
+  // ============================================================================
+
+  describe('tables', () => {
+    it('renders basic table with tbody', () => {
+      const t = table([tableRow([tableCell('A'), tableCell('B')])]);
+      expect(richTextRenderer(t)).toBe(
+        '<table><tbody><tr><td colspan="1" rowspan="1"><p>A</p></td><td colspan="1" rowspan="1"><p>B</p></td></tr></tbody></table>',
+      );
+    });
+
+    it('renders table with thead and tbody', () => {
+      const t = table([
+        tableRow([tableHeader('H1'), tableHeader('H2')]),
+        tableRow([tableCell('C1'), tableCell('C2')]),
+      ]);
+      expect(richTextRenderer(t)).toBe(
+        '<table><thead><tr><th colspan="1" rowspan="1"><p>H1</p></th><th colspan="1" rowspan="1"><p>H2</p></th></tr></thead>'
+        + '<tbody><tr><td colspan="1" rowspan="1"><p>C1</p></td><td colspan="1" rowspan="1"><p>C2</p></td></tr></tbody></table>',
+      );
+    });
+
+    it('renders colspan and rowspan', () => {
+      const t = table([tableRow([tableCell('Merged', { colspan: 2, rowspan: 2 })])]);
+      expect(richTextRenderer(t)).toContain('colspan="2" rowspan="2"');
+    });
+
+    it('renders colwidth as style', () => {
+      const t = table([tableRow([tableCell('Wide', { colwidth: [200] })])]);
+      expect(richTextRenderer(t)).toContain('style="width: 200px;"');
+    });
+
+    it('renders backgroundColor as style', () => {
+      const t = table([tableRow([tableCell('Colored', { backgroundColor: '#FF0000' })])]);
+      expect(richTextRenderer(t)).toContain('background-color: #FF0000;');
+    });
+
+    it('combines multiple styles', () => {
+      const t = table([tableRow([tableCell('Styled', { colwidth: [100], backgroundColor: '#00FF00' })])]);
+      const html = richTextRenderer(t);
+      expect(html).toContain('width: 100px;');
+      expect(html).toContain('background-color: #00FF00;');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Marks (Inline Formatting)
+  // ============================================================================
+
+  describe('marks', () => {
+    it('renders bold', () => {
+      const node = text('Bold', [{ type: 'bold' }]);
+      expect(richTextRenderer(node)).toBe('<strong>Bold</strong>');
+    });
+
+    it('renders italic', () => {
+      const node = text('Italic', [{ type: 'italic' }]);
+      expect(richTextRenderer(node)).toBe('<em>Italic</em>');
+    });
+
+    it('renders strike', () => {
+      const node = text('Strike', [{ type: 'strike' }]);
+      expect(richTextRenderer(node)).toBe('<s>Strike</s>');
+    });
+
+    it('renders underline', () => {
+      const node = text('Underline', [{ type: 'underline' }]);
+      expect(richTextRenderer(node)).toBe('<u>Underline</u>');
+    });
+
+    it('renders code', () => {
+      const node = text('code', [{ type: 'code' }]);
+      expect(richTextRenderer(node)).toBe('<code>code</code>');
+    });
+
+    it('renders superscript', () => {
+      const node = text('sup', [{ type: 'superscript' }]);
+      expect(richTextRenderer(node)).toBe('<sup>sup</sup>');
+    });
+
+    it('renders subscript', () => {
+      const node = text('sub', [{ type: 'subscript' }]);
+      expect(richTextRenderer(node)).toBe('<sub>sub</sub>');
+    });
+
+    it('renders nested marks', () => {
+      const node = text('Bold Italic', [{ type: 'bold' }, { type: 'italic' }]);
+      expect(richTextRenderer(node)).toBe('<em><strong>Bold Italic</strong></em>');
+    });
+
+    it('renders anchor mark as span with id', () => {
+      const node = text('Anchored', [{ type: 'anchor', attrs: { id: 'section-1' } }]);
+      expect(richTextRenderer(node)).toBe('<span id="section-1">Anchored</span>');
+    });
+
+    it('renders styled mark with class', () => {
+      const node = text('Styled', [{ type: 'styled', attrs: { class: 'highlight' } }]);
+      expect(richTextRenderer(node)).toBe('<span class="highlight">Styled</span>');
+    });
+
+    it('renders textStyle with color', () => {
+      const node = text('Red', [{ type: 'textStyle', attrs: { color: 'red', id: null, class: null } }]);
+      expect(richTextRenderer(node)).toBe('<span style="color: red;">Red</span>');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Links
+  // ============================================================================
+
+  describe('links', () => {
+    it('renders external URL link', () => {
+      const node = text('Click', [linkMark('https://example.com', { target: '_blank' })]);
+      expect(richTextRenderer(node)).toBe('<a href="https://example.com" target="_blank">Click</a>');
+    });
+
+    it('renders internal story link', () => {
+      const node = text('Page', [linkMark('/about', { linktype: 'story' })]);
+      expect(richTextRenderer(node)).toBe('<a href="/about">Page</a>');
+    });
+
+    it('renders story link with anchor', () => {
+      const node = text('Section', [linkMark('/page', { linktype: 'story', anchor: 'intro' })]);
+      expect(richTextRenderer(node)).toBe('<a href="/page#intro">Section</a>');
+    });
+
+    it('renders email link with mailto:', () => {
+      const node = text('Email', [linkMark('test@example.com', { linktype: 'email' })]);
+      expect(richTextRenderer(node)).toBe('<a href="mailto:test@example.com">Email</a>');
+    });
+
+    it('does not duplicate mailto: prefix', () => {
+      const node = text('Email', [linkMark('mailto:test@example.com', { linktype: 'email' })]);
+      expect(richTextRenderer(node)).toBe('<a href="mailto:test@example.com">Email</a>');
+    });
+
+    it('renders asset link', () => {
+      const node = text('Download', [linkMark('https://assets.example.com/file.pdf', { linktype: 'asset' })]);
+      expect(richTextRenderer(node)).toBe('<a href="https://assets.example.com/file.pdf">Download</a>');
+    });
+
+    it('renders link without href when empty', () => {
+      const node: SbRichTextDoc = {
+        type: 'text',
+        text: 'No href',
+        marks: [{ type: 'link', attrs: { href: '', linktype: 'url', uuid: null, anchor: null, target: null } }],
+      };
+      expect(richTextRenderer(node)).toBe('<a>No href</a>');
+    });
+
+    it('filters null attributes', () => {
+      const node = text('Link', [linkMark('/')]);
+      const html = richTextRenderer(node);
+      expect(html).not.toContain('target=');
+      expect(html).not.toContain('uuid=');
+      expect(html).not.toContain('anchor=');
+    });
+    it('should render a link with text, and custom attrs', () => {
+      const node: SbRichTextDoc = {
+        type: 'paragraph',
+        content: [{
+          type: 'text',
+          text: 'Click me',
+          marks: [
+            linkMark('https://example.com', { linktype: 'url', custom: { 'title': 'google', 'rel': 'noopener', 'data-custom': 'foo' } }),
+          ],
+        }],
+      };
+      const html = richTextRenderer(node);
+      expect(html).toBe('<p><a href="https://example.com" title="google" rel="noopener" data-custom="foo">Click me</a></p>');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Link Mark Merging
+  // ============================================================================
+
+  describe('link mark merging', () => {
+    it('merges adjacent text nodes with same link', () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            text('Hello ', [linkMark('/url')]),
+            text('World', [linkMark('/url')]),
+          ],
+        }],
+      };
+      expect(richTextRenderer(content)).toBe('<p><a href="/url">Hello World</a></p>');
+    });
+    it('merge groups when link with same custom attributes', () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            text('Hello ', [linkMark('/a', { custom: { title: 'google' } })]),
+            text('Storyblok', [linkMark('/a', { custom: { title: 'google' } })]),
+          ],
+        }],
+      };
+      expect(richTextRenderer(content)).toBe('<p><a href="/a" title="google">Hello Storyblok</a></p>');
+    });
+    it('preserves inner marks when merging', () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            text('normal ', [linkMark('/url')]),
+            text('bold', [{ type: 'bold' }, linkMark('/url')]),
+            text(' text', [linkMark('/url')]),
+          ],
+        }],
+      };
+      expect(richTextRenderer(content)).toBe('<p><a href="/url">normal <strong>bold</strong> text</a></p>');
+    });
+
+    it('handles multiple inner marks', () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            text('start ', [linkMark('/url')]),
+            text('bold', [{ type: 'bold' }, linkMark('/url')]),
+            text(' and ', [linkMark('/url')]),
+            text('italic', [{ type: 'italic' }, linkMark('/url')]),
+            text(' end', [linkMark('/url')]),
+          ],
+        }],
+      };
+      expect(richTextRenderer(content)).toBe(
+        '<p><a href="/url">start <strong>bold</strong> and <em>italic</em> end</a></p>',
+      );
+    });
+
+    it('breaks group on non-text node', () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            text('Before ', [linkMark('/x')]),
+            { type: 'hard_break' },
+            text('After', [linkMark('/x')]),
+          ],
+        }],
+      };
+      expect(richTextRenderer(content)).toBe('<p><a href="/x">Before </a><br><a href="/x">After</a></p>');
+    });
+
+    it('separates groups when link attrs differ', () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            text('A', [linkMark('/a')]),
+            text('B', [linkMark('/a', { target: '_blank' })]),
+          ],
+        }],
+      };
+      expect(richTextRenderer(content)).toBe('<p><a href="/a">A</a><a href="/a" target="_blank">B</a></p>');
+    });
+    it('separates groups when link with different custom attributes', () => {
+      const content: SbRichTextDoc = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            text('A', [linkMark('/a', { custom: { title: 'google' } })]),
+            text('B', [linkMark('/a', { custom: { title: 'new' } })]),
+          ],
+        }],
+      };
+      expect(richTextRenderer(content)).toBe('<p><a href="/a" title="google">A</a><a href="/a" title="new">B</a></p>');
+    });
+  });
+
+  // ============================================================================
+  // Tests: Text Alignment
+  // ============================================================================
+
+  describe('text alignment', () => {
+    it('renders paragraph with text-align style', () => {
+      const p: SbRichTextDoc = {
+        type: 'paragraph',
+        attrs: { textAlign: 'right' },
+        content: [text('Right')],
+      };
+      expect(richTextRenderer(p)).toBe('<p style="text-align: right;">Right</p>');
+    });
+
+    it.each(['left', 'center', 'right', 'justify'] as const)('supports %s alignment', (align) => {
+      const p: SbRichTextDoc = {
+        type: 'paragraph',
+        attrs: { textAlign: align },
+        content: [text('Text')],
+      };
+      expect(richTextRenderer(p)).toContain(`text-align: ${align};`);
+    });
+
+    it('renders heading with alignment', () => {
+      const heading: SbRichTextDoc = {
+        type: 'heading',
+        attrs: { level: 2, textAlign: 'center' },
+        content: [text('Centered')],
+      };
+      expect(richTextRenderer(heading)).toBe('<h2 style="text-align: center;">Centered</h2>');
+    });
+
+    it('combines alignment with marks', () => {
+      const p: SbRichTextDoc = {
+        type: 'paragraph',
+        attrs: { textAlign: 'center' },
+        content: [text('Styled', [{ type: 'bold' }])],
+      };
+      expect(richTextRenderer(p)).toBe('<p style="text-align: center;"><strong>Styled</strong></p>');
+    });
+
+    it('renders empty paragraph with alignment', () => {
+      const p: SbRichTextDoc = {
+        type: 'paragraph',
+        attrs: { textAlign: 'center' },
         content: [],
       };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('');
-    });
-
-    it('should return empty string for doc with undefined content', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('');
+      expect(richTextRenderer(p)).toBe('<p style="text-align: center;"></p>');
     });
   });
-  describe('skip blok rendering', () => {
-    it('should skip rendering blok nodes', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'blok',
-            attrs: { id: '123' },
-          },
-        ],
+  // ============================================================================
+  // Tests: Custom Renderers
+  // ============================================================================
+
+  describe('custom renderers', () => {
+    it('overrides node rendering', () => {
+      const options: SbRichTextOptions = {
+        renderers: {
+          paragraph: ({ content }) => `<div class="custom">${richTextRenderer(content, options)}</div>`,
+        },
       };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('');
-      expect(warnSpy).toHaveBeenCalledWith(
-        'Rendering of "blok" nodes is not supported in richTextRenderer.',
-      );
+      const node: SbRichTextDoc = { type: 'paragraph', content: [text('Hello')] };
+      expect(richTextRenderer(node, options)).toBe('<div class="custom">Hello</div>');
+    });
 
+    it('overrides mark rendering', () => {
+      const options: SbRichTextOptions = {
+        renderers: {
+          bold: ({ children }) => `<b class="heavy">${children}</b>`,
+        },
+      };
+      expect(richTextRenderer(text('Bold', [{ type: 'bold' }]), options)).toBe('<b class="heavy">Bold</b>');
+    });
+
+    it('supports multiple custom renderers', () => {
+      const options: SbRichTextOptions = {
+        renderers: {
+          heading: ({ attrs, content }) => `<h${attrs?.level} class="title">${richTextRenderer(content, options)}</h${attrs?.level}>`,
+          bold: ({ children }) => `<strong class="emphasis">${children}</strong>`,
+        },
+      };
+      const heading: SbRichTextDoc = {
+        type: 'heading',
+        attrs: { level: 1, textAlign: null },
+        content: [text('Title', [{ type: 'bold' }])],
+      };
+      expect(richTextRenderer(heading, options)).toBe(
+        '<h1 class="title"><strong class="emphasis">Title</strong></h1>',
+      );
+    });
+  });
+
+  // ============================================================================
+  // Tests: Blok Nodes
+  // ============================================================================
+
+  describe('blok nodes', () => {
+    const blokDoc: SbRichTextDoc = {
+      type: 'doc',
+      content: [{
+        type: 'blok',
+        attrs: {
+          id: 'blok-123',
+          body: [
+            { _uid: '1', component: 'button', title: 'Click Me' },
+            { _uid: '2', component: 'button', title: 'Submit' },
+          ],
+        },
+      }],
+    };
+
+    it('warns when no custom renderer provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      richTextRenderer(blokDoc);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('blok'));
       warnSpy.mockRestore();
     });
-  });
-  describe('paragraph rendering', () => {
-    it('should render a simple paragraph', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [{ type: 'text', text: 'Hello World' }],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p>Hello World</p>');
+
+    it('returns empty string without custom renderer', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(richTextRenderer(blokDoc)).toBe('');
+      vi.restoreAllMocks();
     });
 
-    it('should render multiple paragraphs', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [{ type: 'text', text: 'First' }],
+    it('renders with custom blok renderer', () => {
+      const options: SbRichTextOptions = {
+        renderers: {
+          blok: ({ attrs }) => {
+            const body = Array.isArray(attrs?.body) ? attrs.body : [];
+            return body.map(b => `<button data-uid="${b._uid}">${b.title}</button>`).join('');
           },
-          {
-            type: 'paragraph',
-            content: [{ type: 'text', text: 'Second' }],
-          },
-        ],
+        },
       };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p>First</p><p>Second</p>');
-    });
-
-    it('should render paragraph with text alignment', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            attrs: { textAlign: 'center' },
-            content: [{ type: 'text', text: 'Centered' }],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p style="text-align: center">Centered</p>');
-    });
-  });
-
-  describe('text marks', () => {
-    it('should render bold text', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: 'Bold',
-                marks: [{ type: 'bold' }],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p><strong>Bold</strong></p>');
-    });
-
-    it('should render italic text', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: 'Italic',
-                marks: [{ type: 'italic' }],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p><em>Italic</em></p>');
-    });
-
-    it('should render nested marks (bold + italic)', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: 'Bold Italic',
-                marks: [{ type: 'bold' }, { type: 'italic' }],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p><em><strong>Bold Italic</strong></em></p>');
-    });
-
-    it('should render link mark', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: 'Link',
-                marks: [
-                  { type: 'link', attrs: { href: 'https://example.com' } },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p><a href="https://example.com">Link</a></p>');
-    });
-  });
-
-  describe('headings', () => {
-    it('should render h1 heading', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'heading',
-            attrs: { level: 1 },
-            content: [{ type: 'text', text: 'Heading 1' }],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<h1>Heading 1</h1>');
-    });
-
-    it('should render h3 heading', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'heading',
-            attrs: { level: 3 },
-            content: [{ type: 'text', text: 'Heading 3' }],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<h3>Heading 3</h3>');
-    });
-  });
-
-  describe('lists', () => {
-    it('should render unordered list', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'bullet_list',
-            content: [
-              {
-                type: 'list_item',
-                content: [
-                  {
-                    type: 'paragraph',
-                    content: [{ type: 'text', text: 'Item 1' }],
-                  },
-                ],
-              },
-              {
-                type: 'list_item',
-                content: [
-                  {
-                    type: 'paragraph',
-                    content: [{ type: 'text', text: 'Item 2' }],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe(
-        '<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>',
+      expect(richTextRenderer(blokDoc, options)).toBe(
+        '<button data-uid="1">Click Me</button><button data-uid="2">Submit</button>',
       );
     });
 
-    it('should render ordered list', () => {
-      const doc: StoryblokRichTextJson = {
+    it('handles empty body', () => {
+      const emptyBlok: SbRichTextDoc = {
+        type: 'doc',
+        content: [{ type: 'blok', attrs: { id: 'x', body: [] } }],
+      };
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(richTextRenderer(emptyBlok)).toBe('');
+      vi.restoreAllMocks();
+    });
+
+    it('handles null body', () => {
+      const nullBlok: SbRichTextDoc = {
+        type: 'doc',
+        content: [{ type: 'blok', attrs: { id: 'x', body: null } }],
+      };
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(richTextRenderer(nullBlok)).toBe('');
+      vi.restoreAllMocks();
+    });
+
+    it('works alongside other content', () => {
+      const options: SbRichTextOptions = {
+        renderers: {
+          blok: () => '<widget />',
+        },
+      };
+      const content: SbRichTextDoc = {
         type: 'doc',
         content: [
-          {
-            type: 'ordered_list',
-            content: [
-              {
-                type: 'list_item',
-                content: [
-                  {
-                    type: 'paragraph',
-                    content: [{ type: 'text', text: 'First' }],
-                  },
-                ],
-              },
-            ],
-          },
+          { type: 'paragraph', content: [text('Before')] },
+          { type: 'blok', attrs: { id: 'x', body: [{ _uid: '1' }] } },
+          { type: 'paragraph', content: [text('After')] },
         ],
       };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<ol><li><p>First</p></li></ol>');
+      expect(richTextRenderer(content, options)).toBe('<p>Before</p><widget /><p>After</p>');
     });
   });
 
-  describe('blockquote', () => {
-    it('should render blockquote', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'blockquote',
-            content: [
-              {
-                type: 'paragraph',
-                content: [{ type: 'text', text: 'Quote' }],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<blockquote><p>Quote</p></blockquote>');
-    });
-  });
-
-  describe('code block', () => {
-    it('should render code block with pre > code structure', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'code_block',
-            content: [{ type: 'text', text: 'const x = 1;' }],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<pre><code>const x = 1;</code></pre>');
-    });
-  });
-
-  describe('self-closing tags', () => {
-    it('should render hard break', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              { type: 'text', text: 'Line 1' },
-              { type: 'hard_break' },
-              { type: 'text', text: 'Line 2' },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p>Line 1<br />Line 2</p>');
-    });
-
-    it('should render horizontal rule', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [{ type: 'horizontal_rule' }],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<hr />');
-    });
-
-    it('should render image', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'image',
-            attrs: { src: 'https://example.com/image.jpg', alt: 'Example' },
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe(
-        '<img src="https://example.com/image.jpg" alt="Example" />',
-      );
-    });
-  });
+  // ============================================================================
+  // Tests: XSS Prevention
+  // ============================================================================
 
   describe('xSS prevention', () => {
-    it('should escape HTML entities in text content', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [{ type: 'text', text: '<script>alert("XSS")</script>' }],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe(
-        '<p>&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;</p>',
-      );
+    it('escapes HTML in text content', () => {
+      const node = text('<script>alert("xss")</script>');
+      expect(richTextRenderer(node)).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
     });
 
-    it('should escape ampersands in text', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [{ type: 'text', text: 'Tom & Jerry' }],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe('<p>Tom &amp; Jerry</p>');
-    });
-
-    it('should escape quotes in attribute values', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: 'Link',
-                marks: [
-                  {
-                    type: 'link',
-                    attrs: { href: 'https://example.com?a="test"' },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toContain('href="https://example.com?a=&quot;test&quot;"');
-    });
-  });
-
-  describe('non-doc root node', () => {
-    it('should render a single paragraph node directly', () => {
-      const node: StoryblokRichTextJson = {
-        type: 'paragraph',
-        content: [{ type: 'text', text: 'Direct' }],
-      };
-      const result = richTextRenderer(node);
-      expect(result).toBe('<p>Direct</p>');
-    });
-  });
-
-  describe('table rendering', () => {
-    it('should render table with tbody structure', () => {
-      const doc: StoryblokRichTextJson = {
-        type: 'doc',
-        content: [
-          {
-            type: 'table',
-            content: [
-              {
-                type: 'tableRow',
-                content: [
-                  {
-                    type: 'tableCell',
-                    content: [
-                      {
-                        type: 'paragraph',
-                        content: [{ type: 'text', text: 'Cell 1' }],
-                      },
-                    ],
-                  },
-                  {
-                    type: 'tableCell',
-                    content: [
-                      {
-                        type: 'paragraph',
-                        content: [{ type: 'text', text: 'Cell 2' }],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-      const result = richTextRenderer(doc);
-      expect(result).toBe(
-        '<table><tbody><tr><td><p>Cell 1</p></td><td><p>Cell 2</p></td></tr></tbody></table>',
-      );
+    it('escapes HTML in attributes', () => {
+      const node = text('Link', [linkMark('javascript:alert("xss")')]);
+      expect(richTextRenderer(node)).toContain('href="javascript:alert(&quot;xss&quot;)"');
     });
   });
 });

--- a/packages/richtext/src/static/richtext-renderer.ts
+++ b/packages/richtext/src/static/richtext-renderer.ts
@@ -97,25 +97,30 @@ function renderNode(node: SbRichTextDoc, options?: SbRichTextOptions): string {
 }
 
 /** Renders an image node with optimization applied. */
-function renderOptimizedImage(node: SbRichTextDoc, options: SbRichTextOptions): string {
+function renderOptimizedImage(
+  node: SbRichTextDoc,
+  options: SbRichTextOptions,
+): string {
   const attrs = node.attrs as Record<string, unknown> | undefined;
   const src = attrs?.src as string | undefined;
 
-  if (!src) {
-    return buildHtmlAttrs('image', attrs) ? `<img${buildHtmlAttrs('image', attrs)}>` : '<img>';
+  let finalAttrs: Record<string, unknown> | undefined = attrs;
+
+  if (src) {
+    const { src: optimizedSrc, attrs: extraAttrs } = optimizeImage(
+      src,
+      options.optimizeImages,
+    );
+
+    finalAttrs = {
+      ...attrs,
+      src: optimizedSrc,
+      ...extraAttrs,
+    };
   }
 
-  const { src: optimizedSrc, attrs: extraAttrs } = optimizeImage(src, options.optimizeImages);
-
-  // Merge original attrs with optimized attrs
-  const mergedAttrs = {
-    ...attrs,
-    src: optimizedSrc,
-    ...extraAttrs,
-  };
-
-  const htmlAttrs = buildHtmlAttrs('image', mergedAttrs);
-  return `<img${htmlAttrs}>`;
+  const htmlAttrs = buildHtmlAttrs('image', finalAttrs);
+  return htmlAttrs ? `<img${htmlAttrs}>` : '<img>';
 }
 
 /**

--- a/packages/richtext/src/static/richtext-renderer.ts
+++ b/packages/richtext/src/static/richtext-renderer.ts
@@ -1,166 +1,322 @@
 import { escapeHtml } from '../utils';
+import { optimizeImage } from '../images-optimization';
 import { escapeAttr, processAttrs } from './attribute';
+import { areLinkMarksEqual, getTextNodeLinkMark, isTableHeaderRow } from './node-helpers';
 import { styleToString } from './style';
-import type { RenderSpec, StoryblokRichTextJson } from './types';
-import type { PMNode } from './types.generated';
+import type { AttrValue, RenderSpec, SbRichTextDoc, SbRichTextElement, SbRichTextOptions } from './types';
+import type { PMMark, PMNode } from './types.generated';
 import { getStaticChildren, isSelfClosing, resolveTag } from './util';
+
+type TextNode = PMNode & { type: 'text' };
 
 /**
  * Renders a Storyblok RichText JSON document to an HTML string.
  *
- * This is a framework-agnostic static renderer that supports Storyblok
- * richtext nodes and marks, applies attributes and styles, and safely
- * escapes text content. `blok` nodes are not rendered and will log a warning.
+ * @param document - RichText JSON document, array of nodes, or nullish value
+ * @param options - Renderer configuration with custom node/mark renderers
+ * @returns Rendered HTML string
  *
- * @param document - The Storyblok RichText JSON document to render
- * @returns The rendered HTML string
- *  @example
+ * @example
  * ```ts
  * const html = richTextRenderer({
  *   type: 'doc',
- *   content: [
- *     {
- *       type: 'paragraph',
- *       content: [
- *         { type: 'text', text: 'Hello World' }
- *       ]
- *     }
- *   ]
+ *   content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }]
  * });
- *
- * console.log(html);
- * // <p>Hello World</p>
+ * // => '<p>Hello</p>'
  * ```
  */
-export function richTextRenderer(document: StoryblokRichTextJson): string {
+export function richTextRenderer(
+  document: SbRichTextDoc | SbRichTextDoc[] | null | undefined,
+  options?: SbRichTextOptions,
+): string {
   if (!document) {
     return '';
   }
 
+  if (Array.isArray(document)) {
+    return renderChildren(document, options);
+  }
+
   const nodes = document.type === 'doc' ? document.content : [document];
-
-  if (!nodes || nodes.length === 0) {
-    return '';
-  }
-
-  const parts: string[] = [];
-  for (const node of nodes) {
-    parts.push(renderNode(node));
-  }
-  return parts.join('');
+  return nodes?.length ? renderChildren(nodes, options) : '';
 }
 
 /** Renders a single node to HTML. */
-function renderNode(node: StoryblokRichTextJson): string {
+function renderNode(node: SbRichTextDoc, options?: SbRichTextOptions): string {
+  // Text nodes: apply marks and escape content
   if (node.type === 'text') {
-    return renderText(node);
+    return renderTextNode(node as TextNode, node.marks, options);
   }
+
+  // Custom renderer takes full control
+  const customRenderer = options?.renderers?.[node.type as keyof typeof options.renderers];
+  if (customRenderer) {
+    return (customRenderer as (props: typeof node) => string)(node);
+  }
+
+  // Blok nodes require custom renderer
   if (node.type === 'blok') {
     console.warn('Rendering of "blok" nodes is not supported in richTextRenderer.');
     return '';
   }
 
   const tag = resolveTag(node);
+
+  // No tag (e.g., nested doc): render children directly
   if (!tag) {
-    return '';
+    return node.content ? renderChildren(node.content, options) : '';
   }
 
-  const selfClosing = isSelfClosing(tag);
+  // Image nodes: apply optimization if configured
+  if (node.type === 'image' && options?.optimizeImages) {
+    return renderOptimizedImage(node, options);
+  }
+
+  const htmlAttrs = buildHtmlAttrs(node.type, node.attrs);
+
+  // Self-closing tags
+  if (isSelfClosing(tag)) {
+    return `<${tag}${htmlAttrs}>`;
+  }
+
+  // Table: special thead/tbody grouping
+  if (node.type === 'table') {
+    return `<${tag}${htmlAttrs}>${renderTableRows(node.content, options)}</${tag}>`;
+  }
+
+  const content = node.content ? renderChildren(node.content, options) : '';
+
+  // Static children (e.g., pre > code)
   const staticChildren = getStaticChildren(node);
-  const attrs = processAttrs(node.type, node.attrs);
-  const styleString = attrs.style ? styleToString(attrs.style) : '';
-  const htmlAttrs = attrsToString({
-    ...attrs,
-    ...(styleString && { style: styleString }),
-  });
-
-  if (selfClosing) {
-    return `<${tag}${htmlAttrs} />`;
-  }
-
-  // Render children content
-  const childContent = node.content
-    ? node.content.map(child => renderNode(child)).join('')
-    : '';
-
-  // Handle static children (e.g., code_block with pre > code structure)
-  // Static children are wrapped inside the parent tag
   if (staticChildren) {
-    const innerContent = renderStaticChildren(
-      staticChildren,
-      attrs,
-      childContent,
-    );
-    return `<${tag}${htmlAttrs}>${innerContent}</${tag}>`;
+    const inner = renderStaticStructure(staticChildren, node.attrs, content);
+    return `<${tag}>${inner}</${tag}>`;
   }
 
-  return `<${tag}${htmlAttrs}>${childContent}</${tag}>`;
+  return `<${tag}${htmlAttrs}>${content}</${tag}>`;
 }
 
-/** Renders static children structure (e.g., table > tbody, pre > code). */
-function renderStaticChildren(
-  staticChildren: readonly RenderSpec[],
-  attrs: Record<string, unknown>,
-  parentChildren: string = '',
-): string {
-  const parts: string[] = [];
+/** Renders an image node with optimization applied. */
+function renderOptimizedImage(node: SbRichTextDoc, options: SbRichTextOptions): string {
+  const attrs = node.attrs as Record<string, unknown> | undefined;
+  const src = attrs?.src as string | undefined;
 
-  for (const child of staticChildren) {
-    const tag = child.tag;
-    const selfClosing = isSelfClosing(tag);
-    const mergedAttrs = { ...child.attrs, ...attrs };
-    const htmlAttrs = attrsToString(mergedAttrs);
-
-    if (selfClosing) {
-      parts.push(`<${tag}${htmlAttrs} />`);
-      continue;
-    }
-
-    const children = child.children
-      ? renderStaticChildren(child.children, attrs, parentChildren)
-      : parentChildren;
-
-    parts.push(`<${tag}${htmlAttrs}>${children}</${tag}>`);
+  if (!src) {
+    return buildHtmlAttrs('image', attrs) ? `<img${buildHtmlAttrs('image', attrs)}>` : '<img>';
   }
 
-  return parts.join('');
+  const { src: optimizedSrc, attrs: extraAttrs } = optimizeImage(src, options.optimizeImages);
+
+  // Merge original attrs with optimized attrs
+  const mergedAttrs = {
+    ...attrs,
+    src: optimizedSrc,
+    ...extraAttrs,
+  };
+
+  const htmlAttrs = buildHtmlAttrs('image', mergedAttrs);
+  return `<img${htmlAttrs}>`;
 }
 
-/** Renders a text node with its marks (bold, italic, etc.). */
-function renderText(node: PMNode & { type: 'text' }): string {
-  const marks = node.marks;
-  // Escape HTML entities in text content to prevent XSS
-  let result = escapeHtml(node.text);
+/**
+ * Renders child nodes, merging adjacent text nodes that share the same link mark.
+ * This produces cleaner HTML: `<a href="...">text <b>bold</b> more</a>`
+ * instead of: `<a>text</a><a><b>bold</b></a><a>more</a>`
+ */
+function renderChildren(children: SbRichTextDoc[], options?: SbRichTextOptions): string {
+  let result = '';
+  let i = 0;
+  const len = children.length;
 
-  if (!marks || marks.length === 0) {
-    return result;
-  }
+  while (i < len) {
+    const node = children[i];
+    const linkMark = getTextNodeLinkMark(node);
 
-  // Apply marks in order (innermost first)
-  for (const mark of marks) {
-    const tag = resolveTag(mark);
-    if (!tag) {
-      continue;
+    if (linkMark) {
+      // Find end of link group (consecutive text nodes with same link)
+      let end = i + 1;
+      while (end < len && areLinkMarksEqual(linkMark, getTextNodeLinkMark(children[end]))) {
+        end++;
+      }
+      result += renderLinkGroup(children, i, end, linkMark, options);
+      i = end;
     }
-
-    const attrs = processAttrs(mark.type, mark.attrs);
-    const htmlAttrs = attrsToString(attrs);
-    result = `<${tag}${htmlAttrs}>${result}</${tag}>`;
+    else {
+      result += renderNode(node, options);
+      i++;
+    }
   }
 
   return result;
 }
 
-/** Converts an attributes object to an HTML attribute string. */
-function attrsToString(attrs: Record<string, unknown>): string {
-  const entries = Object.entries(attrs).filter(([, v]) => v != null);
+/** Renders a text node with its marks. */
+function renderTextNode(
+  node: TextNode,
+  marks: PMMark[] | undefined,
+  options?: SbRichTextOptions,
+): string {
+  let html = escapeHtml(node.text);
 
-  if (entries.length === 0) {
+  if (!marks?.length) {
+    return html;
+  }
+
+  for (const mark of marks) {
+    html = wrapWithMark(html, mark, options);
+  }
+
+  return html;
+}
+
+/** Wraps content with a single mark tag. */
+function wrapWithMark(
+  content: string,
+  mark: PMMark,
+  options?: SbRichTextOptions,
+): string {
+  // Custom mark renderer
+  const customRenderer = options?.renderers?.[mark.type as keyof typeof options.renderers];
+  if (customRenderer) {
+    return (customRenderer as (props: typeof mark & { children: string }) => string)({
+      ...mark,
+      children: content,
+    });
+  }
+
+  const tag = resolveTag(mark);
+  if (!tag) {
+    return content;
+  }
+
+  const htmlAttrs = buildHtmlAttrs(mark.type, mark.attrs);
+  return `<${tag}${htmlAttrs}>${content}</${tag}>`;
+}
+
+/** Link Mark Merging */
+
+/** Renders consecutive text nodes (from start to end) under a single link tag. */
+function renderLinkGroup(
+  children: SbRichTextDoc[],
+  start: number,
+  end: number,
+  linkMark: PMMark,
+  options?: SbRichTextOptions,
+): string {
+  // Render each text node with only its non-link marks
+  let inner = '';
+  for (let i = start; i < end; i++) {
+    const node = children[i] as TextNode;
+    const innerMarks = node.marks?.filter(m => m.type !== 'link');
+    inner += renderTextNode(node, innerMarks, options);
+  }
+
+  const tag = resolveTag(linkMark);
+  if (!tag) {
+    return inner;
+  }
+
+  const htmlAttrs = buildHtmlAttrs(linkMark.type, linkMark.attrs);
+  return `<${tag}${htmlAttrs}>${inner}</${tag}>`;
+}
+
+/** Table Rendering */
+
+/** Renders table rows with thead/tbody grouping based on cell types. */
+function renderTableRows(
+  rows: SbRichTextDoc[] | undefined,
+  options?: SbRichTextOptions,
+): string {
+  if (!rows?.length) {
     return '';
   }
-  const attrParts: string[] = [];
-  for (const [key, value] of entries) {
-    attrParts.push(`${key}="${escapeAttr(value)}"`);
+
+  // Find where header rows end (contiguous tableHeader rows at start)
+  let headerEnd = 0;
+  while (headerEnd < rows.length && isTableHeaderRow(rows[headerEnd])) {
+    headerEnd++;
   }
-  return ` ${attrParts.join(' ')}`;
+
+  let result = '';
+
+  // Render thead
+  if (headerEnd > 0) {
+    result += '<thead>';
+    for (let i = 0; i < headerEnd; i++) {
+      result += renderNode(rows[i], options);
+    }
+    result += '</thead>';
+  }
+
+  // Render tbody
+  if (headerEnd < rows.length) {
+    result += '<tbody>';
+    for (let i = headerEnd; i < rows.length; i++) {
+      result += renderNode(rows[i], options);
+    }
+    result += '</tbody>';
+  }
+
+  return result;
+}
+
+// Static Children (e.g., pre > code)
+
+/** Renders nested static structure defined in render map. */
+function renderStaticStructure(
+  specs: readonly RenderSpec[],
+  parentAttrs: Record<string, unknown> | undefined,
+  content: string,
+): string {
+  let result = '';
+
+  for (const spec of specs) {
+    const { tag, children, attrs: specAttrs } = spec;
+    const mergedAttrs = { ...specAttrs, ...parentAttrs };
+    const htmlAttrs = attrsToHtmlString(mergedAttrs);
+
+    if (isSelfClosing(tag)) {
+      result += `<${tag}${htmlAttrs}>`;
+    }
+    else {
+      const inner = children
+        ? renderStaticStructure(children, parentAttrs, content)
+        : content;
+      result += `<${tag}${htmlAttrs}>${inner}</${tag}>`;
+    }
+  }
+
+  return result;
+}
+
+/** Builds HTML attribute string from node/mark type and attrs. */
+function buildHtmlAttrs(type: SbRichTextElement, attrs: Record<string, unknown> | undefined): string {
+  const processed = processAttrs(type, attrs, {
+    colspan: 'colspan',
+    rowspan: 'rowspan',
+  });
+
+  // Convert style object to string if present
+  const styleObj = processed.style as Record<string, AttrValue> | undefined;
+  const finalAttrs: Record<string, unknown> = { ...processed };
+
+  if (styleObj) {
+    finalAttrs.style = styleToString(styleObj);
+  }
+
+  return attrsToHtmlString(finalAttrs);
+}
+
+/** Converts attribute record to HTML string: ` key="value" key2="value2"` */
+function attrsToHtmlString(attrs: Record<string, unknown>): string {
+  let result = '';
+
+  for (const key in attrs) {
+    const value = attrs[key];
+    if (value != null) {
+      result += ` ${key}="${escapeAttr(value)}"`;
+    }
+  }
+
+  return result;
 }

--- a/packages/richtext/src/static/style.test.ts
+++ b/packages/richtext/src/static/style.test.ts
@@ -63,7 +63,7 @@ describe('styleToString', () => {
         textAlign: 'center',
         backgroundColor: 'red',
       }),
-    ).toBe('text-align: center; background-color: red');
+    ).toBe('text-align: center; background-color: red;');
   });
 
   it('handles numbers', () => {
@@ -71,7 +71,7 @@ describe('styleToString', () => {
       styleToString({
         width: 200,
       }),
-    ).toBe('width: 200');
+    ).toBe('width: 200;');
   });
 
   it('filters empty values', () => {
@@ -80,7 +80,7 @@ describe('styleToString', () => {
         color: '',
         width: 100,
       }),
-    ).toBe('width: 100');
+    ).toBe('width: 100;');
   });
 
   it('returns empty string for empty object', () => {
@@ -94,6 +94,6 @@ describe('styleToString', () => {
         width: '',
         height: 100,
       }),
-    ).toBe('height: 100');
+    ).toBe('height: 100;');
   });
 });

--- a/packages/richtext/src/static/style.ts
+++ b/packages/richtext/src/static/style.ts
@@ -9,11 +9,16 @@ import type { AttrValue } from './types';
  * const cssString = styleToString(styleObj);
  * console.log(cssString); // Output: "color: red; font-size: 16px"
  */
-export function styleToString(style: Record<string, AttrValue>) {
+export function styleToString(
+  style: Record<string, AttrValue>,
+) {
   return Object.entries(style)
-    .filter(([, v]) => isValidStyleValue(v))
-    .map(([k, v]) => `${camelToKebab(k)}: ${v}`)
-    .join('; ');
+    .filter(([, value]) => isValidStyleValue(value))
+    .map(
+      ([key, value]) =>
+        `${camelToKebab(key)}: ${value};`,
+    )
+    .join(' ');
 }
 
 /**

--- a/packages/richtext/src/static/types.ts
+++ b/packages/richtext/src/static/types.ts
@@ -1,12 +1,21 @@
-import type { PMMark, PMNode, TiptapComponentName } from './types.generated';
+import type { StoryblokRichTextImageOptimizationOptions as SbRichTextImageOptions } from '../types';
+import type { PMMark, PMNode, TiptapMarkName, TiptapNodeName } from './types.generated';
+
+export type SbRichTextElement = Exclude<TiptapNodeName | TiptapMarkName, 'text'>;
 
 /** Valid attribute values for DOM elements */
 export type AttrValue = string | number | boolean;
 export type HtmlTag = keyof HTMLElementTagNameMap;
-export interface SbBlokData {
-  _key: string;
-  component: string;
-  [otherKey: string]: unknown;
+
+interface ISbComponentType<T extends string> {
+  _uid?: string;
+  component?: T;
+  _editable?: string;
+}
+type SbBlokKeyDataTypes = string | number | object | boolean | undefined;
+
+export interface SbBlokData extends ISbComponentType<string> {
+  [index: string]: SbBlokKeyDataTypes;
 }
 
 export interface RenderSpec {
@@ -20,31 +29,28 @@ export interface RenderSpec {
 }
 
 /** Canonical type for a Storyblok RichText JSON root */
-export type StoryblokRichTextJson = PMNode;
+export type SbRichTextDoc = PMNode;
 
 /** Base props for node/mark components */
-export type RichTextBaseProps<T extends TiptapComponentName> =
+export type SbRichTextProps<T extends SbRichTextElement> =
   T extends PMNode['type']
     ? Extract<PMNode, { type: T }>
     : T extends PMMark['type']
-      ? Extract<PMMark, { type: T }>
+      ? Extract<PMMark, { type: T }> & { children: string }
       : never;
 
-/** Typed override map for node/mark components */
-export type RichTextComponentProps<
-  T extends TiptapComponentName,
-  TComponent = unknown,
-  ExtraProps extends Record<string, unknown> = Record<string, never>,
-> = RichTextBaseProps<T> &
-  ExtraProps & {
-    components?: StoryblokRichTextComponentMap<TComponent, ExtraProps>;
-  };
-
-export type StoryblokRichTextComponentMap<
-  TComponent = unknown,
-  ExtraProps extends Record<string, unknown> = Record<string, never>,
+/** Generic component map for any renderer target */
+export type SbRichTextComponents<
+  TComponent = string,
 > = {
-  [K in TiptapComponentName]?: (
-    props: RichTextComponentProps<K, TComponent, ExtraProps>
+  [K in SbRichTextElement]?: (
+    props: SbRichTextProps<K>
   ) => TComponent;
 };
+
+export interface SbRichTextOptions {
+  renderers?: SbRichTextComponents<string>;
+  optimizeImages?: boolean | Partial<SbRichTextImageOptions>;
+}
+
+export { SbRichTextImageOptions };

--- a/packages/richtext/src/static/util.ts
+++ b/packages/richtext/src/static/util.ts
@@ -1,7 +1,7 @@
 import { MARK_RENDER_MAP, NODE_RENDER_MAP } from './render-map.generated';
-import type { PMMark, PMNode, TiptapComponentName } from './types.generated';
+import type { PMMark, PMNode } from './types.generated';
 import { SELF_CLOSING_TAGS } from '../utils';
-import type { HtmlTag, StoryblokRichTextComponentMap } from './types';
+import type { HtmlTag, SbRichTextComponents, SbRichTextElement } from './types';
 
 /**
  * Resolves a component from the provided components map based on the type.
@@ -16,13 +16,12 @@ import type { HtmlTag, StoryblokRichTextComponentMap } from './types';
  * console.log(resolvedComponent); // Output: MyCustomHeading
  */
 export function resolveComponent<
-  K extends TiptapComponentName,
+  K extends SbRichTextElement,
   TComponent,
-  ExtraProps extends Record<string, unknown> = Record<string, unknown>,
 >(
   type: K,
-  components?: StoryblokRichTextComponentMap<TComponent, ExtraProps>,
-): StoryblokRichTextComponentMap<TComponent, ExtraProps>[K] | undefined {
+  components?: SbRichTextComponents<TComponent>,
+): SbRichTextComponents<TComponent>[K] | undefined {
   return components?.[type];
 }
 


### PR DESCRIPTION
This PR refines the `richTextRenderer` introduced earlier for static rendering.

Previously, the renderer only generated HTML with no way for users to customise the output. This update introduces full customisation support via `SbRichTextOptions`.

## **What’s new**

### **Custom renderers support**

* Added a `renderers` option to override how nodes and marks are rendered
* Fully typed for all supported nodes and marks

### **Feature parity improvements**

* Supports image optimisation via `optimizeImages`, similar to `richTextResolver`
* Improved handling of:

  * mark merging
  * table rendering (`thead` / `tbody`)
  * nodes with null tags but valid content
* Exported small internal utilities for:

  * table handling
  * mark handling
    (can be reused by other framework SDKs)

### **API and type improvements**

* Introduced `SbRichTextDoc` as the primary RichText document type
* Renamed:

  * `StoryblokRichTextJson` → `SbRichTextDoc`
  * `SBAngularComponentMap` → `SbAngularComponentMap`
* Improved custom richtext component typing across Angular SDK
* These renames are considered safe as the package is not yet v1

## **Usage examples**

```ts
const options: SbRichTextOptions = {
  renderers: {
    paragraph: ({ content }) =>
      `<div class="custom">${richTextRenderer(content, options)}</div>`,
  },
};

const node: SbRichTextDoc = {
  type: 'paragraph',
  content: [text('Hello')],
};

expect(richTextRenderer(node, options))
  .toBe('<div class="custom">Hello</div>');
```

```ts
const options: SbRichTextOptions = {
  renderers: {
    bold: ({ children }) => `<b class="heavy">${children}</b>`,
  },
};

expect(
  richTextRenderer(text('Bold', [{ type: 'bold' }]), options)
).toBe('<b class="heavy">Bold</b>');
```

## **Tests**

* Added comprehensive test coverage for:

  * mark merging
  * table rendering
  * image optimisation
  * renderer overrides
* Improved and cleaned up existing tests
* Ensured consistent output across implementations

## **Angular SDK alignment**

* Updated Angular rich text implementation to match static renderer output
* Reused the same test cases to ensure parity
* Improved custom component type mapping

## **Notes / Next steps**

* This PR focuses on stabilising and validating the API surface
* A follow-up PR will:

  * make this renderer the main export
  * introduce framework-specific components for React, Vue, and Astro with renderer customisation support

## **Open question**

The docs team suggested renaming `richTextRenderer` → `renderRichText`.

Since:

* this API is not yet documented publicly
* it is not exposed yet

We can safely rename it without introducing breaking changes.

👉 Feedback welcome on whether we should proceed with this rename in the next PR.
