### PR TITLE
fix(astro): fix HMR issues for Astro components loaded via StoryblokComponent

### DIFF
--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -1,8 +1,11 @@
 import { normalizeAstroExtension } from '../utils/normalizeAstroExtension';
 import { normalizePath } from '../utils/normalizePath';
 import { toCamelCase } from '../utils/toCamelCase';
-import type { Plugin } from 'vite';
+import type { Plugin, ViteDevServer } from 'vite';
 
+// Virtual module identifiers for Vite's module system
+const VIRTUAL_MODULE_ID = 'virtual:import-storyblok-components';
+const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
 /**
  * Vite plugin that automatically imports Storyblok components from a specified directory
  * and merges them with optional user-provided component mappings.
@@ -15,13 +18,28 @@ export function vitePluginImportStoryblokComponents(
   enableFallbackComponent: boolean,
   customFallbackComponent?: string,
 ): Plugin {
-  // Virtual module identifiers for Vite's module system
-  const VIRTUAL_MODULE_ID = 'virtual:import-storyblok-components';
-  const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
+  let server: ViteDevServer | undefined;
+  let reloadTimer: ReturnType<typeof setTimeout> | undefined;
 
+  function triggerReload() {
+    if (!server) {
+      return;
+    }
+    clearTimeout(reloadTimer);
+    reloadTimer = setTimeout(() => {
+      server?.ws.send({
+        type: 'full-reload',
+      });
+    }, 50);
+  }
   return {
     name: 'vite-plugin-import-storyblok-components',
-
+    configureServer(viteServer) {
+      server = viteServer;
+      viteServer.httpServer?.once('close', () => {
+        clearTimeout(reloadTimer);
+      });
+    },
     /**
      * Resolves virtual module imports
      */
@@ -62,6 +80,32 @@ export function vitePluginImportStoryblokComponents(
       );
 
       return moduleCode;
+    },
+    handleHotUpdate(ctx) {
+      const filePath = ctx.file;
+      const isAstroFile = filePath.endsWith('.astro');
+      if (!isAstroFile) {
+        return;
+      }
+      const isInStoryblokFolder = filePath.includes('/storyblok/');
+      const registryFiles = Object.values(components);
+      const isRegistryMatch = registryFiles.some((componentPath) => {
+        const normalizedComponentPath = getComponentFullPath(componentsDir, componentPath);
+        return filePath.includes(normalizedComponentPath.replace(/\.\.\//g, ''));
+      });
+      let isFallbackMatch = false;
+      if (customFallbackComponent) {
+        const fallbackPath = getComponentFullPath(
+          componentsDir,
+          customFallbackComponent,
+        ).replace(/\.\.\//g, '');
+        isFallbackMatch = filePath.includes(fallbackPath);
+      }
+      if (!isInStoryblokFolder && !isRegistryMatch && !isFallbackMatch) {
+        return;
+      }
+      triggerReload();
+      return [];
     },
   };
 }

--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -1,7 +1,7 @@
 import { normalizeAstroExtension } from '../utils/normalizeAstroExtension';
 import { normalizePath } from '../utils/normalizePath';
 import { toCamelCase } from '../utils/toCamelCase';
-import type { Plugin, ViteDevServer } from 'vite';
+import type { Plugin } from 'vite';
 
 // Virtual module identifiers for Vite's module system
 const VIRTUAL_MODULE_ID = 'virtual:import-storyblok-components';
@@ -18,28 +18,8 @@ export function vitePluginImportStoryblokComponents(
   enableFallbackComponent: boolean,
   customFallbackComponent?: string,
 ): Plugin {
-  let server: ViteDevServer | undefined;
-  let reloadTimer: ReturnType<typeof setTimeout> | undefined;
-
-  function triggerReload() {
-    if (!server) {
-      return;
-    }
-    clearTimeout(reloadTimer);
-    reloadTimer = setTimeout(() => {
-      server?.ws.send({
-        type: 'full-reload',
-      });
-    }, 50);
-  }
   return {
     name: 'vite-plugin-import-storyblok-components',
-    configureServer(viteServer) {
-      server = viteServer;
-      viteServer.httpServer?.once('close', () => {
-        clearTimeout(reloadTimer);
-      });
-    },
     /**
      * Resolves virtual module imports
      */
@@ -81,32 +61,6 @@ export function vitePluginImportStoryblokComponents(
 
       return moduleCode;
     },
-    handleHotUpdate(ctx) {
-      const filePath = ctx.file;
-      const isAstroFile = filePath.endsWith('.astro');
-      if (!isAstroFile) {
-        return;
-      }
-      const isInStoryblokFolder = filePath.includes('/storyblok/');
-      const registryFiles = Object.values(components);
-      const isRegistryMatch = registryFiles.some((componentPath) => {
-        const normalizedComponentPath = getComponentFullPath(componentsDir, componentPath);
-        return filePath.includes(normalizedComponentPath.replace(/\.\.\//g, ''));
-      });
-      let isFallbackMatch = false;
-      if (customFallbackComponent) {
-        const fallbackPath = getComponentFullPath(
-          componentsDir,
-          customFallbackComponent,
-        ).replace(/\.\.\//g, '');
-        isFallbackMatch = filePath.includes(fallbackPath);
-      }
-      if (!isInStoryblokFolder && !isRegistryMatch && !isFallbackMatch) {
-        return;
-      }
-      triggerReload();
-      return [];
-    },
   };
 }
 /**
@@ -136,22 +90,26 @@ function generateModuleCode(
     import { toCamelCase } from '@storyblok/astro';
 
     // Dynamically import all Storyblok components using Vite's glob import
-    const modules = import.meta.glob('${globPattern}');
+    const modules = import.meta.glob('${globPattern}', { eager: true });
     // Process imported modules into a components object
     const storyblokComponents = {};
+    const createComponentLoader = (module) => {
+      return async () => module?.default ?? module;
+    };
     for (const filePath in modules) {
       // Extract component name from file path (remove extension)
       const fileName = filePath.split('/').pop();
-      const componentName = fileName?.replace(/\\.[^/.]+$/, '');
+      const name = fileName?.replace(/\\.[^/.]+$/, '');
 
-        if (componentName) {
+        if (name) {
           // Convert filename to camelCase for Storyblok component naming
-          const camelCaseName = toCamelCase(componentName);
+          const componentName = toCamelCase(name);
 
-          storyblokComponents[camelCaseName] = async () => {
-          const module = await modules[filePath]();
-          return module.default || module;
-        };
+          Object.defineProperty(storyblokComponents, componentName, {
+              enumerable: true,
+              configurable: true,
+              get: () => createComponentLoader(modules[filePath]),
+          });
       }
     }
     
@@ -186,18 +144,18 @@ async function resolveFallbackComponent(
       );
     }
 
-    return `
-      storyblokComponents['FallbackComponent'] = async () => {
-        const module = await import('${resolved.id}');
-        return module.default || module;
-      };`;
+    return createManualComponentDefinition('FallbackComponent', resolved.id);
   }
 
   return `
-    storyblokComponents['FallbackComponent'] = async () => {
-      const module = await import('@storyblok/astro/FallbackComponent.astro');
-      return module.default || module;
-    };`;
+      import FallbackComponent from '@storyblok/astro/FallbackComponent.astro';
+
+      Object.defineProperty(storyblokComponents, 'FallbackComponent', {
+      enumerable: true,
+      configurable: true,
+      get: () => createComponentLoader(FallbackComponentModule),
+    });
+    `;
 }
 /**
  * Resolves user-provided Storyblok components into import statements.
@@ -214,31 +172,25 @@ async function resolveUserComponents(
   componentsDir: string,
   enableFallback: boolean,
 ): Promise<string[]> {
-  const imports: string[] = [];
+  const resolvedComponents: string[] = [];
 
   for await (const [key, value] of Object.entries(components)) {
     const pathWithExt = getComponentFullPath(componentsDir, value);
-    const resolvedId = await ctx.resolve(pathWithExt);
+    const resolved = await ctx.resolve(pathWithExt);
 
-    if (!resolvedId) {
+    if (!resolved) {
       if (!enableFallback) {
         throw new Error(
           `Component could not be found for blok "${key}"! Does "${pathWithExt}" exist?`,
         );
       }
-    }
-    else {
-      const camelCaseName = toCamelCase(key);
-
-      imports.push(`
-      storyblokComponents['${camelCaseName}'] = async () => {
-        const module = await import('${resolvedId.id}');
-        return module.default || module;
-      };`);
-    }
+      continue;
+    };
+    const componentName = toCamelCase(key);
+    resolvedComponents.push(createManualComponentDefinition(componentName, resolved.id));
   }
 
-  return imports;
+  return resolvedComponents;
 }
 
 /**
@@ -264,4 +216,17 @@ function getComponentFullPath(
   const normalizedComponentsDir = normalizePath(componentsDir);
   const fullComponentPath = `${normalizedComponentsDir}${normalizePath(componentPath)}`;
   return normalizeAstroExtension(fullComponentPath);
+}
+function createManualComponentDefinition(
+  componentName: string,
+  importPath: string,
+): string {
+  return `
+    import ${componentName} from '${importPath}';
+    Object.defineProperty(storyblokComponents, '${componentName}', {
+      enumerable: true,
+      configurable: true,
+      get: () => createComponentLoader(${componentName}),
+    });
+`.trim();
 }

--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -96,25 +96,24 @@ function generateModuleCode(
     const createComponentLoader = (module) => {
       return async () => module?.default ?? module;
     };
+    const registerComponent = (name, component) => {
+      Object.defineProperty(storyblokComponents, name, {
+        enumerable: true,
+        configurable: true,
+        get: () => createComponentLoader(component),
+      });
+    };
     for (const filePath in modules) {
       // Extract component name from file path (remove extension)
       const fileName = filePath.split('/').pop();
-      const name = fileName?.replace(/\\.[^/.]+$/, '');
-
-        if (name) {
-          // Convert filename to camelCase for Storyblok component naming
-          const componentName = toCamelCase(name);
-
-          Object.defineProperty(storyblokComponents, componentName, {
-              enumerable: true,
-              configurable: true,
-              get: () => createComponentLoader(modules[filePath]),
-          });
+      const componentName = toCamelCase(fileName?.replace(/\.[^/.]+$/, '') ?? '');
+      if (componentName) {
+        registerComponent(componentName, modules[filePath]);
       }
     }
     
     // Manual components
-    ${manualImports.join('\n')}
+    ${manualImports.join('\n\n')}
     // Add fallback component if enabled
     ${fallbackImport}    
     // Export the components object for use in Storyblok initialization
@@ -131,31 +130,28 @@ async function resolveFallbackComponent(
   if (!enableFallbackComponent) {
     return '';
   }
-
-  if (customFallbackComponent) {
-    const customPath = getComponentFullPath(
-      componentsDir,
-      customFallbackComponent,
-    );
-    const resolved = await ctx.resolve(customPath);
-    if (!resolved) {
-      throw new Error(
-        `Custom fallback component could not be found. Does "${customPath}" exist?`,
-      );
-    }
-
-    return createManualComponentDefinition('FallbackComponent', resolved.id);
+  if (!customFallbackComponent) {
+    return createComponentRegistrationCode({
+      componentName: 'FallbackComponent',
+      importPath: '@storyblok/astro/FallbackComponent.astro',
+    });
   }
 
-  return `
-      import FallbackComponent from '@storyblok/astro/FallbackComponent.astro';
+  const componentPath = getComponentFullPath(
+    componentsDir,
+    customFallbackComponent,
+  );
+  const resolved = await ctx.resolve(componentPath);
+  if (!resolved) {
+    throw new Error(
+      `Custom fallback component could not be found. Does "${componentPath}" exist?`,
+    );
+  }
 
-      Object.defineProperty(storyblokComponents, 'FallbackComponent', {
-      enumerable: true,
-      configurable: true,
-      get: () => createComponentLoader(FallbackComponentModule),
-    });
-    `;
+  return createComponentRegistrationCode({
+    componentName: 'FallbackComponent',
+    importPath: resolved.id,
+  });
 }
 /**
  * Resolves user-provided Storyblok components into import statements.
@@ -174,22 +170,24 @@ async function resolveUserComponents(
 ): Promise<string[]> {
   const resolvedComponents: string[] = [];
 
-  for await (const [key, value] of Object.entries(components)) {
-    const pathWithExt = getComponentFullPath(componentsDir, value);
-    const resolved = await ctx.resolve(pathWithExt);
+  for (const [blokName, componentPath] of Object.entries(components)) {
+    const fullPath = getComponentFullPath(componentsDir, componentPath);
+    const resolved = await ctx.resolve(fullPath);
 
     if (!resolved) {
       if (!enableFallback) {
         throw new Error(
-          `Component could not be found for blok "${key}"! Does "${pathWithExt}" exist?`,
+          `Component could not be found for blok "${blokName}"! Does "${fullPath}" exist?`,
         );
       }
       continue;
     };
-    const componentName = toCamelCase(key);
-    resolvedComponents.push(createManualComponentDefinition(componentName, resolved.id));
+    const componentName = toCamelCase(blokName);
+    resolvedComponents.push(createComponentRegistrationCode({
+      componentName,
+      importPath: resolved.id,
+    }));
   }
-
   return resolvedComponents;
 }
 
@@ -217,16 +215,18 @@ function getComponentFullPath(
   const fullComponentPath = `${normalizedComponentsDir}${normalizePath(componentPath)}`;
   return normalizeAstroExtension(fullComponentPath);
 }
-function createManualComponentDefinition(
-  componentName: string,
-  importPath: string,
-): string {
+
+interface CreateComponentRegistrationCodeOptions {
+  componentName: string;
+  importPath: string;
+}
+
+function createComponentRegistrationCode({
+  componentName,
+  importPath,
+}: CreateComponentRegistrationCodeOptions): string {
   return `
-    import ${componentName} from '${importPath}';
-    Object.defineProperty(storyblokComponents, '${componentName}', {
-      enumerable: true,
-      configurable: true,
-      get: () => createComponentLoader(${componentName}),
-    });
+  import ${componentName} from '${importPath}';
+  registerComponent('${componentName}', ${componentName});
 `.trim();
 }


### PR DESCRIPTION
This PR fixes Hot Module Replacement (HMR) not triggering correctly for Astro components resolved and rendered via `StoryblokComponent`.

In the previous PR #551, which addressed #547, we introduced lazy component loading to prevent circular dependency issues in Vite SSR. While that solved the circular dependency problem, it also caused HMR to stop working correctly for components rendered through `StoryblokComponent`.

This PR updates the component registry implementation to use eager module loading via `import.meta.glob(..., { eager: true })`, while still deferring component access through async loaders. This keeps the benefits of avoiding circular dependency / TDZ issues while restoring proper HMR behavior for Storyblok components.

Fixes #603