### PR TITLE
feat: adds config for retriesDelay to allow for longer delay than 0.3s

### DIFF
--- a/packages/js-client/README.md
+++ b/packages/js-client/README.md
@@ -145,7 +145,8 @@ We added retro-compatibility when using `resolve_assets: 1` parameter under V2. 
   - (`https` Boolean, optional)
   - (`rateLimit` Integer, optional - Custom rate limit in requests per second. When set, this overrides all automatic rate limiting for all request types. See [Rate Limiting](#rate-limiting) section below for details.)
   - (`timeout` Integer, optional)
-  - (`maxRetries` Integer, optional, defaults to 5)
+  - (`maxRetries` Integer, optional, defaults to 10)
+  - (`retriesDelay` Integer, optional, defaults to 300 — delay in milliseconds between retries when rate-limited)
   - (`resolveNestedRelations` Boolean, optional - By default is true)
 - (`endpoint` String, optional)
 
@@ -200,6 +201,18 @@ Override automatic rate limiting by setting a custom `rateLimit`:
 const Storyblok = new StoryblokClient({
   accessToken: '<YOUR_SPACE_ACCESS_TOKEN>',
   rateLimit: 25, // Apply 25 req/s to ALL requests
+});
+```
+
+#### Retry Configuration
+
+When the client receives a `429 Too Many Requests` response, it automatically retries the request. You can configure the retry behavior:
+
+```javascript
+const Storyblok = new StoryblokClient({
+  accessToken: '<YOUR_SPACE_ACCESS_TOKEN>',
+  maxRetries: 10, // Maximum number of retries (default: 10)
+  retriesDelay: 300, // Delay in ms between retries (default: 300)
 });
 ```
 

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -1,5 +1,5 @@
 import StoryblokClient from '.';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResponseFn } from './sbFetch';
 import SbFetch from './sbFetch';
 import type { ISbLink, ISbStoryData } from './interfaces';
@@ -130,6 +130,13 @@ describe('storyblokClient', () => {
 
       expect(client.retriesDelay).toBe(1000);
     });
+    it('should respect retriesDelay of 0', () => {
+      client = new StoryblokClient({
+        retriesDelay: 0,
+      });
+
+      expect(client.retriesDelay).toBe(0);
+    });
     // TODO: seems like implmentation is missing
     it.skip('should desactivate resolveNestedRelations', () => {
       client = new StoryblokClient({
@@ -226,6 +233,76 @@ describe('storyblokClient', () => {
     it('should clear the cache version', async () => {
       client.clearCacheVersion('test-token');
       expect(client.cacheVersion()).toEqual(0);
+    });
+  });
+
+  describe('retry behaviour on 429', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should retry the request after a 429 using the configured retriesDelay', async () => {
+      client = new StoryblokClient({
+        retriesDelay: 500,
+        maxRetries: 3,
+      });
+
+      const mockGet = vi.fn()
+        .mockRejectedValueOnce({
+          status: 429,
+          statusText: 'Too Many Requests',
+          response: {},
+        })
+        .mockResolvedValueOnce({
+          data: { story: { id: 1 } },
+          headers: {},
+          status: 200,
+        });
+
+      client.client = {
+        get: mockGet,
+        post: vi.fn(),
+        setFetchOptions: vi.fn(),
+        baseURL: 'https://api.storyblok.com/v2',
+      };
+
+      const promise = client.cacheResponse('/cdn/stories', { token: 'test-token' });
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(promise).resolves.toMatchObject({ data: { story: { id: 1 } } });
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it('should give up after maxRetries 429 responses', async () => {
+      client = new StoryblokClient({
+        retriesDelay: 10,
+        maxRetries: 2,
+      });
+
+      const mockGet = vi.fn().mockRejectedValue({
+        status: 429,
+        statusText: 'Too Many Requests',
+        response: {},
+      });
+
+      client.client = {
+        get: mockGet,
+        post: vi.fn(),
+        setFetchOptions: vi.fn(),
+        baseURL: 'https://api.storyblok.com/v2',
+      };
+
+      const promise = client.cacheResponse('/cdn/stories', { token: 'test-token' });
+      const assertion = expect(promise).rejects.toMatchObject({ status: 429 });
+      await vi.advanceTimersByTimeAsync(100);
+      await assertion;
+
+      // Initial call + 2 retries = 3 total
+      expect(mockGet).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -123,6 +123,13 @@ describe('storyblokClient', () => {
 
       expect(client.maxRetries).toBe(5);
     });
+    it('should set retriesDelay', () => {
+      client = new StoryblokClient({
+        retriesDelay: 1000,
+      });
+
+      expect(client.retriesDelay).toBe(1000);
+    });
     // TODO: seems like implmentation is missing
     it.skip('should desactivate resolveNestedRelations', () => {
       client = new StoryblokClient({

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -141,7 +141,7 @@ export class Storyblok {
     this.rateLimitConfig = createRateLimitConfig(config.rateLimit, !!config.oauthToken);
 
     this.maxRetries = config.maxRetries || 10;
-    this.retriesDelay = 300;
+    this.retriesDelay = config.retriesDelay || 300;
 
     // Initialize throttle queue manager
     this.throttleManager = new ThrottleQueueManager(

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -141,7 +141,7 @@ export class Storyblok {
     this.rateLimitConfig = createRateLimitConfig(config.rateLimit, !!config.oauthToken);
 
     this.maxRetries = config.maxRetries || 10;
-    this.retriesDelay = config.retriesDelay || 300;
+    this.retriesDelay = config.retriesDelay ?? 300;
 
     // Initialize throttle queue manager
     this.throttleManager = new ThrottleQueueManager(

--- a/packages/js-client/src/interfaces.ts
+++ b/packages/js-client/src/interfaces.ts
@@ -245,6 +245,7 @@ export interface ISbConfig {
   headers?: any;
   region?: string;
   maxRetries?: number;
+  retriesDelay?: number;
   https?: boolean;
   rateLimit?: number;
   endpoint?: string;


### PR DESCRIPTION
This pull request adds retriesDelay to the retry configuration for the `StoryblokClient` in the JavaScript client package. The main updates include making the delay between retries configurable, updating documentation, and updating tests to reflect these changes.

## Changes
**Retry configuration improvements:**
- Made `retriesDelay` (delay in milliseconds between retries after a `429 Too Many Requests` response) configurable via the `ISbConfig` interface and the client constructor. [[1]](diffhunk://#diff-8b93c79e77de0f37b0f8b1bcce59ac79b134dd55e28004ff1abdc905e5c521a7L144-R144) [[2]](diffhunk://#diff-02732547ce32cc2e222813d6d9e9d061526c7c787bd01a3652e6d2dbefbe9e45R248)
- Updated the documentation for `maxRetries` to correctly correspond to the code and added documentation for `retriesDelay` documented both `maxRetries` and `retriesDelay` in the README. [[1]](diffhunk://#diff-2c04d9362b2f1138ab14881329b7b3ab2901da4a453f0e4ba6e55949a11b8552L148-R149) [[2]](diffhunk://#diff-2c04d9362b2f1138ab14881329b7b3ab2901da4a453f0e4ba6e55949a11b8552R207-R218)

**Testing updates:**
- Added a test to verify that the `retriesDelay` property is correctly set when passed in the configuration.

## Why
Rate limits from the Content Delivery API reset every second. With the hardcoded 300ms delay, retries fire 3+ times within the same window and worsen the rate limiting instead of recovering from it. Allowing a configurable delay lets users back off long enough for the window to reset.