### PR TITLE
fix: consolidate rate limit, introduce new name and deprecate old one

### DIFF
--- a/.agents/skills/investigate/SKILL.md
+++ b/.agents/skills/investigate/SKILL.md
@@ -15,8 +15,12 @@ Investigate the following GitHub issue: $ARGUMENTS
 
 ### Phase 1: Fetch Issue Details
 
-1. Parse the input (full URL, `#123`, or `123`)
-2. Fetch with `gh issue view <number> --json title,body,labels,comments,author,createdAt,state`
+1. Parse the input:
+   - `WDX-123` or `linear.app` URL → **Linear ticket**
+   - `#123`, bare number, or `github.com` URL → **GitHub issue**
+2. Fetch the ticket:
+   - **GitHub:** `gh issue view <number> --json title,body,labels,comments,author,createdAt,state`
+   - **Linear:** `bash .agents/skills/triage/scripts/linear-fetch.sh issue WDX-123`
 3. Extract: error messages, stack traces, reproduction steps, environment details
 
 ### Phase 2: Identify Affected Package(s)

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -13,7 +13,7 @@ export function createMapiClient(options: ManagementApiClientConfig) {
   const { api } = getActiveConfig();
   return createManagementApiClient({
     ...options,
-    rateLimit: options.rateLimit ?? (api.maxConcurrency > 0 ? { maxConcurrency: api.maxConcurrency } : false),
+    rateLimit: options.rateLimit ?? (api.rateLimit > 0 ? { maxConcurrency: api.rateLimit } : false),
   });
 }
 

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -13,7 +13,7 @@ export function createMapiClient(options: ManagementApiClientConfig) {
   const { api } = getActiveConfig();
   return createManagementApiClient({
     ...options,
-    rateLimit: options.rateLimit ?? (api.rateLimit > 0 ? { maxConcurrency: api.rateLimit } : false),
+    rateLimit: options.rateLimit ?? (api.rateLimit > 0 ? api.rateLimit : false),
   });
 }
 

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -12,7 +12,7 @@ import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolder
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { FetchError } from '../../utils/fetch';
-import { createPipelineBackpressureLock } from '../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../utils/backpressure-lock';
 import { getAssetBinaryFilename, getAssetFilename, getFolderFilename, getSidecarFilename, isRemoteSource, loadSidecarAssetData } from './utils';
 
 let _pipelineSlot: Sema | null = null;

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { basename, extname, join } from 'pathe';
 import { Readable, Transform, Writable } from 'node:stream';
-import { Sema } from 'async-sema';
+import type { Sema } from 'async-sema';
 import { readdir, readFile, unlink } from 'node:fs/promises';
 import { appendToFile, fileExists, saveToFile } from '../../utils/filesystem';
 import { toError } from '../../utils/error/error';
@@ -12,9 +12,16 @@ import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolder
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { FetchError } from '../../utils/fetch';
+import { createConcurrencyLock } from '../../utils/concurrency';
 import { getAssetBinaryFilename, getAssetFilename, getFolderFilename, getSidecarFilename, isRemoteSource, loadSidecarAssetData } from './utils';
 
-const apiConcurrencyLock = new Sema(12);
+let _apiConcurrencyLock: Sema | null = null;
+const getApiConcurrencyLock = (): Sema => {
+  if (!_apiConcurrencyLock) {
+    _apiConcurrencyLock = createConcurrencyLock();
+  }
+  return _apiConcurrencyLock;
+};
 
 export const fetchAssetsStream = ({
   spaceId,
@@ -95,7 +102,7 @@ export const downloadAssetStream = ({
   return new Transform({
     objectMode: true,
     async transform(asset: Asset, _encoding, callback) {
-      await apiConcurrencyLock.acquire();
+      await getApiConcurrencyLock().acquire();
 
       const task = downloadAssetFile(asset, { assetToken, region })
         .then((fileBuffer) => {
@@ -110,7 +117,7 @@ export const downloadAssetStream = ({
         })
         .finally(() => {
           onIncrement?.();
-          apiConcurrencyLock.release();
+          getApiConcurrencyLock().release();
           processing.delete(task);
         });
       processing.add(task);
@@ -151,7 +158,7 @@ export const writeAssetStream = ({
   return new Writable({
     objectMode: true,
     async write(payload: { asset: Asset; fileBuffer: ArrayBuffer }, _encoding, callback) {
-      await apiConcurrencyLock.acquire();
+      await getApiConcurrencyLock().acquire();
 
       const task = (async () => {
         try {
@@ -166,7 +173,7 @@ export const writeAssetStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        apiConcurrencyLock.release();
+        getApiConcurrencyLock().release();
         processing.delete(task);
       });
 
@@ -235,7 +242,7 @@ export const writeAssetFolderStream = ({
   return new Writable({
     objectMode: true,
     async write(folder: AssetFolder, _encoding, callback) {
-      await apiConcurrencyLock.acquire();
+      await getApiConcurrencyLock().acquire();
 
       const task = (async () => {
         try {
@@ -250,7 +257,7 @@ export const writeAssetFolderStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        apiConcurrencyLock.release();
+        getApiConcurrencyLock().release();
         processing.delete(task);
       });
 
@@ -717,7 +724,7 @@ export const upsertAssetStream = ({
   return new Writable({
     objectMode: true,
     async write({ asset: localAsset, context }: LocalAssetPayload, _encoding, callback) {
-      await apiConcurrencyLock.acquire();
+      await getApiConcurrencyLock().acquire();
       const task = (async () => {
         try {
           const { remoteAsset } = await processAsset({
@@ -739,7 +746,7 @@ export const upsertAssetStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        apiConcurrencyLock.release();
+        getApiConcurrencyLock().release();
         processing.delete(task);
       });
 

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -12,15 +12,15 @@ import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolder
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { FetchError } from '../../utils/fetch';
-import { createConcurrencyLock } from '../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../utils/concurrency';
 import { getAssetBinaryFilename, getAssetFilename, getFolderFilename, getSidecarFilename, isRemoteSource, loadSidecarAssetData } from './utils';
 
-let _apiConcurrencyLock: Sema | null = null;
-const getApiConcurrencyLock = (): Sema => {
-  if (!_apiConcurrencyLock) {
-    _apiConcurrencyLock = createConcurrencyLock();
+let _pipelineSlot: Sema | null = null;
+const getPipelineSlot = (): Sema => {
+  if (!_pipelineSlot) {
+    _pipelineSlot = createPipelineBackpressureLock();
   }
-  return _apiConcurrencyLock;
+  return _pipelineSlot;
 };
 
 export const fetchAssetsStream = ({
@@ -102,7 +102,7 @@ export const downloadAssetStream = ({
   return new Transform({
     objectMode: true,
     async transform(asset: Asset, _encoding, callback) {
-      await getApiConcurrencyLock().acquire();
+      await getPipelineSlot().acquire();
 
       const task = downloadAssetFile(asset, { assetToken, region })
         .then((fileBuffer) => {
@@ -117,7 +117,7 @@ export const downloadAssetStream = ({
         })
         .finally(() => {
           onIncrement?.();
-          getApiConcurrencyLock().release();
+          getPipelineSlot().release();
           processing.delete(task);
         });
       processing.add(task);
@@ -158,7 +158,7 @@ export const writeAssetStream = ({
   return new Writable({
     objectMode: true,
     async write(payload: { asset: Asset; fileBuffer: ArrayBuffer }, _encoding, callback) {
-      await getApiConcurrencyLock().acquire();
+      await getPipelineSlot().acquire();
 
       const task = (async () => {
         try {
@@ -173,7 +173,7 @@ export const writeAssetStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        getApiConcurrencyLock().release();
+        getPipelineSlot().release();
         processing.delete(task);
       });
 
@@ -242,7 +242,7 @@ export const writeAssetFolderStream = ({
   return new Writable({
     objectMode: true,
     async write(folder: AssetFolder, _encoding, callback) {
-      await getApiConcurrencyLock().acquire();
+      await getPipelineSlot().acquire();
 
       const task = (async () => {
         try {
@@ -257,7 +257,7 @@ export const writeAssetFolderStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        getApiConcurrencyLock().release();
+        getPipelineSlot().release();
         processing.delete(task);
       });
 
@@ -724,7 +724,7 @@ export const upsertAssetStream = ({
   return new Writable({
     objectMode: true,
     async write({ asset: localAsset, context }: LocalAssetPayload, _encoding, callback) {
-      await getApiConcurrencyLock().acquire();
+      await getPipelineSlot().acquire();
       const task = (async () => {
         try {
           const { remoteAsset } = await processAsset({
@@ -746,7 +746,7 @@ export const upsertAssetStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        getApiConcurrencyLock().release();
+        getPipelineSlot().release();
         processing.delete(task);
       });
 

--- a/packages/cli/src/commands/components/push/graph-operations/index.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/index.ts
@@ -30,7 +30,7 @@ export async function pushWithDependencyGraph(
   space: string,
   spaceState: SpaceComponentsDataState,
 
-  maxConcurrency: number = getActiveConfig().api.maxConcurrency,
+  maxConcurrency: number = getActiveConfig().api.rateLimit,
 ): Promise<PushResults> {
   // Build and validate the dependency graph with colocated target data
   const context: GraphBuildingContext = { spaceState };

--- a/packages/cli/src/commands/components/push/graph-operations/index.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/index.ts
@@ -30,7 +30,7 @@ export async function pushWithDependencyGraph(
   space: string,
   spaceState: SpaceComponentsDataState,
 
-  maxConcurrency: number = getActiveConfig().api.rateLimit,
+  backpressure: number = getActiveConfig().api.rateLimit,
 ): Promise<PushResults> {
   // Build and validate the dependency graph with colocated target data
   const context: GraphBuildingContext = { spaceState };
@@ -38,7 +38,7 @@ export async function pushWithDependencyGraph(
   validateGraph(graph);
 
   // Process all resources using the dependency graph
-  const results = await processAllResources(graph, space, maxConcurrency);
+  const results = await processAllResources(graph, space, backpressure);
 
   return results;
 }

--- a/packages/cli/src/commands/components/push/graph-operations/resource-processor.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/resource-processor.ts
@@ -18,7 +18,7 @@ export async function processAllResources(
   graph: DependencyGraph,
   space: string,
 
-  maxConcurrency: number = getActiveConfig().api.maxConcurrency,
+  maxConcurrency: number = getActiveConfig().api.rateLimit,
 ): Promise<PushResults> {
   const levels = determineProcessingOrder(graph);
   const results: PushResults = { successful: [], failed: [] };

--- a/packages/cli/src/commands/components/push/graph-operations/resource-processor.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/resource-processor.ts
@@ -18,7 +18,7 @@ export async function processAllResources(
   graph: DependencyGraph,
   space: string,
 
-  maxConcurrency: number = getActiveConfig().api.rateLimit,
+  backpressure: number = getActiveConfig().api.rateLimit,
 ): Promise<PushResults> {
   const levels = determineProcessingOrder(graph);
   const results: PushResults = { successful: [], failed: [] };
@@ -32,12 +32,12 @@ export async function processAllResources(
   for (const level of levels) {
     if (level.isCyclic) {
       // Handle circular dependencies with stub creation
-      const cyclicResults = await processCyclicLevel(level, graph, space, maxConcurrency);
+      const cyclicResults = await processCyclicLevel(level, graph, space, backpressure);
       mergeResults(results, cyclicResults);
     }
     else {
       // Handle regular level
-      const levelResults = await processLevel(level.nodes, graph, space, maxConcurrency);
+      const levelResults = await processLevel(level.nodes, graph, space, backpressure);
       mergeResults(results, levelResults);
     }
   }
@@ -63,7 +63,7 @@ async function processCyclicLevel(
   level: ProcessingLevel,
   graph: DependencyGraph,
   space: string,
-  maxConcurrency: number,
+  backpressure: number,
 ): Promise<PushResults> {
   // Clear current progress display and show circular dependency message
   progressDisplay.clearProgress();
@@ -73,7 +73,7 @@ async function processCyclicLevel(
   await createStubComponents(level.nodes, graph, space);
 
   // STEP 2: Process the cyclic level normally (references can now resolve)
-  return await processLevel(level.nodes, graph, space, maxConcurrency);
+  return await processLevel(level.nodes, graph, space, backpressure);
 }
 
 /**
@@ -144,7 +144,7 @@ async function processLevel(
   level: string[],
   graph: DependencyGraph,
   space: string,
-  maxConcurrency: number,
+  backpressure: number,
 ): Promise<PushResults> {
   // PASS 1: Resolve references for this level (now that dependencies from previous levels exist)
   for (const nodeId of level) {
@@ -153,15 +153,15 @@ async function processLevel(
   }
 
   // PASS 2: Process all nodes in this level with resolved references
-  const semaphore: Array<Promise<NodeProcessingResult> | null> = Array.from({ length: maxConcurrency }, () => null);
+  const semaphore: Array<Promise<NodeProcessingResult> | null> = Array.from({ length: backpressure }, () => null);
   const promises: Promise<NodeProcessingResult>[] = [];
 
   for (let i = 0; i < level.length; i++) {
     const nodeId = level[i];
 
     // Wait for an available slot
-    const slotIndex = i % maxConcurrency;
-    if (i >= maxConcurrency && semaphore[slotIndex]) {
+    const slotIndex = i % backpressure;
+    if (i >= backpressure && semaphore[slotIndex]) {
       await semaphore[slotIndex];
     }
 

--- a/packages/cli/src/commands/components/push/graph-operations/types.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/types.ts
@@ -80,7 +80,7 @@ export interface PushConfig {
   space: string;
   password: string;
   region: RegionCode;
-  maxConcurrency: number;
+  backpressure: number;
 }
 
 /** Graph building context with source and target data */

--- a/packages/cli/src/commands/migrations/run/index.ts
+++ b/packages/cli/src/commands/migrations/run/index.ts
@@ -93,7 +93,6 @@ runCmd
           query,
           starts_with: startsWith,
         },
-        batchSize: 12,
         onTotal: (total) => {
           storiesProgress.setTotal(total);
           migrationsProgress.setTotal(total);
@@ -121,7 +120,6 @@ runCmd
         space,
         publish,
         dryRun,
-        batchSize: 12,
         onProgress: () => {
           updateProgress.increment();
         },

--- a/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
@@ -4,7 +4,7 @@ import { fetchStories, fetchStory } from '../../../stories/actions';
 import type { StoriesQueryParams, Story } from '../../../stories/constants';
 import { handleAPIError, toError } from '../../../../utils/error';
 import { getLogger } from '../../../../lib/logger/logger';
-import { createConcurrencyLock } from '../../../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../../../utils/concurrency';
 import { ERROR_CODES } from '../constants';
 
 /**
@@ -95,7 +95,7 @@ class StoriesStream extends Transform {
       objectMode: true,
     });
 
-    this.semaphore = createConcurrencyLock();
+    this.semaphore = createPipelineBackpressureLock();
   }
 
   async _transform(chunk: Omit<Story, 'content'>, _encoding: string, callback: (error?: Error | null, data?: any) => void) {

--- a/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
@@ -4,7 +4,7 @@ import { fetchStories, fetchStory } from '../../../stories/actions';
 import type { StoriesQueryParams, Story } from '../../../stories/constants';
 import { handleAPIError, toError } from '../../../../utils/error';
 import { getLogger } from '../../../../lib/logger/logger';
-import { createPipelineBackpressureLock } from '../../../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../../../utils/backpressure-lock';
 import { ERROR_CODES } from '../constants';
 
 /**

--- a/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/stories-stream.ts
@@ -1,9 +1,10 @@
 import { pipeline, Readable, Transform } from 'node:stream';
-import { Sema } from 'async-sema';
+import type { Sema } from 'async-sema';
 import { fetchStories, fetchStory } from '../../../stories/actions';
 import type { StoriesQueryParams, Story } from '../../../stories/constants';
 import { handleAPIError, toError } from '../../../../utils/error';
 import { getLogger } from '../../../../lib/logger/logger';
+import { createConcurrencyLock } from '../../../../utils/concurrency';
 import { ERROR_CODES } from '../constants';
 
 /**
@@ -89,12 +90,12 @@ export async function* storiesIterator(
 class StoriesStream extends Transform {
   private semaphore: Sema;
 
-  constructor(private spaceId: string, private batchSize: number, private onProgress?: () => void) {
+  constructor(private spaceId: string, private onProgress?: () => void) {
     super({
       objectMode: true,
     });
 
-    this.semaphore = new Sema(this.batchSize);
+    this.semaphore = createConcurrencyLock();
   }
 
   async _transform(chunk: Omit<Story, 'content'>, _encoding: string, callback: (error?: Error | null, data?: any) => void) {
@@ -130,19 +131,17 @@ class StoriesStream extends Transform {
 export const createStoriesStream = async ({
   spaceId,
   params,
-  batchSize = 100,
   onTotal,
   onProgress,
 }: {
   spaceId: string;
   params: StoriesQueryParams;
-  batchSize: number;
   onTotal: (total: number) => void;
   onProgress: () => void;
 }): Promise<Readable> => {
   const iterator = storiesIterator(spaceId, params, onTotal);
   const listStoriesStream = Readable.from(iterator);
-  return pipeline(listStoriesStream, new StoriesStream(spaceId, batchSize, onProgress), (err) => {
+  return pipeline(listStoriesStream, new StoriesStream(spaceId, onProgress), (err) => {
     if (err) {
       console.error(err);
       getLogger().error(err.message, { errorCode: ERROR_CODES.MIGRATION_CREATE_STORIES_PIPELINE_ERROR });

--- a/packages/cli/src/commands/migrations/run/streams/update-stream.test.ts
+++ b/packages/cli/src/commands/migrations/run/streams/update-stream.test.ts
@@ -26,7 +26,6 @@ describe('updateStream', () => {
         space: '12345',
         publish: 'published',
         dryRun: false,
-        batchSize: 10,
       });
 
       vi.mocked(updateStory).mockResolvedValue({
@@ -107,7 +106,6 @@ describe('updateStream', () => {
         space: '12345',
         publish: 'published-with-changes',
         dryRun: false,
-        batchSize: 10,
       });
 
       vi.mocked(updateStory).mockResolvedValue({
@@ -188,7 +186,6 @@ describe('updateStream', () => {
         space: '12345',
         publish: 'all',
         dryRun: false,
-        batchSize: 10,
       });
 
       vi.mocked(updateStory).mockResolvedValue({
@@ -266,7 +263,6 @@ describe('updateStream', () => {
       const updateStream = new UpdateStream({
         space: '12345',
         dryRun: false,
-        batchSize: 10,
       });
 
       vi.mocked(updateStory).mockResolvedValue({

--- a/packages/cli/src/commands/migrations/run/streams/update-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/update-stream.ts
@@ -1,10 +1,11 @@
 import { Writable } from 'node:stream';
-import { Sema } from 'async-sema';
+import type { Sema } from 'async-sema';
 import type { StoryUpdate } from '../../../../types';
 import type { StoryContent } from '../../../stories/constants';
 import { updateStory } from '../../../stories/actions';
 import { isStoryPublishedWithoutChanges, isStoryWithUnpublishedChanges } from '../../../stories/utils';
 import { getLogger } from '../../../../lib/logger/logger';
+import { createConcurrencyLock } from '../../../../utils/concurrency';
 import { ERROR_CODES } from '../constants';
 import { toError } from '../../../../utils/error';
 
@@ -12,7 +13,6 @@ export interface UpdateStreamOptions {
   space: string;
   publish?: 'all' | 'published' | 'published-with-changes';
   dryRun?: boolean;
-  batchSize?: number;
   onProgress?: (current: number) => void;
   onTotal?: (total: number) => void;
 }
@@ -29,7 +29,6 @@ export interface UpdateStreamResult {
  */
 export class UpdateStream extends Writable {
   private results: UpdateStreamResult;
-  private readonly batchSize: number;
   private semaphore: Sema;
 
   constructor(private options: UpdateStreamOptions) {
@@ -37,14 +36,13 @@ export class UpdateStream extends Writable {
       objectMode: true,
     });
 
-    this.batchSize = options.batchSize || 10;
     this.results = {
       successful: [],
       failed: [],
       totalProcessed: 0,
     };
 
-    this.semaphore = new Sema(this.batchSize);
+    this.semaphore = createConcurrencyLock();
   }
 
   async _write(chunk: { storyId: number; name: string | undefined; content: StoryContent; published?: boolean; unpublished_changes?: boolean }, _encoding: string, callback: (error?: Error | null) => void) {

--- a/packages/cli/src/commands/migrations/run/streams/update-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/update-stream.ts
@@ -5,7 +5,7 @@ import type { StoryContent } from '../../../stories/constants';
 import { updateStory } from '../../../stories/actions';
 import { isStoryPublishedWithoutChanges, isStoryWithUnpublishedChanges } from '../../../stories/utils';
 import { getLogger } from '../../../../lib/logger/logger';
-import { createPipelineBackpressureLock } from '../../../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../../../utils/backpressure-lock';
 import { ERROR_CODES } from '../constants';
 import { toError } from '../../../../utils/error';
 

--- a/packages/cli/src/commands/migrations/run/streams/update-stream.ts
+++ b/packages/cli/src/commands/migrations/run/streams/update-stream.ts
@@ -5,7 +5,7 @@ import type { StoryContent } from '../../../stories/constants';
 import { updateStory } from '../../../stories/actions';
 import { isStoryPublishedWithoutChanges, isStoryWithUnpublishedChanges } from '../../../stories/utils';
 import { getLogger } from '../../../../lib/logger/logger';
-import { createConcurrencyLock } from '../../../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../../../utils/concurrency';
 import { ERROR_CODES } from '../constants';
 import { toError } from '../../../../utils/error';
 
@@ -42,7 +42,7 @@ export class UpdateStream extends Writable {
       totalProcessed: 0,
     };
 
-    this.semaphore = createConcurrencyLock();
+    this.semaphore = createPipelineBackpressureLock();
   }
 
   async _write(chunk: { storyId: number; name: string | undefined; content: StoryContent; published?: boolean; unpublished_changes?: boolean }, _encoding: string, callback: (error?: Error | null) => void) {

--- a/packages/cli/src/commands/stories/actions.ts
+++ b/packages/cli/src/commands/stories/actions.ts
@@ -201,8 +201,7 @@ const fetchChunkAllPages = async (
  * or by numeric id (resume against a same-space manifest).
  *
  * Slug and id batches are dispatched concurrently through the MAPI client's
- * existing throttle (default `maxConcurrency = 6`, adapts to the server's
- * `X-RateLimit-Policy` header, auto-retries 429).
+ * existing throttle (default 6 requests per second, auto-retries 429).
  */
 export const prefetchTargetStoriesByKeys = async (
   spaceId: string,

--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -1,16 +1,23 @@
 import { readFile, unlink } from 'node:fs/promises';
 import { extname, join, resolve } from 'pathe';
 import { Readable, Transform, Writable } from 'node:stream';
-import { Sema } from 'async-sema';
+import type { Sema } from 'async-sema';
 import { createStory, fetchStories, fetchStory, updateStory } from './actions';
 import type { ExistingTargetStories, StoriesQueryParams, Story, StoryIndexEntry, TargetStoryRef } from './constants';
 import { normalizeFullSlug } from './constants';
 import { appendToFile, readDirectory, saveToFile } from '../../utils/filesystem';
 import { toError } from '../../utils/error/error';
+import { createConcurrencyLock } from '../../utils/concurrency';
 import { type ComponentSchemas, type RefMaps, storyRefMapper } from './ref-mapper';
 import { getStoryFilename, isStoryPublishedWithoutChanges } from './utils';
 
-const apiConcurrencyLock = new Sema(12);
+let _apiConcurrencyLock: Sema | null = null;
+const getApiConcurrencyLock = (): Sema => {
+  if (!_apiConcurrencyLock) {
+    _apiConcurrencyLock = createConcurrencyLock();
+  }
+  return _apiConcurrencyLock;
+};
 
 export const fetchStoriesStream = ({
   spaceId,
@@ -92,7 +99,7 @@ export const fetchStoryStream = ({
     objectMode: true,
     async transform(listStory: Story, _encoding, callback) {
       // Wait for a slot
-      await apiConcurrencyLock.acquire();
+      await getApiConcurrencyLock().acquire();
 
       const task = fetchStory(spaceId, listStory.id.toString())
         .then((story) => {
@@ -107,7 +114,7 @@ export const fetchStoryStream = ({
         })
         .finally(() => {
           onIncrement?.();
-          apiConcurrencyLock.release();
+          getApiConcurrencyLock().release();
           processing.delete(task);
         });
       processing.add(task);
@@ -357,7 +364,7 @@ export const createStoriesForLevel = async ({
   onStoryError?: (error: Error, entry: StoryIndexEntry) => void;
 }): Promise<void> => {
   const processEntry = async (entry: StoryIndexEntry) => {
-    await apiConcurrencyLock.acquire();
+    await getApiConcurrencyLock().acquire();
     try {
       // Primary: check manifest mapping (from a previous push).
       const mappedStoryId = maps.stories?.get(entry.id);
@@ -427,7 +434,7 @@ export const createStoriesForLevel = async ({
       onStoryError?.(toError(maybeError), entry);
     }
     finally {
-      apiConcurrencyLock.release();
+      getApiConcurrencyLock().release();
     }
   };
 
@@ -519,7 +526,7 @@ export const writeStoryStream = ({
   return new Writable({
     objectMode: true,
     async write(mappedLocalStory: Story, _encoding, callback) {
-      await apiConcurrencyLock.acquire();
+      await getApiConcurrencyLock().acquire();
 
       const task = (async () => {
         try {
@@ -536,7 +543,7 @@ export const writeStoryStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        apiConcurrencyLock.release();
+        getApiConcurrencyLock().release();
         processing.delete(task);
       });
 

--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -7,16 +7,16 @@ import type { ExistingTargetStories, StoriesQueryParams, Story, StoryIndexEntry,
 import { normalizeFullSlug } from './constants';
 import { appendToFile, readDirectory, saveToFile } from '../../utils/filesystem';
 import { toError } from '../../utils/error/error';
-import { createConcurrencyLock } from '../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../utils/concurrency';
 import { type ComponentSchemas, type RefMaps, storyRefMapper } from './ref-mapper';
 import { getStoryFilename, isStoryPublishedWithoutChanges } from './utils';
 
-let _apiConcurrencyLock: Sema | null = null;
-const getApiConcurrencyLock = (): Sema => {
-  if (!_apiConcurrencyLock) {
-    _apiConcurrencyLock = createConcurrencyLock();
+let _pipelineSlot: Sema | null = null;
+const getPipelineSlot = (): Sema => {
+  if (!_pipelineSlot) {
+    _pipelineSlot = createPipelineBackpressureLock();
   }
-  return _apiConcurrencyLock;
+  return _pipelineSlot;
 };
 
 export const fetchStoriesStream = ({
@@ -99,7 +99,7 @@ export const fetchStoryStream = ({
     objectMode: true,
     async transform(listStory: Story, _encoding, callback) {
       // Wait for a slot
-      await getApiConcurrencyLock().acquire();
+      await getPipelineSlot().acquire();
 
       const task = fetchStory(spaceId, listStory.id.toString())
         .then((story) => {
@@ -114,7 +114,7 @@ export const fetchStoryStream = ({
         })
         .finally(() => {
           onIncrement?.();
-          getApiConcurrencyLock().release();
+          getPipelineSlot().release();
           processing.delete(task);
         });
       processing.add(task);
@@ -364,7 +364,7 @@ export const createStoriesForLevel = async ({
   onStoryError?: (error: Error, entry: StoryIndexEntry) => void;
 }): Promise<void> => {
   const processEntry = async (entry: StoryIndexEntry) => {
-    await getApiConcurrencyLock().acquire();
+    await getPipelineSlot().acquire();
     try {
       // Primary: check manifest mapping (from a previous push).
       const mappedStoryId = maps.stories?.get(entry.id);
@@ -434,7 +434,7 @@ export const createStoriesForLevel = async ({
       onStoryError?.(toError(maybeError), entry);
     }
     finally {
-      getApiConcurrencyLock().release();
+      getPipelineSlot().release();
     }
   };
 
@@ -526,7 +526,7 @@ export const writeStoryStream = ({
   return new Writable({
     objectMode: true,
     async write(mappedLocalStory: Story, _encoding, callback) {
-      await getApiConcurrencyLock().acquire();
+      await getPipelineSlot().acquire();
 
       const task = (async () => {
         try {
@@ -543,7 +543,7 @@ export const writeStoryStream = ({
       processing.add(task);
       task.finally(() => {
         onIncrement?.();
-        getApiConcurrencyLock().release();
+        getPipelineSlot().release();
         processing.delete(task);
       });
 

--- a/packages/cli/src/commands/stories/streams.ts
+++ b/packages/cli/src/commands/stories/streams.ts
@@ -7,7 +7,7 @@ import type { ExistingTargetStories, StoriesQueryParams, Story, StoryIndexEntry,
 import { normalizeFullSlug } from './constants';
 import { appendToFile, readDirectory, saveToFile } from '../../utils/filesystem';
 import { toError } from '../../utils/error/error';
-import { createPipelineBackpressureLock } from '../../utils/concurrency';
+import { createPipelineBackpressureLock } from '../../utils/backpressure-lock';
 import { type ComponentSchemas, type RefMaps, storyRefMapper } from './ref-mapper';
 import { getStoryFilename, isStoryPublishedWithoutChanges } from './utils';
 

--- a/packages/cli/src/lib/config/defaults.ts
+++ b/packages/cli/src/lib/config/defaults.ts
@@ -6,7 +6,7 @@ const BASE_GLOBAL_CONFIG: GlobalConfig = {
   path: undefined,
   api: {
     maxRetries: 3,
-    maxConcurrency: 6,
+    rateLimit: 6,
   },
   log: {
     console: {

--- a/packages/cli/src/lib/config/helpers.test.ts
+++ b/packages/cli/src/lib/config/helpers.test.ts
@@ -134,7 +134,7 @@ const mockConfig: ResolvedCliConfig = {
   region: 'us',
   api: {
     maxRetries: 5,
-    maxConcurrency: 6,
+    rateLimit: 6,
   },
   log: {
     console: {

--- a/packages/cli/src/lib/config/options.ts
+++ b/packages/cli/src/lib/config/options.ts
@@ -33,7 +33,7 @@ export const GLOBAL_OPTION_DEFINITIONS: GlobalOptionDefinition[] = [
   },
   {
     flags: '--api-rate-limit <number>',
-    description: 'Maximum number of concurrent HTTP requests the CLI executes against the API',
+    description: 'Maximum MAPI requests per second (default: 6)',
     defaultValue: DEFAULT_GLOBAL_CONFIG.api.rateLimit,
     parser: parseNumber,
   },

--- a/packages/cli/src/lib/config/options.ts
+++ b/packages/cli/src/lib/config/options.ts
@@ -32,9 +32,15 @@ export const GLOBAL_OPTION_DEFINITIONS: GlobalOptionDefinition[] = [
     parser: parseNumber,
   },
   {
+    flags: '--api-rate-limit <number>',
+    description: 'Maximum number of concurrent HTTP requests the CLI executes against the API',
+    defaultValue: DEFAULT_GLOBAL_CONFIG.api.rateLimit,
+    parser: parseNumber,
+  },
+  // @todo(next-major): Remove deprecated --api-max-concurrency flag.
+  {
     flags: '--api-max-concurrency <number>',
-    description: 'Maximum concurrent API requests executed by the CLI',
-    defaultValue: DEFAULT_GLOBAL_CONFIG.api.maxConcurrency,
+    description: '[Deprecated] Use --api-rate-limit instead.',
     parser: parseNumber,
   },
   // Boolean flags that default to true need both positive and negative forms

--- a/packages/cli/src/lib/config/resolver.ts
+++ b/packages/cli/src/lib/config/resolver.ts
@@ -78,6 +78,13 @@ export async function resolveConfig(
   const knownModuleKeys = getModuleNames(root);
   for (const layer of layers) {
     const { modules, ...globalLayer } = layer;
+    // @todo(next-major): Remove deprecated api.maxConcurrency support from config files.
+    // Handle deprecated api.maxConcurrency from config files
+    if (globalLayer.api?.maxConcurrency !== undefined) {
+      console.warn('[storyblok] Config option `api.maxConcurrency` is deprecated. Use `api.rateLimit` instead.');
+      globalLayer.api.rateLimit = globalLayer.api.maxConcurrency;
+      delete globalLayer.api.maxConcurrency;
+    }
     // Later layers overwrite earlier ones because loadConfigLayers orders them from general to specific.
     mergeDeep(globalResolved, globalLayer);
     if (modules && isPlainObject(modules)) {
@@ -87,6 +94,15 @@ export async function resolveConfig(
   }
 
   applyCliOverrides(commandChain, globalResolved, localResolved);
+
+  // @todo(next-major): Remove deprecated --api-max-concurrency CLI flag support.
+  // Handle deprecated --api-max-concurrency CLI flag
+  const globalResolvedApi = globalResolved.api;
+  if (globalResolvedApi?.maxConcurrency !== undefined) {
+    console.warn('[storyblok] CLI flag `--api-max-concurrency` is deprecated. Use `--api-rate-limit` instead.');
+    globalResolvedApi.rateLimit = globalResolvedApi.maxConcurrency;
+    delete globalResolvedApi.maxConcurrency;
+  }
 
   const resolved = structuredClone(defaultConfig);
   mergeDeep(resolved as PlainObject, globalResolved);

--- a/packages/cli/src/lib/config/types.ts
+++ b/packages/cli/src/lib/config/types.ts
@@ -23,7 +23,9 @@ export type PlainObject = Record<string, any>;
 
 export interface ApiConfig {
   maxRetries: number;
-  maxConcurrency: number;
+  rateLimit: number;
+  /** @deprecated Use `rateLimit` instead. @todo(next-major): Remove this field. */
+  maxConcurrency?: number;
 }
 
 export interface LogConsoleConfig {

--- a/packages/cli/src/utils/backpressure-lock.ts
+++ b/packages/cli/src/utils/backpressure-lock.ts
@@ -3,6 +3,9 @@ import { getActiveConfig } from '../lib/config';
 
 // 2× the per-second rate limit so the pipeline always has work queued for the
 // next API window without over-loading memory.
+// In edge-case scenarios like ~2 s request duration: 12 / 2 s = 6 req/s, saturating the
+// default 6 req/s rate limit. If requests take longer (e.g. 2.5 s →
+// 12 / 2.5 s = 4.8 req/s) the pipeline under-utilises the limit slightly
 const PIPELINE_BACKPRESSURE_MULTIPLIER = 2;
 const DEFAULT_PIPELINE_BACKPRESSURE = 12;
 

--- a/packages/cli/src/utils/concurrency.ts
+++ b/packages/cli/src/utils/concurrency.ts
@@ -1,10 +1,13 @@
 import { Sema } from 'async-sema';
 import { getActiveConfig } from '../lib/config';
 
-// Default used when rateLimit is disabled (<=0) or unset
-const DEFAULT_CONCURRENCY = 12;
+// 2× the per-second rate limit so the pipeline always has work queued for the
+// next API window without over-loading memory.
+const PIPELINE_BACKPRESSURE_MULTIPLIER = 2;
+const DEFAULT_PIPELINE_BACKPRESSURE = 12;
 
-export function createConcurrencyLock(limit?: number): Sema {
-  const n = limit ?? getActiveConfig().api.rateLimit;
-  return new Sema(n > 0 ? n : DEFAULT_CONCURRENCY);
+export function createPipelineBackpressureLock(limit?: number): Sema {
+  const rateLimit = getActiveConfig().api.rateLimit;
+  const n = limit ?? (rateLimit > 0 ? rateLimit * PIPELINE_BACKPRESSURE_MULTIPLIER : DEFAULT_PIPELINE_BACKPRESSURE);
+  return new Sema(n);
 }

--- a/packages/cli/src/utils/concurrency.ts
+++ b/packages/cli/src/utils/concurrency.ts
@@ -1,0 +1,10 @@
+import { Sema } from 'async-sema';
+import { getActiveConfig } from '../lib/config';
+
+// Default used when rateLimit is disabled (<=0) or unset
+const DEFAULT_CONCURRENCY = 12;
+
+export function createConcurrencyLock(limit?: number): Sema {
+  const n = limit ?? getActiveConfig().api.rateLimit;
+  return new Sema(n > 0 ? n : DEFAULT_CONCURRENCY);
+}

--- a/packages/cli/src/utils/fetch.ts
+++ b/packages/cli/src/utils/fetch.ts
@@ -37,7 +37,7 @@ export interface FetchOptions {
 }
 
 export async function customFetch<T>(url: string, options: FetchOptions = {}): Promise<T & { perPage: number; total: number }> {
-  const { api } = getActiveConfig(); // live config includes CLI overrides (maxRetries, maxConcurrency, etc.)
+  const { api } = getActiveConfig(); // live config includes CLI overrides (maxRetries, rateLimit, etc.)
   const maxRetries = options.maxRetries ?? api.maxRetries;
   const baseDelay = options.baseDelay ?? 500; // 500ms base delay
   const requestContext: FetchErrorRequest = { url, method: options.method ?? 'GET' };

--- a/packages/cli/test/setup.ts
+++ b/packages/cli/test/setup.ts
@@ -39,6 +39,8 @@ vi.mock('../src/session.ts', async (importOriginal) => {
 
 vi.mock('../src/lib/config/store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/lib/config/store')>();
+  // Disable the rate limiter in tests so per-second throttling does not slow down fake-timer tests.
+  actual.setActiveConfig({ ...actual.getActiveConfig(), api: { ...actual.getActiveConfig().api, rateLimit: -1 } });
   return {
     ...actual,
     setActiveConfig: (config: import('../src/lib/config/types').ResolvedCliConfig) =>

--- a/packages/cli/test/setup.ts
+++ b/packages/cli/test/setup.ts
@@ -42,7 +42,7 @@ vi.mock('../src/lib/config/store', async (importOriginal) => {
   return {
     ...actual,
     setActiveConfig: (config: import('../src/lib/config/types').ResolvedCliConfig) =>
-      actual.setActiveConfig({ ...config, api: { ...config.api, maxConcurrency: -1 } }),
+      actual.setActiveConfig({ ...config, api: { ...config.api, rateLimit: -1 } }),
   };
 });
 

--- a/packages/mapi-client/package.json
+++ b/packages/mapi-client/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@storyblok/region-helper": "workspace:*",
+    "async-sema": "^3.1.1",
     "ky": "^1.14.3"
   },
   "devDependencies": {

--- a/packages/mapi-client/src/index.ts
+++ b/packages/mapi-client/src/index.ts
@@ -80,19 +80,16 @@ export const createManagementApiClient = (config: ManagementApiClientConfig) => 
   );
 
   /**
-   * Wraps an SDK call with throttling and response adaptation.
-   * The throttle slot is held for the entire duration of the request.
+   * Wraps an SDK call with throttling.
    * When throwOnError is true, errors throw and data is guaranteed non-null.
    */
   function wrapRequest<TData, ThrowOnError extends boolean = false>(
     fn: () => Promise<unknown>,
     _throwOnError?: ThrowOnError,
   ): Promise<ApiResponse<TData, ThrowOnError>> {
-    return throttleManager.execute(async () => {
-      const result = await fn() as ApiResponse<TData, ThrowOnError>;
-      throttleManager.adaptToResponse((result as { response: Response }).response);
-      return result;
-    }) as Promise<ApiResponse<TData, ThrowOnError>>;
+    return throttleManager.execute(
+      () => fn() as Promise<ApiResponse<TData, ThrowOnError>>,
+    );
   }
 
   const deps: MapiResourceDeps = { client, spaceId, wrapRequest };

--- a/packages/mapi-client/src/types.ts
+++ b/packages/mapi-client/src/types.ts
@@ -103,11 +103,11 @@ export interface ManagementApiClientConfig {
    */
   timeout?: number;
   /**
-   * Preventive rate limiting to avoid hitting the Storyblok Management API rate limits.
+   * Rate limiting to avoid hitting the Storyblok Management API throttle (6 req/s paid, 3 req/s free).
    *
-   * - `undefined` (default): single bucket at maxConcurrency: 6.
-   * - `number`: fixed max concurrent requests per second.
-   * - `{ maxConcurrency?: number; adaptToServerHeaders?: boolean }`: full config.
+   * - `undefined` (default): 6 requests per second.
+   * - `number`: N requests per second.
+   * - `{ requestsPerSecond?: number }`: full config object.
    * - `false`: disable rate limiting entirely.
    */
   rateLimit?: RateLimitConfig | number | false;

--- a/packages/mapi-client/src/utils/rate-limit.test.ts
+++ b/packages/mapi-client/src/utils/rate-limit.test.ts
@@ -9,181 +9,59 @@ describe('createThrottleManager(false)', () => {
     expect(result).toBe('result');
     expect(fn).toHaveBeenCalledOnce();
   });
-
-  it('should treat adaptToResponse as a no-op', () => {
-    const manager = createThrottleManager(false);
-    expect(() => manager.adaptToResponse(undefined)).not.toThrow();
-  });
 });
 
 describe('createThrottleManager(number)', () => {
   afterEach(() => vi.useRealTimers());
 
-  it('should limit concurrent requests to the specified number', async () => {
+  it('should start at most N requests per second', async () => {
     vi.useFakeTimers();
     const manager = createThrottleManager(2);
 
-    let activeCount = 0;
-    let maxActive = 0;
-
-    const makeSlowFn = () => async () => {
-      activeCount++;
-      maxActive = Math.max(maxActive, activeCount);
-      await new Promise(resolve => setTimeout(resolve, 100));
-      activeCount--;
+    const starts: number[] = [];
+    const makeFn = () => async () => {
+      starts.push(Date.now());
       return 'done';
     };
 
-    const p1 = manager.execute(makeSlowFn());
-    const p2 = manager.execute(makeSlowFn());
-    const p3 = manager.execute(makeSlowFn());
+    const p1 = manager.execute(makeFn());
+    const p2 = manager.execute(makeFn());
+    const p3 = manager.execute(makeFn()); // must wait for next window
+
+    // Flush microtasks so the first two slots are acquired.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(starts).toHaveLength(2);
 
     await vi.runAllTimersAsync();
     await Promise.all([p1, p2, p3]);
 
-    expect(maxActive).toBeLessThanOrEqual(2);
-  });
-
-  it('should adapt limit from server headers, respecting user ceiling', async () => {
-    vi.useFakeTimers();
-    const manager = createThrottleManager(50);
-
-    let activeCount = 0;
-    let maxActive = 0;
-
-    const serverResponse = new Response(null, {
-      headers: { 'x-ratelimit-policy': '"concurrent-requests";q=5' },
-    });
-    manager.adaptToResponse(serverResponse);
-
-    const makeSlowFn = () => async () => {
-      activeCount++;
-      maxActive = Math.max(maxActive, activeCount);
-      await new Promise(resolve => setTimeout(resolve, 50));
-      activeCount--;
-      return 'done';
-    };
-
-    const promises = Array.from({ length: 10 }, () => manager.execute(makeSlowFn()));
-
-    await vi.runAllTimersAsync();
-    await Promise.all(promises);
-
-    // Server said 5, user ceiling is 50 -> effective limit is min(50, 5) = 5.
-    expect(maxActive).toBeLessThanOrEqual(5);
-  });
-
-  it('should not exceed user ceiling even if server reports higher', async () => {
-    vi.useFakeTimers();
-    const manager = createThrottleManager(3);
-
-    const serverResponse = new Response(null, {
-      headers: { 'x-ratelimit-policy': '"concurrent-requests";q=100' },
-    });
-    manager.adaptToResponse(serverResponse);
-
-    let activeCount = 0;
-    let maxActive = 0;
-
-    const makeSlowFn = () => async () => {
-      activeCount++;
-      maxActive = Math.max(maxActive, activeCount);
-      await new Promise(resolve => setTimeout(resolve, 50));
-      activeCount--;
-      return 'done';
-    };
-
-    const promises = Array.from({ length: 9 }, () => manager.execute(makeSlowFn()));
-
-    await vi.runAllTimersAsync();
-    await Promise.all(promises);
-
-    expect(maxActive).toBeLessThanOrEqual(3);
+    // Third request started in the second window (≥1000ms later).
+    expect(starts).toHaveLength(3);
+    expect(starts[2]! - starts[0]!).toBeGreaterThanOrEqual(1000);
   });
 });
 
 describe('createThrottleManager({})', () => {
   afterEach(() => vi.useRealTimers());
 
-  it('should use default maxConcurrency of 6', async () => {
+  it('should use default of 6 requests per second', async () => {
     vi.useFakeTimers();
     const manager = createThrottleManager({});
 
-    let activeCount = 0;
-    let maxActive = 0;
-
-    const makeSlowFn = () => async () => {
-      activeCount++;
-      maxActive = Math.max(maxActive, activeCount);
-      await new Promise(resolve => setTimeout(resolve, 50));
-      activeCount--;
+    const starts: number[] = [];
+    const makeFn = () => async () => {
+      starts.push(Date.now());
       return 'done';
     };
 
-    const promises = Array.from({ length: 12 }, () => manager.execute(makeSlowFn()));
+    const promises = Array.from({ length: 12 }, () => manager.execute(makeFn()));
 
     await vi.runAllTimersAsync();
     await Promise.all(promises);
 
-    expect(maxActive).toBeLessThanOrEqual(6);
-  });
-
-  it('should adapt limit from server headers', async () => {
-    vi.useFakeTimers();
-    const manager = createThrottleManager({});
-
-    const serverResponse = new Response(null, {
-      headers: { 'x-ratelimit-policy': '"concurrent-requests";q=3' },
-    });
-    manager.adaptToResponse(serverResponse);
-
-    let activeCount = 0;
-    let maxActive = 0;
-
-    const makeSlowFn = () => async () => {
-      activeCount++;
-      maxActive = Math.max(maxActive, activeCount);
-      await new Promise(resolve => setTimeout(resolve, 50));
-      activeCount--;
-      return 'done';
-    };
-
-    const promises = Array.from({ length: 10 }, () => manager.execute(makeSlowFn()));
-
-    await vi.runAllTimersAsync();
-    await Promise.all(promises);
-
-    // Default is 6, server said 3 -> effective limit is min(6, 3) = 3.
-    expect(maxActive).toBeLessThanOrEqual(3);
-  });
-
-  it('should ignore server headers when adaptToServerHeaders is false', async () => {
-    vi.useFakeTimers();
-    const manager = createThrottleManager({ adaptToServerHeaders: false });
-
-    const serverResponse = new Response(null, {
-      headers: { 'x-ratelimit-policy': '"concurrent-requests";q=1' },
-    });
-    manager.adaptToResponse(serverResponse);
-
-    let activeCount = 0;
-    let maxActive = 0;
-
-    const makeSlowFn = () => async () => {
-      activeCount++;
-      maxActive = Math.max(maxActive, activeCount);
-      await new Promise(resolve => setTimeout(resolve, 50));
-      activeCount--;
-      return 'done';
-    };
-
-    // With limit ignored, the default 6 slots should be available.
-    const promises = Array.from({ length: 6 }, () => manager.execute(makeSlowFn()));
-
-    await vi.runAllTimersAsync();
-    await Promise.all(promises);
-
-    expect(maxActive).toBe(6);
+    // At most 6 start in the first window.
+    const firstWindowStarts = starts.filter(t => t < starts[0]! + 1000);
+    expect(firstWindowStarts.length).toBeLessThanOrEqual(6);
   });
 
   it('should propagate errors from the wrapped function', async () => {
@@ -192,10 +70,5 @@ describe('createThrottleManager({})', () => {
     await expect(
       manager.execute(() => Promise.reject(error)),
     ).rejects.toThrow('boom');
-  });
-
-  it('should treat adaptToResponse as a no-op when response is undefined', () => {
-    const manager = createThrottleManager({});
-    expect(() => manager.adaptToResponse(undefined)).not.toThrow();
   });
 });

--- a/packages/mapi-client/src/utils/rate-limit.ts
+++ b/packages/mapi-client/src/utils/rate-limit.ts
@@ -1,130 +1,47 @@
-const DEFAULT_MAX_CONCURRENT = 6;
+import { RateLimit } from 'async-sema';
+
+const DEFAULT_REQUESTS_PER_SECOND = 6;
 const MAX_RATE_LIMIT = 1_000;
 
 export interface RateLimitConfig {
   /**
-   * Maximum number of concurrent in-flight requests.
+   * Maximum number of MAPI requests to start per second.
    * Defaults to 6. Capped at 1000.
    */
-  maxConcurrency?: number;
+  requestsPerSecond?: number;
   /**
-   * Dynamically adjust the rate limit based on the `X-RateLimit-Policy`
-   * response header returned by the Storyblok API.
-   * @default true
+   * @deprecated Use `requestsPerSecond` instead.
+   * @todo(next-major): Remove this field.
    */
-  adaptToServerHeaders?: boolean;
+  maxConcurrency?: number;
 }
 
 export interface ThrottleManager {
   execute: <T>(fn: () => Promise<T>) => Promise<T>;
-  adaptToResponse: (response: Response | undefined) => void;
-}
-
-interface Throttle {
-  execute: <T>(fn: () => Promise<T>) => Promise<T>;
-  setLimit: (n: number) => void;
-}
-
-/**
- * Concurrency limiter: allows up to `initialLimit` requests to be in-flight
- * at the same time. A slot is freed as soon as the request's promise settles
- * (resolves or rejects), so throughput scales with how quickly requests
- * complete rather than being artificially capped at N per second.
- */
-export function createThrottle(initialLimit: number): Throttle {
-  let limit = initialLimit;
-  let activeCount = 0;
-  const queue: Array<() => void> = [];
-
-  const tryNext = () => {
-    while (queue.length > 0 && activeCount < limit) {
-      activeCount++;
-      const run = queue.shift()!;
-      run();
-    }
-  };
-
-  const execute = <T>(fn: () => Promise<T>): Promise<T> => {
-    return new Promise<T>((resolve, reject) => {
-      queue.push(() => {
-        fn().then(
-          (value) => {
-            activeCount--;
-            tryNext();
-            resolve(value);
-          },
-          (error) => {
-            activeCount--;
-            tryNext();
-            reject(error);
-          },
-        );
-      });
-      tryNext();
-    });
-  };
-
-  const setLimit = (n: number) => {
-    limit = n;
-    // If the limit increased, unblock any waiting requests.
-    tryNext();
-  };
-
-  return { execute, setLimit };
-}
-
-/**
- * Extracts the quota (`q=`) value from the `X-RateLimit-Policy` response header.
- * Returns `undefined` if the header is absent or unparseable.
- *
- * Example header: `"concurrent-requests";q=30`
- */
-export function parseRateLimitPolicyHeader(response: Response): number | undefined {
-  const policy = response.headers.get('x-ratelimit-policy');
-  if (!policy) {
-    return undefined;
-  }
-  const match = policy.match(/q=(\d+)/);
-  if (!match) {
-    return undefined;
-  }
-  return Math.min(Number.parseInt(match[1], 10), MAX_RATE_LIMIT);
 }
 
 /**
  * Creates a `ThrottleManager` from the user-supplied `rateLimit` config.
  *
- * - `false`                     -> no throttling (passthrough)
- * - `number`                    -> fixed single queue at that concurrency
- * - `{ maxConcurrency: n }`      -> fixed single queue at n concurrent requests
- * - `{}` / `undefined` (default)-> single queue at DEFAULT_MAX_CONCURRENT
+ * - `false`                       -> no throttling (passthrough)
+ * - `number`                      -> N requests per second
+ * - `{ requestsPerSecond: n }`    -> N requests per second
+ * - `{}` / `undefined` (default)  -> DEFAULT_REQUESTS_PER_SECOND per second
  */
 export function createThrottleManager(config: RateLimitConfig | number | false): ThrottleManager {
-  // Disabled - every request goes straight through.
   if (config === false) {
-    return {
-      execute: fn => fn(),
-      adaptToResponse: () => {},
-    };
+    return { execute: fn => fn() };
   }
 
-  const resolvedConfig: RateLimitConfig = typeof config === 'number' ? { maxConcurrency: config } : config;
-  const { maxConcurrency = DEFAULT_MAX_CONCURRENT, adaptToServerHeaders = true } = resolvedConfig;
-
-  const cappedLimit = Math.min(maxConcurrency, MAX_RATE_LIMIT);
-  const throttle = createThrottle(cappedLimit);
+  const resolvedConfig: RateLimitConfig = typeof config === 'number' ? { requestsPerSecond: config } : config;
+  const { requestsPerSecond, maxConcurrency } = resolvedConfig;
+  const rps = requestsPerSecond ?? maxConcurrency ?? DEFAULT_REQUESTS_PER_SECOND;
+  const rl = RateLimit(Math.min(rps, MAX_RATE_LIMIT));
 
   return {
-    execute: fn => throttle.execute(fn),
-    adaptToResponse: (response) => {
-      if (!adaptToServerHeaders || response === undefined) {
-        return;
-      }
-      const serverLimit = parseRateLimitPolicyHeader(response);
-      if (serverLimit !== undefined) {
-        // Never exceed the user-configured ceiling.
-        throttle.setLimit(Math.min(cappedLimit, serverLimit));
-      }
+    execute: async (fn) => {
+      await rl();
+      return fn();
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,16 +188,16 @@ importers:
         version: 5.0.1(@types/node@24.11.0)(@types/react-dom@19.2.3(@types/react@19.1.4))(@types/react@19.1.4)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/svelte':
         specifier: ^8.0.3
-        version: 8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       '@astrojs/vue':
         specifier: ^6.0.1
-        version: 6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
+        version: 6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
         specifier: ^6.1.1
-        version: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -209,7 +209,7 @@ importers:
         version: 5.55.0
       vue:
         specifier: ^3.5.30
-        version: 3.5.30(typescript@5.9.3)
+        version: 3.5.30(typescript@5.8.3)
     devDependencies:
       vite-plugin-mkcert:
         specifier: ^1.17.10
@@ -222,19 +222,19 @@ importers:
         version: 5.0.1(@types/node@24.11.0)(@types/react-dom@19.2.3(@types/react@19.1.4))(@types/react@19.1.4)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/svelte':
         specifier: ^8.0.3
-        version: 8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       '@astrojs/vercel':
         specifier: ^10.0.2
-        version: 10.0.2(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(rollup@4.59.0)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 10.0.2(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(rollup@4.59.0)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.8.3)))(vue@3.5.30(typescript@5.8.3))
       '@astrojs/vue':
         specifier: ^6.0.1
-        version: 6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
+        version: 6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
         specifier: ^6.1.1
-        version: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -246,7 +246,7 @@ importers:
         version: 5.55.0
       vue:
         specifier: ^3.5.30
-        version: 3.5.30(typescript@5.9.3)
+        version: 3.5.30(typescript@5.8.3)
     devDependencies:
       vite-plugin-mkcert:
         specifier: ^1.17.10
@@ -259,16 +259,16 @@ importers:
         version: 5.0.1(@types/node@24.11.0)(@types/react-dom@19.2.3(@types/react@19.1.4))(@types/react@19.1.4)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/svelte':
         specifier: ^8.0.3
-        version: 8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       '@astrojs/vue':
         specifier: ^6.0.1
-        version: 6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
+        version: 6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
         specifier: ^6.1.1
-        version: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -280,7 +280,7 @@ importers:
         version: 5.55.0
       vue:
         specifier: ^3.5.30
-        version: 3.5.30(typescript@5.9.3)
+        version: 3.5.30(typescript@5.8.3)
 
   packages/capi-client:
     dependencies:
@@ -293,10 +293,10 @@ importers:
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: ^0.92.3
-        version: 0.92.4(magicast@0.5.2)(typescript@5.9.3)
+        version: 0.92.4(magicast@0.5.2)(typescript@5.8.3)
       '@msw/source':
         specifier: ^0.6.1
-        version: 0.6.1(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))
+        version: 0.6.1(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))
       '@storyblok/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -314,19 +314,19 @@ importers:
         version: 13.0.6
       msw:
         specifier: ^2.12.9
-        version: 2.12.10(@types/node@24.11.0)(typescript@5.9.3)
+        version: 2.12.10(@types/node@24.11.0)(typescript@5.8.3)
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
       tsdown:
         specifier: ^0.20.3
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.8.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/cli:
     dependencies:
@@ -444,7 +444,7 @@ importers:
     dependencies:
       '@antfu/eslint-config':
         specifier: ~3.6.0
-        version: 3.6.2(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(astro-eslint-parser@1.3.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-astro@1.6.0(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-format@0.1.3(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-react-refresh@0.4.26(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-svelte@3.15.0(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0))(eslint@9.26.0(jiti@2.6.1))(prettier-plugin-astro@0.13.0)(svelte@5.55.0)(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.6.2(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.30)(astro-eslint-parser@1.3.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-astro@1.6.0(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-format@0.1.3(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-react-refresh@0.4.26(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-svelte@3.15.0(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0))(eslint@9.26.0(jiti@2.6.1))(prettier-plugin-astro@0.13.0)(svelte@5.55.0)(typescript@5.8.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       eslint-plugin-format:
         specifier: ^0.1.2
         version: 0.1.3(eslint@9.26.0(jiti@2.6.1))
@@ -454,7 +454,7 @@ importers:
         version: 9.26.0(jiti@2.6.1)
       tsdown:
         specifier: ^0.20.3
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.8.3)
 
   packages/js:
     dependencies:
@@ -563,7 +563,7 @@ importers:
         version: 8.55.0
       eslint-config-next:
         specifier: 14.0.4
-        version: 14.0.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint@8.55.0)(typescript@5.9.3)
+        version: 14.0.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint@8.55.0)(typescript@5.8.3)
       next:
         specifier: ^13.5.7
         version: 13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0)
@@ -684,16 +684,19 @@ importers:
       '@storyblok/region-helper':
         specifier: workspace:*
         version: link:../region-helper
+      async-sema:
+        specifier: ^3.1.1
+        version: 3.1.1
       ky:
         specifier: ^1.14.3
         version: 1.14.3
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: ^0.92.3
-        version: 0.92.4(magicast@0.5.2)(typescript@5.9.3)
+        version: 0.92.4(magicast@0.5.2)(typescript@5.8.3)
       '@msw/source':
         specifier: ^0.6.1
-        version: 0.6.1(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))
+        version: 0.6.1(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))
       '@storyblok/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -711,19 +714,19 @@ importers:
         version: 13.0.6
       msw:
         specifier: ^2.12.9
-        version: 2.12.10(@types/node@24.11.0)(typescript@5.9.3)
+        version: 2.12.10(@types/node@24.11.0)(typescript@5.8.3)
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
       tsdown:
         specifier: ^0.20.3
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.8.3)
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
       vitest:
         specifier: ^3.1.3
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.11.0)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.11.0)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/migrations:
     dependencies:
@@ -773,22 +776,22 @@ importers:
         version: 6.0.3(cypress@14.5.4)
       '@nuxt/eslint':
         specifier: ^1.2.0
-        version: 1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(magicast@0.5.2)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/eslint-config':
         specifier: ^1.2.0
-        version: 1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
       '@nuxt/kit':
         specifier: ^4.2.2
         version: 4.3.1(magicast@0.5.2)
       '@nuxt/module-builder':
         specifier: ^1.0.0
-        version: 1.0.2(@nuxt/cli@3.33.1(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(sass@1.98.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.2(@nuxt/cli@3.33.1(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(sass@1.98.0)(typescript@5.8.3)(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))
       '@nuxt/schema':
         specifier: ^4.2.2
         version: 4.3.1
       '@nuxt/test-utils':
         specifier: ^3.23.0
-        version: 3.23.0(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4)
+        version: 3.23.0(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.8.3)(vitest@3.2.4)
       '@storyblok/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -812,7 +815,7 @@ importers:
         version: 9.33.0(eslint@9.39.3(jiti@2.6.1))
       nuxt:
         specifier: ^4.2.2
-        version: 4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2)
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
@@ -934,7 +937,7 @@ importers:
         version: 8.57.1
       eslint-config-next:
         specifier: ^14.2.28
-        version: 14.2.35(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1)(typescript@5.9.3)
+        version: 14.2.35(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1)(typescript@5.8.3)
       next:
         specifier: ^13.4.2
         version: 13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0)
@@ -1305,7 +1308,7 @@ importers:
         version: link:../..
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 5.18.1(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
 
   packages/richtext/playground/node:
     dependencies:
@@ -14824,6 +14827,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -15821,32 +15825,32 @@ snapshots:
     optionalDependencies:
       '@angular/platform-server': 21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/compiler@21.2.5)(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)))(rxjs@7.8.2)
 
-  '@antfu/eslint-config@3.6.2(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(astro-eslint-parser@1.3.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-astro@1.6.0(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-format@0.1.3(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-react-refresh@0.4.26(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-svelte@3.15.0(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0))(eslint@9.26.0(jiti@2.6.1))(prettier-plugin-astro@0.13.0)(svelte@5.55.0)(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@antfu/eslint-config@3.6.2(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.30)(astro-eslint-parser@1.3.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-astro@1.6.0(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-format@0.1.3(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-react-refresh@0.4.26(eslint@9.26.0(jiti@2.6.1)))(eslint-plugin-svelte@3.15.0(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0))(eslint@9.26.0(jiti@2.6.1))(prettier-plugin-astro@0.13.0)(svelte@5.55.0)(typescript@5.8.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.7.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@9.26.0(jiti@2.6.1))
       '@eslint/markdown': 6.6.0
-      '@stylistic/eslint-plugin': 2.13.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
-      '@vitest/eslint-plugin': 1.6.9(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@stylistic/eslint-plugin': 2.13.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
+      '@vitest/eslint-plugin': 1.6.9(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       eslint: 9.26.0(jiti@2.6.1)
       eslint-config-flat-gitignore: 0.3.0(eslint@9.26.0(jiti@2.6.1))
       eslint-flat-config-utils: 0.4.0
       eslint-merge-processors: 0.1.0(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-antfu: 2.7.0(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-command: 0.2.7(eslint@9.26.0(jiti@2.6.1))
-      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.26.0(jiti@2.6.1))
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-jsdoc: 50.8.0(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-jsonc: 2.21.1(eslint@9.26.0(jiti@2.6.1))
-      eslint-plugin-n: 17.24.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-n: 17.24.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 3.9.1(astro-eslint-parser@1.3.0)(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0)(typescript@5.9.3)(vue-eslint-parser@9.4.3(eslint@9.26.0(jiti@2.6.1)))
+      eslint-plugin-perfectionist: 3.9.1(astro-eslint-parser@1.3.0)(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0)(typescript@5.8.3)(vue-eslint-parser@9.4.3(eslint@9.26.0(jiti@2.6.1)))
       eslint-plugin-regexp: 2.10.0(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-toml: 0.11.1(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-unicorn: 55.0.0(eslint@9.26.0(jiti@2.6.1))
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-vue: 9.33.0(eslint@9.26.0(jiti@2.6.1))
       eslint-plugin-yml: 1.19.1(eslint@9.26.0(jiti@2.6.1))
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.30)(eslint@9.26.0(jiti@2.6.1))
@@ -16033,13 +16037,13 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)':
+  '@astrojs/svelte@8.0.3(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      astro: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       svelte: 5.55.0
-      svelte2tsx: 0.7.51(svelte@5.55.0)(typescript@5.9.3)
-      typescript: 5.9.3
+      svelte2tsx: 0.7.51(svelte@5.55.0)(typescript@5.8.3)
+      typescript: 5.8.3
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -16066,14 +16070,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@10.0.2(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(rollup@4.59.0)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@astrojs/vercel@10.0.2(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(rollup@4.59.0)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.8.3)))(vue@3.5.30(typescript@5.8.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
-      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.8.3)))(vue@3.5.30(typescript@5.8.3))
       '@vercel/functions': 3.4.3
       '@vercel/nft': 1.3.2(rollup@4.59.0)
       '@vercel/routing-utils': 5.3.3
-      astro: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       esbuild: 0.27.3
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -16089,15 +16093,15 @@ snapshots:
       - vue
       - vue-router
 
-  '@astrojs/vue@6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
+  '@astrojs/vue@6.0.1(@types/node@24.11.0)(astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)':
     dependencies:
-      '@vitejs/plugin-vue': 6.0.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
+      '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
       '@vue/compiler-sfc': 3.5.29
-      astro: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-vue-devtools: 8.1.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
+      vite-plugin-vue-devtools: 8.1.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
+      vue: 3.5.30(typescript@5.8.3)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@types/node'
@@ -17704,13 +17708,13 @@ snapshots:
   '@harperfast/extended-iterable@1.0.3':
     optional: true
 
-  '@hey-api/codegen-core@0.7.0(magicast@0.5.2)(typescript@5.9.3)':
+  '@hey-api/codegen-core@0.7.0(magicast@0.5.2)(typescript@5.8.3)':
     dependencies:
-      '@hey-api/types': 0.1.3(typescript@5.9.3)
+      '@hey-api/types': 0.1.3(typescript@5.8.3)
       ansi-colors: 4.1.3
       c12: 3.3.3(magicast@0.5.2)
       color-support: 1.1.3
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - magicast
 
@@ -17720,35 +17724,35 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@hey-api/openapi-ts@0.92.4(magicast@0.5.2)(typescript@5.9.3)':
+  '@hey-api/openapi-ts@0.92.4(magicast@0.5.2)(typescript@5.8.3)':
     dependencies:
-      '@hey-api/codegen-core': 0.7.0(magicast@0.5.2)(typescript@5.9.3)
+      '@hey-api/codegen-core': 0.7.0(magicast@0.5.2)(typescript@5.8.3)
       '@hey-api/json-schema-ref-parser': 1.3.0
-      '@hey-api/shared': 0.2.0(magicast@0.5.2)(typescript@5.9.3)
-      '@hey-api/types': 0.1.3(typescript@5.9.3)
+      '@hey-api/shared': 0.2.0(magicast@0.5.2)(typescript@5.8.3)
+      '@hey-api/types': 0.1.3(typescript@5.8.3)
       ansi-colors: 4.1.3
       color-support: 1.1.3
       commander: 14.0.3
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/shared@0.2.0(magicast@0.5.2)(typescript@5.9.3)':
+  '@hey-api/shared@0.2.0(magicast@0.5.2)(typescript@5.8.3)':
     dependencies:
-      '@hey-api/codegen-core': 0.7.0(magicast@0.5.2)(typescript@5.9.3)
+      '@hey-api/codegen-core': 0.7.0(magicast@0.5.2)(typescript@5.8.3)
       '@hey-api/json-schema-ref-parser': 1.3.0
-      '@hey-api/types': 0.1.3(typescript@5.9.3)
+      '@hey-api/types': 0.1.3(typescript@5.8.3)
       ansi-colors: 4.1.3
       cross-spawn: 7.0.6
       open: 11.0.0
       semver: 7.7.3
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/types@0.1.3(typescript@5.9.3)':
+  '@hey-api/types@0.1.3(typescript@5.8.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
 
   '@hono/node-server@1.19.9(hono@4.12.3)':
     dependencies:
@@ -18530,13 +18534,13 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@msw/source@0.6.1(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))':
+  '@msw/source@0.6.1(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))':
     dependencies:
       '@mswjs/interceptors': 0.40.0
       '@stoplight/json': 3.21.7
       '@types/har-format': 1.2.16
       '@yellow-ticket/seed-json-schema': 0.1.7
-      msw: 2.12.10(@types/node@24.11.0)(typescript@5.9.3)
+      msw: 2.12.10(@types/node@24.11.0)(typescript@5.8.3)
       openapi-types: 12.1.3
       outvariant: 1.4.3
       yaml: 2.8.2
@@ -18847,6 +18851,47 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.7.4
 
+  '@nuxt/devtools@3.2.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.2.2(magicast@0.5.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@nuxt/devtools-wizard': 3.2.2
+      '@nuxt/kit': 4.3.1(magicast@0.5.2)
+      '@vue/devtools-core': 8.0.7(vue@3.5.30(typescript@5.8.3))
+      '@vue/devtools-kit': 8.0.7
+      birpc: 4.0.0
+      consola: 3.4.2
+      destr: 2.0.5
+      error-stack-parser-es: 1.0.5
+      execa: 8.0.1
+      fast-npm-meta: 1.3.0
+      get-port-please: 3.2.0
+      hookable: 6.0.1
+      image-meta: 0.2.2
+      is-installed-globally: 1.0.0
+      launch-editor: 2.13.1
+      local-pkg: 1.1.2
+      magicast: 0.5.2
+      nypm: 0.6.5
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      semver: 7.7.4
+      simple-git: 3.32.3
+      sirv: 3.0.2
+      structured-clone-es: 1.0.0
+      tinyglobby: 0.2.15
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.3.1(magicast@0.5.2))(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vite-plugin-vue-tracer: 1.2.0(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
+      which: 5.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - vue
+
   '@nuxt/devtools@3.2.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.2(magicast@0.5.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -18888,25 +18933,25 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/eslint-config@1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@nuxt/eslint-config@1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.0.1
       '@eslint/js': 9.39.3
-      '@nuxt/eslint-plugin': 1.15.2(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@nuxt/eslint-plugin': 1.15.2(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
       '@stylistic/eslint-plugin': 5.9.0(eslint@9.39.3(jiti@2.6.1))
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.39.3(jiti@2.6.1)
       eslint-config-flat-gitignore: 2.2.1(eslint@9.39.3(jiti@2.6.1))
       eslint-flat-config-utils: 3.0.1
       eslint-merge-processors: 2.0.0(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-import-lite: 0.5.2(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.3(jiti@2.6.1))
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-jsdoc: 62.7.1(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-regexp: 3.0.0(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-unicorn: 63.0.0(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.9.0(eslint@9.39.3(jiti@2.6.1)))(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1)))
+      eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.9.0(eslint@9.39.3(jiti@2.6.1)))(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1)))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.30)(eslint@9.39.3(jiti@2.6.1))
       globals: 17.4.0
       local-pkg: 1.1.2
@@ -18921,21 +18966,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint-plugin@1.15.2(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@nuxt/eslint-plugin@1.15.2(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.39.3(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@nuxt/eslint@1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(magicast@0.5.2)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@eslint/config-inspector': 1.4.2(eslint@9.39.3(jiti@2.6.1))
       '@nuxt/devtools-kit': 3.2.2(magicast@0.5.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@nuxt/eslint-config': 1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      '@nuxt/eslint-plugin': 1.15.2(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@nuxt/eslint-config': 1.15.2(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.30)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@0.1.3(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
+      '@nuxt/eslint-plugin': 1.15.2(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
       chokidar: 5.0.0
       eslint: 9.39.3(jiti@2.6.1)
@@ -19009,7 +19054,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.33.1(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(sass@1.98.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.33.1(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(sass@1.98.0)(typescript@5.8.3)(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))':
     dependencies:
       '@nuxt/cli': 3.33.1(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
       citty: 0.1.6
@@ -19017,14 +19062,14 @@ snapshots:
       defu: 6.1.4
       jiti: 2.6.1
       magic-regexp: 0.10.0
-      mkdist: 2.4.1(sass@1.98.0)(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
+      mkdist: 2.4.1(sass@1.98.0)(typescript@5.8.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.8.3)))(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
-      tsconfck: 3.1.6(typescript@5.9.3)
-      typescript: 5.9.3
-      unbuild: 3.6.1(sass@1.98.0)(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3))
+      tsconfck: 3.1.6(typescript@5.8.3)
+      typescript: 5.8.3
+      unbuild: 3.6.1(sass@1.98.0)(typescript@5.8.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.8.3)))(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.8.3))
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - esbuild
@@ -19032,11 +19077,11 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.3.1(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.5)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.3.1(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2))(rolldown@1.0.0-rc.5)(typescript@5.8.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
-      '@unhead/vue': 2.1.10(vue@3.5.30(typescript@5.9.3))
+      '@unhead/vue': 2.1.10(vue@3.5.30(typescript@5.8.3))
       '@vue/shared': 3.5.29
       consola: 3.4.2
       defu: 6.1.4
@@ -19050,7 +19095,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1(@vercel/functions@3.4.3)(rolldown@1.0.0-rc.5)
-      nuxt: 4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2)
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -19059,7 +19104,7 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unstorage: 1.17.4(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@5.8.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     transitivePeerDependencies:
@@ -19181,7 +19226,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/test-utils@3.23.0(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4)':
+  '@nuxt/test-utils@3.23.0(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.8.3)(vitest@3.2.4)':
     dependencies:
       '@clack/prompts': 1.0.0-alpha.9
       '@nuxt/kit': 3.21.1(magicast@0.5.2)
@@ -19209,24 +19254,24 @@ snapshots:
       tinyexec: 1.0.2
       ufo: 1.6.3
       unplugin: 2.3.11
-      vitest-environment-nuxt: 1.0.1(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4)
-      vue: 3.5.30(typescript@5.9.3)
+      vitest-environment-nuxt: 1.0.1(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.8.3)(vitest@3.2.4)
+      vue: 3.5.30(typescript@5.8.3)
     optionalDependencies:
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 20.8.9
       jsdom: 27.4.0(@noble/hashes@1.8.0)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.11.0)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.11.0)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - crossws
       - magicast
       - typescript
 
-  '@nuxt/vite-builder@4.3.1(@types/node@24.11.0)(eslint@9.39.3(jiti@2.6.1))(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.3.1(@types/node@24.11.0)(eslint@9.39.3(jiti@2.6.1))(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
+      '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
       autoprefixer: 10.4.27(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.2(postcss@8.5.6)
@@ -19240,7 +19285,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.6
@@ -19251,8 +19296,8 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-node: 5.3.0(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.12.0(eslint@9.39.3(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
+      vite-plugin-checker: 0.12.0(eslint@9.39.3(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))
+      vue: 3.5.30(typescript@5.8.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       rolldown: 1.0.0-rc.5
@@ -19311,7 +19356,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-node: 5.3.0(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.12.0(eslint@9.39.3(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))
+      vite-plugin-checker: 0.12.0(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -20696,9 +20741,9 @@ snapshots:
     optionalDependencies:
       next: 13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.98.0)
 
-  '@stylistic/eslint-plugin@2.13.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@stylistic/eslint-plugin@2.13.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.6.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -20774,7 +20819,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       typescript: 5.9.3
 
-  '@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
@@ -20793,7 +20838,7 @@ snapshots:
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      typescript: 5.9.3
+      typescript: 5.8.3
     optional: true
 
   '@sveltejs/package@2.5.7(svelte@5.55.0)(typescript@5.8.3)':
@@ -21445,35 +21490,35 @@ snapshots:
       '@types/node': 24.11.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/type-utils': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.56.1
       eslint: 8.57.1
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/type-utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.56.1
       eslint: 9.26.0(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21509,40 +21554,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.55.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.26.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21606,27 +21651,27 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.56.1(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.56.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.26.0(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21658,7 +21703,7 @@ snapshots:
 
   '@typescript-eslint/types@8.56.1': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -21667,9 +21712,9 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.4
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@5.8.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21703,37 +21748,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.55.0)
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.8.3)
       eslint: 8.55.0
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.8.3)
       eslint: 8.57.1
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.26.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21770,6 +21815,12 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@unhead/vue@2.1.10(vue@3.5.30(typescript@5.8.3))':
+    dependencies:
+      hookable: 6.0.1
+      unhead: 2.1.10
+      vue: 3.5.30(typescript@5.8.3)
 
   '@unhead/vue@2.1.10(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -21836,14 +21887,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.8.3)))(vue@3.5.30(typescript@5.8.3))':
     optionalDependencies:
-      '@sveltejs/kit': 2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/kit': 2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
       react: 19.2.4
       svelte: 5.55.0
-      vue: 3.5.30(typescript@5.9.3)
-      vue-router: 4.6.4(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.8.3)
+      vue-router: 4.6.4(vue@3.5.30(typescript@5.8.3))
 
   '@vercel/functions@3.4.3':
     dependencies:
@@ -21925,6 +21976,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue-jsx@5.1.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.6
+      '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vue: 3.5.30(typescript@5.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-vue-jsx@5.1.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -21957,6 +22020,12 @@ snapshots:
       vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.29(typescript@5.9.3)
 
+  '@vitejs/plugin-vue@6.0.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.2
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vue: 3.5.30(typescript@5.8.3)
+
   '@vitejs/plugin-vue@6.0.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
@@ -21982,14 +22051,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.6.9(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/eslint-plugin@1.6.9(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.6.1)
     optionalDependencies:
-      typescript: 5.9.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      typescript: 5.8.3
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -22028,15 +22097,6 @@ snapshots:
       msw: 2.12.10(@types/node@24.11.0)(typescript@5.8.3)
       vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.12.10(@types/node@24.11.0)(typescript@5.9.3)
-      vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
   '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.37)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -22045,6 +22105,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.10(@types/node@20.19.37)(typescript@5.9.3)
       vite: 6.4.1(@types/node@20.19.37)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@24.11.0)(typescript@5.8.3)
+      vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -22137,6 +22206,16 @@ snapshots:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+
+  '@vue-macros/common@3.1.2(vue@3.5.30(typescript@5.8.3))':
+    dependencies:
+      '@vue/compiler-sfc': 3.5.29
+      ast-kit: 2.2.0
+      local-pkg: 1.1.2
+      magic-string-ast: 1.0.3
+      unplugin-utils: 0.3.1
+    optionalDependencies:
+      vue: 3.5.30(typescript@5.8.3)
 
   '@vue-macros/common@3.1.2(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -22273,17 +22352,23 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
+  '@vue/devtools-core@8.0.7(vue@3.5.30(typescript@5.8.3))':
+    dependencies:
+      '@vue/devtools-kit': 8.0.7
+      '@vue/devtools-shared': 8.0.7
+      vue: 3.5.30(typescript@5.8.3)
+
   '@vue/devtools-core@8.0.7(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@vue/devtools-kit': 8.0.7
       '@vue/devtools-shared': 8.0.7
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vue/devtools-core@8.1.1(vue@3.5.30(typescript@5.9.3))':
+  '@vue/devtools-core@8.1.1(vue@3.5.30(typescript@5.8.3))':
     dependencies:
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@5.8.3)
 
   '@vue/devtools-kit@8.0.7':
     dependencies:
@@ -22420,7 +22505,6 @@ snapshots:
       '@vue/compiler-ssr': 3.5.30
       '@vue/shared': 3.5.30
       vue: 3.5.30(typescript@5.8.3)
-    optional: true
 
   '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -22762,7 +22846,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@5.18.1(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@5.18.1(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -22813,7 +22897,7 @@ snapshots:
       svgo: 4.0.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@5.8.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -22826,7 +22910,7 @@ snapshots:
       yocto-spinner: 0.2.3
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@5.8.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -22911,100 +22995,6 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tsconfck: 3.1.6(typescript@5.8.3)
-      ultrahtml: 1.6.0
-      unifont: 0.7.4
-      unist-util-visit: 5.1.0
-      unstorage: 1.17.4(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)
-      vfile: 6.0.3
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      xxhash-wasm: 1.1.0
-      yargs-parser: 22.0.0
-      zod: 4.3.6
-    optionalDependencies:
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - lightningcss
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - yaml
-
-  astro@6.1.2(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
-    dependencies:
-      '@astrojs/compiler': 3.0.1
-      '@astrojs/internal-helpers': 0.8.0
-      '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/telemetry': 3.3.0
-      '@capsizecss/unpack': 4.0.0
-      '@clack/prompts': 1.1.0
-      '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      ci-info: 4.4.0
-      clsx: 2.1.1
-      common-ancestor-path: 2.0.0
-      cookie: 1.1.1
-      devalue: 5.6.4
-      diff: 8.0.3
-      dlv: 1.1.3
-      dset: 3.1.4
-      es-module-lexer: 2.0.0
-      esbuild: 0.27.3
-      flattie: 1.1.1
-      fontace: 0.4.1
-      github-slugger: 2.0.0
-      html-escaper: 3.0.3
-      http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
-      magic-string: 0.30.21
-      magicast: 0.5.2
-      mrmime: 2.0.1
-      neotraverse: 0.6.18
-      obug: 2.1.1
-      p-limit: 7.3.0
-      p-queue: 9.1.0
-      package-manager-detector: 1.6.0
-      piccolore: 0.1.3
-      picomatch: 4.0.3
-      rehype: 13.0.2
-      semver: 7.7.4
-      shiki: 4.0.2
-      smol-toml: 1.6.0
-      svgo: 4.0.1
-      tinyclip: 0.1.12
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -24682,40 +24672,40 @@ snapshots:
       '@eslint/compat': 2.0.2(eslint@9.39.3(jiti@2.6.1))
       eslint: 9.39.3(jiti@2.6.1)
 
-  eslint-config-next@14.0.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint@8.55.0)(typescript@5.9.3):
+  eslint-config-next@14.0.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint@8.55.0)(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 14.0.4
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.8.3)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint-plugin-import@2.32.0(eslint@8.55.0))(eslint@8.55.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint-plugin-import@2.32.0(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.55.0)
       eslint-plugin-react: 7.37.5(eslint@8.55.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.55.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@14.2.35(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1)(typescript@5.9.3):
+  eslint-config-next@14.2.35(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1)(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 14.2.35
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
@@ -24772,7 +24762,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint-plugin-import@2.32.0(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint-plugin-import@2.32.0(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -24783,12 +24773,12 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
-      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -24799,8 +24789,8 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24818,25 +24808,25 @@ snapshots:
     dependencies:
       eslint: 9.39.3(jiti@2.6.1)
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.8.3)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint-plugin-import@2.32.0(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0))(eslint-plugin-import@2.32.0(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24920,7 +24910,7 @@ snapshots:
     dependencies:
       eslint: 9.39.3(jiti@2.6.1)
 
-  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0):
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0):
     dependencies:
       '@typescript-eslint/types': 8.56.1
       comment-parser: 1.4.5
@@ -24933,13 +24923,13 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.56.1(eslint@8.55.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@8.55.0)(typescript@5.8.3)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
       '@typescript-eslint/types': 8.56.1
       comment-parser: 1.4.5
@@ -24952,13 +24942,13 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.26.0(jiti@2.6.1)):
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.26.0(jiti@2.6.1)):
     dependencies:
       '@typescript-eslint/types': 8.56.1
       comment-parser: 1.4.5
@@ -24971,12 +24961,12 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.3(jiti@2.6.1)):
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       '@typescript-eslint/types': 8.56.1
       comment-parser: 1.4.5
@@ -24989,12 +24979,12 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -25005,7 +24995,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.55.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -25017,13 +25007,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -25034,7 +25024,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -25046,7 +25036,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -25158,7 +25148,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-n@17.24.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-n@17.24.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.26.0(jiti@2.6.1))
       enhanced-resolve: 5.20.0
@@ -25169,16 +25159,16 @@ snapshots:
       globrex: 0.1.2
       ignore: 5.3.2
       semver: 7.7.4
-      ts-declaration-location: 1.0.7(typescript@5.9.3)
+      ts-declaration-location: 1.0.7(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@3.9.1(astro-eslint-parser@1.3.0)(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0)(typescript@5.9.3)(vue-eslint-parser@9.4.3(eslint@9.26.0(jiti@2.6.1))):
+  eslint-plugin-perfectionist@3.9.1(astro-eslint-parser@1.3.0)(eslint@9.26.0(jiti@2.6.1))(svelte@5.55.0)(typescript@5.8.3)(vue-eslint-parser@9.4.3(eslint@9.26.0(jiti@2.6.1))):
     dependencies:
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.6.1)
       minimatch: 9.0.9
       natural-compare-lite: 1.4.0
@@ -25385,13 +25375,13 @@ snapshots:
       semver: 7.7.4
       strip-indent: 4.1.1
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.6.1)):
     dependencies:
       eslint: 9.26.0(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
 
-  eslint-plugin-vue@10.8.0(@stylistic/eslint-plugin@5.9.0(eslint@9.39.3(jiti@2.6.1)))(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1))):
+  eslint-plugin-vue@10.8.0(@stylistic/eslint-plugin@5.9.0(eslint@9.39.3(jiti@2.6.1)))(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
       eslint: 9.39.3(jiti@2.6.1)
@@ -25403,7 +25393,7 @@ snapshots:
       xml-name-validator: 4.0.0
     optionalDependencies:
       '@stylistic/eslint-plugin': 5.9.0(eslint@9.39.3(jiti@2.6.1))
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.8.3)
 
   eslint-plugin-vue@9.33.0(eslint@9.26.0(jiti@2.6.1)):
     dependencies:
@@ -28206,28 +28196,6 @@ snapshots:
       vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.8.3))
       vue-tsc: 2.2.12(typescript@5.8.3)
 
-  mkdist@2.4.1(sass@1.98.0)(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3)):
-    dependencies:
-      autoprefixer: 10.4.27(postcss@8.5.6)
-      citty: 0.1.6
-      cssnano: 7.1.2(postcss@8.5.6)
-      defu: 6.1.4
-      esbuild: 0.25.12
-      jiti: 1.21.7
-      mlly: 1.8.0
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      postcss: 8.5.6
-      postcss-nested: 7.0.2(postcss@8.5.6)
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      sass: 1.98.0
-      typescript: 5.9.3
-      vue: 3.5.30(typescript@5.9.3)
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3))
-      vue-tsc: 2.2.12(typescript@5.9.3)
-
   mlly@1.8.0:
     dependencies:
       acorn: 8.16.0
@@ -28381,6 +28349,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   muggle-string@0.4.1: {}
 
@@ -28792,17 +28761,17 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2):
+  nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.3.2(magicast@0.5.2)
       '@nuxt/cli': 3.33.1(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.3.1(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.5)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.3.1(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2))(rolldown@1.0.0-rc.5)(typescript@5.8.3)
       '@nuxt/schema': 4.3.1
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.3.1(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.3.1(@types/node@24.11.0)(eslint@9.39.3(jiti@2.6.1))(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
-      '@unhead/vue': 2.1.10(vue@3.5.30(typescript@5.9.3))
+      '@nuxt/vite-builder': 4.3.1(@types/node@24.11.0)(eslint@9.39.3(jiti@2.6.1))(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@24.11.0)(@vercel/functions@3.4.3)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.10.0)(less@4.6.4)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.5)(rollup@4.59.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)
+      '@unhead/vue': 2.1.10(vue@3.5.30(typescript@5.8.3))
       '@vue/shared': 3.5.29
       c12: 3.3.3(magicast@0.5.2)
       chokidar: 5.0.0
@@ -28847,10 +28816,10 @@ snapshots:
       unctx: 2.5.0
       unimport: 5.7.0
       unplugin: 3.0.0
-      unplugin-vue-router: 0.19.2(@vue/compiler-sfc@3.5.30)(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      unplugin-vue-router: 0.19.2(@vue/compiler-sfc@3.5.30)(vue-router@4.6.4(vue@3.5.30(typescript@5.8.3)))(vue@3.5.30(typescript@5.8.3))
       untyped: 2.0.0
-      vue: 3.5.30(typescript@5.9.3)
-      vue-router: 4.6.4(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.8.3)
+      vue-router: 4.6.4(vue@3.5.30(typescript@5.8.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 24.11.0
@@ -30765,14 +30734,6 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.29.0
 
-  rollup-plugin-dts@6.3.0(rollup@4.59.0)(typescript@5.9.3):
-    dependencies:
-      magic-string: 0.30.21
-      rollup: 4.59.0
-      typescript: 5.9.3
-    optionalDependencies:
-      '@babel/code-frame': 7.29.0
-
   rollup-plugin-dts@6.4.1(rollup@4.59.0)(typescript@5.9.3):
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -31599,13 +31560,6 @@ snapshots:
       svelte: 5.55.0
       typescript: 5.8.3
 
-  svelte2tsx@0.7.51(svelte@5.55.0)(typescript@5.9.3):
-    dependencies:
-      dedent-js: 1.0.1
-      scule: 1.3.0
-      svelte: 5.55.0
-      typescript: 5.9.3
-
   svelte@5.55.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -31851,9 +31805,9 @@ snapshots:
 
   ts-algebra@1.2.2: {}
 
-  ts-api-utils@1.4.3(typescript@5.9.3):
+  ts-api-utils@1.4.3(typescript@5.8.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
 
   ts-api-utils@2.4.0(typescript@5.8.3):
     dependencies:
@@ -31863,18 +31817,14 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-declaration-location@1.0.7(typescript@5.9.3):
+  ts-declaration-location@1.0.7(typescript@5.8.3):
     dependencies:
       picomatch: 4.0.3
-      typescript: 5.9.3
+      typescript: 5.8.3
 
   tsconfck@3.1.6(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
-
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -32106,40 +32056,6 @@ snapshots:
       - vue-sfc-transformer
       - vue-tsc
 
-  unbuild@3.6.1(sass@1.98.0)(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3)):
-    dependencies:
-      '@rollup/plugin-alias': 5.1.1(rollup@4.59.0)
-      '@rollup/plugin-commonjs': 28.0.9(rollup@4.59.0)
-      '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      citty: 0.1.6
-      consola: 3.4.2
-      defu: 6.1.4
-      esbuild: 0.25.12
-      fix-dts-default-cjs-exports: 1.0.1
-      hookable: 5.5.3
-      jiti: 2.6.1
-      magic-string: 0.30.21
-      mkdist: 2.4.1(sass@1.98.0)(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
-      mlly: 1.8.0
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      pretty-bytes: 7.1.0
-      rollup: 4.59.0
-      rollup-plugin-dts: 6.3.0(rollup@4.59.0)(typescript@5.9.3)
-      scule: 1.3.0
-      tinyglobby: 0.2.15
-      untyped: 2.0.0
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - sass
-      - vue
-      - vue-sfc-transformer
-      - vue-tsc
-
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -32285,6 +32201,31 @@ snapshots:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.3
+
+  unplugin-vue-router@0.19.2(@vue/compiler-sfc@3.5.30)(vue-router@4.6.4(vue@3.5.30(typescript@5.8.3)))(vue@3.5.30(typescript@5.8.3)):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@vue-macros/common': 3.1.2(vue@3.5.30(typescript@5.8.3))
+      '@vue/compiler-sfc': 3.5.30
+      '@vue/language-core': 3.2.5
+      ast-walker-scope: 0.8.3
+      chokidar: 5.0.0
+      json5: 2.2.3
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      muggle-string: 0.4.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      scule: 1.3.0
+      tinyglobby: 0.2.15
+      unplugin: 2.3.11
+      unplugin-utils: 0.3.1
+      yaml: 2.8.2
+    optionalDependencies:
+      vue-router: 4.6.4(vue@3.5.30(typescript@5.8.3))
+    transitivePeerDependencies:
+      - vue
 
   unplugin-vue-router@0.19.2(@vue/compiler-sfc@3.5.30)(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
@@ -32551,7 +32492,7 @@ snapshots:
 
   vite-plugin-banner@0.8.1: {}
 
-  vite-plugin-checker@0.12.0(eslint@9.39.3(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3)):
+  vite-plugin-checker@0.12.0(eslint@9.39.3(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.8.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
@@ -32564,6 +32505,23 @@ snapshots:
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.39.3(jiti@2.6.1)
+      meow: 13.2.0
+      optionator: 0.9.4
+      typescript: 5.8.3
+      vue-tsc: 2.2.12(typescript@5.8.3)
+
+  vite-plugin-checker@0.12.0(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3)):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      chokidar: 4.0.3
+      npm-run-path: 6.0.0
+      picocolors: 1.1.1
+      picomatch: 4.0.3
+      tiny-invariant: 1.3.3
+      tinyglobby: 0.2.15
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vscode-uri: 3.1.0
+    optionalDependencies:
       meow: 13.2.0
       optionator: 0.9.4
       typescript: 5.9.3
@@ -32662,9 +32620,9 @@ snapshots:
       picocolors: 1.1.1
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vite-plugin-vue-devtools@8.1.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
+  vite-plugin-vue-devtools@8.1.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3)):
     dependencies:
-      '@vue/devtools-core': 8.1.1(vue@3.5.30(typescript@5.9.3))
+      '@vue/devtools-core': 8.1.1(vue@3.5.30(typescript@5.8.3))
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
       sirv: 3.0.2
@@ -32690,6 +32648,16 @@ snapshots:
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-vue-tracer@1.2.0(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3)):
+    dependencies:
+      estree-walker: 3.0.3
+      exsolve: 1.0.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      source-map-js: 1.2.1
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vue: 3.5.30(typescript@5.8.3)
 
   vite-plugin-vue-tracer@1.2.0(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
@@ -32817,9 +32785,9 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest-environment-nuxt@1.0.1(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4):
+  vitest-environment-nuxt@1.0.1(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.8.3)(vitest@3.2.4):
     dependencies:
-      '@nuxt/test-utils': 3.23.0(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4)
+      '@nuxt/test-utils': 3.23.0(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(magicast@0.5.2)(typescript@5.8.3)(vitest@3.2.4)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -32970,51 +32938,6 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.11.0)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 24.11.0
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
-      happy-dom: 20.8.9
-      jsdom: 27.4.0(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
@@ -33040,6 +32963,46 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.37
+      happy-dom: 20.8.9
+      jsdom: 27.4.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@24.11.0)(typescript@5.8.3))(vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.11.0
       happy-dom: 20.8.9
       jsdom: 27.4.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
@@ -33156,6 +33119,11 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.29(typescript@5.9.3)
 
+  vue-router@4.6.4(vue@3.5.30(typescript@5.8.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.30(typescript@5.8.3)
+
   vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
@@ -33167,14 +33135,6 @@ snapshots:
       '@vue/compiler-core': 3.5.30
       esbuild: 0.27.3
       vue: 3.5.30(typescript@5.8.3)
-    optional: true
-
-  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)):
-    dependencies:
-      '@babel/parser': 7.29.0
-      '@vue/compiler-core': 3.5.30
-      esbuild: 0.27.3
-      vue: 3.5.30(typescript@5.9.3)
 
   vue-tsc@2.2.12(typescript@5.6.3):
     dependencies:
@@ -33233,7 +33193,6 @@ snapshots:
       '@vue/shared': 3.5.30
     optionalDependencies:
       typescript: 5.8.3
-    optional: true
 
   vue@3.5.30(typescript@5.9.3):
     dependencies:
@@ -33549,9 +33508,9 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
-  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
+  zod-to-ts@1.2.0(typescript@5.8.3)(zod@3.25.76):
     dependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
       zod: 3.25.76
 
   zod@3.25.76: {}


### PR DESCRIPTION
Renames `api.maxConcurrency` to `api.rateLimit` across the CLI — the old name was ambiguous and bled into stream internals via ad-hoc `batchSize` parameters that bypassed the global config entirely.

Done as an **alias** -> old `maxConcurrency` still works but it's deprecated.

### What's included

- **`ApiConfig.rateLimit`** replaces `maxConcurrency` as the canonical field (default: `6`). The old name is kept as an optional deprecated field for backward compatibility.
- **`--api-rate-limit`** is the new CLI flag; `--api-max-concurrency` and `api.maxConcurrency` in config files still work but emit a deprecation warning and are forwarded to `rateLimit` at resolve time. Both are marked `@todo(next-major)` for removal.
- **`createConcurrencyLock()`** (`src/utils/concurrency.ts`) — shared utility that reads `getActiveConfig().api.rateLimit` at call time. Replaces the hardcoded `new Sema(12)` module-level constants in `assets/streams.ts` and `stories/streams.ts`, which were initialised before config resolution.
- **`batchSize` removed** from `StoriesStream` and `UpdateStream` — it was never passed by any caller and silently bypassed the global config.

Before/after for config files and CLI:

```diff
- api:
-   maxConcurrency: 10
+ api:
+   rateLimit: 10
```

```diff
- --api-max-concurrency 10
+ --api-rate-limit 10
```

Fixes WDX-302
