### PR TITLE
feat: add patch method

### DIFF
--- a/packages/js-client/README.md
+++ b/packages/js-client/README.md
@@ -80,6 +80,9 @@ Storyblok.post(`spaces/${spaceId}/stories`, {
 Storyblok.put(`spaces/${spaceId}/stories/1`, {
   story: { name: "xy", slug: "xy" },
 });
+Storyblok.patch(`spaces/${spaceId}/stories/1/experiments/select_winner`, {
+  winner_id: 42,
+});
 Storyblok.delete(`spaces/${spaceId}/stories/1`);
 ```
 
@@ -140,6 +143,8 @@ We added retro-compatibility when using `resolve_assets: 1` parameter under V2. 
   - (`oauthToken` String, optional - The personal access token you can find in your account at https://app.storyblok.com/#/me/account?tab=token. This is mandatory only if you are using the Management API.)
   - (`cache` Object, optional)
     - (`type` String, optional - `none` or `memory`)
+    - (`clear` String, optional - `auto`, `onpreview`, or `manual`. Default: `manual`)
+    - (`cv` String, optional - `auto` or `manual`. Default: `auto`. Controls content version tracking. See [CV management](#cv-management).)
   - (`responseInterceptor` Function, optional - You can pass a function and return the result. For security reasons, Storyblok client will deal only with the response interceptor.)
   - (`region` String, optional)
   - (`https` Boolean, optional)
@@ -164,6 +169,23 @@ let Storyblok = new StoryblokClient({
   cache: {
     clear: "auto",
     type: "memory",
+  },
+});
+```
+
+### CV management
+
+By default (`cv: 'auto'`), the client tracks the `cv` (content version) returned by the CDN API and automatically appends it to every subsequent published request, enabling cache invalidation across deployments.
+
+Set `cv: 'manual'` to opt out of this automatic tracking. This is useful in SSR/edge caching scenarios where appending a tracked `cv` would defeat CDN cache reuse, or when cache invalidation is handled externally via webhooks.
+
+```javascript
+let Storyblok = new StoryblokClient({
+  accessToken: <YOUR_SPACE_ACCESS_TOKEN>,
+  cache: {
+    clear: "auto",
+    type: "memory",
+    cv: "manual", // disable automatic cv tracking
   },
 });
 ```
@@ -307,7 +329,7 @@ window.storyblok.on('input', (event) => {
 
 ### Custom Fetch parameter
 
-You can now pass an aditional paramater to the following calls: `get`, `getAll`, `post`, `put`, `delete`, `getStory` and `getStories`. This parameter is optional and it is the same as the Fetch API [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) parameter.
+You can now pass an aditional paramater to the following calls: `get`, `getAll`, `post`, `put`, `patch`, `delete`, `getStory` and `getStories`. This parameter is optional and it is the same as the Fetch API [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) parameter.
 **_It's important to note that we extended the `RequestInit` interface omitting the `method` parameter. This is because the method is already defined by the Storyblok client._**
 
 **Example**
@@ -449,6 +471,29 @@ Storyblok.put('spaces/<YOUR_SPACE_ID>/stories/1', {
 
 ```javascript
 Storyblok.delete('spaces/<YOUR_SPACE_ID>/stories/1')
+  .then((response) => {
+    console.log(response)
+  })
+  .catch((error) => {
+    console.log(error)
+  })
+```
+
+#### Method `Storyblok#patch` (only management api)
+
+**Parameters**
+
+- `[return]` Promise, Object `response`
+- `slug` String, _required_. Path to the Management API endpoint.
+- `params` Object, _optional_. Request body. Options can be found in the [API documentation](https://www.storyblok.com/docs/api/management/v1?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client).
+- `fetchOptions` Object, _optional_, Fetch options can be found in the [Fetch API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch). **_It's important to note that we extended the `RequestInit` interface omitting the `method` parameter. This is because the method is already defined by the Storyblok client._**
+
+**Example**
+
+```javascript
+Storyblok.patch(`spaces/<YOUR_SPACE_ID>/stories/<STORY_ID>/experiments/select_winner`, {
+  winner_id: <VARIANT_ID>,
+})
   .then((response) => {
     console.log(response)
   })

--- a/packages/js-client/src/constants.ts
+++ b/packages/js-client/src/constants.ts
@@ -3,6 +3,7 @@ const _METHOD = {
   DELETE: 'delete',
   POST: 'post',
   PUT: 'put',
+  PATCH: 'patch',
 } as const;
 
 type ObjectValues<T> = T[keyof T];

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -38,7 +38,7 @@ vi.mock('../src/sbFetch', () => {
 });
 
 describe('storyblokClient', () => {
-  let client;
+  let client: any;
 
   beforeEach(() => {
     // Setup default mocks
@@ -790,6 +790,27 @@ describe('storyblokClient', () => {
       expect(result).toEqual({
         data: {
           stories: [{ id: 1, title: 'Update' }],
+        },
+        headers: {},
+        status: 200,
+      });
+    });
+  });
+
+  describe('patch', () => {
+    it('should patch data to the API', async () => {
+      const mockExecute = vi.fn().mockResolvedValue({
+        data: {
+          story: { id: 1, title: 'Patch' },
+        },
+        headers: {},
+        status: 200,
+      });
+      client.throttleManager.execute = mockExecute;
+      const result = await client.patch('test', { data: 'test' });
+      expect(result).toEqual({
+        data: {
+          story: { id: 1, title: 'Patch' },
         },
         headers: {},
         status: 200,

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -307,6 +307,17 @@ export class Storyblok {
     return this.throttleManager.execute(rateLimit, 'put', url, params, fetchOptions) as Promise<ISbResponseData>;
   }
 
+  public patch(
+    slug: string,
+    params: ISbStoriesParams | ISbContentMangmntAPI = {},
+    fetchOptions?: ISbCustomFetch,
+  ): Promise<ISbResponseData> {
+    const url = `/${slug}`;
+
+    const rateLimit = determineRateLimit(undefined, undefined, this.rateLimitConfig, MANAGEMENT_API_DEFAULT_RATE_LIMIT);
+    return this.throttleManager.execute(rateLimit, 'patch', url, params, fetchOptions) as Promise<ISbResponseData>;
+  }
+
   public delete(
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI = {},

--- a/packages/js-client/src/sbFetch.test.ts
+++ b/packages/js-client/src/sbFetch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ISbFetch } from './sbFetch';
 import SbFetch from './sbFetch';
 import { headersToObject } from '../tests/utils';
+import type { ISbStoriesParams } from './interfaces';
 
 describe('sbFetch', () => {
   let sbFetch: SbFetch;
@@ -95,6 +96,27 @@ describe('sbFetch', () => {
         'https://api.storyblok.com/v2/stories/1',
         {
           method: 'put',
+          body: JSON.stringify(testPayload),
+          headers: expect.any(Headers),
+          signal: expect.any(AbortSignal),
+        },
+      );
+    });
+  });
+
+  describe('patch', () => {
+    it('should handle PATCH requests correctly', async () => {
+      const testPayload = { winner_id: 42 } as ISbStoriesParams;
+      const response = new Response(JSON.stringify({ data: 'test' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      mockFetch.mockResolvedValue(response);
+      await sbFetch.patch('stories/1/experiments/select_winner', testPayload);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.storyblok.com/v2/stories/1/experiments/select_winner',
+        {
+          method: 'patch',
           body: JSON.stringify(testPayload),
           headers: expect.any(Headers),
           signal: expect.any(AbortSignal),

--- a/packages/js-client/src/sbFetch.ts
+++ b/packages/js-client/src/sbFetch.ts
@@ -68,6 +68,12 @@ class SbFetch {
     return this._methodHandler('put');
   }
 
+  public patch(url: string, params: ISbStoriesParams) {
+    this.url = url;
+    this.parameters = params;
+    return this._methodHandler('patch');
+  }
+
   public delete(url: string, params?: ISbStoriesParams) {
     this.url = url;
     this.parameters = params ?? {} as ISbStoriesParams;


### PR DESCRIPTION
With new upcoming `patch` endpoints (a/b testing experiments), we need to add support in js-client for patch methods