### PR TITLE
perf(cli): targeted parallel prefetch for stories push

### DIFF
--- a/packages/cli/src/commands/stories/actions.test.ts
+++ b/packages/cli/src/commands/stories/actions.test.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchStories } from './actions';
+import { fetchStories, prefetchTargetStoriesByKeys } from './actions';
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 
@@ -272,6 +272,174 @@ describe('stories/actions', () => {
         'pull_stories',
         expect.anything(),
       );
+    });
+  });
+
+  describe('prefetchTargetStoriesByKeys', () => {
+    const space = '12345';
+
+    const buildRemoteStory = (overrides: { id: number; uuid: string; full_slug: string; is_folder?: boolean }) => ({
+      ...mockStories[0],
+      ...overrides,
+      slug: overrides.full_slug.split('/').pop()!,
+      is_folder: overrides.is_folder ?? false,
+    });
+
+    it('returns empty maps when no keys are provided', async () => {
+      const result = await prefetchTargetStoriesByKeys(space, { slugs: [], ids: [] });
+      expect(result.bySlug.size).toBe(0);
+      expect(result.byId.size).toBe(0);
+    });
+
+    it('fetches stories by slug and indexes them by normalized full_slug and id', async () => {
+      const remote = buildRemoteStory({ id: 7, uuid: 'uuid-7', full_slug: 'home' });
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/stories', ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('by_slugs')).toBe('home');
+          return HttpResponse.json(
+            { stories: [remote] },
+            { headers: { 'Total': '1', 'Per-Page': '100' } },
+          );
+        }),
+      );
+
+      const result = await prefetchTargetStoriesByKeys(space, { slugs: ['home'], ids: [] });
+
+      expect(result.bySlug.get('home')).toEqual([
+        { id: 7, uuid: 'uuid-7', is_folder: false },
+      ]);
+      expect(result.byId.get(7)).toEqual({ id: 7, uuid: 'uuid-7', is_folder: false });
+    });
+
+    it('stores folder + startpage that share a full_slug as separate entries', async () => {
+      const folder = buildRemoteStory({ id: 10, uuid: 'uuid-folder', full_slug: 'about', is_folder: true });
+      const startpage = buildRemoteStory({ id: 11, uuid: 'uuid-startpage', full_slug: 'about', is_folder: false });
+
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/stories', () =>
+          HttpResponse.json(
+            { stories: [folder, startpage] },
+            { headers: { 'Total': '2', 'Per-Page': '100' } },
+          )),
+      );
+
+      const result = await prefetchTargetStoriesByKeys(space, { slugs: ['about'], ids: [] });
+
+      const entries = result.bySlug.get('about');
+      expect(entries).toHaveLength(2);
+      expect(entries).toEqual(expect.arrayContaining([
+        { id: 10, uuid: 'uuid-folder', is_folder: true },
+        { id: 11, uuid: 'uuid-startpage', is_folder: false },
+      ]));
+    });
+
+    it('omits slugs that have no remote match', async () => {
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/stories', () =>
+          HttpResponse.json(
+            { stories: [] },
+            { headers: { 'Total': '0', 'Per-Page': '100' } },
+          )),
+      );
+
+      const result = await prefetchTargetStoriesByKeys(space, { slugs: ['missing'], ids: [] });
+
+      expect(result.bySlug.has('missing')).toBe(false);
+    });
+
+    it('treats slugs as exact matches (no wildcard interpretation)', async () => {
+      let captured: string | null = null;
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/stories', ({ request }) => {
+          captured = new URL(request.url).searchParams.get('by_slugs');
+          return HttpResponse.json(
+            { stories: [] },
+            { headers: { 'Total': '0', 'Per-Page': '100' } },
+          );
+        }),
+      );
+
+      await prefetchTargetStoriesByKeys(space, { slugs: ['foo/bar'], ids: [] });
+
+      // The literal slug is sent as-is; callers should not be expected to
+      // escape characters because real Storyblok slugs cannot contain `*`/`?`.
+      expect(captured).toBe('foo/bar');
+    });
+
+    it('fetches stories by id and indexes them by id and full_slug', async () => {
+      const remote = buildRemoteStory({ id: 99, uuid: 'uuid-99', full_slug: 'pricing' });
+      let captured: string | null = null;
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/stories', ({ request }) => {
+          const url = new URL(request.url);
+          captured = url.searchParams.get('by_ids');
+          expect(url.searchParams.get('by_slugs')).toBeNull();
+          return HttpResponse.json(
+            { stories: [remote] },
+            { headers: { 'Total': '1', 'Per-Page': '100' } },
+          );
+        }),
+      );
+
+      const result = await prefetchTargetStoriesByKeys(space, { slugs: [], ids: [99] });
+
+      expect(captured).toBe('99');
+      expect(result.byId.get(99)).toEqual({ id: 99, uuid: 'uuid-99', is_folder: false });
+      expect(result.bySlug.get('pricing')).toEqual([
+        { id: 99, uuid: 'uuid-99', is_folder: false },
+      ]);
+    });
+
+    it('paginates when a chunk returns more results than one page', async () => {
+      const perPage = 100;
+      const page1 = Array.from({ length: perPage }, (_, i) =>
+        buildRemoteStory({ id: i + 1, uuid: `uuid-p1-${i + 1}`, full_slug: `s${i + 1}` }));
+      const page2 = [
+        buildRemoteStory({ id: 1001, uuid: 'uuid-p2-1', full_slug: 's1', is_folder: true }),
+        buildRemoteStory({ id: 1002, uuid: 'uuid-p2-2', full_slug: 's2', is_folder: true }),
+      ];
+      const total = page1.length + page2.length;
+
+      const pagesSeen: number[] = [];
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/stories', ({ request }) => {
+          const page = Number(new URL(request.url).searchParams.get('page') || '1');
+          pagesSeen.push(page);
+          const stories = page === 1 ? page1 : page === 2 ? page2 : [];
+          return HttpResponse.json(
+            { stories },
+            { headers: { 'Total': String(total), 'Per-Page': String(perPage) } },
+          );
+        }),
+      );
+
+      const slugs = page1.map(s => s.full_slug);
+      const result = await prefetchTargetStoriesByKeys(space, { slugs, ids: [] });
+
+      expect(pagesSeen).toEqual([1, 2]);
+      expect(result.byId.size).toBe(total);
+      // s1 and s2 each appear on page 2 as folders alongside their page-1 entry.
+      expect(result.bySlug.get('s1')).toHaveLength(2);
+      expect(result.bySlug.get('s2')).toHaveLength(2);
+      expect(result.bySlug.get('s3')).toHaveLength(1);
+    });
+
+    it('deduplicates a story returned by both slug and id queries', async () => {
+      const remote = buildRemoteStory({ id: 42, uuid: 'uuid-42', full_slug: 'shared' });
+
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/stories', () =>
+          HttpResponse.json(
+            { stories: [remote] },
+            { headers: { 'Total': '1', 'Per-Page': '100' } },
+          )),
+      );
+
+      const result = await prefetchTargetStoriesByKeys(space, { slugs: ['shared'], ids: [42] });
+
+      expect(result.bySlug.get('shared')).toHaveLength(1);
+      expect(result.byId.get(42)?.uuid).toBe('uuid-42');
     });
   });
 });

--- a/packages/cli/src/commands/stories/actions.ts
+++ b/packages/cli/src/commands/stories/actions.ts
@@ -2,6 +2,7 @@ import type { StoryCreate, StoryUpdate } from '../../types';
 import type { ExistingTargetStories, FetchStoriesResult, StoriesQueryParams, Story, TargetStoryRef } from './constants';
 import { normalizeFullSlug } from './constants';
 import { getMapiClient } from '../../api';
+import { chunk } from '../../utils/array';
 import { handleAPIError } from '../../utils/error/api-error';
 
 /**
@@ -143,43 +144,125 @@ export const updateStory = async (
   }
 };
 
-export const prefetchTargetStories = async (spaceId: string, options?: {
-  onTotal?: (total: number) => void;
-  onIncrement?: (count: number) => void;
-}): Promise<ExistingTargetStories> => {
+// 100 keys per chunk: matches MAPI's `per_page=100` so id queries fill a page
+// exactly (1 result per id) and slug queries paginate when folder + startpage
+// pairs push the result count above one page. At ~30 char slugs, 100 entries
+// ≈ 3 KB — well below typical URL length limits.
+const PREFETCH_CHUNK_SIZE = 100;
+const PREFETCH_PER_PAGE = 100;
+
+const addRef = (result: ExistingTargetStories, story: Story): void => {
+  const ref: TargetStoryRef = { id: story.id, uuid: story.uuid, is_folder: story.is_folder };
+  if (story.full_slug) {
+    const key = normalizeFullSlug(story.full_slug);
+    const existing = result.bySlug.get(key);
+    if (existing) {
+      // Avoid duplicates if the same story comes back via both by_slugs and by_ids.
+      if (!existing.some(r => r.id === ref.id)) {
+        existing.push(ref);
+      }
+    }
+    else {
+      result.bySlug.set(key, [ref]);
+    }
+  }
+  result.byId.set(story.id, ref);
+};
+
+/**
+ * Fetches every page of a single chunk query (`by_slugs` / `by_ids`).
+ * A 100-id chunk returns ≤100 stories and resolves in one page; a 100-slug
+ * chunk may exceed 100 results when slugs match folder + startpage pairs.
+ */
+const fetchChunkAllPages = async (
+  spaceId: string,
+  params: StoriesQueryParams,
+  onPageStories: (stories: Story[]) => void,
+): Promise<void> => {
+  let page = 1;
+  while (true) {
+    const response = await fetchStories(spaceId, { ...params, page, per_page: PREFETCH_PER_PAGE });
+    if (!response) {
+      return;
+    }
+    onPageStories(response.stories);
+    const total = Number(response.headers.get('Total'));
+    const perPage = Number(response.headers.get('Per-Page')) || PREFETCH_PER_PAGE;
+    if (!Number.isFinite(total) || total <= page * perPage) {
+      return;
+    }
+    page++;
+  }
+};
+
+/**
+ * Targeted prefetch: fetches only the remote stories that match the local push set,
+ * either by `full_slug` (cross-space duplicate matching, same-space slug fallback)
+ * or by numeric id (resume against a same-space manifest).
+ *
+ * Slug and id batches are dispatched concurrently through the MAPI client's
+ * existing throttle (default `maxConcurrency = 6`, adapts to the server's
+ * `X-RateLimit-Policy` header, auto-retries 429).
+ */
+export const prefetchTargetStoriesByKeys = async (
+  spaceId: string,
+  keys: { slugs: Iterable<string>; ids: Iterable<number> },
+  options?: {
+    onTotal?: (total: number) => void;
+    onIncrement?: (count: number) => void;
+  },
+): Promise<ExistingTargetStories> => {
   const result: ExistingTargetStories = {
     bySlug: new Map(),
     byId: new Map(),
   };
-  let page = 1;
-  let totalPages = 1;
-  while (page <= totalPages) {
-    const response = await fetchStories(spaceId, { page, per_page: 100 });
-    if (!response) {
-      break;
+
+  const slugSet = new Set<string>();
+  for (const slug of keys.slugs) {
+    if (slug) {
+      slugSet.add(normalizeFullSlug(slug));
     }
-    const total = Number(response.headers.get('Total'));
-    const perPage = Number(response.headers.get('Per-Page'));
-    totalPages = Math.ceil(total / perPage);
-    if (page === 1) {
-      options?.onTotal?.(total);
-    }
-    for (const story of response.stories) {
-      const ref: TargetStoryRef = { id: story.id, uuid: story.uuid, is_folder: story.is_folder };
-      if (story.full_slug) {
-        const key = normalizeFullSlug(story.full_slug);
-        const existing = result.bySlug.get(key);
-        if (existing) {
-          existing.push(ref);
-        }
-        else {
-          result.bySlug.set(key, [ref]);
-        }
-      }
-      result.byId.set(story.id, ref);
-    }
-    options?.onIncrement?.(response.stories.length);
-    page++;
   }
+  const idSet = new Set<number>();
+  for (const id of keys.ids) {
+    if (typeof id === 'number' && Number.isFinite(id)) {
+      idSet.add(id);
+    }
+  }
+
+  options?.onTotal?.(slugSet.size + idSet.size);
+
+  if (slugSet.size === 0 && idSet.size === 0) {
+    return result;
+  }
+
+  const slugChunks = chunk(slugSet, PREFETCH_CHUNK_SIZE);
+  const idChunks = chunk(idSet, PREFETCH_CHUNK_SIZE);
+
+  const requests: Array<Promise<void>> = [];
+
+  for (const slugs of slugChunks) {
+    requests.push((async () => {
+      await fetchChunkAllPages(spaceId, { by_slugs: slugs.join(',') }, (stories) => {
+        for (const story of stories) {
+          addRef(result, story);
+        }
+      });
+      options?.onIncrement?.(slugs.length);
+    })());
+  }
+
+  for (const ids of idChunks) {
+    requests.push((async () => {
+      await fetchChunkAllPages(spaceId, { by_ids: ids.join(',') }, (stories) => {
+        for (const story of stories) {
+          addRef(result, story);
+        }
+      });
+      options?.onIncrement?.(ids.length);
+    })());
+  }
+
+  await Promise.all(requests);
   return result;
 };

--- a/packages/cli/src/commands/stories/push/index.test.ts
+++ b/packages/cli/src/commands/stories/push/index.test.ts
@@ -136,16 +136,26 @@ const preconditions = {
     }
   },
   canListStories(stories: MockStory[], space = DEFAULT_SPACE) {
-    const perPage = 2;
+    // The push command issues targeted list calls filtered by `by_slugs` or
+    // `by_ids`. Honor both filters so the handler matches the real MAPI shape;
+    // fall back to returning everything for any unfiltered callers.
     server.use(
       http.get(`https://mapi.storyblok.com/v1/spaces/${space}/stories`, ({ request }) => {
         const url = new URL(request.url);
-        const page = Number(url.searchParams.get('page') || '1');
-        const start = (page - 1) * perPage;
-        const pageStories = stories.slice(start, start + perPage);
+        const bySlugs = url.searchParams.get('by_slugs');
+        const byIds = url.searchParams.get('by_ids');
+        let matched: MockStory[] = stories;
+        if (bySlugs !== null) {
+          const slugSet = new Set(bySlugs.split(',').map(s => s.replace(/\/$/, '')));
+          matched = stories.filter(s => slugSet.has(String(s.full_slug ?? s.slug).replace(/\/$/, '')));
+        }
+        else if (byIds !== null) {
+          const idSet = new Set(byIds.split(',').map(n => Number(n)));
+          matched = stories.filter(s => idSet.has(s.id));
+        }
         return HttpResponse.json(
-          { stories: pageStories },
-          { headers: { 'Total': String(stories.length), 'Per-Page': String(perPage) } },
+          { stories: matched },
+          { headers: { 'Total': String(matched.length), 'Per-Page': '100' } },
         );
       }),
     );

--- a/packages/cli/src/commands/stories/push/index.ts
+++ b/packages/cli/src/commands/stories/push/index.ts
@@ -12,7 +12,7 @@ import { getReporter } from '../../../lib/reporter/reporter';
 import { createStoriesForLevel, groupStoriesByDepth, makeAppendToManifestFSTransport, makeCleanupStoryFSTransport, makeWriteStoryAPITransport, mapReferencesStream, readLocalStoriesStream, scanLocalStoryIndex, writeStoryStream } from '../streams';
 import { findComponentSchemas } from '../utils';
 import { loadAssetMap } from '../../assets/utils';
-import { prefetchTargetStories } from '../actions';
+import { prefetchTargetStoriesByKeys } from '../actions';
 import { collectSchemaIssues, formatSchemaIssues, hasSchemaIssues } from '../validate-story';
 import { FailureCollector } from './failure-report';
 
@@ -120,17 +120,13 @@ pushCmd
         visit(story.content);
       };
 
-      const fetchProgress = ui.createProgressBar({ title: 'Matching Stories...'.padEnd(21) });
-      const existingTargetStories = await prefetchTargetStories(space, {
-        onTotal: total => fetchProgress.setTotal(total),
-        onIncrement: count => fetchProgress.increment(count),
-      });
-      fetchProgress.stop();
-
       /**
        * Pass 1: Scan local stories, group by depth, and create remote
        * placeholders level-by-level so that parent folders exist before
        * their children are created.
+       *
+       * Scan happens before the prefetch so we know which slugs and ids
+       * to look up — the prefetch only fetches what the push actually needs.
        */
       const scanProgress = ui.createProgressBar({ title: 'Scanning Stories...'.padEnd(21) });
       const storyIndex = await scanLocalStoryIndex({
@@ -150,6 +146,28 @@ pushCmd
       });
       const levels = groupStoriesByDepth(storyIndex);
       scanProgress.stop();
+
+      // Targeted prefetch: only the local stories' slugs + manifest-mapped ids.
+      // For a small push against a large target space, this is O(local) calls
+      // instead of O(target/100) — and they run concurrently through the MAPI throttle.
+      const localSlugs = storyIndex.map(entry => entry.full_slug).filter(Boolean);
+      const localIdSet = new Set(storyIndex.map(entry => entry.id));
+      const manifestIds: number[] = [];
+      for (const [key, value] of maps.stories.entries()) {
+        if (typeof key === 'number' && localIdSet.has(key) && typeof value === 'number') {
+          manifestIds.push(value);
+        }
+      }
+      const fetchProgress = ui.createProgressBar({ title: 'Matching Stories...'.padEnd(21) });
+      const existingTargetStories = await prefetchTargetStoriesByKeys(
+        space,
+        { slugs: localSlugs, ids: manifestIds },
+        {
+          onTotal: total => fetchProgress.setTotal(total),
+          onIncrement: count => fetchProgress.increment(count),
+        },
+      );
+      fetchProgress.stop();
 
       const creationProgress = ui.createProgressBar({ title: 'Creating Stories...'.padEnd(21) });
       const processProgress = ui.createProgressBar({ title: 'Processing Stories...'.padEnd(21) });

--- a/packages/cli/src/utils/array.test.ts
+++ b/packages/cli/src/utils/array.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { chunk } from './array';
+
+describe('chunk', () => {
+  it('returns empty array for empty input', () => {
+    expect(chunk([], 10)).toEqual([]);
+  });
+
+  it('splits a set into batches of the given size', () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('returns a single batch when input is smaller than size', () => {
+    expect(chunk(['a', 'b'], 10)).toEqual([['a', 'b']]);
+  });
+
+  it('accepts a Set (any Iterable)', () => {
+    expect(chunk(new Set([1, 2, 3]), 2)).toEqual([[1, 2], [3]]);
+  });
+
+  it('returns a single batch when size is 0 or negative', () => {
+    expect(chunk([1, 2, 3], 0)).toEqual([[1, 2, 3]]);
+    expect(chunk([1, 2, 3], -1)).toEqual([[1, 2, 3]]);
+  });
+});

--- a/packages/cli/src/utils/array.ts
+++ b/packages/cli/src/utils/array.ts
@@ -1,0 +1,18 @@
+/**
+ * Splits an iterable into batches of at most `size` items, preserving order.
+ * Returns `[]` for empty input. If `size <= 0`, returns the full input as a single batch.
+ */
+export const chunk = <T>(items: Iterable<T>, size: number): T[][] => {
+  const all = Array.from(items);
+  if (all.length === 0) {
+    return [];
+  }
+  if (size <= 0) {
+    return [all];
+  }
+  const chunks: T[][] = [];
+  for (let i = 0; i < all.length; i += size) {
+    chunks.push(all.slice(i, i + size));
+  }
+  return chunks;
+};

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -3,6 +3,7 @@ import { dirname } from 'pathe';
 import type { RegionCode } from '../constants';
 import { regions } from '../constants';
 
+export * from './array';
 export * from './auth';
 export * from './error/';
 export * from './format';


### PR DESCRIPTION
## Summary

- Replace `prefetchTargetStories` (sequential pagination of every target story) with `prefetchTargetStoriesByKeys` — concurrent `by_slugs` / `by_ids` chunks driven by the local push payload.
- `manifestIds` is filtered by the local story ids actually being pushed, so a sparse push against a large historical manifest no longer fans out one id-chunk per stale manifest entry.
- Push time on a large target space now scales with the number of local stories being pushed, not the size of the target space.

## Why

For customers with large target spaces (e.g. 125k stories), every `stories push` paid a ~10–15 minute prefetch cost — even when pushing a handful of stories. The prefetch existed to fix a real correctness bug from #473 (cross-space duplicates matched by slug); this PR preserves that fix while making the prefetch O(local) instead of O(target).

## Benchmark — prefetch primitive (target = 5000 stories, push = 10)

Measured against a real Storyblok space (EU region) seeded with 5000 flat stories. Each strategy ran 3× back-to-back on a warm connection.

| Strategy | HTTP calls | Median | Payload |
|---|---:|---:|---:|
| `main` — sequential `page=N, per_page=100` | 50 | **13,795 ms** | 5000 stories returned |
| this PR — single `by_slugs` chunk | 1 | **130 ms** | 10 stories returned |

Raw runs (ms): old `13274 / 13795 / 15484` · new `103 / 192 / 130`.

**~106× faster on the prefetch step.** Network payload also collapses ~500× (10 stories' worth vs 5000). The win scales linearly with target size — the old path makes `ceil(target/100)` sequential round-trips regardless of how many stories the user is actually pushing.

## Test plan

- [x] `pnpm nx lint:fix storyblok` — green
- [x] `pnpm nx test storyblok` — 688 tests passing
- [x] Manual QA against real Storyblok spaces — same-space push, cross-space push, nested folder+startpage, bulk 150-story push, sparse push with manifest, all PASS
- [x] Cross-space regression from #473 (slug-based match for duplicated target) still passes
- [ ] Reviewer: confirm `by_slugs` / `by_ids` MAPI semantics for edge cases (very long slugs, special characters)

Fixes WDX-416