### PR TITLE
feature(js-client): skip CORS preflight headers for browser delivery API requests

### DIFF
--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -110,8 +110,14 @@ export class Storyblok {
     }
 
     const headers: Headers = new Headers();
+    const isManagementApi = !!config.oauthToken;
+    const isBrowser = typeof window !== 'undefined';
+    const skipPreflightHeaders = !isManagementApi && isBrowser;
 
-    headers.set('Content-Type', 'application/json');
+    if (!skipPreflightHeaders) {
+      headers.set('Content-Type', 'application/json');
+    }
+
     headers.set('Accept', 'application/json');
 
     if (config.headers) {
@@ -125,7 +131,7 @@ export class Storyblok {
       });
     }
 
-    if (!headers.has(STORYBLOK_AGENT)) {
+    if (!skipPreflightHeaders && !headers.has(STORYBLOK_AGENT)) {
       headers.set(STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT.defaultAgentName);
       headers.set(
         STORYBLOK_JS_CLIENT_AGENT.defaultAgentVersion,


### PR DESCRIPTION
Browser delivery API requests in storyblok-js-client were sending headers that trigger CORS preflight (OPTIONS): Content-Type: application/json, SB-Agent, and SB-Agent-Version. Those headers are unnecessary for typical CDN GET calls and add an extra round trip in the browser.

This change omits those headers only when both are true:

Content Delivery API (no oauthToken)
Running in a browser (typeof window !== 'undefined')
Server-side delivery clients (Node, SSR, edge) still send the full header set. Management API behavior is unchanged.