### PR TITLE
chore: suppress AI attribution via .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "allow": [
       "Read",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,6 @@ When a significant architectural decision is made, add a concise new ADR in `adr
 ## Git
 
 - **IMPORTANT:** Never stage or commit any code yourself unless explicitly told so!
-- **IMPORTANT:** Never add `Co-Authored-By` or similar AI attribution trailers to commit messages or PRs.
 - **IMPORTANT:** Never use `git push --force`; if a force push is explicitly required, use `git push --force-with-lease` instead.
 - **Branch naming:** `[fix|feat|chore]/WDX-XXX-[title]` e.g. `feat/WDX-351-type-safe-schema-support`, `fix/WDX-391-push-stories-missing-story-identification`, or `chore/update-eslint-config`.
 - **Commits:** If information is available, add `Fixes WDX-*` and `Fixes #*` as footer lines at the end of commit messages for Linear and GitHub tracking.


### PR DESCRIPTION
## Summary
- Add empty `attribution.commit` and `attribution.pr` in `.claude/settings.json` so Claude Code no longer appends Co-Authored-By trailers or PR footers.
- Drop the now-redundant prose rule from `AGENTS.md` (the setting enforces it).

## Test plan
- [x] Verify a Claude-generated commit/PR contains no Co-Authored-By trailer or attribution footer.