### PR TITLE
fix(cli): map asset internal_tag_ids between spaces on push

### DIFF
--- a/packages/cli/src/commands/assets/__tests__/helpers.ts
+++ b/packages/cli/src/commands/assets/__tests__/helpers.ts
@@ -21,6 +21,7 @@ export interface MockAsset {
   expire_at?: string;
   publish_at?: string;
   internal_tag_ids?: string[];
+  internal_tags_list?: Array<{ id: number; name: string }>;
   meta_data?: Record<string, unknown>;
 }
 

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -4,7 +4,7 @@ import { handleAPIError } from '../../utils/error/api-error';
 import { toError } from '../../utils/error/error';
 import { fetchAllPages } from '../../utils/pagination';
 import type { RegionCode } from '../../constants';
-import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetInternalTagsMap, AssetListQuery, AssetUpdate, AssetUpload } from './types';
+import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetInternalTagsByName, AssetListQuery, AssetUpdate, AssetUpload } from './types';
 
 export interface AssetInternalTag {
   id: number;
@@ -47,8 +47,8 @@ export const fetchAssets = async ({ spaceId, params }: {
 /**
  * Fetches every internal tag of type `asset` for the given space.
  *
- * Used by `assets push` to translate source-space `internal_tag_ids` carried in
- * pulled sidecars into the target space's tag IDs by matching on tag name.
+ * Used by `assets push` to translate source-space tag names carried in pulled
+ * sidecars into the target space's tag IDs.
  */
 export const fetchAssetInternalTags = async (spaceId: string): Promise<AssetInternalTag[]> => {
   try {
@@ -69,37 +69,11 @@ export const fetchAssetInternalTags = async (spaceId: string): Promise<AssetInte
 };
 
 /**
- * Builds the source→target `AssetInternalTagsMap` for `assets push`.
- *
- * Fetches tags from both spaces and joins them by name so source-space tag IDs
- * carried in pulled sidecars can be translated to target-space IDs. Also returns
- * `sourceNamesById` so the command layer can produce helpful warnings for tag
- * names absent from the target space.
- *
- * When source and target are the same space, returns an identity map and skips
- * the redundant second fetch.
+ * Fetches asset internal tags keyed by name for the given space.
  */
-export const scanAssetInternalTagsMap = async (
-  fromSpace: string,
-  targetSpace: string,
-): Promise<{ map: AssetInternalTagsMap; sourceNamesById: ReadonlyMap<number, string> }> => {
-  const sourceTags = await fetchAssetInternalTags(fromSpace);
-  const sourceNamesById = new Map(sourceTags.map(tag => [tag.id, tag.name]));
-
-  if (fromSpace === targetSpace) {
-    return { map: new Map(sourceTags.map(tag => [tag.id, tag.id])), sourceNamesById };
-  }
-
-  const targetTags = await fetchAssetInternalTags(targetSpace);
-  const targetByName = new Map(targetTags.map(tag => [tag.name, tag.id]));
-  const map = new Map<number, number>();
-  for (const tag of sourceTags) {
-    const targetId = targetByName.get(tag.name);
-    if (typeof targetId === 'number') {
-      map.set(tag.id, targetId);
-    }
-  }
-  return { map, sourceNamesById };
+export const fetchAssetInternalTagsByName = async (spaceId: string): Promise<AssetInternalTagsByName> => {
+  const tags = await fetchAssetInternalTags(spaceId);
+  return new Map(tags.map(tag => [tag.name, tag.id]));
 };
 
 export const downloadFile = async (filename: string) => {

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -69,7 +69,7 @@ export const fetchAssetInternalTags = async (spaceId: string): Promise<AssetInte
 };
 
 /**
- * Builds the source→target `AssetInternalTagsMap` for `assets push` (WDX-332).
+ * Builds the source→target `AssetInternalTagsMap` for `assets push`.
  *
  * Fetches tags from both spaces and joins them by name so source-space tag IDs
  * carried in pulled sidecars can be translated to target-space IDs. Also returns

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -2,8 +2,14 @@ import Storyblok from 'storyblok-js-client';
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { toError } from '../../utils/error/error';
+import { fetchAllPages } from '../../utils/pagination';
 import type { RegionCode } from '../../constants';
 import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetListQuery, AssetUpdate, AssetUpload } from './types';
+
+export interface AssetInternalTag {
+  id: number;
+  name: string;
+}
 
 /**
  * Fetches a single page of assets from Storyblok Management API.
@@ -35,6 +41,30 @@ export const fetchAssets = async ({ spaceId, params }: {
   }
   catch (maybeError) {
     handleAPIError('pull_assets', toError(maybeError));
+  }
+};
+
+/**
+ * Fetches every internal tag of type `asset` for the given space.
+ *
+ * Used by `assets push` to translate source-space `internal_tag_ids` carried in
+ * pulled sidecars into the target space's tag IDs by matching on tag name.
+ */
+export const fetchAssetInternalTags = async (spaceId: string): Promise<AssetInternalTag[]> => {
+  try {
+    const client = getMapiClient();
+    const tags = await fetchAllPages(
+      (page: number) => client.internalTags.list({
+        path: { space_id: Number(spaceId) },
+        query: { page, by_object_type: 'asset' },
+        throwOnError: true,
+      }),
+      data => data?.internal_tags ?? [],
+    );
+    return tags.filter((tag): tag is AssetInternalTag => typeof tag?.id === 'number' && typeof tag?.name === 'string');
+  }
+  catch (maybeError) {
+    handleAPIError('pull_asset_internal_tags', toError(maybeError));
   }
 };
 

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -4,7 +4,7 @@ import { handleAPIError } from '../../utils/error/api-error';
 import { toError } from '../../utils/error/error';
 import { fetchAllPages } from '../../utils/pagination';
 import type { RegionCode } from '../../constants';
-import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetListQuery, AssetUpdate, AssetUpload } from './types';
+import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetInternalTagsMap, AssetListQuery, AssetUpdate, AssetUpload } from './types';
 
 export interface AssetInternalTag {
   id: number;
@@ -66,6 +66,40 @@ export const fetchAssetInternalTags = async (spaceId: string): Promise<AssetInte
   catch (maybeError) {
     handleAPIError('pull_asset_internal_tags', toError(maybeError));
   }
+};
+
+/**
+ * Builds the source→target `AssetInternalTagsMap` for `assets push` (WDX-332).
+ *
+ * Fetches tags from both spaces and joins them by name so source-space tag IDs
+ * carried in pulled sidecars can be translated to target-space IDs. Also returns
+ * `sourceNamesById` so the command layer can produce helpful warnings for tag
+ * names absent from the target space.
+ *
+ * When source and target are the same space, returns an identity map and skips
+ * the redundant second fetch.
+ */
+export const scanAssetInternalTagsMap = async (
+  fromSpace: string,
+  targetSpace: string,
+): Promise<{ map: AssetInternalTagsMap; sourceNamesById: ReadonlyMap<number, string> }> => {
+  const sourceTags = await fetchAssetInternalTags(fromSpace);
+  const sourceNamesById = new Map(sourceTags.map(tag => [tag.id, tag.name]));
+
+  if (fromSpace === targetSpace) {
+    return { map: new Map(sourceTags.map(tag => [tag.id, tag.id])), sourceNamesById };
+  }
+
+  const targetTags = await fetchAssetInternalTags(targetSpace);
+  const targetByName = new Map(targetTags.map(tag => [tag.name, tag.id]));
+  const map = new Map<number, number>();
+  for (const tag of sourceTags) {
+    const targetId = targetByName.get(tag.name);
+    if (typeof targetId === 'number') {
+      map.set(tag.id, targetId);
+    }
+  }
+  return { map, sourceNamesById };
 };
 
 export const downloadFile = async (filename: string) => {

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -6,11 +6,6 @@ import { fetchAllPages } from '../../utils/pagination';
 import type { RegionCode } from '../../constants';
 import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetInternalTagsByName, AssetListQuery, AssetUpdate, AssetUpload } from './types';
 
-export interface AssetInternalTag {
-  id: number;
-  name: string;
-}
-
 /**
  * Fetches a single page of assets from Storyblok Management API.
  */
@@ -45,12 +40,12 @@ export const fetchAssets = async ({ spaceId, params }: {
 };
 
 /**
- * Fetches every internal tag of type `asset` for the given space.
+ * Fetches the space's internal tags of type `asset` keyed by name.
  *
  * Used by `assets push` to translate source-space tag names carried in pulled
  * sidecars into the target space's tag IDs.
  */
-export const fetchAssetInternalTags = async (spaceId: string): Promise<AssetInternalTag[]> => {
+export const fetchAssetInternalTagsByName = async (spaceId: string): Promise<AssetInternalTagsByName> => {
   try {
     const client = getMapiClient();
     const tags = await fetchAllPages(
@@ -61,19 +56,15 @@ export const fetchAssetInternalTags = async (spaceId: string): Promise<AssetInte
       }),
       data => data?.internal_tags ?? [],
     );
-    return tags.filter((tag): tag is AssetInternalTag => typeof tag?.id === 'number' && typeof tag?.name === 'string');
+    return new Map(
+      tags
+        .filter((tag): tag is { id: number; name: string } => typeof tag?.id === 'number' && typeof tag?.name === 'string')
+        .map(tag => [tag.name, tag.id]),
+    );
   }
   catch (maybeError) {
     handleAPIError('pull_asset_internal_tags', toError(maybeError));
   }
-};
-
-/**
- * Fetches asset internal tags keyed by name for the given space.
- */
-export const fetchAssetInternalTagsByName = async (spaceId: string): Promise<AssetInternalTagsByName> => {
-  const tags = await fetchAssetInternalTags(spaceId);
-  return new Map(tags.map(tag => [tag.name, tag.id]));
 };
 
 export const downloadFile = async (filename: string) => {

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -67,6 +67,35 @@ export const fetchAssetInternalTagsByName = async (spaceId: string): Promise<Ass
   }
 };
 
+/**
+ * Creates an internal tag of type `asset` in the target space.
+ *
+ * Used by `assets push` to pre-create source-space tag names that do not yet
+ * exist in the target space, so pushed assets keep their tags instead of having
+ * the unknown references dropped.
+ */
+export const createAssetInternalTag = async (
+  spaceId: string,
+  name: string,
+): Promise<{ id: number; name: string }> => {
+  try {
+    const client = getMapiClient();
+    const { data } = await client.internalTags.create({
+      path: { space_id: Number(spaceId) },
+      body: { name, object_type: 'asset' },
+      throwOnError: true,
+    });
+    const tag = data?.internal_tag;
+    if (typeof tag?.id !== 'number' || typeof tag?.name !== 'string') {
+      throw new TypeError('Created internal tag is missing an id or name');
+    }
+    return { id: tag.id, name: tag.name };
+  }
+  catch (maybeError) {
+    handleAPIError('push_asset_internal_tag', toError(maybeError), `Failed to create internal asset tag "${name}"`);
+  }
+};
+
 export const downloadFile = async (filename: string) => {
   const response = await fetch(filename);
   if (!response.ok) {

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -17,12 +17,11 @@ import type {
   CreateAssetTransport,
   GetAssetFolderTransport,
   GetAssetTransport,
-  MapInternalTagIdsTransport,
   UpdateAssetFolderTransport,
   UpdateAssetTransport,
 } from './streams';
 import { readLocalAssetFoldersStream, readLocalAssetsStream, readSingleAssetStream, upsertAssetFolderStream, upsertAssetStream } from './streams';
-import type { AssetFolderMap, AssetMap, AssetUpload } from './types';
+import type { AssetFolderMap, AssetInternalTagsMap, AssetMap, AssetUpload } from './types';
 
 const PROGRESS_BAR_PADDING = 23;
 
@@ -89,21 +88,22 @@ export const upsertAssetsPipeline = async ({
   maps,
   transports,
   ui,
+  onUnmappedTag,
 }: {
   assetBinaryPath?: string;
   assetData?: AssetUpload;
   directoryPath: string;
   logger: Logger;
-  maps: { assets: AssetMap; assetFolders: AssetFolderMap };
+  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTags?: AssetInternalTagsMap };
   transports: {
     getAsset: GetAssetTransport;
     createAsset: CreateAssetTransport;
     updateAsset: UpdateAssetTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset: CleanupAssetTransport;
-    mapInternalTagIds?: MapInternalTagIdsTransport;
   };
   ui: UI;
+  onUnmappedTag?: (sourceId: number) => void;
 }): Promise<Summaries> => {
   const assetProgress = ui.createProgressBar({ title: 'Assets...'.padEnd(PROGRESS_BAR_PADDING) });
   const summary = { total: 0, succeeded: 0, failed: 0 };
@@ -143,6 +143,7 @@ export const upsertAssetsPipeline = async ({
   steps.push(upsertAssetStream({
     transports,
     maps,
+    onUnmappedTag,
     onIncrement: () => assetProgress.increment(),
     onAssetSuccess: (localAssetResult, remoteAsset) => {
       if ('id' in localAssetResult && localAssetResult.id) {

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -17,6 +17,7 @@ import type {
   CreateAssetTransport,
   GetAssetFolderTransport,
   GetAssetTransport,
+  MapInternalTagIdsTransport,
   UpdateAssetFolderTransport,
   UpdateAssetTransport,
 } from './streams';
@@ -100,6 +101,7 @@ export const upsertAssetsPipeline = async ({
     updateAsset: UpdateAssetTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset: CleanupAssetTransport;
+    mapInternalTagIds?: MapInternalTagIdsTransport;
   };
   ui: UI;
 }): Promise<Summaries> => {

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -21,7 +21,7 @@ import type {
   UpdateAssetTransport,
 } from './streams';
 import { readLocalAssetFoldersStream, readLocalAssetsStream, readSingleAssetStream, upsertAssetFolderStream, upsertAssetStream } from './streams';
-import type { AssetFolderMap, AssetInternalTagsMap, AssetMap, AssetUpload } from './types';
+import type { AssetFolderMap, AssetInternalTagsByName, AssetMap, AssetUpload, UnmappedAssetInternalTag } from './types';
 
 const PROGRESS_BAR_PADDING = 23;
 
@@ -94,7 +94,7 @@ export const upsertAssetsPipeline = async ({
   assetData?: AssetUpload;
   directoryPath: string;
   logger: Logger;
-  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTags?: AssetInternalTagsMap };
+  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTagsByName?: AssetInternalTagsByName };
   transports: {
     getAsset: GetAssetTransport;
     createAsset: CreateAssetTransport;
@@ -103,7 +103,7 @@ export const upsertAssetsPipeline = async ({
     cleanupAsset: CleanupAssetTransport;
   };
   ui: UI;
-  onUnmappedTag?: (sourceId: number) => void;
+  onUnmappedTag?: (tag: UnmappedAssetInternalTag) => void;
 }): Promise<Summaries> => {
   const assetProgress = ui.createProgressBar({ title: 'Assets...'.padEnd(PROGRESS_BAR_PADDING) });
   const summary = { total: 0, succeeded: 0, failed: 0 };

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -59,6 +59,10 @@ const server = setupServer(
     { message: 'Not Found' },
     { status: 404 },
   )),
+  http.get('https://mapi.storyblok.com/v1/spaces/:spaceId/internal_tags', () => HttpResponse.json(
+    { internal_tags: [] },
+    { headers: { 'Total': '0', 'Per-Page': '100' } },
+  )),
 );
 
 const preconditions = {
@@ -199,6 +203,14 @@ const preconditions = {
       http.put(`https://mapi.storyblok.com/v1/spaces/${space}/asset_folders/:folderId`, () => HttpResponse.json(
         { message: 'Update failed' },
         { status: 500 },
+      )),
+    );
+  },
+  hasTargetAssetInternalTags(tags: Array<{ id: number; name: string }>, { space = DEFAULT_SPACE }: { space?: string } = {}) {
+    server.use(
+      http.get(`https://mapi.storyblok.com/v1/spaces/${space}/internal_tags`, () => HttpResponse.json(
+        { internal_tags: tags },
+        { headers: { 'Total': String(tags.length), 'Per-Page': '100' } },
       )),
     );
   },
@@ -1391,5 +1403,76 @@ describe('assets push command', () => {
     expect(storyActions.fetchStories).toHaveBeenCalledWith(DEFAULT_SPACE, expect.objectContaining({
       reference_search: localAsset.filename,
     }));
+  });
+
+  // WDX-332: source-space `internal_tag_ids` carried in the pulled sidecar must
+  // be translated to the matching target-space tag IDs by name, or dropped when
+  // no target tag with the same name exists.
+  it('should translate source-space internal_tag_ids to target-space tag IDs by name', async () => {
+    const targetSpace = '54321';
+    const sourceTagId = 111;
+    const targetTagId = 999;
+    const asset = makeMockAsset({
+      internal_tag_ids: [String(sourceTagId)],
+      internal_tags_list: [{ id: sourceTagId, name: 'shared-tag' }],
+    });
+    preconditions.canLoadFolders([]);
+    preconditions.canLoadAssets([asset]);
+    preconditions.hasTargetAssetInternalTags(
+      [{ id: targetTagId, name: 'shared-tag' }],
+      { space: targetSpace },
+    );
+    preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    expect(actions.createAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ internal_tag_ids: [String(targetTagId)] }),
+      expect.anything(),
+      expect.anything(),
+    );
+    const createPayload = (actions.createAsset as unknown as Mock).mock.calls[0][0];
+    expect(createPayload).not.toHaveProperty('internal_tags_list');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('should omit internal_tag_ids from the create payload when the source has no tag metadata', async () => {
+    const targetSpace = '54321';
+    const asset = makeMockAsset();
+    preconditions.canLoadFolders([]);
+    preconditions.canLoadAssets([asset]);
+    preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    const createPayload = (actions.createAsset as unknown as Mock).mock.calls[0][0];
+    expect(createPayload).not.toHaveProperty('internal_tag_ids');
+    expect(createPayload).not.toHaveProperty('internal_tags_list');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('should drop unmapped internal tag names with a warning', async () => {
+    const targetSpace = '54321';
+    const sourceTagId = 222;
+    const asset = makeMockAsset({
+      internal_tag_ids: [String(sourceTagId)],
+      internal_tags_list: [{ id: sourceTagId, name: 'missing-tag' }],
+    });
+    preconditions.canLoadFolders([]);
+    preconditions.canLoadAssets([asset]);
+    preconditions.hasTargetAssetInternalTags([], { space: targetSpace });
+    preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    expect(actions.createAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ internal_tag_ids: [] }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped 1 unknown internal asset tag not present in target space: missing-tag'),
+    );
+    expect(process.exitCode).not.toBe(1);
   });
 });

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -214,6 +214,20 @@ const preconditions = {
       )),
     );
   },
+  canCreateAssetInternalTags({ space = DEFAULT_SPACE, idByName = {} }: { space?: string; idByName?: Record<string, number> } = {}) {
+    const spy = vi.fn();
+    server.use(
+      http.post(`https://mapi.storyblok.com/v1/spaces/${space}/internal_tags`, async ({ request }) => {
+        const body = await request.json() as { name: string; object_type?: string };
+        spy(body);
+        return HttpResponse.json(
+          { internal_tag: { id: idByName[body.name] ?? getID(), name: body.name, object_type: body.object_type } },
+          { status: 201 },
+        );
+      }),
+    );
+    return spy;
+  },
   canFetchRemoteAssets(assets: MockAsset[], { space = DEFAULT_SPACE }: { space?: string } = {}) {
     for (const asset of assets) {
       server.use(
@@ -1490,9 +1504,10 @@ describe('assets push command', () => {
     expect(process.exitCode).not.toBe(1);
   });
 
-  it('should drop unmapped internal tag names with a warning', async () => {
+  it('should create internal tags missing from the target space and map to the new tag ID', async () => {
     const targetSpace = '54321';
     const sourceTagId = 222;
+    const createdTagId = 7777;
     const asset = makeMockAsset({
       internal_tag_ids: [String(sourceTagId)],
       internal_tags_list: [{ id: sourceTagId, name: 'missing-tag' }],
@@ -1500,17 +1515,24 @@ describe('assets push command', () => {
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([asset]);
     preconditions.hasAssetInternalTags([], { space: targetSpace });
+    const createTagSpy = preconditions.canCreateAssetInternalTags({
+      space: targetSpace,
+      idByName: { 'missing-tag': createdTagId },
+    });
     preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
 
     await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
 
+    expect(createTagSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'missing-tag', object_type: 'asset' }),
+    );
     expect(actions.createAsset).toHaveBeenCalledWith(
-      expect.objectContaining({ internal_tag_ids: [] }),
+      expect.objectContaining({ internal_tag_ids: [String(createdTagId)] }),
       expect.anything(),
       expect.anything(),
     );
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Dropped 1 unknown internal asset tag not present in target space: missing-tag'),
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('Created 1 internal asset tag in target space: missing-tag'),
     );
     expect(process.exitCode).not.toBe(1);
   });
@@ -1538,6 +1560,35 @@ describe('assets push command', () => {
     );
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('Dropped 1 unknown internal asset tag not present in target space: #333'),
+    );
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('should drop the tag reference and not fail the push when creating a missing tag fails', async () => {
+    const targetSpace = '54321';
+    const sourceTagId = 444;
+    const asset = makeMockAsset({
+      internal_tag_ids: [String(sourceTagId)],
+      internal_tags_list: [{ id: sourceTagId, name: 'uncreatable-tag' }],
+    });
+    preconditions.canLoadFolders([]);
+    preconditions.canLoadAssets([asset]);
+    preconditions.hasAssetInternalTags([], { space: targetSpace });
+    server.use(
+      http.post(`https://mapi.storyblok.com/v1/spaces/${targetSpace}/internal_tags`, () =>
+        HttpResponse.json({ error: 'nope' }, { status: 500 })),
+    );
+    preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    expect(actions.createAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ internal_tag_ids: [] }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped 1 unknown internal asset tag not present in target space: uncreatable-tag'),
     );
     expect(process.exitCode).not.toBe(1);
   });

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -292,12 +292,13 @@ const preconditions = {
         return HttpResponse.json({ message: 'Upload finalized' });
       }),
       // Update asset metadata/folder/etc.
-      http.put(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:assetId`, async ({ params }) => {
+      http.put(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:assetId`, async ({ params, request }) => {
         const match = remoteAssets.find(asset => String(asset.id) === String(params.assetId));
         if (!match) {
           return HttpResponse.json({ message: 'Asset not found' }, { status: 404 });
         }
-        updateSpy(match);
+        const body = await request.json() as { asset?: Record<string, unknown> };
+        updateSpy(body.asset ?? {});
         return HttpResponse.json({});
       }),
     );
@@ -1405,7 +1406,7 @@ describe('assets push command', () => {
     }));
   });
 
-  it('should translate source-space internal_tag_ids to target-space tag IDs by name', async () => {
+  it('should translate source-space internal_tag_ids to target-space tag IDs by sidecar tag name', async () => {
     const targetSpace = '54321';
     const sourceTagId = 111;
     const targetTagId = 999;
@@ -1416,7 +1417,7 @@ describe('assets push command', () => {
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([asset]);
     preconditions.hasAssetInternalTags(
-      [{ id: sourceTagId, name: 'shared-tag' }],
+      [{ id: sourceTagId, name: 'stale-source-name' }],
       { space: DEFAULT_SPACE },
     );
     preconditions.hasAssetInternalTags(
@@ -1434,6 +1435,43 @@ describe('assets push command', () => {
     );
     const createPayload = (actions.createAsset as unknown as Mock).mock.calls[0][0];
     expect(createPayload).not.toHaveProperty('internal_tags_list');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('should translate source-space internal_tag_ids when updating an existing target asset', async () => {
+    const targetSpace = '54321';
+    const sourceTagId = 112;
+    const targetTagId = 998;
+    const localAsset = makeMockAsset({
+      internal_tag_ids: [String(sourceTagId)],
+      internal_tags_list: [{ id: sourceTagId, name: 'shared-tag' }],
+    });
+    preconditions.canLoadFolders([]);
+    preconditions.canLoadAssets([localAsset]);
+    preconditions.hasAssetInternalTags(
+      [{ id: targetTagId, name: 'shared-tag' }],
+      { space: targetSpace },
+    );
+    const updateSpy = vi.fn();
+    const [remoteAsset] = preconditions.canUpsertRemoteAssets([localAsset], { updateSpy, space: targetSpace });
+    preconditions.canFetchRemoteAssets([remoteAsset], { space: targetSpace });
+    preconditions.canLoadAssetsManifest([{
+      old_id: localAsset.id,
+      old_filename: localAsset.filename,
+      new_id: remoteAsset.id,
+      new_filename: remoteAsset.filename,
+    }]);
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    expect(actions.updateAsset).toHaveBeenCalledWith(
+      remoteAsset.id,
+      expect.objectContaining({ internal_tag_ids: [String(targetTagId)] }),
+      expect.anything(),
+    );
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      internal_tag_ids: [String(targetTagId)],
+    }));
     expect(process.exitCode).not.toBe(1);
   });
 
@@ -1461,10 +1499,6 @@ describe('assets push command', () => {
     });
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([asset]);
-    preconditions.hasAssetInternalTags(
-      [{ id: sourceTagId, name: 'missing-tag' }],
-      { space: DEFAULT_SPACE },
-    );
     preconditions.hasAssetInternalTags([], { space: targetSpace });
     preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
 
@@ -1477,6 +1511,33 @@ describe('assets push command', () => {
     );
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('Dropped 1 unknown internal asset tag not present in target space: missing-tag'),
+    );
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('should drop internal tag IDs without sidecar tag metadata with an ID warning', async () => {
+    const targetSpace = '54321';
+    const sourceTagId = 333;
+    const asset = makeMockAsset({
+      internal_tag_ids: [String(sourceTagId)],
+    });
+    preconditions.canLoadFolders([]);
+    preconditions.canLoadAssets([asset]);
+    preconditions.hasAssetInternalTags(
+      [{ id: 999, name: 'shared-tag' }],
+      { space: targetSpace },
+    );
+    preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    expect(actions.createAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ internal_tag_ids: [] }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped 1 unknown internal asset tag not present in target space: #333'),
     );
     expect(process.exitCode).not.toBe(1);
   });

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -1405,9 +1405,6 @@ describe('assets push command', () => {
     }));
   });
 
-  // WDX-332: source-space `internal_tag_ids` carried in the pulled sidecar must
-  // be translated to the matching target-space tag IDs by name, or dropped when
-  // no target tag with the same name exists.
   it('should translate source-space internal_tag_ids to target-space tag IDs by name', async () => {
     const targetSpace = '54321';
     const sourceTagId = 111;

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -206,7 +206,7 @@ const preconditions = {
       )),
     );
   },
-  hasTargetAssetInternalTags(tags: Array<{ id: number; name: string }>, { space = DEFAULT_SPACE }: { space?: string } = {}) {
+  hasAssetInternalTags(tags: Array<{ id: number; name: string }>, { space = DEFAULT_SPACE }: { space?: string } = {}) {
     server.use(
       http.get(`https://mapi.storyblok.com/v1/spaces/${space}/internal_tags`, () => HttpResponse.json(
         { internal_tags: tags },
@@ -1418,7 +1418,11 @@ describe('assets push command', () => {
     });
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([asset]);
-    preconditions.hasTargetAssetInternalTags(
+    preconditions.hasAssetInternalTags(
+      [{ id: sourceTagId, name: 'shared-tag' }],
+      { space: DEFAULT_SPACE },
+    );
+    preconditions.hasAssetInternalTags(
       [{ id: targetTagId, name: 'shared-tag' }],
       { space: targetSpace },
     );
@@ -1460,7 +1464,11 @@ describe('assets push command', () => {
     });
     preconditions.canLoadFolders([]);
     preconditions.canLoadAssets([asset]);
-    preconditions.hasTargetAssetInternalTags([], { space: targetSpace });
+    preconditions.hasAssetInternalTags(
+      [{ id: sourceTagId, name: 'missing-tag' }],
+      { space: DEFAULT_SPACE },
+    );
+    preconditions.hasAssetInternalTags([], { space: targetSpace });
     preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
 
     await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -156,7 +156,7 @@ pushCmd
 
       // Build a source→target asset internal tag id map so source-space ids in
       // pulled sidecars are translated to the matching target-space ids
-      // (WDX-332). Source ids without a name match in target are dropped and
+      // Source ids without a name match in target are dropped and
       // surfaced via a single aggregated warning after the pipeline.
       const { map: assetInternalTags, sourceNamesById } = await scanAssetInternalTagsMap(fromSpace, targetSpace);
       const unmappedTagIds = new Set<number>();

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -21,8 +21,8 @@ import {
   makeUpdateAssetAPITransport,
   makeUpdateAssetFolderAPITransport,
 } from '../streams';
-import { scanAssetInternalTagsMap } from '../actions';
-import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderUpdate, AssetMapped, AssetUpload } from '../types';
+import { fetchAssetInternalTagsByName } from '../actions';
+import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderUpdate, AssetMapped, AssetUpload, UnmappedAssetInternalTag } from '../types';
 import { isRemoteSource, loadAssetFolderMap, loadAssetMap, loadSidecarAssetData, parseAssetData } from '../utils';
 import { findComponentSchemas } from '../../stories/utils';
 import { mapAssetReferencesInStoriesPipeline, upsertAssetFoldersPipeline, upsertAssetsPipeline } from '../pipelines';
@@ -154,20 +154,20 @@ pushCmd
         ? makeCleanupAssetFSTransport()
         : () => Promise.resolve();
 
-      // Build a source→target asset internal tag id map so source-space ids in
-      // pulled sidecars are translated to the matching target-space ids
-      // Source ids without a name match in target are dropped and
-      // surfaced via a single aggregated warning after the pipeline.
-      const { map: assetInternalTags, sourceNamesById } = await scanAssetInternalTagsMap(fromSpace, targetSpace);
-      const unmappedTagIds = new Set<number>();
-      const onUnmappedTag = (sourceId: number) => { unmappedTagIds.add(sourceId); };
+      const assetInternalTagsByName = fromSpace === targetSpace
+        ? undefined
+        : await fetchAssetInternalTagsByName(targetSpace);
+      const unmappedTagLabels = new Set<string>();
+      const onUnmappedTag = ({ sourceId, name }: UnmappedAssetInternalTag) => {
+        unmappedTagLabels.add(name ?? `#${sourceId}`);
+      };
 
       summaries.push(...await upsertAssetsPipeline({
         assetBinaryPath,
         assetData,
         directoryPath: assetsDirectoryPath,
         logger,
-        maps: { ...maps, assetInternalTags },
+        maps: { ...maps, assetInternalTagsByName },
         transports: {
           getAsset: getAssetTransport,
           createAsset: createAssetTransport,
@@ -179,12 +179,11 @@ pushCmd
         onUnmappedTag,
       }));
 
-      if (unmappedTagIds.size > 0) {
-        const sortedIds = [...unmappedTagIds].sort((a, b) => a - b);
-        const labels = sortedIds.map(id => sourceNamesById.get(id) ?? `#${id}`);
+      if (unmappedTagLabels.size > 0) {
+        const labels = [...unmappedTagLabels].sort((a, b) => a.localeCompare(b));
         const message = `Dropped ${labels.length} unknown internal asset tag${labels.length === 1 ? '' : 's'} not present in target space: ${labels.join(', ')}`;
         ui.warn(message);
-        logger.warn(message, { unmappedTagIds: sortedIds });
+        logger.warn(message, { unmappedTags: labels });
       }
 
       /**

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -21,9 +21,9 @@ import {
   makeUpdateAssetAPITransport,
   makeUpdateAssetFolderAPITransport,
 } from '../streams';
-import { fetchAssetInternalTagsByName } from '../actions';
+import { createAssetInternalTag, fetchAssetInternalTagsByName } from '../actions';
 import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderUpdate, AssetMapped, AssetUpload, UnmappedAssetInternalTag } from '../types';
-import { isRemoteSource, loadAssetFolderMap, loadAssetMap, loadSidecarAssetData, parseAssetData } from '../utils';
+import { collectAssetInternalTagNames, ensureAssetInternalTags, internalTagNamesFromAssets, isRemoteSource, loadAssetFolderMap, loadAssetMap, loadSidecarAssetData, parseAssetData } from '../utils';
 import { findComponentSchemas } from '../../stories/utils';
 import { mapAssetReferencesInStoriesPipeline, upsertAssetFoldersPipeline, upsertAssetsPipeline } from '../pipelines';
 import type { Story } from '../../stories/constants';
@@ -157,9 +157,35 @@ pushCmd
       // Only build the target-space tag map for cross-space pushes; same-space
       // pushes keep their IDs as-is. A failed fetch throws and aborts the push:
       // fail fast rather than push unmappable IDs.
-      const assetInternalTagsByName = fromSpace === targetSpace
+      let assetInternalTagsByName = fromSpace === targetSpace
         ? undefined
         : await fetchAssetInternalTagsByName(targetSpace);
+
+      // Pre-create source tag names missing from the target space so pushed
+      // assets keep their tags instead of having the references dropped. Skipped
+      // on dry runs (no writes); creation is best-effort, a failed create leaves
+      // the name unmapped and the reference is dropped with the warning below.
+      if (assetInternalTagsByName && !options.dryRun) {
+        const sourceTagNames = assetBinaryPath
+          ? internalTagNamesFromAssets(assetData ? [assetData] : [])
+          : await collectAssetInternalTagNames(assetsDirectoryPath);
+        const createdTagLabels: string[] = [];
+        assetInternalTagsByName = await ensureAssetInternalTags({
+          sourceTagNames,
+          targetTagsByName: assetInternalTagsByName,
+          createTag: name => createAssetInternalTag(targetSpace, name),
+          onTagCreated: name => createdTagLabels.push(name),
+          onTagCreateError: (name, error) =>
+            logger.warn(`Failed to create internal asset tag "${name}"`, { error: error.message }),
+        });
+        if (createdTagLabels.length > 0) {
+          const labels = [...createdTagLabels].sort((a, b) => a.localeCompare(b));
+          const message = `Created ${labels.length} internal asset tag${labels.length === 1 ? '' : 's'} in target space: ${labels.join(', ')}`;
+          ui.info(message);
+          logger.info(message, { createdTags: labels });
+        }
+      }
+
       const unmappedTagLabels = new Set<string>();
       const onUnmappedTag = ({ sourceId, name }: UnmappedAssetInternalTag) => {
         unmappedTagLabels.add(name ?? `#${sourceId}`);

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -154,6 +154,9 @@ pushCmd
         ? makeCleanupAssetFSTransport()
         : () => Promise.resolve();
 
+      // Only build the target-space tag map for cross-space pushes; same-space
+      // pushes keep their IDs as-is. A failed fetch throws and aborts the push:
+      // fail fast rather than push unmappable IDs.
       const assetInternalTagsByName = fromSpace === targetSpace
         ? undefined
         : await fetchAssetInternalTagsByName(targetSpace);

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -18,11 +18,10 @@ import {
   makeCreateAssetFolderAPITransport,
   makeGetAssetAPITransport,
   makeGetAssetFolderAPITransport,
-  makeMapInternalTagIdsTransport,
   makeUpdateAssetAPITransport,
   makeUpdateAssetFolderAPITransport,
 } from '../streams';
-import { fetchAssetInternalTags } from '../actions';
+import { scanAssetInternalTagsMap } from '../actions';
 import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderUpdate, AssetMapped, AssetUpload } from '../types';
 import { isRemoteSource, loadAssetFolderMap, loadAssetMap, loadSidecarAssetData, parseAssetData } from '../utils';
 import { findComponentSchemas } from '../../stories/utils';
@@ -155,41 +154,37 @@ pushCmd
         ? makeCleanupAssetFSTransport()
         : () => Promise.resolve();
 
-      // Build a target-space tag name → id map so that source-space tag IDs in
-      // pulled sidecars are translated to the matching target-space IDs by name
-      // (WDX-332). Tag names that do not exist in target are dropped + warned.
-      const targetAssetInternalTags = await fetchAssetInternalTags(targetSpace);
-      const targetTagNameToId = new Map<string, number>(
-        targetAssetInternalTags.map(tag => [tag.name, tag.id]),
-      );
-      const unmappedTagNames = new Set<string>();
-      const mapInternalTagIdsTransport = makeMapInternalTagIdsTransport(
-        targetTagNameToId,
-        (name) => { unmappedTagNames.add(name); },
-      );
+      // Build a source→target asset internal tag id map so source-space ids in
+      // pulled sidecars are translated to the matching target-space ids
+      // (WDX-332). Source ids without a name match in target are dropped and
+      // surfaced via a single aggregated warning after the pipeline.
+      const { map: assetInternalTags, sourceNamesById } = await scanAssetInternalTagsMap(fromSpace, targetSpace);
+      const unmappedTagIds = new Set<number>();
+      const onUnmappedTag = (sourceId: number) => { unmappedTagIds.add(sourceId); };
 
       summaries.push(...await upsertAssetsPipeline({
         assetBinaryPath,
         assetData,
         directoryPath: assetsDirectoryPath,
         logger,
-        maps,
+        maps: { ...maps, assetInternalTags },
         transports: {
           getAsset: getAssetTransport,
           createAsset: createAssetTransport,
           updateAsset: updateAssetTransport,
           appendAssetManifest: assetManifestTransport,
           cleanupAsset: cleanupAssetTransport,
-          mapInternalTagIds: mapInternalTagIdsTransport,
         },
         ui,
+        onUnmappedTag,
       }));
 
-      if (unmappedTagNames.size > 0) {
-        const names = [...unmappedTagNames].sort();
-        const message = `Dropped ${names.length} unknown internal asset tag${names.length === 1 ? '' : 's'} not present in target space: ${names.join(', ')}`;
+      if (unmappedTagIds.size > 0) {
+        const sortedIds = [...unmappedTagIds].sort((a, b) => a - b);
+        const labels = sortedIds.map(id => sourceNamesById.get(id) ?? `#${id}`);
+        const message = `Dropped ${labels.length} unknown internal asset tag${labels.length === 1 ? '' : 's'} not present in target space: ${labels.join(', ')}`;
         ui.warn(message);
-        logger.warn(message, { unmappedTagNames: names });
+        logger.warn(message, { unmappedTagIds: sortedIds });
       }
 
       /**

--- a/packages/cli/src/commands/assets/push/index.ts
+++ b/packages/cli/src/commands/assets/push/index.ts
@@ -18,9 +18,11 @@ import {
   makeCreateAssetFolderAPITransport,
   makeGetAssetAPITransport,
   makeGetAssetFolderAPITransport,
+  makeMapInternalTagIdsTransport,
   makeUpdateAssetAPITransport,
   makeUpdateAssetFolderAPITransport,
 } from '../streams';
+import { fetchAssetInternalTags } from '../actions';
 import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderUpdate, AssetMapped, AssetUpload } from '../types';
 import { isRemoteSource, loadAssetFolderMap, loadAssetMap, loadSidecarAssetData, parseAssetData } from '../utils';
 import { findComponentSchemas } from '../../stories/utils';
@@ -153,6 +155,19 @@ pushCmd
         ? makeCleanupAssetFSTransport()
         : () => Promise.resolve();
 
+      // Build a target-space tag name → id map so that source-space tag IDs in
+      // pulled sidecars are translated to the matching target-space IDs by name
+      // (WDX-332). Tag names that do not exist in target are dropped + warned.
+      const targetAssetInternalTags = await fetchAssetInternalTags(targetSpace);
+      const targetTagNameToId = new Map<string, number>(
+        targetAssetInternalTags.map(tag => [tag.name, tag.id]),
+      );
+      const unmappedTagNames = new Set<string>();
+      const mapInternalTagIdsTransport = makeMapInternalTagIdsTransport(
+        targetTagNameToId,
+        (name) => { unmappedTagNames.add(name); },
+      );
+
       summaries.push(...await upsertAssetsPipeline({
         assetBinaryPath,
         assetData,
@@ -165,9 +180,17 @@ pushCmd
           updateAsset: updateAssetTransport,
           appendAssetManifest: assetManifestTransport,
           cleanupAsset: cleanupAssetTransport,
+          mapInternalTagIds: mapInternalTagIdsTransport,
         },
         ui,
       }));
+
+      if (unmappedTagNames.size > 0) {
+        const names = [...unmappedTagNames].sort();
+        const message = `Dropped ${names.length} unknown internal asset tag${names.length === 1 ? '' : 's'} not present in target space: ${names.join(', ')}`;
+        ui.warn(message);
+        logger.warn(message, { unmappedTagNames: names });
+      }
 
       /**
        * Map Asset References in Stories

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -574,6 +574,32 @@ export const makeAppendAssetFolderManifestFSTransport = ({ manifestFile }: { man
     }));
   };
 
+export type MapInternalTagIdsTransport = (asset: {
+  internal_tag_ids?: ReadonlyArray<number | string> | null;
+  internal_tags_list?: ReadonlyArray<{ id: number; name: string }> | null;
+}) => string[];
+
+export const makeMapInternalTagIdsTransport = (
+  targetTagNameToId: ReadonlyMap<string, number>,
+  onUnmappedTag?: (name: string) => void,
+): MapInternalTagIdsTransport => (asset) => {
+  const list = asset.internal_tags_list;
+  if (!Array.isArray(list) || list.length === 0) {
+    return (asset.internal_tag_ids ?? []).map(id => String(id));
+  }
+  const mapped: string[] = [];
+  for (const tag of list) {
+    const targetId = targetTagNameToId.get(tag.name);
+    if (typeof targetId === 'number') {
+      mapped.push(String(targetId));
+    }
+    else {
+      onUnmappedTag?.(tag.name);
+    }
+  }
+  return mapped;
+};
+
 export type GetAssetTransport = (assetId: number) => Promise<Asset | undefined>;
 
 export const makeGetAssetAPITransport = ({ spaceId }: { spaceId: string }): GetAssetTransport =>
@@ -636,6 +662,7 @@ const processAsset = async ({
     updateAsset: UpdateAssetTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
+    mapInternalTagIds?: MapInternalTagIdsTransport;
   };
   maps: { assets: AssetMap; assetFolders: AssetFolderMap };
 }): Promise<{ status: 'created' | 'updated'; remoteAsset: Asset }> => {
@@ -645,6 +672,18 @@ const processAsset = async ({
     ? maps.assets.get(localAsset.id)?.new.id || localAsset.id
     : undefined;
   const remoteAsset = remoteAssetId ? await transports.getAsset(remoteAssetId) : null;
+
+  const resolveInternalTagIds = (source: typeof localAsset | Asset): string[] => {
+    if (transports.mapInternalTagIds) {
+      return transports.mapInternalTagIds(source as {
+        internal_tag_ids?: ReadonlyArray<number | string> | null;
+        internal_tags_list?: ReadonlyArray<{ id: number; name: string }> | null;
+      });
+    }
+    return 'internal_tag_ids' in source && Array.isArray(source.internal_tag_ids)
+      ? source.internal_tag_ids.map(id => String(id))
+      : [];
+  };
 
   let newRemoteAsset: Asset;
   let status: 'created' | 'updated';
@@ -661,7 +700,7 @@ const processAsset = async ({
       focus: 'focus' in localAsset ? localAsset.focus : remoteAsset.focus,
       expire_at: 'expire_at' in localAsset ? localAsset.expire_at : remoteAsset.expire_at,
       publish_at: 'publish_at' in localAsset ? localAsset.publish_at : remoteAsset.publish_at,
-      internal_tag_ids: 'internal_tag_ids' in localAsset ? localAsset.internal_tag_ids : remoteAsset.internal_tag_ids,
+      internal_tag_ids: 'internal_tag_ids' in localAsset ? resolveInternalTagIds(localAsset) : remoteAsset.internal_tag_ids,
       meta_data: 'meta_data' in localAsset ? localAsset.meta_data : remoteAsset.meta_data,
     };
 
@@ -677,9 +716,21 @@ const processAsset = async ({
     status = 'updated';
   }
   else if (hasShortFilename(localAsset)) {
+    // `internal_tags_list` is server-managed (read-only) and must not be sent.
+    // `internal_tag_ids` is rewritten via mapInternalTagIds so source-space IDs
+    // are translated to target-space IDs by name (WDX-332). When the source has
+    // no tag metadata, omit the field entirely so mapi-client skips the
+    // follow-up metadata PUT for tagless assets.
+    const { internal_tags_list: _internalTagsList, internal_tag_ids: _sourceTagIds, ...rest } = localAsset as AssetUpload & {
+      internal_tags_list?: ReadonlyArray<{ id: number; name: string }> | null;
+    };
+    const hasSourceTagMetadata = 'internal_tag_ids' in localAsset
+      || (Array.isArray(_internalTagsList) && _internalTagsList.length > 0);
+    const mappedTagIds = hasSourceTagMetadata ? resolveInternalTagIds(localAsset) : undefined;
     const createPayload = {
-      ...localAsset,
+      ...rest,
       asset_folder_id: remoteFolderId,
+      ...(mappedTagIds !== undefined ? { internal_tag_ids: mappedTagIds } : {}),
     } satisfies AssetUpload;
     newRemoteAsset = await transports.createAsset(createPayload, fileBuffer);
     status = 'created';
@@ -713,6 +764,7 @@ export const upsertAssetStream = ({
     updateAsset: UpdateAssetTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
+    mapInternalTagIds?: MapInternalTagIdsTransport;
   };
   maps: { assets: AssetMap; assetFolders: AssetFolderMap };
   onIncrement?: () => void;

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -713,7 +713,7 @@ const processAsset = async ({
   else if (hasShortFilename(localAsset)) {
     // `internal_tags_list` is server-managed (read-only) and must not be sent.
     // `internal_tag_ids` is rewritten through `maps.assetInternalTags` so
-    // source-space IDs are translated to target-space IDs (WDX-332). When the
+    // source-space IDs are translated to target-space IDs. When the
     // source has no tag metadata, omit the field entirely so mapi-client skips
     // the follow-up metadata PUT for tagless assets.
     const { internal_tags_list: _internalTagsList, internal_tag_ids: _sourceTagIds, ...rest } = localAsset as AssetUpload & {

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -8,7 +8,7 @@ import { toError } from '../../utils/error/error';
 import type { RegionCode } from '../../constants';
 import { SUPPORTED_ASSET_EXTENSIONS } from '../../constants';
 import { createAsset, createAssetFolder, downloadAssetFile, downloadFile, fetchAssetFolders, fetchAssets, updateAsset, updateAssetFolder } from './actions';
-import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolderUpdate, AssetInternalTagsMap, AssetListQuery, AssetMap, AssetUpdate, AssetUpload } from './types';
+import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolderUpdate, AssetInternalTagsByName, AssetListQuery, AssetMap, AssetUpdate, AssetUpload, UnmappedAssetInternalTag } from './types';
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { FetchError } from '../../utils/fetch';
@@ -575,27 +575,39 @@ export const makeAppendAssetFolderManifestFSTransport = ({ manifestFile }: { man
   };
 
 /**
- * Translates source-space internal tag ids to target-space ids via a precomputed
- * `AssetInternalTagsMap`. Ids absent from the map are dropped and reported via
- * `onUnmappedTag` so the caller can warn once at the end of a push.
+ * Translates source-space internal tag ids to target-space ids by looking up the
+ * source tag names carried in the pulled sidecar.
  */
-export const mapInternalTagIds = (
+const mapInternalTagIds = (
   sourceIds: ReadonlyArray<number | string> | null | undefined,
-  assetInternalTags: AssetInternalTagsMap,
-  onUnmappedTag?: (sourceId: number) => void,
+  sourceTags: ReadonlyArray<{ id?: number; name?: string }> | null | undefined,
+  assetInternalTagsByName: AssetInternalTagsByName,
+  onUnmappedTag?: (tag: UnmappedAssetInternalTag) => void,
 ): string[] => {
   if (!sourceIds || sourceIds.length === 0) {
     return [];
   }
+  const sourceNamesById = new Map<number, string>();
+  for (const tag of sourceTags ?? []) {
+    if (typeof tag?.id === 'number' && typeof tag.name === 'string') {
+      sourceNamesById.set(tag.id, tag.name);
+    }
+  }
   const mapped: string[] = [];
   for (const raw of sourceIds) {
     const sourceId = Number(raw);
-    const targetId = assetInternalTags.get(sourceId);
+    const sourceName = sourceNamesById.get(sourceId);
+    const targetId = typeof sourceName === 'string'
+      ? assetInternalTagsByName.get(sourceName)
+      : undefined;
     if (typeof targetId === 'number') {
       mapped.push(String(targetId));
     }
     else {
-      onUnmappedTag?.(sourceId);
+      onUnmappedTag?.({
+        sourceId,
+        ...(typeof sourceName === 'string' ? { name: sourceName } : {}),
+      });
     }
   }
   return mapped;
@@ -665,8 +677,8 @@ const processAsset = async ({
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
   };
-  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTags?: AssetInternalTagsMap };
-  onUnmappedTag?: (sourceId: number) => void;
+  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTagsByName?: AssetInternalTagsByName };
+  onUnmappedTag?: (tag: UnmappedAssetInternalTag) => void;
 }): Promise<{ status: 'created' | 'updated'; remoteAsset: Asset }> => {
   const remoteFolderId = localAsset.asset_folder_id
     && (maps.assetFolders.get(localAsset.asset_folder_id) || localAsset.asset_folder_id);
@@ -675,9 +687,12 @@ const processAsset = async ({
     : undefined;
   const remoteAsset = remoteAssetId ? await transports.getAsset(remoteAssetId) : null;
 
+  const sourceTags = 'internal_tags_list' in localAsset
+    ? localAsset.internal_tags_list
+    : undefined;
   const resolveInternalTagIds = (sourceIds: ReadonlyArray<number | string> | undefined): string[] =>
-    maps.assetInternalTags
-      ? mapInternalTagIds(sourceIds, maps.assetInternalTags, onUnmappedTag)
+    maps.assetInternalTagsByName
+      ? mapInternalTagIds(sourceIds, sourceTags, maps.assetInternalTagsByName, onUnmappedTag)
       : (sourceIds ?? []).map(id => String(id));
 
   let newRemoteAsset: Asset;
@@ -712,7 +727,7 @@ const processAsset = async ({
   }
   else if (hasShortFilename(localAsset)) {
     // `internal_tags_list` is server-managed (read-only) and must not be sent.
-    // `internal_tag_ids` is rewritten through `maps.assetInternalTags` so
+    // `internal_tag_ids` is rewritten through `maps.assetInternalTagsByName` so
     // source-space IDs are translated to target-space IDs. When the
     // source has no tag metadata, omit the field entirely so mapi-client skips
     // the follow-up metadata PUT for tagless assets.
@@ -761,11 +776,11 @@ export const upsertAssetStream = ({
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
   };
-  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTags?: AssetInternalTagsMap };
+  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTagsByName?: AssetInternalTagsByName };
   onIncrement?: () => void;
   onAssetSuccess?: (localAsset: Asset | AssetUpload, remoteAsset: Asset) => void;
   onAssetError?: (error: Error, asset: Asset | AssetUpload) => void;
-  onUnmappedTag?: (sourceId: number) => void;
+  onUnmappedTag?: (tag: UnmappedAssetInternalTag) => void;
 }) => {
   const processing = new Set<Promise<void>>();
 

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -8,7 +8,7 @@ import { toError } from '../../utils/error/error';
 import type { RegionCode } from '../../constants';
 import { SUPPORTED_ASSET_EXTENSIONS } from '../../constants';
 import { createAsset, createAssetFolder, downloadAssetFile, downloadFile, fetchAssetFolders, fetchAssets, updateAsset, updateAssetFolder } from './actions';
-import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolderUpdate, AssetListQuery, AssetMap, AssetUpdate, AssetUpload } from './types';
+import type { Asset, AssetFolder, AssetFolderCreate, AssetFolderMap, AssetFolderUpdate, AssetInternalTagsMap, AssetListQuery, AssetMap, AssetUpdate, AssetUpload } from './types';
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { FetchError } from '../../utils/fetch';
@@ -574,27 +574,28 @@ export const makeAppendAssetFolderManifestFSTransport = ({ manifestFile }: { man
     }));
   };
 
-export type MapInternalTagIdsTransport = (asset: {
-  internal_tag_ids?: ReadonlyArray<number | string> | null;
-  internal_tags_list?: ReadonlyArray<{ id: number; name: string }> | null;
-}) => string[];
-
-export const makeMapInternalTagIdsTransport = (
-  targetTagNameToId: ReadonlyMap<string, number>,
-  onUnmappedTag?: (name: string) => void,
-): MapInternalTagIdsTransport => (asset) => {
-  const list = asset.internal_tags_list;
-  if (!Array.isArray(list) || list.length === 0) {
-    return (asset.internal_tag_ids ?? []).map(id => String(id));
+/**
+ * Translates source-space internal tag ids to target-space ids via a precomputed
+ * `AssetInternalTagsMap`. Ids absent from the map are dropped and reported via
+ * `onUnmappedTag` so the caller can warn once at the end of a push.
+ */
+export const mapInternalTagIds = (
+  sourceIds: ReadonlyArray<number | string> | null | undefined,
+  assetInternalTags: AssetInternalTagsMap,
+  onUnmappedTag?: (sourceId: number) => void,
+): string[] => {
+  if (!sourceIds || sourceIds.length === 0) {
+    return [];
   }
   const mapped: string[] = [];
-  for (const tag of list) {
-    const targetId = targetTagNameToId.get(tag.name);
+  for (const raw of sourceIds) {
+    const sourceId = Number(raw);
+    const targetId = assetInternalTags.get(sourceId);
     if (typeof targetId === 'number') {
       mapped.push(String(targetId));
     }
     else {
-      onUnmappedTag?.(tag.name);
+      onUnmappedTag?.(sourceId);
     }
   }
   return mapped;
@@ -651,6 +652,7 @@ const processAsset = async ({
   assetPath,
   transports,
   maps,
+  onUnmappedTag,
 }: {
   localAsset: Asset | AssetUpload;
   fileBuffer: ArrayBuffer;
@@ -662,9 +664,9 @@ const processAsset = async ({
     updateAsset: UpdateAssetTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
-    mapInternalTagIds?: MapInternalTagIdsTransport;
   };
-  maps: { assets: AssetMap; assetFolders: AssetFolderMap };
+  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTags?: AssetInternalTagsMap };
+  onUnmappedTag?: (sourceId: number) => void;
 }): Promise<{ status: 'created' | 'updated'; remoteAsset: Asset }> => {
   const remoteFolderId = localAsset.asset_folder_id
     && (maps.assetFolders.get(localAsset.asset_folder_id) || localAsset.asset_folder_id);
@@ -673,17 +675,10 @@ const processAsset = async ({
     : undefined;
   const remoteAsset = remoteAssetId ? await transports.getAsset(remoteAssetId) : null;
 
-  const resolveInternalTagIds = (source: typeof localAsset | Asset): string[] => {
-    if (transports.mapInternalTagIds) {
-      return transports.mapInternalTagIds(source as {
-        internal_tag_ids?: ReadonlyArray<number | string> | null;
-        internal_tags_list?: ReadonlyArray<{ id: number; name: string }> | null;
-      });
-    }
-    return 'internal_tag_ids' in source && Array.isArray(source.internal_tag_ids)
-      ? source.internal_tag_ids.map(id => String(id))
-      : [];
-  };
+  const resolveInternalTagIds = (sourceIds: ReadonlyArray<number | string> | undefined): string[] =>
+    maps.assetInternalTags
+      ? mapInternalTagIds(sourceIds, maps.assetInternalTags, onUnmappedTag)
+      : (sourceIds ?? []).map(id => String(id));
 
   let newRemoteAsset: Asset;
   let status: 'created' | 'updated';
@@ -700,7 +695,7 @@ const processAsset = async ({
       focus: 'focus' in localAsset ? localAsset.focus : remoteAsset.focus,
       expire_at: 'expire_at' in localAsset ? localAsset.expire_at : remoteAsset.expire_at,
       publish_at: 'publish_at' in localAsset ? localAsset.publish_at : remoteAsset.publish_at,
-      internal_tag_ids: 'internal_tag_ids' in localAsset ? resolveInternalTagIds(localAsset) : remoteAsset.internal_tag_ids,
+      internal_tag_ids: 'internal_tag_ids' in localAsset ? resolveInternalTagIds(localAsset.internal_tag_ids) : remoteAsset.internal_tag_ids,
       meta_data: 'meta_data' in localAsset ? localAsset.meta_data : remoteAsset.meta_data,
     };
 
@@ -717,16 +712,16 @@ const processAsset = async ({
   }
   else if (hasShortFilename(localAsset)) {
     // `internal_tags_list` is server-managed (read-only) and must not be sent.
-    // `internal_tag_ids` is rewritten via mapInternalTagIds so source-space IDs
-    // are translated to target-space IDs by name (WDX-332). When the source has
-    // no tag metadata, omit the field entirely so mapi-client skips the
-    // follow-up metadata PUT for tagless assets.
+    // `internal_tag_ids` is rewritten through `maps.assetInternalTags` so
+    // source-space IDs are translated to target-space IDs (WDX-332). When the
+    // source has no tag metadata, omit the field entirely so mapi-client skips
+    // the follow-up metadata PUT for tagless assets.
     const { internal_tags_list: _internalTagsList, internal_tag_ids: _sourceTagIds, ...rest } = localAsset as AssetUpload & {
       internal_tags_list?: ReadonlyArray<{ id: number; name: string }> | null;
     };
-    const hasSourceTagMetadata = 'internal_tag_ids' in localAsset
-      || (Array.isArray(_internalTagsList) && _internalTagsList.length > 0);
-    const mappedTagIds = hasSourceTagMetadata ? resolveInternalTagIds(localAsset) : undefined;
+    const mappedTagIds = 'internal_tag_ids' in localAsset
+      ? resolveInternalTagIds(localAsset.internal_tag_ids)
+      : undefined;
     const createPayload = {
       ...rest,
       asset_folder_id: remoteFolderId,
@@ -757,6 +752,7 @@ export const upsertAssetStream = ({
   onIncrement,
   onAssetSuccess,
   onAssetError,
+  onUnmappedTag,
 }: {
   transports: {
     getAsset: GetAssetTransport;
@@ -764,12 +760,12 @@ export const upsertAssetStream = ({
     updateAsset: UpdateAssetTransport;
     appendAssetManifest: AppendAssetManifestTransport;
     cleanupAsset?: CleanupAssetTransport;
-    mapInternalTagIds?: MapInternalTagIdsTransport;
   };
-  maps: { assets: AssetMap; assetFolders: AssetFolderMap };
+  maps: { assets: AssetMap; assetFolders: AssetFolderMap; assetInternalTags?: AssetInternalTagsMap };
   onIncrement?: () => void;
   onAssetSuccess?: (localAsset: Asset | AssetUpload, remoteAsset: Asset) => void;
   onAssetError?: (error: Error, asset: Asset | AssetUpload) => void;
+  onUnmappedTag?: (sourceId: number) => void;
 }) => {
   const processing = new Set<Promise<void>>();
 
@@ -786,6 +782,7 @@ export const upsertAssetStream = ({
             assetPath: context.assetPath,
             transports,
             maps,
+            onUnmappedTag,
           });
 
           onAssetSuccess?.(localAsset, remoteAsset);

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -604,10 +604,7 @@ const mapInternalTagIds = (
       mapped.push(String(targetId));
     }
     else {
-      onUnmappedTag?.({
-        sourceId,
-        ...(typeof sourceName === 'string' ? { name: sourceName } : {}),
-      });
+      onUnmappedTag?.({ sourceId, name: sourceName });
     }
   }
   return mapped;
@@ -687,9 +684,7 @@ const processAsset = async ({
     : undefined;
   const remoteAsset = remoteAssetId ? await transports.getAsset(remoteAssetId) : null;
 
-  const sourceTags = 'internal_tags_list' in localAsset
-    ? localAsset.internal_tags_list
-    : undefined;
+  const sourceTags = localAsset.internal_tags_list;
   const resolveInternalTagIds = (sourceIds: ReadonlyArray<number | string> | undefined): string[] =>
     maps.assetInternalTagsByName
       ? mapInternalTagIds(sourceIds, sourceTags, maps.assetInternalTagsByName, onUnmappedTag)
@@ -731,9 +726,7 @@ const processAsset = async ({
     // source-space IDs are translated to target-space IDs. When the
     // source has no tag metadata, omit the field entirely so mapi-client skips
     // the follow-up metadata PUT for tagless assets.
-    const { internal_tags_list: _internalTagsList, internal_tag_ids: _sourceTagIds, ...rest } = localAsset as AssetUpload & {
-      internal_tags_list?: ReadonlyArray<{ id: number; name: string }> | null;
-    };
+    const { internal_tags_list: _internalTagsList, internal_tag_ids: _sourceTagIds, ...rest } = localAsset;
     const mappedTagIds = 'internal_tag_ids' in localAsset
       ? resolveInternalTagIds(localAsset.internal_tag_ids)
       : undefined;

--- a/packages/cli/src/commands/assets/types.ts
+++ b/packages/cli/src/commands/assets/types.ts
@@ -7,8 +7,11 @@ export type { Asset, AssetCreate, AssetFolder, AssetFolderCreate, AssetFolderUpd
  * Adds an optional `id` field used for manifest-based local↔remote ID mapping.
  * The `id` identifies the local/source asset and is stripped before the
  * mapi-client create/upload call so it does not leak into the metadata update.
+ * `internal_tags_list` is the server-managed (read-only) tag detail carried in
+ * pulled sidecars; it is used to translate source-space tag names to
+ * target-space IDs and is stripped before the create/upload call.
  */
-export type AssetUpload = AssetCreate & { id?: number };
+export type AssetUpload = AssetCreate & { id?: number; internal_tags_list?: Asset['internal_tags_list'] };
 
 export type AssetMapped = Pick<Asset, 'id' | 'filename' | 'alt' | 'title' | 'copyright' | 'source' | 'is_private' | 'meta_data'>;
 

--- a/packages/cli/src/commands/assets/types.ts
+++ b/packages/cli/src/commands/assets/types.ts
@@ -23,6 +23,11 @@ export type AssetMap = Map<number, { old: Asset | AssetMapped | AssetUpload; new
 export type AssetFolderMap = Map<number, number>;
 
 /**
+ * Maps source-space asset internal tag ids to target-space ids.
+ */
+export type AssetInternalTagsMap = ReadonlyMap<number, number>;
+
+/**
  * Maps local with remote story ids and UUIDs.
  */
 export interface StoryMap extends Map<string | number, string | number> {

--- a/packages/cli/src/commands/assets/types.ts
+++ b/packages/cli/src/commands/assets/types.ts
@@ -23,9 +23,14 @@ export type AssetMap = Map<number, { old: Asset | AssetMapped | AssetUpload; new
 export type AssetFolderMap = Map<number, number>;
 
 /**
- * Maps source-space asset internal tag ids to target-space ids.
+ * Maps target-space asset internal tag names to target-space ids.
  */
-export type AssetInternalTagsMap = ReadonlyMap<number, number>;
+export type AssetInternalTagsByName = ReadonlyMap<string, number>;
+
+export interface UnmappedAssetInternalTag {
+  sourceId: number;
+  name?: string;
+}
 
 /**
  * Maps local with remote story ids and UUIDs.

--- a/packages/cli/src/commands/assets/utils.test.ts
+++ b/packages/cli/src/commands/assets/utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { vol } from 'memfs';
+import { collectAssetInternalTagNames, ensureAssetInternalTags, internalTagNamesFromAssets } from './utils';
+
+describe('internalTagNamesFromAssets', () => {
+  it('collects unique tag names in first-seen order, ignoring blanks', () => {
+    const names = internalTagNamesFromAssets([
+      { internal_tags_list: [{ id: 1, name: 'blue' }, { id: 2, name: 'green' }] },
+      { internal_tags_list: [{ id: 3, name: 'blue' }, { id: 4, name: '' }, { id: 5 }] },
+      {},
+    ]);
+
+    expect(names).toEqual(['blue', 'green']);
+  });
+});
+
+describe('collectAssetInternalTagNames', () => {
+  it('reads sidecars in a directory and returns their unique tag names', async () => {
+    vol.fromJSON({
+      '/assets/a.png': 'binary',
+      '/assets/a.json': JSON.stringify({ internal_tags_list: [{ id: 1, name: 'blue' }] }),
+      '/assets/b.png': 'binary',
+      '/assets/b.json': JSON.stringify({ internal_tags_list: [{ id: 2, name: 'green' }, { id: 3, name: 'blue' }] }),
+      '/assets/notes.txt': 'ignored',
+    });
+
+    const names = await collectAssetInternalTagNames('/assets');
+
+    expect([...names].sort()).toEqual(['blue', 'green']);
+  });
+});
+
+describe('ensureAssetInternalTags', () => {
+  it('creates tags missing from the target space and returns them in the map', async () => {
+    const createTag = vi.fn(async (name: string) => ({ id: name === 'blue' ? 10 : 11, name }));
+
+    const result = await ensureAssetInternalTags({
+      sourceTagNames: ['blue', 'green'],
+      targetTagsByName: new Map([['green', 5]]),
+      createTag,
+    });
+
+    expect(createTag).toHaveBeenCalledTimes(1);
+    expect(createTag).toHaveBeenCalledWith('blue');
+    expect(result.get('blue')).toBe(10);
+    expect(result.get('green')).toBe(5);
+  });
+
+  it('reports created tag names via onTagCreated', async () => {
+    const onTagCreated = vi.fn();
+
+    await ensureAssetInternalTags({
+      sourceTagNames: ['blue', 'red'],
+      targetTagsByName: new Map(),
+      createTag: async (name: string) => ({ id: 1, name }),
+      onTagCreated,
+    });
+
+    expect(onTagCreated).toHaveBeenCalledTimes(2);
+    expect(onTagCreated).toHaveBeenCalledWith('blue');
+    expect(onTagCreated).toHaveBeenCalledWith('red');
+  });
+
+  it('deduplicates source names and skips creation when all already exist', async () => {
+    const createTag = vi.fn(async (name: string) => ({ id: 1, name }));
+
+    const result = await ensureAssetInternalTags({
+      sourceTagNames: ['green', 'green'],
+      targetTagsByName: new Map([['green', 5]]),
+      createTag,
+    });
+
+    expect(createTag).not.toHaveBeenCalled();
+    expect(result.get('green')).toBe(5);
+  });
+
+  it('degrades gracefully when a tag cannot be created: leaves it unmapped and reports the error', async () => {
+    const onTagCreateError = vi.fn();
+    const createTag = vi.fn(async (name: string) => {
+      if (name === 'blue') {
+        throw new Error('boom');
+      }
+      return { id: 7, name };
+    });
+
+    const result = await ensureAssetInternalTags({
+      sourceTagNames: ['blue', 'green'],
+      targetTagsByName: new Map(),
+      createTag,
+      onTagCreateError,
+    });
+
+    expect(result.has('blue')).toBe(false);
+    expect(result.get('green')).toBe(7);
+    expect(onTagCreateError).toHaveBeenCalledWith('blue', expect.any(Error));
+  });
+});

--- a/packages/cli/src/commands/assets/utils.ts
+++ b/packages/cli/src/commands/assets/utils.ts
@@ -1,5 +1,6 @@
 import { basename, dirname, extname, join } from 'pathe';
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
+import { SUPPORTED_ASSET_EXTENSIONS } from '../../constants';
 import { toError } from '../../utils/error/error';
 import type { ManifestEntry } from '../../utils/filesystem';
 import { loadManifest, sanitizeFilename } from '../../utils/filesystem';
@@ -120,4 +121,74 @@ export const getFolderFilename = (folder: Pick<AssetFolder, 'name' | 'uuid'>) =>
   const sanitizedName = sanitizeFilename(folder.name || '');
   const baseName = sanitizedName || folder.uuid;
   return `${baseName}_${folder.uuid}.json`;
+};
+
+/**
+ * Extracts the unique internal tag names carried in the `internal_tags_list`
+ * of the given source assets, preserving first-seen order.
+ */
+export const internalTagNamesFromAssets = (
+  assets: ReadonlyArray<Pick<Asset, 'internal_tags_list'>>,
+): string[] => {
+  const names = new Set<string>();
+  for (const asset of assets) {
+    for (const tag of asset.internal_tags_list ?? []) {
+      if (typeof tag?.name === 'string' && tag.name.length > 0) {
+        names.add(tag.name);
+      }
+    }
+  }
+  return [...names];
+};
+
+/**
+ * Reads every asset sidecar in a pulled assets directory and returns the unique
+ * internal tag names they reference. Used by `assets push` to pre-create missing
+ * tags in the target space before mapping `internal_tag_ids`.
+ */
+export const collectAssetInternalTagNames = async (directoryPath: string): Promise<string[]> => {
+  const files = await readdir(directoryPath);
+  const binaryFiles = files.filter(file => SUPPORTED_ASSET_EXTENSIONS.has(extname(file).toLowerCase()));
+  const sidecars = await Promise.all(
+    binaryFiles.map(file => loadSidecarAssetData(join(directoryPath, file))),
+  );
+  return internalTagNamesFromAssets(sidecars);
+};
+
+/**
+ * Ensures the source assets' internal tag names exist in the target space.
+ *
+ * Names already present in `targetTagsByName` are left untouched; missing names
+ * are created via `createTag` and merged into the returned map. Creation is
+ * best-effort: a failure leaves the name unmapped (the caller drops the
+ * reference with its existing warning) and is surfaced via `onTagCreateError`.
+ */
+export const ensureAssetInternalTags = async ({
+  sourceTagNames,
+  targetTagsByName,
+  createTag,
+  onTagCreated,
+  onTagCreateError,
+}: {
+  sourceTagNames: Iterable<string>;
+  targetTagsByName: ReadonlyMap<string, number>;
+  createTag: (name: string) => Promise<{ id: number; name: string } | undefined>;
+  onTagCreated?: (name: string) => void;
+  onTagCreateError?: (name: string, error: Error) => void;
+}): Promise<ReadonlyMap<string, number>> => {
+  const tagsByName = new Map(targetTagsByName);
+  const missing = [...new Set(sourceTagNames)].filter(name => !tagsByName.has(name));
+  for (const name of missing) {
+    try {
+      const created = await createTag(name);
+      if (created) {
+        tagsByName.set(created.name, created.id);
+        onTagCreated?.(created.name);
+      }
+    }
+    catch (maybeError) {
+      onTagCreateError?.(name, toError(maybeError));
+    }
+  }
+  return tagsByName;
 };

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -32,6 +32,7 @@ export const API_ACTIONS = {
   push_asset_create: 'Failed to create asset',
   push_asset_update: 'Failed to update asset',
   pull_asset_internal_tags: 'Failed to pull asset internal tags',
+  push_asset_internal_tag: 'Failed to push asset internal tag',
   pull_datasources: 'Failed to pull datasources',
   push_datasource: 'Failed to push datasource',
   update_datasource: 'Failed to update datasource',

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -31,6 +31,7 @@ export const API_ACTIONS = {
   push_asset_folder: 'Failed to push asset folder',
   push_asset_create: 'Failed to create asset',
   push_asset_update: 'Failed to update asset',
+  pull_asset_internal_tags: 'Failed to pull asset internal tags',
   pull_datasources: 'Failed to pull datasources',
   push_datasource: 'Failed to push datasource',
   update_datasource: 'Failed to update datasource',


### PR DESCRIPTION
## Summary

- `storyblok assets push --from <SRC> --space <TGT>` previously forwarded source-space `internal_tag_ids` from pulled sidecars verbatim; the target space rejected them with HTTP 422 and assets were created but untagged (exit code 1).
- The push command now fetches the target space's asset internal tags, builds a `name → id` map, and translates each asset's `internal_tag_ids` via the sidecar's `internal_tags_list` names before the create/update call.
- **Tag names missing from the target space are now created there** (mirroring `components push`) so pushed assets keep their tags. Before the upsert pipeline the command gathers source tag names from the sidecars, diffs them against the target's existing asset tags, and creates the missing ones via `createAssetInternalTag` (`object_type: 'asset'`). Created IDs are merged into the `name → id` map.
- Creation is **best-effort**: a failed create (or a tag ID with no sidecar name to create from) falls back to the existing drop-and-warn, so behavior is never worse than before. Same-space pushes and dry runs skip creation.
- `internal_tags_list` is stripped from outgoing payloads (read-only server-side). Tagless sources omit `internal_tag_ids` entirely so the mapi-client skips the follow-up metadata PUT for assets without tag metadata.

Fixes WDX-332
Fixes #509

## Test plan

- [x] Reproduced 422 against real spaces (source asset tagged, target tag exists with same name, different ID).
- [x] After fix: `assets push` exits 0; target asset carries the target-space tag ID, not the source-space ID.
- [x] Cross-space push with a tag absent from the target creates the tag and maps the asset to the new ID.
- [x] `pnpm nx lint:fix storyblok` passes.
- [x] `pnpm nx run storyblok:test:types` passes.
- [x] `pnpm --filter storyblok exec vitest run` — 706 passed, 1 todo.
- [x] New tests cover: source→target ID mapping by name, creating a missing tag and mapping to the new ID, graceful degradation when a tag create fails (reference dropped, push still exits 0), dropped ID without sidecar name, omitted `internal_tag_ids` for tagless sources; plus unit tests for the gather/ensure helpers.
- [x] QA: pull tagged assets from one space, push to another; verify matching-name tags map to existing IDs and absent tags are created in the target, and process exits 0.