### PR TITLE
perf(astro): externalize deps and split entry points for tree shaking

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -21,29 +21,31 @@
     "astro-sdk",
     "withastro"
   ],
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/storyblok-astro.es.js",
-      "require": "./dist/storyblok-astro.umd.js"
+      "import": "./dist/index.js"
+    },
+    "./richtext": {
+      "types": "./dist/richtext.d.ts",
+      "import": "./dist/richtext.js"
     },
     "./middleware.ts": {
       "types": "./dist/live-preview/middleware.d.ts",
-      "import": "./dist/live-preview/middleware.ts",
-      "require": "./dist/live-preview/middleware.ts"
+      "import": "./dist/live-preview/middleware.ts"
     },
     "./toolbarApp.ts": {
       "types": "./dist/dev-toolbar/toolbarApp.d.ts",
-      "import": "./dist/dev-toolbar/toolbarApp.ts",
-      "require": "./dist/dev-toolbar/toolbarApp.ts"
+      "import": "./dist/dev-toolbar/toolbarApp.ts"
     },
     "./client": "./dist/lib/client.ts",
     "./FallbackComponent.astro": "./dist/components/FallbackComponent.astro",
     "./StoryblokComponent.astro": "./dist/components/StoryblokComponent.astro",
     "./StoryblokServerData.astro": "./dist/components/StoryblokServerData.astro"
   },
-  "main": "./dist/storyblok-astro.es.js",
-  "module": "./dist/storyblok-astro.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "*.d.ts",
@@ -72,6 +74,7 @@
   },
   "dependencies": {
     "@storyblok/js": "workspace:*",
+    "@storyblok/richtext": "workspace:*",
     "camelcase": "^8.0.0",
     "morphdom": "^2.7.8"
   },

--- a/packages/astro/src/components/StoryblokComponent.astro
+++ b/packages/astro/src/components/StoryblokComponent.astro
@@ -1,6 +1,7 @@
 ---
 import options from 'virtual:storyblok-options';
-import { toCamelCase, type SbBlokData } from '@storyblok/astro';
+import { toCamelCase } from '../utils/toCamelCase';
+import type { SbBlokData } from '../types';
 import type { AstroComponentFactory } from 'astro/runtime/server/index.js';
 import { storyblokComponents } from 'virtual:import-storyblok-components';
 

--- a/packages/astro/src/richtext.ts
+++ b/packages/astro/src/richtext.ts
@@ -1,0 +1,36 @@
+import type {
+  StoryblokRichTextNode,
+  StoryblokRichTextOptions,
+} from '@storyblok/richtext';
+import { richTextResolver } from '@storyblok/richtext';
+
+/**
+ * Render Rich Text using the default `@storyblok/richtext` resolver.
+ *
+ * Equivalent to `richTextResolver(options).render(data)`.
+ */
+export function renderRichText<T = string>(
+  data: StoryblokRichTextNode<T>,
+  options?: StoryblokRichTextOptions<T>,
+): T | undefined {
+  return richTextResolver(options).render(data);
+}
+
+export {
+  asTag,
+  BlockTypes,
+  ComponentBlok,
+  LinkTypes,
+  MarkTypes,
+  richTextResolver,
+  segmentStoryblokRichText,
+  TextTypes,
+} from '@storyblok/richtext';
+
+export type {
+  StoryblokRichTextDocumentNode,
+  StoryblokRichTextImageOptimizationOptions,
+  StoryblokRichTextNode,
+  StoryblokRichTextNodeTypes,
+  StoryblokRichTextOptions,
+} from '@storyblok/richtext';

--- a/packages/astro/vite.config.ts
+++ b/packages/astro/vite.config.ts
@@ -8,12 +8,31 @@ export default defineConfig(() => {
   return {
     build: {
       lib: {
-        entry: path.resolve(__dirname, 'src/index.ts'),
-        name: 'storyblokAstro',
-        fileName: format => `storyblok-astro.${format}.js`,
+        entry: {
+          'index': path.resolve(__dirname, 'src/index.ts'),
+          'richtext': path.resolve(__dirname, 'src/richtext.ts'),
+          'types': path.resolve(__dirname, 'src/types.ts'),
+          'utils/toCamelCase': path.resolve(__dirname, 'src/utils/toCamelCase.ts'),
+        },
+        formats: ['es'],
       },
       rollupOptions: {
-        external: ['astro', '@astrijs/check', 'typescript'],
+        external: [
+          'astro',
+          '@astrojs/check',
+          'typescript',
+          '@storyblok/js',
+          '@storyblok/richtext',
+          'storyblok-js-client',
+          'morphdom',
+          'camelcase',
+        ],
+        output: {
+          preserveModules: true,
+          preserveModulesRoot: 'src',
+          entryFileNames: '[name].js',
+          chunkFileNames: 'chunks/[name]-[hash].js',
+        },
       },
     },
     plugins: [

--- a/packages/astro/vite.config.ts
+++ b/packages/astro/vite.config.ts
@@ -4,72 +4,70 @@ import path from 'node:path';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import fs from 'node:fs';
 
-export default defineConfig(() => {
-  return {
-    build: {
-      lib: {
-        entry: {
-          'index': path.resolve(__dirname, 'src/index.ts'),
-          'richtext': path.resolve(__dirname, 'src/richtext.ts'),
-          'types': path.resolve(__dirname, 'src/types.ts'),
-          'utils/toCamelCase': path.resolve(__dirname, 'src/utils/toCamelCase.ts'),
-        },
-        formats: ['es'],
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        'index': path.resolve(__dirname, 'src/index.ts'),
+        'richtext': path.resolve(__dirname, 'src/richtext.ts'),
+        'types': path.resolve(__dirname, 'src/types.ts'),
+        'utils/toCamelCase': path.resolve(__dirname, 'src/utils/toCamelCase.ts'),
       },
-      rollupOptions: {
-        external: [
-          'astro',
-          '@astrojs/check',
-          'typescript',
-          '@storyblok/js',
-          '@storyblok/richtext',
-          'storyblok-js-client',
-          'morphdom',
-          'camelcase',
-        ],
-        output: {
-          preserveModules: true,
-          preserveModulesRoot: 'src',
-          entryFileNames: '[name].js',
-          chunkFileNames: 'chunks/[name]-[hash].js',
-        },
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: [
+        'astro',
+        '@astrojs/check',
+        'typescript',
+        '@storyblok/js',
+        '@storyblok/richtext',
+        'storyblok-js-client',
+        'morphdom',
+        'camelcase',
+      ],
+      output: {
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        entryFileNames: '[name].js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
       },
     },
-    plugins: [
-      dts({
-        afterBuild: () => {
-          const indexDtsPath = path.resolve(__dirname, 'dist/index.d.ts');
+  },
+  plugins: [
+    dts({
+      afterBuild: () => {
+        const indexDtsPath = path.resolve(__dirname, 'dist/index.d.ts');
 
-          if (fs.existsSync(indexDtsPath)) {
-            const currentContent = fs.readFileSync(indexDtsPath, 'utf-8');
-            const referenceLine = `/// <reference path="./public.d.ts" />`;
+        if (fs.existsSync(indexDtsPath)) {
+          const currentContent = fs.readFileSync(indexDtsPath, 'utf-8');
+          const referenceLine = `/// <reference path="./public.d.ts" />`;
 
-            if (!currentContent.includes(referenceLine)) {
-              const newContent = `${referenceLine}\n${currentContent}`;
-              fs.writeFileSync(indexDtsPath, newContent);
-            }
+          if (!currentContent.includes(referenceLine)) {
+            const newContent = `${referenceLine}\n${currentContent}`;
+            fs.writeFileSync(indexDtsPath, newContent);
           }
+        }
+      },
+    }),
+    viteStaticCopy({
+      targets: [
+        { src: 'src/live-preview/middleware.ts', dest: 'live-preview' },
+        { src: 'src/dev-toolbar/toolbarApp.ts', dest: 'dev-toolbar' },
+        {
+          src: ['src/lib/richTextToHTML.ts', 'src/lib/client.ts'],
+          dest: 'lib',
         },
-      }),
-      viteStaticCopy({
-        targets: [
-          { src: 'src/live-preview/middleware.ts', dest: 'live-preview' },
-          { src: 'src/dev-toolbar/toolbarApp.ts', dest: 'dev-toolbar' },
-          {
-            src: ['src/lib/richTextToHTML.ts', 'src/lib/client.ts'],
-            dest: 'lib',
-          },
-          { src: 'src/public.d.ts', dest: '.' },
-          {
-            src: [
-              'src/components/StoryblokComponent.astro',
-              'src/components/FallbackComponent.astro',
-              'src/components/StoryblokServerData.astro',
-            ],
-            dest: 'components',
-          },
-        ],
-      }),
-    ],
-  };
+        { src: 'src/public.d.ts', dest: '.' },
+        {
+          src: [
+            'src/components/StoryblokComponent.astro',
+            'src/components/FallbackComponent.astro',
+            'src/components/StoryblokServerData.astro',
+          ],
+          dest: 'components',
+        },
+      ],
+    }),
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@storyblok/js':
         specifier: workspace:*
         version: link:../js
+      '@storyblok/richtext':
+        specifier: workspace:*
+        version: link:../richtext
       camelcase:
         specifier: ^8.0.0
         version: 8.0.0


### PR DESCRIPTION
## Summary

Externalizes runtime deps, switches `@storyblok/astro` to multi-entry `preserveModules` ESM output, and adds a `@storyblok/astro/richtext` subpath. Mirrors the pattern from #572 (which did the same for `@storyblok/js`), applied one layer up.

After this change, importing utilities like `storyblokEditable` or `storyblok` no longer drags the dev toolbar, live-preview message handler, `@storyblok/js`, `@storyblok/richtext` (TipTap + ProseMirror), `storyblok-js-client`, or `morphdom` into the consumer bundle. Routes that don’t use rich text are completely free of `@storyblok/richtext`.

Fixes #599.

## Problem

`packages/astro/vite.config.ts` produces a single bundled `dist/storyblok-astro.es.js` (~1.1 MB) with only `astro`, `@astrijs/check`, `typescript` in the external list. Every other dependency is inlined. Even `dist/components/StoryblokComponent.astro` transitively pulls the pre-bundle through its `import { toCamelCase } from '@storyblok/astro'` line. Consumers can’t tree-shake across the boundary.

(Side note: `@astrijs/check` in the existing external list is a typo of `@astrojs/check`; harmless because `@astrojs/check` isn’t actually imported. This PR fixes it as a free-rider — happy to split it out if you’d prefer.)

## Changes

**`packages/astro/vite.config.ts`**

- Multi-entry input (`index`, `richtext`, `types`, `utils/toCamelCase`) + `formats: ['es']`.
- Externalize `@storyblok/js`, `@storyblok/richtext`, `storyblok-js-client`, `morphdom`, `camelcase` (plus existing `astro`, `typescript`, and corrected `@astrojs/check`).
- `preserveModules: true` + `preserveModulesRoot: 'src'` — one output file per source file.

**`packages/astro/package.json`**

- `"sideEffects": false`.
- New `./richtext` subpath export.
- `main` / `module` / `exports["."]` repointed at `./dist/index.js` (per-file entry instead of the bundled blob).
- Dropped the UMD / `require` paths. The package is `"type": "module"` and consumed via Astro’s ESM module graph; the UMD output was unused in practice.
- Added `@storyblok/richtext` to `dependencies` (now used directly by `src/richtext.ts`; was previously transitive through `@storyblok/js`).

**`packages/astro/src/components/StoryblokComponent.astro`**

- Imports `toCamelCase` and `SbBlokData` from internal relative paths (`../utils/toCamelCase`, `../types`) instead of `@storyblok/astro`. After `preserveModules`, those resolve to `dist/utils/toCamelCase.js` and `dist/types.d.ts` (type-only) — both exist as standalone outputs.

**`packages/astro/src/richtext.ts`** (new)

- Thin entry that re-exports `renderRichText`, `richTextResolver`, `segmentStoryblokRichText`, and the rich-text types directly from `@storyblok/richtext` (skips `@storyblok/js`).

## Bundle measurements

esbuild, browser ESM, minified, gzipped — against `@storyblok/astro@9.0.5` (before) vs this branch (after). Reproduce with the snippet in #599.

| Scenario | Before (gz) | After (gz) | Delta |
|---|---:|---:|---|
| `import { storyblokEditable }` | 170.4 KB | **0.2 KB** | **−99.9%** |
| `import { storyblok }` | 176.1 KB | **5.7 KB** | **−97%** |
| `import { renderRichText }` (root) | 172.2 KB | 192.9 KB | +12% (¹) |
| `import { renderRichText } from '@storyblok/astro/richtext'` | n/a | 192.9 KB | new |
| `import * as sb` | 184.7 KB | 207.3 KB | +12% (¹) |

(¹) Routes that pull `@storyblok/richtext` grow slightly because the externalized `@storyblok/richtext@4.3.0` is heavier raw than what 9.0.5 inlined — the regression tracked in #471, orthogonal to this PR. Routes that don’t use rich text (the common case) are now free of it entirely.

## Test plan

- [x] `pnpm --filter @storyblok/astro build` — clean. Total dist JS output is ~22 KB (per-file ESM) versus 1.2 MB ES + 880 KB UMD before.
- [x] `pnpm --filter @storyblok/astro test:unit` — 67/67 passing.
- [x] `pnpm --filter @storyblok/astro test:types` — clean.
- [x] Functional smoke test against a real Astro 6 SSG site: installed the patched tarball over `@storyblok/astro@9.0.5`, exercised every public surface (`storyblok`, `storyblokEditable`, `storyblokInit`, `apiPlugin`, `loadStoryblokBridge`, `toCamelCase`, `renderRichText` from both root and the new `/richtext` subpath, plus the type re-exports), and type-checked clean under `astro/tsconfigs/strictest` with `verbatimModuleSyntax`.
- [x] CI green.
- [x] `test:e2e` (Cypress against the playground) — please run, I don’t have the env set up locally.

## Notes for reviewers

- This is a **non-breaking** change for the documented public API. Consumers doing `import { ... } from '@storyblok/astro'` keep working, and existing subpath exports (`./StoryblokComponent.astro`, `./FallbackComponent.astro`, `./StoryblokServerData.astro`, `./middleware.ts`, `./toolbarApp.ts`, `./client`) are preserved.
- The new `./richtext` subpath is additive. The root-level `renderRichText` re-export is preserved for back-compat; it just routes through `@storyblok/js` instead of skipping straight to `@storyblok/richtext`.
