### PR TITLE
feat: allow configure cv management

### DIFF
--- a/packages/capi-client/src/index.ts
+++ b/packages/capi-client/src/index.ts
@@ -51,6 +51,17 @@ interface CacheConfig {
   /** Time-to-live in milliseconds for cached entries. @default 60_000 */
   ttlMs?: number;
   /**
+   * Controls how the `cv` (content version) query parameter is managed.
+   *
+   * - `'auto'` (default): automatically attach the tracked `cv` to
+   *   subsequent published requests for cache busting.
+   * - `'manual'`: do not attach `cv` to outgoing requests. The client still
+   *   tracks cv internally for cache invalidation (flushing when cv changes),
+   *   but the query parameter is not sent. Useful for SSR with edge caching
+   *   where stable URLs are required.
+   */
+  cv?: 'auto' | 'manual';
+  /**
    * Controls when the cache is flushed on cv change.
    *
    * - `'auto'` (default): automatically flush the cache whenever the API returns a new cv value.
@@ -135,6 +146,7 @@ export const createApiClient = <
     : createStrategy('cache-first');
   const cacheTtlMs = cache.ttlMs ?? 60_000;
   const cacheFlush = cache.flush ?? 'auto';
+  const cvMode = cache.cv ?? 'auto';
   let currentCv: number | undefined;
 
   const client: Client = createClient(
@@ -234,7 +246,7 @@ export const createApiClient = <
     fetchFn: (query: Record<string, unknown>) => Promise<ApiResponse<TData, ThrowOnError>>,
     cacheOptions?: RequestWithCacheOptions,
   ): Promise<ApiResponse<TData, ThrowOnError>> => {
-    const query = currentCv !== undefined ? applyCvToQuery(rawQuery, currentCv) : rawQuery;
+    const query = cvMode === 'auto' && currentCv !== undefined ? applyCvToQuery(rawQuery, currentCv) : rawQuery;
     const cacheEnabled = shouldUseCache(method, path, rawQuery);
 
     if (!cacheEnabled) {

--- a/packages/capi-client/src/resources/stories.test.ts
+++ b/packages/capi-client/src/resources/stories.test.ts
@@ -1002,3 +1002,28 @@ describe('cache and cv', () => {
     expect(thirdResult.data?.marker).toBe('fresh');
   });
 });
+
+describe('cache.cv: manual', () => {
+  it('should not attach cv to subsequent requests', async () => {
+    const capturedUrls: string[] = [];
+    server.use(
+      http.get('https://api.storyblok.com/v2/cdn/stories', ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({
+          stories: [makeStory('s1', { component: 'page', _uid: 'u1' })],
+          cv: 999,
+        });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: 'test-token',
+      cache: { cv: 'manual' },
+    });
+
+    await client.stories.list({ query: { version: 'published' } });
+    await client.stories.list({ query: { version: 'published', page: 2 } });
+
+    const secondUrl = new URL(capturedUrls[1]!);
+    expect(secondUrl.searchParams.has('cv')).toBe(false);
+  });
+});

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -80,6 +80,7 @@ export class Storyblok {
   public links: LinksType;
   public version: StoryblokContentVersionKeys | undefined;
   private rateLimitConfig: RateLimitConfig;
+  private cvMode: 'auto' | 'manual';
   /**
    * @deprecated This property is deprecated. Use the standalone `richTextResolver` from `@storyblok/richtext` instead.
    * @see https://github.com/storyblok/richtext
@@ -153,6 +154,7 @@ export class Storyblok {
     this.relations = {} as RelationsType;
     this.links = {} as LinksType;
     this.cache = config.cache || { clear: 'manual' };
+    this.cvMode = config.cache?.cv ?? 'auto';
     this.resolveCounter = 0;
     this.resolveNestedRelations = config.resolveNestedRelations || true;
     this.stringifiedStoriesCache = {} as Record<string, string>;
@@ -173,7 +175,7 @@ export class Storyblok {
       params.token = this.getToken();
     }
 
-    if (!params.cv) {
+    if (!params.cv && this.cvMode === 'auto') {
       params.cv = cacheVersions[params.token];
     }
 

--- a/packages/js-client/src/interfaces.ts
+++ b/packages/js-client/src/interfaces.ts
@@ -232,6 +232,17 @@ export interface ISbCache {
   type?: 'none' | 'memory' | 'custom';
   clear?: 'auto' | 'manual' | 'onpreview';
   custom?: ICacheProvider;
+  /**
+   * Controls how the `cv` (content version) query parameter is managed.
+   *
+   * - `'auto'` (default): automatically attach the tracked `cv` to
+   *   subsequent CDN requests for cache busting.
+   * - `'manual'`: do not attach `cv` to outgoing requests. The client still
+   *   tracks cv internally for cache invalidation (flushing when cv changes),
+   *   but the query parameter is not sent. Useful for SSR with edge caching
+   *   where stable URLs are required.
+   */
+  cv?: 'auto' | 'manual';
 }
 
 export interface ISbConfig {

--- a/packages/js-client/tests/api/index.test.ts
+++ b/packages/js-client/tests/api/index.test.ts
@@ -214,5 +214,51 @@ describe('storyblokClient (MSW)', () => {
       expect(cvBefore).not.toBe(undefined);
       expect(cvAfterFirst).toBe(cvAfterSecond);
     });
+
+    describe('cache.cv: manual', () => {
+      it('should not attach cv to subsequent requests', async () => {
+        const capturedUrls: string[] = [];
+        server.use(
+          http.get(`${BASE_URL}/cdn/stories`, ({ request }) => {
+            capturedUrls.push(request.url);
+            return HttpResponse.json(
+              { stories: [], cv: 12345 },
+              { headers: { 'Total': '0', 'Per-Page': '25' } },
+            );
+          }),
+        );
+
+        const manualClient = new StoryblokClient({
+          accessToken: 'manual-cv-unique',
+          cache: { cv: 'manual' },
+        });
+
+        await manualClient.get('cdn/stories', { version: 'published' });
+        await manualClient.get('cdn/stories', { version: 'published', page: 2 });
+
+        expect(capturedUrls).toHaveLength(2);
+        const secondUrl = new URL(capturedUrls[1]!);
+        expect(secondUrl.searchParams.has('cv')).toBe(false);
+      });
+
+      it('should still track cv internally for cache invalidation', async () => {
+        server.use(
+          http.get(`${BASE_URL}/cdn/stories`, () =>
+            HttpResponse.json(
+              { stories: [], cv: 77777 },
+              { headers: { 'Total': '0', 'Per-Page': '25' } },
+            )),
+        );
+
+        const manualClient = new StoryblokClient({
+          accessToken: 'manual-cv-track',
+          cache: { cv: 'manual' },
+        });
+
+        await manualClient.get('cdn/stories', { version: 'published' });
+
+        expect(manualClient.cacheVersion()).toBe(77777);
+      });
+    });
   });
 });


### PR DESCRIPTION
### Problem

Both storyblok-js-client and @storyblok/api-client automatically track the cv (content version) returned by the CDN API and attach it to every subsequent published request. This is hardcoded with no opt-out.

This causes problems in scenarios where the cv should not be managed by the client:

SSR with edge/CDN caching — attaching a tracked cv defeats edge-cache reuse; every new deployment or publish changes the cv, making all CDN-cached responses stale.

Webhook-driven invalidation — when cache purging is triggered externally, having the client auto-track cv adds noise and unpredictability.

External cv control — teams that set cv manually per-request cannot prevent the client from overriding or overwriting the tracked value.

### Solution

Add a cv option to the cache configuration in both clients.

```js
// storyblok-js-client
new StoryblokClient({
  cache: { cv: 'manual' },
})
// @storyblok/api-client
createApiClient({
  cache: { cv: 'manual' },
})
```

Fixes WDX-428