### PR TITLE
fix(js-client): remove unneeded headers to prevent CORS preflight being triggered

### DIFF
--- a/packages/js-client/src/constants.ts
+++ b/packages/js-client/src/constants.ts
@@ -11,14 +11,6 @@ type Method = ObjectValues<typeof _METHOD>;
 
 export default Method;
 
-export const STORYBLOK_AGENT = 'SB-Agent';
-
-export const STORYBLOK_JS_CLIENT_AGENT = {
-  defaultAgentName: 'SB-JS-CLIENT',
-  defaultAgentVersion: 'SB-Agent-Version',
-  packageVersion: '7.0.0',
-};
-
 export const StoryblokContentVersion = {
   DRAFT: 'draft',
   PUBLISHED: 'published',

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -12,7 +12,7 @@ import {
 import SbFetch from './sbFetch';
 import type Method from './constants';
 import type { StoryblokContentVersionKeys } from './constants';
-import { STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT, StoryblokContentVersion } from './constants';
+import { StoryblokContentVersion } from './constants';
 import { createRateLimitConfig, determineRateLimit, MANAGEMENT_API_DEFAULT_RATE_LIMIT, parseRateLimitHeaders, type RateLimitConfig } from './rateLimit';
 import { ThrottleQueueManager } from './throttleQueueManager';
 
@@ -111,7 +111,13 @@ export class Storyblok {
 
     const headers: Headers = new Headers();
 
-    headers.set('Content-Type', 'application/json');
+    // Skip Content-Type for GET browser CDN requests to avoid CORS preflight.
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#simple_requests
+    const isBrowserCdn = !config.oauthToken && typeof window !== 'undefined';
+    if (!isBrowserCdn) {
+      headers.set('Content-Type', 'application/json');
+    }
+
     headers.set('Accept', 'application/json');
 
     if (config.headers) {
@@ -123,14 +129,6 @@ export class Storyblok {
       entries.forEach(([key, value]: [string, string]) => {
         headers.set(key, value);
       });
-    }
-
-    if (!headers.has(STORYBLOK_AGENT)) {
-      headers.set(STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT.defaultAgentName);
-      headers.set(
-        STORYBLOK_JS_CLIENT_AGENT.defaultAgentVersion,
-        STORYBLOK_JS_CLIENT_AGENT.packageVersion,
-      );
     }
 
     if (config.oauthToken) {

--- a/packages/js-client/tests/api/index.test.ts
+++ b/packages/js-client/tests/api/index.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import StoryblokClient from 'storyblok-js-client';
@@ -259,6 +259,97 @@ describe('storyblokClient (MSW)', () => {
 
         expect(manualClient.cacheVersion()).toBe(77777);
       });
+    });
+  });
+
+  describe('headers', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('omits Content-Type and SB-* headers for browser CDN requests', async () => {
+      vi.stubGlobal('window', {});
+      const captured: Headers[] = [];
+      server.use(
+        http.get(`${BASE_URL}/cdn/stories`, ({ request }) => {
+          captured.push(request.headers);
+          return HttpResponse.json(
+            { stories: [], cv: 12345678 },
+            { headers: { 'Total': '0', 'Per-Page': '25' } },
+          );
+        }),
+      );
+      const browserClient = new StoryblokClient({
+        accessToken: 'browser-cdn-test',
+      });
+      await browserClient.get('cdn/stories');
+      expect(captured).toHaveLength(1);
+      expect(captured[0].has('Content-Type')).toBe(false);
+      expect(captured[0].has('SB-Agent')).toBe(false);
+      expect(captured[0].has('SB-Agent-Version')).toBe(false);
+      expect(captured[0].get('Accept')).toBe('application/json');
+    });
+
+    it('includes Content-Type for server-side CDN requests', async () => {
+      const captured: Headers[] = [];
+      server.use(
+        http.get(`${BASE_URL}/cdn/stories`, ({ request }) => {
+          captured.push(request.headers);
+          return HttpResponse.json(
+            { stories: [], cv: 12345678 },
+            { headers: { 'Total': '0', 'Per-Page': '25' } },
+          );
+        }),
+      );
+      const serverClient = new StoryblokClient({
+        accessToken: 'server-cdn-test',
+      });
+      await serverClient.get('cdn/stories');
+      expect(captured).toHaveLength(1);
+      expect(captured[0].get('Content-Type')).toBe('application/json');
+      expect(captured[0].has('SB-Agent')).toBe(false);
+      expect(captured[0].has('SB-Agent-Version')).toBe(false);
+    });
+
+    it('includes Content-Type for Management API requests even in browser', async () => {
+      vi.stubGlobal('window', {});
+      const captured: Headers[] = [];
+      server.use(
+        http.get(`${BASE_URL}/cdn/stories`, ({ request }) => {
+          captured.push(request.headers);
+          return HttpResponse.json(
+            { stories: [], cv: 12345678 },
+            { headers: { 'Total': '0', 'Per-Page': '25' } },
+          );
+        }),
+      );
+      const mgmtClient = new StoryblokClient({
+        oauthToken: 'mgmt-token',
+        accessToken: 'mgmt-test',
+        endpoint: BASE_URL,
+      });
+      await mgmtClient.get('cdn/stories');
+      expect(captured).toHaveLength(1);
+      expect(captured[0].get('Content-Type')).toBe('application/json');
+    });
+
+    it('forwards custom headers from config.headers', async () => {
+      const captured: Headers[] = [];
+      server.use(
+        http.get(`${BASE_URL}/cdn/stories`, ({ request }) => {
+          captured.push(request.headers);
+          return HttpResponse.json(
+            { stories: [], cv: 12345678 },
+            { headers: { 'Total': '0', 'Per-Page': '25' } },
+          );
+        }),
+      );
+      const customClient = new StoryblokClient({
+        accessToken: 'custom-headers',
+        headers: { 'X-Custom': 'custom-value' },
+      });
+      await customClient.get('cdn/stories');
+      expect(captured[0].get('X-Custom')).toBe('custom-value');
     });
   });
 });


### PR DESCRIPTION
Browser CDN requests sent unnecessary headers (`Content-Type: application/json`, `SB-Agent`, `SB-Agent-Version`) that trigger a CORS preflight OPTIONS round-trip on every request — doubling latency for client-side API calls.

- Remove `SB-Agent` / `SB-Agent-Version` headers entirely (unused by backend, not present in capi-client)
- Skip `Content-Type` for browser CDN requests (read-only GET, no body needed)
- Management API and server-side requests unchanged

`@storyblok/api-client` (capi-client) is not affected — it already strips `Content-Type` on bodyless requests and never set `SB-Agent`.

Fixes WDX-433