### PR TITLE
spike: mirror Dipankar's React SDK approach for live preview eval

### DIFF
--- a/packages/react/playground/next-latest/src/app/experiment/[[...slug]]/page.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/[[...slug]]/page.tsx
@@ -1,0 +1,52 @@
+// REAL — page wiring. The story comes from the client-response stub. Toggle
+// preview with `?lp=1`. Production path renders the registry directly from an
+// RSC; preview path delegates to the client-side `StoryblokPreview` which
+// subscribes to the bridge and re-renders the whole tree client-side.
+//
+// The ONLY stubbed pieces are imports from `../_stub` (client response +
+// fake bridge); the SDK (`_sdk`), registry, and bloks are Dipankar's actual
+// pattern.
+import { storyblok } from '../_bloks/registry';
+import { StoryblokPreview } from '../_bloks/storyblok-preview';
+import { initialStory } from '../_stub/client-response';
+import { BridgeControls } from '../_stub/bridge-controls';
+
+type PageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function Route({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const livePreview = sp.lp === '1';
+  const story = initialStory;
+
+  return (
+    <main
+      style={{
+        minHeight: '100vh',
+        background: '#ffffff',
+        color: '#111827',
+        colorScheme: 'light',
+      }}
+    >
+      <div style={{ padding: 24, fontFamily: 'system-ui', maxWidth: 880, margin: '0 auto' }}>
+        <h1>Experiment: Dipankar-style live preview (client-rerender)</h1>
+        <p style={{ fontSize: 14, color: '#1f2937', lineHeight: 1.5 }}>
+          livePreview={String(livePreview)} (toggle with <code>?lp=1</code>). Blue =
+          server blok, orange = client blok, purple = client context, green =
+          async blok, red dashed = fallback / server-only loss. Only the{' '}
+          <code>_stub/</code> client response and bridge are faked; the SDK
+          (<code>_sdk/</code>), registry and bloks follow Dipankar&apos;s real
+          design. In live preview, edit the JSON below and press Submit to fake
+          a bridge update — the whole tree re-renders <em>on the client</em>.
+        </p>
+        {livePreview && <BridgeControls initialStory={story} />}
+        {livePreview ? (
+          <StoryblokPreview story={story} />
+        ) : (
+          <storyblok.StoryblokComponent blok={story.content} />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/async-server-fetch.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/async-server-fetch.tsx
@@ -1,0 +1,30 @@
+// REAL — async blok, mirrors Dipankar's `PostComponent` (jsonplaceholder).
+//
+// On the server (production route or initial preview render): runs as a true
+// async server component, fetched on the server.
+//
+// On the client (live-preview re-renders): Dipankar's renderer detects the
+// returned Promise and wraps it with <Suspense> + React 19's `use()` via
+// the per-component cache. Fetch happens in the browser. This is the key
+// "preview preserves async data" claim — verify it here.
+import type { SbBlokData } from '../_sdk/types';
+import { asyncBox, asyncTag } from './styles';
+
+type Post = { userId: number; id: number; title: string; body: string };
+
+export async function AsyncServerFetch({ blok }: { blok: SbBlokData }) {
+  const postId = blok.postId ?? 1;
+  const res = await fetch(`https://jsonplaceholder.typicode.com/posts/${String(postId)}`, {
+    cache: 'no-store',
+  });
+  const post: Post = await res.json();
+  return (
+    <div style={asyncBox}>
+      <div style={asyncTag}>
+        [async-server-fetch] (async) — postId={String(postId)}
+      </div>
+      <h4 style={{ margin: '6px 0 4px', color: '#111827' }}>{post.title}</h4>
+      <p style={{ margin: 0, color: '#374151', fontSize: 14 }}>{post.body}</p>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/client-card.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/client-card.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+// REAL — client blok that recursively renders nested bloks (which may be
+// server bloks) via the SDK registry. In Dipankar's design this is how
+// "server-in-client" works: the client component invokes StoryblokBlocks,
+// which through the registry resolves each child. Local `open` state proves
+// client state survives live-preview re-renders.
+import { useState } from 'react';
+import type { SbBlokData } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+import { storyblok } from './registry';
+
+export function ClientCard({ blok }: { blok: SbBlokData }) {
+  const [open, setOpen] = useState(true);
+  const body = Array.isArray(blok.body) ? (blok.body as SbBlokData[]) : [];
+
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[client-card] (client, hosts nested via StoryblokBlocks)</div>
+      <strong style={{ color: '#111827' }}>{String(blok.title ?? '')}</strong>
+      <div style={{ marginTop: 6 }}>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          style={{ padding: '4px 10px', cursor: 'pointer' }}
+          data-testid="card-toggle"
+        >
+          {open ? 'Collapse' : 'Expand'}
+        </button>
+      </div>
+      {open && (
+        <div style={{ marginTop: 8 }}>
+          <storyblok.StoryblokBlocks blocks={body} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/client-leaf.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/client-leaf.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+// REAL — client leaf at the bottom of the deep-alternation chain.
+// Local `note` input proves nested client state survives re-renders.
+import { useState } from 'react';
+import type { SbBlokData } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+
+export function ClientLeaf({ blok }: { blok: SbBlokData }) {
+  const [note, setNote] = useState('');
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[client-leaf] (client) — {String(blok.label ?? '')}</div>
+      <input
+        type="text"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        placeholder="local state (should survive edits)"
+        style={{
+          marginTop: 6, width: '100%', boxSizing: 'border-box', padding: '4px 8px',
+          color: '#111827', border: '1px solid #9ca3af', borderRadius: 4,
+        }}
+        data-testid="leaf-note"
+      />
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/client-panel.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/client-panel.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+// REAL — client blok in the deep-alternation chain
+// (server-section > client-panel > server-section > client-leaf).
+import type { SbBlokData } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+import { storyblok } from './registry';
+
+export function ClientPanel({ blok }: { blok: SbBlokData }) {
+  const body = Array.isArray(blok.body) ? (blok.body as SbBlokData[]) : [];
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[client-panel] (client) — {String(blok.label ?? '')}</div>
+      <div style={{ marginTop: 8 }}>
+        <storyblok.StoryblokBlocks blocks={body} />
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/fallback.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/fallback.tsx
@@ -1,0 +1,18 @@
+// REAL — fallback component for unregistered bloks. Registered via
+// ResolverConfig.fallback. Same pattern as Dipankar's FallbackBlock.
+import type { SbBlokData } from '../_sdk/types';
+import { errorBox, errorTag } from './styles';
+
+export function Fallback({ blok }: { blok: SbBlokData }) {
+  return (
+    <div style={errorBox}>
+      <div style={errorTag}>[fallback]</div>
+      <div style={{ marginTop: 6 }}>
+        Component not registered for{' '}
+        <code style={{ background: '#fee2e2', padding: '2px 6px', borderRadius: 4 }}>
+          {blok.component}
+        </code>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/feature.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/feature.tsx
@@ -1,0 +1,13 @@
+// REAL — server leaf blok.
+import type { SbBlokData } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+
+export function Feature({ blok }: { blok: SbBlokData }) {
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[feature] (server)</div>
+      <strong style={{ color: '#111827' }}>{String(blok.name ?? '')}</strong>
+      <p style={{ margin: '4px 0 0', color: '#374151' }}>{String(blok.text ?? '')}</p>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/grid.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/grid.tsx
@@ -1,0 +1,17 @@
+// REAL — server blok. Hosts mixed (server + client) children via StoryblokBlocks.
+import type { SbBlokData } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+import { storyblok } from './registry';
+
+export function Grid({ blok }: { blok: SbBlokData }) {
+  const body = Array.isArray(blok.body) ? (blok.body as SbBlokData[]) : [];
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[grid] (server)</div>
+      <h3 style={{ margin: '6px 0', color: '#111827' }}>{String(blok.heading ?? '')}</h3>
+      <div style={{ display: 'grid', gap: 8 }}>
+        <storyblok.StoryblokBlocks blocks={body} />
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/page.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/page.tsx
@@ -1,0 +1,15 @@
+// REAL — server blok. The story root; recurses via StoryblokBlocks.
+// Key adaptation from spike: no `children` prop magic. Each parent blok
+// explicitly renders its nested body through the SDK's StoryblokBlocks.
+import type { SbBlokData } from '../_sdk/types';
+import { storyblok } from './registry';
+
+export function Page({ blok }: { blok: SbBlokData }) {
+  const body = Array.isArray(blok.body) ? (blok.body as SbBlokData[]) : [];
+  return (
+    <main>
+      <h2 style={{ fontSize: 18, margin: '0 0 12px' }}>{String(blok.title ?? '')}</h2>
+      <storyblok.StoryblokBlocks blocks={body} />
+    </main>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/registry.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/registry.ts
@@ -1,0 +1,51 @@
+// REAL — composition root. App imports all bloks, creates the renderer, and
+// exports { StoryblokComponent, StoryblokBlocks } for both the route and the
+// individual bloks (which recurse via StoryblokBlocks).
+//
+// Mirrors Dipankar's `lib/storyblok.ts` pattern. Circular import with bloks
+// is fine because bloks only access `storyblok` at render time, not module init.
+import { createStoryblokRenderer } from '../_sdk/create-storyblok-renderer';
+import type { ResolverConfig } from '../_sdk/create-resolver';
+import { Page } from './page';
+import { Grid } from './grid';
+import { Feature } from './feature';
+import { Teaser } from './teaser';
+import { ServerQuote } from './server-quote';
+import { ServerSection } from './server-section';
+import { ClientCard } from './client-card';
+import { ClientPanel } from './client-panel';
+import { ClientLeaf } from './client-leaf';
+import { ThemeProvider } from './theme-provider';
+import { ThemeConsumer } from './theme-consumer';
+import { AsyncServerFetch } from './async-server-fetch';
+import { ServerOnlySecret } from './server-only-secret';
+import { Fallback } from './fallback';
+import { SuspenseFallback } from './suspense-fallback';
+
+const resolverConfig: ResolverConfig = {
+  fallback: Fallback,
+  suspenseFallback: SuspenseFallback,
+  warnMissingComponents: true,
+  cacheKeys: {
+    'async-server-fetch': (blok) => `${blok._uid}-${String(blok.postId ?? '')}`,
+  },
+};
+
+export const storyblok = createStoryblokRenderer(
+  {
+    'page': Page,
+    'grid': Grid,
+    'feature': Feature,
+    'teaser': Teaser,
+    'server-quote': ServerQuote,
+    'server-section': ServerSection,
+    'client-card': ClientCard,
+    'client-panel': ClientPanel,
+    'client-leaf': ClientLeaf,
+    'theme-provider': ThemeProvider,
+    'theme-consumer': ThemeConsumer,
+    'async-server-fetch': AsyncServerFetch,
+    'server-only-secret': ServerOnlySecret,
+  },
+  resolverConfig,
+);

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-only-secret.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-only-secret.tsx
@@ -1,0 +1,29 @@
+// REAL — blok that reads a server-only secret (a NON-NEXT_PUBLIC env var).
+//
+// On the server: `process.env.SERVER_ONLY_SECRET` resolves to whatever the
+// server has configured (set in `.env.local`, never exposed to the client).
+//
+// On the client (live-preview re-renders): without `NEXT_PUBLIC_` prefix,
+// Next.js does not inline this for the browser. The value will be `undefined`.
+// This blok is the canonical example of what server-only access *loses* when
+// preview re-renders the tree client-side.
+import type { SbBlokData } from '../_sdk/types';
+import { errorBox, errorTag, serverBox, serverTag } from './styles';
+
+export function ServerOnlySecret(_props: { blok: SbBlokData }) {
+  const secret = process.env.SERVER_ONLY_SECRET;
+  const isServer = typeof window === 'undefined';
+  const ok = Boolean(secret);
+
+  return (
+    <div style={ok ? serverBox : errorBox}>
+      <div style={ok ? serverTag : errorTag}>
+        [server-only-secret] ({isServer ? 'server' : 'client'} render) —{' '}
+        {ok ? 'secret available ✅' : 'secret undefined ❌'}
+      </div>
+      <div style={{ marginTop: 6, color: '#111827', fontFamily: 'monospace', fontSize: 12 }}>
+        process.env.SERVER_ONLY_SECRET = {JSON.stringify(secret ?? null)}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
@@ -1,16 +1,34 @@
 // REAL — server leaf blok. Reached from inside a client parent via the SDK
 // registry (server-in-client scenario, the Dipankar way: client parent renders
 // <StoryblokBlocks> which recursively resolves nested bloks).
+//
+// This blok is async and reads from a simulated server-only DB. In this SDK
+// preview re-renders on the client, so this is the same hazard as
+// `server-only-secret`: the client bundle cannot import `_stub/server-db`
+// (its module-level guard throws). The renderer goes through the `use()` +
+// Suspense path; on preview the fetch still has to happen somewhere with
+// server access — exposing whether the SDK can keep the call server-side.
 import type { SbBlokData } from '../_sdk/types';
-import { serverBox, serverTag } from './styles';
+import { getAuthorById } from '../_stub/server-db';
+import { errorBox, errorTag, serverBox, serverTag } from './styles';
 
-export function ServerQuote({ blok }: { blok: SbBlokData }) {
+export async function ServerQuote({ blok }: { blok: SbBlokData }) {
+  const authorId = String(blok.authorId ?? 'author-1');
+  const author = await getAuthorById(authorId);
+  const isServer = typeof window === 'undefined';
+  const ok = Boolean(author);
+
   return (
-    <div style={serverBox}>
-      <div style={serverTag}>[server-quote] (server)</div>
+    <div style={ok ? serverBox : errorBox}>
+      <div style={ok ? serverTag : errorTag}>
+        [server-quote] ({isServer ? 'server' : 'client'} render) — author={authorId}
+      </div>
       <blockquote style={{ margin: '6px 0 0', color: '#111827', fontStyle: 'italic' }}>
         &ldquo;{String(blok.quote ?? '')}&rdquo;
       </blockquote>
+      <div style={{ marginTop: 6, color: '#374151', fontSize: 12 }}>
+        — {author ? `${author.name} <${author.email}>` : 'unknown'}
+      </div>
     </div>
   );
 }

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
@@ -1,0 +1,16 @@
+// REAL — server leaf blok. Reached from inside a client parent via the SDK
+// registry (server-in-client scenario, the Dipankar way: client parent renders
+// <StoryblokBlocks> which recursively resolves nested bloks).
+import type { SbBlokData } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+
+export function ServerQuote({ blok }: { blok: SbBlokData }) {
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[server-quote] (server)</div>
+      <blockquote style={{ margin: '6px 0 0', color: '#111827', fontStyle: 'italic' }}>
+        &ldquo;{String(blok.quote ?? '')}&rdquo;
+      </blockquote>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-section.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-section.tsx
@@ -1,0 +1,16 @@
+// REAL — server blok used in the deep-alternation and context chains.
+import type { SbBlokData } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+import { storyblok } from './registry';
+
+export function ServerSection({ blok }: { blok: SbBlokData }) {
+  const body = Array.isArray(blok.body) ? (blok.body as SbBlokData[]) : [];
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[server-section] (server) — {String(blok.heading ?? '')}</div>
+      <div style={{ marginTop: 8 }}>
+        <storyblok.StoryblokBlocks blocks={body} />
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/storyblok-preview.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/storyblok-preview.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+// REAL — app-level live-preview wrapper. Mirrors Dipankar's pattern:
+// https://github.com/dipankarmaikap/storyblok-react-sdk/blob/main/playground/nextjs-app-router/app/lib/StoryblokPreview.tsx
+//
+// Must be defined in the app (not the SDK) because it imports the app's
+// registry. Functions can't cross the server→client boundary as props, so
+// the client side imports `storyblok` directly from the registry module.
+import type { Story } from '../_sdk/types';
+import { useStoryblokPreview } from '../_sdk/use-storyblok-preview';
+import { storyblok } from './registry';
+
+export function StoryblokPreview({ story }: { story: Story | null }) {
+  const liveStory = useStoryblokPreview(story);
+  if (!liveStory) return null;
+  return <storyblok.StoryblokComponent blok={liveStory.content} />;
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/styles.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/styles.ts
@@ -1,0 +1,31 @@
+// REAL — shared presentational styles.
+// Legend: blue = server, orange = client, purple = client context,
+// green = async server, red dashed = error/unknown.
+import type { CSSProperties } from 'react';
+
+export const serverBox: CSSProperties = {
+  padding: 12, margin: '8px 0', border: '1px solid #2563eb',
+  borderRadius: 6, background: '#eef4ff',
+};
+export const clientBox: CSSProperties = {
+  padding: 12, margin: '8px 0', border: '1px solid #d97706',
+  borderRadius: 6, background: '#fff7ed',
+};
+export const contextBox: CSSProperties = {
+  padding: 12, margin: '8px 0', border: '1px solid #7c3aed',
+  borderRadius: 6, background: '#f5f3ff',
+};
+export const asyncBox: CSSProperties = {
+  padding: 12, margin: '8px 0', border: '1px solid #059669',
+  borderRadius: 6, background: '#ecfdf5',
+};
+export const errorBox: CSSProperties = {
+  padding: 12, margin: '8px 0', border: '1px dashed #b91c1c',
+  borderRadius: 6, background: '#fef2f2', color: '#7f1d1d',
+};
+
+export const serverTag: CSSProperties = { fontFamily: 'monospace', fontSize: 12, color: '#1e3a8a' };
+export const clientTag: CSSProperties = { fontFamily: 'monospace', fontSize: 12, color: '#92400e' };
+export const contextTag: CSSProperties = { fontFamily: 'monospace', fontSize: 12, color: '#5b21b6' };
+export const asyncTag: CSSProperties = { fontFamily: 'monospace', fontSize: 12, color: '#065f46' };
+export const errorTag: CSSProperties = { fontFamily: 'monospace', fontSize: 12, color: '#7f1d1d' };

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/suspense-fallback.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/suspense-fallback.tsx
@@ -1,0 +1,10 @@
+// REAL — default Suspense fallback registered on the resolver. Shows briefly
+// while async-server-fetch resolves (especially noticeable on the client
+// preview path).
+export function SuspenseFallback() {
+  return (
+    <div style={{ padding: 8, color: '#6b7280', fontStyle: 'italic' }}>
+      Loading async blok…
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/teaser.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/teaser.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+// REAL — client leaf blok (client-in-server scenario). Local state proves
+// the counter survives across edits when only the server tree above changes.
+import { useState } from 'react';
+import type { SbBlokData } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+
+export function Teaser({ blok }: { blok: SbBlokData }) {
+  const [count, setCount] = useState(0);
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[teaser] (client)</div>
+      <strong style={{ color: '#111827' }}>{String(blok.headline ?? '')}</strong>
+      <div style={{ marginTop: 6 }}>
+        <button
+          onClick={() => setCount((c) => c + 1)}
+          style={{ padding: '4px 10px', cursor: 'pointer' }}
+          data-testid="teaser-counter"
+        >
+          Counter {count}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-consumer.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-consumer.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+// REAL — client leaf reading the theme context through an intervening server
+// blok. Tests context propagation across the server boundary.
+import { useContext } from 'react';
+import { ThemeContext } from './theme-context';
+import { contextBox, contextTag } from './styles';
+
+export function ThemeConsumer() {
+  const theme = useContext(ThemeContext);
+  return (
+    <div style={contextBox}>
+      <div style={contextTag}>[theme-consumer] (client, reads context)</div>
+      <div style={{ marginTop: 6, color: '#111827' }} data-testid="theme-value">
+        theme from context: <strong>{theme ?? '(no context)'}</strong>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-context.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-context.ts
@@ -1,0 +1,6 @@
+'use client';
+
+// REAL — shared React context for theme-provider / theme-consumer.
+import { createContext } from 'react';
+
+export const ThemeContext = createContext<string | null>(null);

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-provider.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-provider.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+// REAL — client blok that provides a context value, then recurses into a
+// server subtree via StoryblokBlocks. A client descendant (theme-consumer)
+// nested beneath the server blok should read the value.
+import type { SbBlokData } from '../_sdk/types';
+import { ThemeContext } from './theme-context';
+import { contextBox, contextTag } from './styles';
+import { storyblok } from './registry';
+
+export function ThemeProvider({ blok }: { blok: SbBlokData }) {
+  const theme = String(blok.theme ?? '');
+  const body = Array.isArray(blok.body) ? (blok.body as SbBlokData[]) : [];
+  return (
+    <ThemeContext.Provider value={theme}>
+      <div style={contextBox}>
+        <div style={contextTag}>[theme-provider] (client) — provides theme &ldquo;{theme}&rdquo;</div>
+        <div style={{ marginTop: 8 }}>
+          <storyblok.StoryblokBlocks blocks={body} />
+        </div>
+      </div>
+    </ThemeContext.Provider>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/create-resolver.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/create-resolver.ts
@@ -1,0 +1,36 @@
+// REAL — Dipankar's SDK resolver, inlined verbatim.
+// Source: https://github.com/dipankarmaikap/storyblok-react-sdk/blob/main/packages/react/src/create-resolver.ts
+import type { ElementType, ReactNode } from 'react';
+import type { SbBlokData } from './types';
+
+export type ComponentMap = Record<string, ElementType>;
+
+export type ResolverConfig = {
+  fallback?: ElementType;
+  suspenseFallback?: ElementType | ReactNode;
+  suspenseFallbacks?: Record<string, ElementType | ReactNode>;
+  cacheKeys?: Record<string, (blok: SbBlokData) => unknown>;
+  warnMissingComponents?: boolean;
+};
+
+export type StoryblokResolver = (blockName: string) => ElementType | null;
+
+export function createResolver(
+  components: ComponentMap,
+  config?: ResolverConfig,
+): StoryblokResolver {
+  return function resolve(blockName: string): ElementType | null {
+    const Component = components[blockName];
+    if (Component) {
+      return Component;
+    }
+    if (config?.fallback) {
+      return config.fallback;
+    }
+    if (config?.warnMissingComponents !== false) {
+      // eslint-disable-next-line no-console
+      console.warn(`[Storyblok SDK] Component "${blockName}" is not registered.`);
+    }
+    return null;
+  };
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/create-storyblok-renderer.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/create-storyblok-renderer.tsx
@@ -1,0 +1,115 @@
+// REAL — Dipankar's renderer factory, inlined verbatim.
+// Source: https://github.com/dipankarmaikap/storyblok-react-sdk/blob/main/packages/react/src/create-storyblok-renderer.tsx
+//
+// Returns { StoryblokComponent, StoryblokBlocks }. On the server it renders
+// via JSX (RSC handles async natively). On the client it detects whether a
+// plain function component returned a Promise and wraps it with Suspense +
+// React 19's `use()` via a promise cache.
+import { Suspense, cloneElement, isValidElement, use } from 'react';
+import type { ElementType, ReactElement, ReactNode } from 'react';
+import type { ComponentMap, ResolverConfig } from './create-resolver';
+import { createResolver } from './create-resolver';
+import type { SbBlokData } from './types';
+import { createPromiseCache } from './promise-cache';
+
+const hasUse = typeof use === 'function';
+const isServer = typeof window === 'undefined';
+
+function withSuppressHydrationWarning(element: unknown): ReactNode {
+  if (isValidElement(element)) {
+    return cloneElement(element as ReactElement<{ suppressHydrationWarning?: boolean }>, {
+      suppressHydrationWarning: true,
+    });
+  }
+  return element as ReactNode;
+}
+
+function getSuspenseFallback(config: ResolverConfig | undefined, componentName: string) {
+  const fallback = config?.suspenseFallbacks?.[componentName] ?? config?.suspenseFallback;
+  if (fallback == null) return <div className="storyblok-blok-loading" />;
+  if (typeof fallback === 'function') {
+    const Comp = fallback as ElementType;
+    return <Comp />;
+  }
+  return fallback as ReactNode;
+}
+
+function getCacheKey(config: ResolverConfig | undefined, componentName: string, blok: SbBlokData) {
+  const fn = config?.cacheKeys?.[componentName] ?? ((b: SbBlokData) => b._uid ?? b);
+  return fn(blok);
+}
+
+export function createStoryblokRenderer(components: ComponentMap, config?: ResolverConfig) {
+  const resolver = createResolver(components, config);
+  const cache = createPromiseCache();
+
+  function AsyncBlok({
+    promise,
+    cacheKey,
+    componentName,
+  }: {
+    promise: Promise<unknown>;
+    cacheKey: unknown;
+    componentName: string;
+  }) {
+    return withSuppressHydrationWarning(
+      use(cache.getOrSet(promise, cacheKey, componentName)) as ReactNode,
+    );
+  }
+
+  function StoryblokComponent({ blok }: { blok: SbBlokData }) {
+    const Component = resolver(blok.component || '');
+    if (!Component) return null;
+
+    const componentName = blok.component!;
+    const fallback = getSuspenseFallback(config, componentName);
+    const cacheKey = getCacheKey(config, componentName, blok);
+
+    if (isServer) {
+      return (
+        <Suspense fallback={fallback}>
+          {withSuppressHydrationWarning(<Component blok={blok} />)}
+        </Suspense>
+      );
+    }
+
+    const isPlainFunction =
+      typeof Component === 'function' &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      !(Component.prototype as any)?.isReactComponent;
+
+    if (isPlainFunction) {
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      const result = (Component as Function)({ blok });
+
+      if (result instanceof Promise) {
+        if (!hasUse) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[Storyblok SDK] Component "${componentName}" is async and requires React 19+.`,
+          );
+          return <Suspense fallback={fallback}>{fallback}</Suspense>;
+        }
+        return (
+          <Suspense fallback={fallback}>
+            <AsyncBlok promise={result} cacheKey={cacheKey} componentName={componentName} />
+          </Suspense>
+        );
+      }
+
+      return <Suspense fallback={fallback}>{withSuppressHydrationWarning(result)}</Suspense>;
+    }
+
+    return (
+      <Suspense fallback={fallback}>
+        {withSuppressHydrationWarning(<Component blok={blok} />)}
+      </Suspense>
+    );
+  }
+
+  function StoryblokBlocks({ blocks }: { blocks: SbBlokData[] }) {
+    return blocks.map((blok) => <StoryblokComponent key={blok._uid} blok={blok} />);
+  }
+
+  return { StoryblokComponent, StoryblokBlocks };
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/promise-cache.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/promise-cache.ts
@@ -1,0 +1,28 @@
+// REAL — Dipankar's promise cache, inlined verbatim.
+// Source: https://github.com/dipankarmaikap/storyblok-react-sdk/blob/main/packages/react/src/promise-cache.ts
+export function createPromiseCache(maxSize = 1000) {
+  const cache = new Map<string, Map<unknown, Promise<unknown>>>();
+
+  function getOrSet(promise: Promise<unknown>, key: unknown, namespace: string) {
+    let ns = cache.get(namespace);
+    if (!ns) {
+      ns = new Map();
+      cache.set(namespace, ns);
+    }
+    let cached = ns.get(key);
+    if (!cached) {
+      if (ns.size >= maxSize) {
+        const first = ns.keys().next().value;
+        if (first !== undefined) ns.delete(first);
+      }
+      cached = promise.catch((err: unknown) => {
+        ns!.delete(key);
+        throw err;
+      });
+      ns.set(key, cached);
+    }
+    return cached;
+  }
+
+  return { getOrSet };
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/types.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/types.ts
@@ -1,0 +1,23 @@
+// REAL — Dipankar's SDK types, inlined verbatim.
+// Source: https://github.com/dipankarmaikap/storyblok-react-sdk/blob/main/packages/react/src/types.ts
+
+interface ISbComponentType<T extends string> {
+  _uid?: string;
+  component?: T;
+  _editable?: string;
+}
+
+type SbBlokKeyDataTypes = string | number | object | boolean | undefined;
+
+export interface SbBlokData extends ISbComponentType<string> {
+  [index: string]: SbBlokKeyDataTypes;
+}
+
+// Local shape for the stub bridge / client response. The real client returns
+// a CAPI `Story` from `@storyblok/api-client`; this is the subset the
+// playground actually uses.
+export type Story = {
+  id?: string | number;
+  name: string;
+  content: SbBlokData;
+};

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/use-storyblok-preview.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/use-storyblok-preview.ts
@@ -1,0 +1,25 @@
+'use client';
+
+// REAL — Dipankar's live-preview hook, adapted to subscribe to the stub bridge
+// instead of @storyblok/live-preview. The contract is identical:
+//   (story) => void  callback, returns a () => void cleanup.
+// Drop-in swap: change the import below to:
+//   import { onStoryblokEditorEvent } from '@storyblok/live-preview';
+// Source: https://github.com/dipankarmaikap/storyblok-react-sdk/blob/main/packages/react/src/use-storyblok-preview.ts
+import { useEffect, useState } from 'react';
+import type { Story } from './types';
+import { subscribeToLivePreview } from '../_stub/bridge';
+
+export function useStoryblokPreview(story: Story | null): Story | null {
+  const [bridgeStory, setBridgeStory] = useState<Story | null>(story);
+  const storyId = story?.id ?? null;
+
+  useEffect(() => {
+    const unsubscribe = subscribeToLivePreview((updated) => {
+      setBridgeStory(updated);
+    });
+    return unsubscribe;
+  }, [storyId]);
+
+  return bridgeStory?.id === storyId ? bridgeStory : story;
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/bridge-controls.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/bridge-controls.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+// STUB — JSON editor that fakes a bridge `input` event when Submit is pressed.
+import { useState } from 'react';
+import { emitStoryUpdate } from './bridge';
+import type { Story } from '../_sdk/types';
+
+const panel: React.CSSProperties = {
+  margin: '16px 0', padding: 16, border: '2px dashed #6b7280',
+  borderRadius: 8, background: '#f9fafb',
+};
+const textarea: React.CSSProperties = {
+  width: '100%', minHeight: 220, fontFamily: 'ui-monospace, monospace', fontSize: 12,
+  color: '#111827', background: '#ffffff', border: '1px solid #9ca3af',
+  borderRadius: 6, padding: 10, boxSizing: 'border-box', resize: 'vertical',
+};
+const button: React.CSSProperties = {
+  marginTop: 10, padding: '10px 18px', background: '#2563eb', color: '#ffffff',
+  border: 'none', borderRadius: 8, fontSize: 14, fontWeight: 600, cursor: 'pointer',
+};
+
+export function BridgeControls({ initialStory }: { initialStory: Story }) {
+  const [json, setJson] = useState(() => JSON.stringify(initialStory, null, 2));
+  const [error, setError] = useState<string | null>(null);
+
+  function submit() {
+    try {
+      const story = JSON.parse(json) as Story;
+      setError(null);
+      emitStoryUpdate(story);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }
+
+  return (
+    <div style={panel}>
+      <div style={{ fontFamily: 'monospace', fontSize: 12, color: '#374151', marginBottom: 8 }}>
+        [BridgeControls] (stub) — edit the story JSON and Submit to fake a live-preview bridge update
+      </div>
+      <textarea
+        style={textarea}
+        value={json}
+        onChange={(e) => setJson(e.target.value)}
+        spellCheck={false}
+        data-testid="story-json"
+      />
+      <div>
+        <button style={button} onClick={submit} data-testid="submit-story">Submit</button>
+      </div>
+      {error && (
+        <div style={{ marginTop: 8, color: '#b91c1c', fontFamily: 'monospace', fontSize: 12 }}>
+          Invalid JSON: {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/bridge.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/bridge.ts
@@ -1,0 +1,21 @@
+// STUB #1 (of 2) — the live-preview bridge.
+//
+// Mimics `@storyblok/live-preview`'s `onStoryblokEditorEvent(cb): () => cleanup`
+// contract with a plain in-page event emitter. In production this file is
+// deleted and the hook imports `onStoryblokEditorEvent` instead.
+import type { Story } from '../_sdk/types';
+
+type Listener = (story: Story) => void;
+
+const listeners = new Set<Listener>();
+
+export function subscribeToLivePreview(callback: Listener): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+export function emitStoryUpdate(story: Story): void {
+  listeners.forEach((listener) => listener(story));
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
@@ -1,0 +1,88 @@
+// STUB #2 (of 2) — the client response.
+//
+// Hardcoded nested story whose `body` exercises every nesting case the spike
+// validates, plus Dipankar-specific cases:
+//
+//   page (server)
+//    └ grid (server) ├ teaser (client)  └ feature (server)              client-in-server
+//    ├ client-card (client) └ server-quote (server)                     server-in-client via StoryblokBlocks
+//    ├ server-section > client-panel > server-section > client-leaf     deep alternation
+//    ├ theme-provider (client) └ server-section > theme-consumer        context through a server subtree
+//    ├ async-server-fetch (async, jsonplaceholder)                      use() + Suspense + cache
+//    ├ server-only-secret                                               process.env access
+//    └ unregistered-blok                                                fallback path
+import type { Story } from '../_sdk/types';
+
+export const initialStory: Story = {
+  id: 'home',
+  name: 'home',
+  content: {
+    _uid: 'root',
+    component: 'page',
+    title: 'Storyblok live preview — RSC nesting probe (Dipankar approach)',
+    body: [
+      {
+        _uid: 'grid-1',
+        component: 'grid',
+        heading: 'Grid (server) hosting mixed children',
+        body: [
+          { _uid: 'teaser-1', component: 'teaser', headline: 'Teaser headline (client in server)' },
+          {
+            _uid: 'feature-1',
+            component: 'feature',
+            name: 'Feature (server leaf)',
+            text: 'Rendered entirely on the server.',
+          },
+        ],
+      },
+      {
+        _uid: 'card-1',
+        component: 'client-card',
+        title: 'Client card wrapping a server blok via StoryblokBlocks',
+        body: [
+          {
+            _uid: 'quote-1',
+            component: 'server-quote',
+            quote: 'A server component rendered from inside a client one via the SDK registry.',
+          },
+        ],
+      },
+      {
+        _uid: 'sec-l1',
+        component: 'server-section',
+        heading: 'L1 server',
+        body: [
+          {
+            _uid: 'panel-l2',
+            component: 'client-panel',
+            label: 'L2 client',
+            body: [
+              {
+                _uid: 'sec-l3',
+                component: 'server-section',
+                heading: 'L3 server',
+                body: [{ _uid: 'leaf-l4', component: 'client-leaf', label: 'L4 client' }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        _uid: 'provider-1',
+        component: 'theme-provider',
+        theme: 'midnight',
+        body: [
+          {
+            _uid: 'sec-ctx',
+            component: 'server-section',
+            heading: 'Server subtree between provider and consumer',
+            body: [{ _uid: 'consumer-1', component: 'theme-consumer' }],
+          },
+        ],
+      },
+      { _uid: 'async-1', component: 'async-server-fetch', postId: 1 },
+      { _uid: 'secret-1', component: 'server-only-secret' },
+      { _uid: 'missing-1', component: 'totally-unregistered-blok-name' },
+    ],
+  },
+};

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
@@ -44,6 +44,7 @@ export const initialStory: Story = {
             _uid: 'quote-1',
             component: 'server-quote',
             quote: 'A server component rendered from inside a client one via the SDK registry.',
+            authorId: 'author-1',
           },
         ],
       },

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/server-db.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/server-db.ts
@@ -1,0 +1,18 @@
+// STUB — simulated server-only DB. Module-level guard throws if this file
+// ever ends up in a client bundle (mimics what `server-only` would enforce
+// at build time). Async + artificial latency to mimic a real query.
+if (typeof window !== 'undefined') {
+  throw new Error('[server-db] imported on the client — server-only module');
+}
+
+type Author = { id: string; name: string; email: string };
+
+const authors: Record<string, Author> = {
+  'author-1': { id: 'author-1', name: 'Ada Lovelace', email: 'ada@example.com' },
+  'author-2': { id: 'author-2', name: 'Alan Turing', email: 'alan@example.com' },
+};
+
+export async function getAuthorById(id: string): Promise<Author | null> {
+  await new Promise((r) => setTimeout(r, 50));
+  return authors[id] ?? null;
+}


### PR DESCRIPTION
## Summary

Spike that inlines Dipankar's [storyblok-react-sdk](https://github.com/dipankarmaikap/storyblok-react-sdk) (`createStoryblokRenderer` + factory resolver + promise cache + `useStoryblokPreview`) into the `next-latest` playground under a dedicated `experiment/` route, paired with a stub bridge and stub CAPI response so the renderer/resolver/cache logic can be exercised without external services.

Goal: side-by-side comparison with the `spike/react` SDK approach to evaluate which direction we want to take for React + RSC live preview.

## What's in `experiment/`

- `_sdk/` — near-verbatim mirror of Dipankar's SDK (`create-resolver`, `create-storyblok-renderer`, `promise-cache`, `use-storyblok-preview`). The only adaptation: the preview hook subscribes to a stub bridge instead of `@storyblok/live-preview`'s `onStoryblokEditorEvent` — same contract, deterministic signal.
- `_bloks/` — server + client bloks covering the cases we want to validate: server/client nesting, deep alternation, context through a server subtree, async server fetch (`async-server-fetch`), and a server-only env var (`server-only-secret`).
- `_stub/` — hardcoded client response + in-process bridge with manual edit controls, so preview behavior can be triggered without the Storyblok app.

## Test plan

- [ ] `pnpm nx dev @storyblok/playground-react-next-latest` and visit `/experiment` — page renders the nested story
- [ ] Trigger the stub bridge controls and confirm previews update (client re-render path through `use()` + Suspense)
- [ ] `server-only-secret` blok: confirm `process.env.SERVER_ONLY_SECRET` is `undefined` during client-side preview re-render (the contrast point with the server-action approach in `spike/react`)
- [ ] `async-server-fetch` blok: confirm async server component unwraps via `use()` cache without re-fetching on unrelated edits
- [ ] Lint clean: `pnpm nx lint @storyblok/playground-react-next-latest`

## Not for merge

Draft / spike — kept on the `spike/` branch namespace. Decision artifact, not a feature.