### PR TITLE
chore(ci): harden publish workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-.github/workflows/ @storyblok/plugins
-.github/actions/ @storyblok/plugins
+.github/workflows/ @storyblok/dx
+.github/actions/ @storyblok/dx
 
 packages/region-helper @storyblok/plugins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
+.github/workflows/ @storyblok/plugins
+.github/actions/ @storyblok/plugins
+
 packages/region-helper @storyblok/plugins

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,18 +1,32 @@
 name: Setup Node
 description: Setup node
+inputs:
+  cache:
+    description: Restore/save pnpm and Nx caches
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
     - uses: ./.github/actions/cache-monorepo
+      if: ${{ inputs.cache == 'true' }}
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4 # no need to specify version, it reads from package.json -> packageManager
 
-    - name: Setup Node.js
+    - name: Setup Node.js with cache
+      if: ${{ inputs.cache == 'true' }}
       uses: actions/setup-node@v6
       with:
         node-version-file: ".nvmrc"
         cache: "pnpm"
+
+    - name: Setup Node.js without cache
+      if: ${{ inputs.cache != 'true' }}
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: ".nvmrc"
+        package-manager-cache: false
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ env:
   HUSKY: 0
   NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     environment: test
@@ -45,6 +48,8 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
 
@@ -58,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -5,6 +5,7 @@ on:
       - "!**"
     branches:
       - "**"
+      - "!main"
 
 env:
   PNPM_CACHE_FOLDER: .pnpm-store

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -11,7 +11,8 @@ env:
   PNPM_CACHE_FOLDER: .pnpm-store
   HUSKY: 0 # Bypass husky commit hook for CI
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
@@ -25,6 +26,8 @@ jobs:
         node-version: [20]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
       - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,8 +18,11 @@ jobs:
         with:
           fetch-depth: 0
           filter: tree:0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
+        with:
+          cache: "false"
 
       - name: Determine npm tag
         id: npm-tag

--- a/.github/workflows/release-guard.yaml
+++ b/.github/workflows/release-guard.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, edited]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -13,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Fetch changed files
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

- Make the publish workflow a no-cache path by adding a `cache` input to `.github/actions/setup-node` and calling it with `cache: "false"` from `publish.yaml`. This skips the shared pnpm/Nx cache composite and disables `actions/setup-node` package-manager caching while still running `pnpm install --frozen-lockfile`.
- Keep normal CI and preview workflows on the default cached setup path.
- Keep `pkg.pr.new.yml` from running on `main`, since protected release-branch commits are handled by the real publish workflow.
- Add `persist-credentials: false` to checkout steps that do not push, and add explicit `contents: read` permissions where those workflows need checkout.
- Add CODEOWNERS coverage for `.github/workflows/` and `.github/actions/` using `@storyblok/plugins`.

## Why

The publish job receives `id-token: write` for npm trusted publishing, so it should not restore or save dependency/Nx caches that could be influenced by other workflows. Strictly disabling caches in publish is simpler and safer than maintaining a separate cache namespace for the release path.

## Test plan

- [x] YAML parse for `.github/workflows/*` and `.github/actions/*`.
- [x] `git diff --check origin/main..HEAD`.
- [x] Confirmed `.github/actions/cache-monorepo/action.yaml` has no branch diff after dropping the obsolete cache namespace commit.
- [x] Confirmed `publish.yaml` keeps `contents: read` and `id-token: write`, uses `persist-credentials: false`, and calls setup-node with `cache: "false"`.
- [x] Confirmed CI and pkg.pr.new still use the default cached setup path.

Third-party action SHA pinning is intentionally left out of this pass.