### PR TITLE
chore(react): RSC live-preview nesting spike playground

### DIFF
--- a/packages/react/playground/next-latest/src/app/experiment/[[...slug]]/page.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/[[...slug]]/page.tsx
@@ -1,0 +1,54 @@
+// REAL — page wiring. The story comes from the client-response stub; the
+// `render` server action resolves it through the registry; `StoryblokView`
+// renders it (and mounts the live-preview island when `?lp=1`). The only
+// stubbed pieces are the imports from `../_stub` (client response + bridge).
+import { StoryblokView } from '../_sdk/storyblok-view';
+import { StoryblokServerComponent } from '../_sdk/storyblok-component';
+import { components } from '../_bloks';
+import { initialStory } from '../_stub/client-response';
+import { BridgeControls } from '../_stub/bridge-controls';
+import type { Story } from '../_sdk/types';
+
+type PageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function Route({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const livePreview = sp.lp === '1';
+
+  const story = initialStory;
+
+  // Single "use server" action that re-renders the whole story through the
+  // registry. The live-preview island re-invokes it for each bridge update.
+  async function render(updated: Story) {
+    'use server';
+    return <StoryblokServerComponent blok={updated.content} components={components} />;
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: '100vh',
+        background: '#ffffff',
+        color: '#111827',
+        colorScheme: 'light',
+      }}
+    >
+      <div style={{ padding: 24, fontFamily: 'system-ui', maxWidth: 880, margin: '0 auto' }}>
+      <h1>Experiment: registry-driven RSC live preview</h1>
+      <p style={{ fontSize: 14, color: '#1f2937', lineHeight: 1.5 }}>
+        livePreview={String(livePreview)} (toggle with <code>?lp=1</code>). Blue =
+        server blok, orange = client blok, purple = client context. Only the{' '}
+        <code>_stub/</code> client response and bridge are faked; the registry,
+        recursive resolver, blok components, <code>StoryblokView</code> and the
+        live-preview island are real-SDK-shaped. In live preview, edit the story
+        JSON below and press Submit to fake a bridge update — the whole nested
+        tree re-renders while client state (card toggle, leaf input) survives.
+      </p>
+      {livePreview && <BridgeControls initialStory={story} />}
+      <StoryblokView story={story} render={render} livePreview={livePreview} />
+      </div>
+    </main>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/async-server-fetch.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/async-server-fetch.tsx
@@ -1,0 +1,27 @@
+// REAL — async server blok, mirrors Dipankar's `PostComponent` (jsonplaceholder).
+//
+// In this SDK rendering happens server-side: the recursive resolver awaits
+// async components naturally during the RSC pass. In preview, the SDK takes
+// a server-action + revalidatePath roundtrip, so this still runs on the
+// server — fetch never leaves the server.
+import type { BlokProps } from '../_sdk/types';
+import { asyncBox, asyncTag } from './styles';
+
+type Post = { userId: number; id: number; title: string; body: string };
+
+export async function AsyncServerFetch({ blok }: BlokProps) {
+  const postId = blok.postId ?? 1;
+  const res = await fetch(`https://jsonplaceholder.typicode.com/posts/${String(postId)}`, {
+    cache: 'no-store',
+  });
+  const post: Post = await res.json();
+  return (
+    <div style={asyncBox}>
+      <div style={asyncTag}>
+        [async-server-fetch] (async) — postId={String(postId)}
+      </div>
+      <h4 style={{ margin: '6px 0 4px', color: '#111827' }}>{post.title}</h4>
+      <p style={{ margin: 0, color: '#374151', fontSize: 14 }}>{post.body}</p>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/client-card.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/client-card.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+// REAL — client blok that hosts a pre-rendered SERVER blok as `children`
+// (server-in-client). The local `open` state proves client state survives the
+// RSC payload swap on each live-preview edit.
+import { useState } from 'react';
+import type { BlokProps } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+
+export function ClientCard({ blok, children }: BlokProps) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[client-card] (client, hosts server children)</div>
+      <strong style={{ color: '#111827' }}>{String(blok.title ?? '')}</strong>
+      <div style={{ marginTop: 6 }}>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          style={{ padding: '4px 10px', cursor: 'pointer' }}
+          data-testid="card-toggle"
+        >
+          {open ? 'Collapse' : 'Expand'}
+        </button>
+      </div>
+      {open && <div style={{ marginTop: 8 }}>{children}</div>}
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/client-leaf.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/client-leaf.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+// REAL — client leaf at the bottom of the deep-alternation chain. The local
+// `note` input proves nested client state survives the RSC payload swap.
+import { useState } from 'react';
+import type { BlokProps } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+
+export function ClientLeaf({ blok }: BlokProps) {
+  const [note, setNote] = useState('');
+
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[client-leaf] (client) — {String(blok.label ?? '')}</div>
+      <input
+        type="text"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        placeholder="local state (should survive edits)"
+        style={{
+          marginTop: 6,
+          width: '100%',
+          boxSizing: 'border-box',
+          padding: '4px 8px',
+          color: '#111827',
+          border: '1px solid #9ca3af',
+          borderRadius: 4,
+        }}
+        data-testid="leaf-note"
+      />
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/client-panel.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/client-panel.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+// REAL — client blok in the deep-alternation chain
+// (server-section > client-panel > server-section > client-leaf). Renders the
+// pre-rendered server children it receives.
+import type { BlokProps } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+
+export function ClientPanel({ blok, children }: BlokProps) {
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[client-panel] (client) — {String(blok.label ?? '')}</div>
+      <div style={{ marginTop: 8 }}>{children}</div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/feature.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/feature.tsx
@@ -1,0 +1,13 @@
+// REAL — server leaf blok.
+import type { BlokProps } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+
+export function Feature({ blok }: BlokProps) {
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[feature] (server)</div>
+      <strong style={{ color: '#111827' }}>{String(blok.name ?? '')}</strong>
+      <p style={{ margin: '4px 0 0', color: '#374151' }}>{String(blok.text ?? '')}</p>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/grid.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/grid.tsx
@@ -1,0 +1,13 @@
+// REAL — server blok. Hosts mixed (server + client) children.
+import type { BlokProps } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+
+export function Grid({ blok, children }: BlokProps) {
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[grid] (server)</div>
+      <h3 style={{ margin: '6px 0', color: '#111827' }}>{String(blok.heading ?? '')}</h3>
+      <div style={{ display: 'grid', gap: 8 }}>{children}</div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/index.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/index.ts
@@ -1,0 +1,32 @@
+// REAL — the registry the app passes to the SDK: component name -> component.
+// Mixes server and client modules freely (client imports resolve to references).
+import type { ComponentsMap } from '../_sdk/types';
+import { Page } from './page';
+import { Grid } from './grid';
+import { Feature } from './feature';
+import { ServerQuote } from './server-quote';
+import { ServerSection } from './server-section';
+import { Teaser } from './teaser';
+import { ClientCard } from './client-card';
+import { ClientPanel } from './client-panel';
+import { ClientLeaf } from './client-leaf';
+import { ThemeProvider } from './theme-provider';
+import { ThemeConsumer } from './theme-consumer';
+import { AsyncServerFetch } from './async-server-fetch';
+import { ServerOnlySecret } from './server-only-secret';
+
+export const components: ComponentsMap = {
+  'page': Page,
+  'grid': Grid,
+  'feature': Feature,
+  'server-quote': ServerQuote,
+  'server-section': ServerSection,
+  'teaser': Teaser,
+  'client-card': ClientCard,
+  'client-panel': ClientPanel,
+  'client-leaf': ClientLeaf,
+  'theme-provider': ThemeProvider,
+  'theme-consumer': ThemeConsumer,
+  'async-server-fetch': AsyncServerFetch,
+  'server-only-secret': ServerOnlySecret,
+};

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/page.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/page.tsx
@@ -1,0 +1,11 @@
+// REAL — server blok. The story root; renders its nested body.
+import type { BlokProps } from '../_sdk/types';
+
+export function Page({ blok, children }: BlokProps) {
+  return (
+    <main>
+      <h2 style={{ fontSize: 18, margin: '0 0 12px' }}>{String(blok.title ?? '')}</h2>
+      {children}
+    </main>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-only-secret.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-only-secret.tsx
@@ -1,0 +1,26 @@
+// REAL — blok that reads a server-only secret (a NON-NEXT_PUBLIC env var).
+//
+// In this SDK preview goes through a server action + revalidatePath, so the
+// blok always renders on the server and the secret is available. Contrast
+// with Dipankar's approach, where preview re-renders on the client and the
+// value becomes `undefined`.
+import type { BlokProps } from '../_sdk/types';
+import { errorBox, errorTag, serverBox, serverTag } from './styles';
+
+export function ServerOnlySecret(_props: BlokProps) {
+  const secret = process.env.SERVER_ONLY_SECRET;
+  const isServer = typeof window === 'undefined';
+  const ok = Boolean(secret);
+
+  return (
+    <div style={ok ? serverBox : errorBox}>
+      <div style={ok ? serverTag : errorTag}>
+        [server-only-secret] ({isServer ? 'server' : 'client'} render) —{' '}
+        {ok ? 'secret available ✅' : 'secret undefined ❌'}
+      </div>
+      <div style={{ marginTop: 6, color: '#111827', fontFamily: 'monospace', fontSize: 12 }}>
+        process.env.SERVER_ONLY_SECRET = {JSON.stringify(secret ?? null)}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
@@ -1,0 +1,15 @@
+// REAL — server leaf blok. Commonly passed as `children` into a client blok
+// (the legal server-in-client direction).
+import type { BlokProps } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+
+export function ServerQuote({ blok }: BlokProps) {
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[server-quote] (server)</div>
+      <blockquote style={{ margin: '6px 0 0', color: '#111827', fontStyle: 'italic' }}>
+        “{String(blok.quote ?? '')}”
+      </blockquote>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-quote.tsx
@@ -1,15 +1,31 @@
 // REAL — server leaf blok. Commonly passed as `children` into a client blok
 // (the legal server-in-client direction).
+//
+// This blok is async and reads from a simulated server-only DB. Because this
+// SDK does preview via a server action + revalidatePath, the blok always
+// renders on the server — even in preview — so the DB call stays server-side
+// and the module's `typeof window` guard is never tripped.
 import type { BlokProps } from '../_sdk/types';
-import { serverBox, serverTag } from './styles';
+import { getAuthorById } from '../_stub/server-db';
+import { errorBox, errorTag, serverBox, serverTag } from './styles';
 
-export function ServerQuote({ blok }: BlokProps) {
+export async function ServerQuote({ blok }: BlokProps) {
+  const authorId = String(blok.authorId ?? 'author-1');
+  const author = await getAuthorById(authorId);
+  const isServer = typeof window === 'undefined';
+  const ok = Boolean(author);
+
   return (
-    <div style={serverBox}>
-      <div style={serverTag}>[server-quote] (server)</div>
+    <div style={ok ? serverBox : errorBox}>
+      <div style={ok ? serverTag : errorTag}>
+        [server-quote] ({isServer ? 'server' : 'client'} render) — author={authorId}
+      </div>
       <blockquote style={{ margin: '6px 0 0', color: '#111827', fontStyle: 'italic' }}>
         “{String(blok.quote ?? '')}”
       </blockquote>
+      <div style={{ marginTop: 6, color: '#374151', fontSize: 12 }}>
+        — {author ? `${author.name} <${author.email}>` : 'unknown'}
+      </div>
     </div>
   );
 }

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/server-section.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/server-section.tsx
@@ -1,0 +1,13 @@
+// REAL — server blok. A labelled container used in the deep-alternation and
+// context chains; renders its nested body.
+import type { BlokProps } from '../_sdk/types';
+import { serverBox, serverTag } from './styles';
+
+export function ServerSection({ blok, children }: BlokProps) {
+  return (
+    <div style={serverBox}>
+      <div style={serverTag}>[server-section] (server) — {String(blok.heading ?? '')}</div>
+      <div style={{ marginTop: 8 }}>{children}</div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/styles.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/styles.ts
@@ -1,0 +1,74 @@
+// REAL — shared presentational styles for the demo bloks.
+// Legend: blue = server, orange = client, purple = client context,
+// green = async, red dashed = error / server-only loss.
+import type { CSSProperties } from 'react';
+
+export const serverBox: CSSProperties = {
+  padding: 12,
+  margin: '8px 0',
+  border: '1px solid #2563eb',
+  borderRadius: 6,
+  background: '#eef4ff',
+};
+
+export const clientBox: CSSProperties = {
+  padding: 12,
+  margin: '8px 0',
+  border: '1px solid #d97706',
+  borderRadius: 6,
+  background: '#fff7ed',
+};
+
+export const contextBox: CSSProperties = {
+  padding: 12,
+  margin: '8px 0',
+  border: '1px solid #7c3aed',
+  borderRadius: 6,
+  background: '#f5f3ff',
+};
+
+export const serverTag: CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 12,
+  color: '#1e3a8a',
+};
+
+export const clientTag: CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 12,
+  color: '#92400e',
+};
+
+export const contextTag: CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 12,
+  color: '#5b21b6',
+};
+
+export const asyncBox: CSSProperties = {
+  padding: 12,
+  margin: '8px 0',
+  border: '1px solid #16a34a',
+  borderRadius: 6,
+  background: '#ecfdf5',
+};
+
+export const asyncTag: CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 12,
+  color: '#14532d',
+};
+
+export const errorBox: CSSProperties = {
+  padding: 12,
+  margin: '8px 0',
+  border: '1px dashed #b91c1c',
+  borderRadius: 6,
+  background: '#fef2f2',
+};
+
+export const errorTag: CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 12,
+  color: '#7f1d1d',
+};

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/teaser.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/teaser.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+// REAL — client leaf blok rendered inside a server parent (client-in-server).
+import type { BlokProps } from '../_sdk/types';
+import { clientBox, clientTag } from './styles';
+
+export function Teaser({ blok }: BlokProps) {
+  return (
+    <div style={clientBox}>
+      <div style={clientTag}>[teaser] (client)</div>
+      <strong style={{ color: '#111827' }}>{String(blok.headline ?? '')}</strong>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-consumer.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-consumer.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+// REAL — client leaf that reads the theme context provided higher up, across an
+// intervening server blok.
+import { useContext } from 'react';
+import type { BlokProps } from '../_sdk/types';
+import { ThemeContext } from './theme-context';
+import { contextBox, contextTag } from './styles';
+
+export function ThemeConsumer(_props: BlokProps) {
+  const theme = useContext(ThemeContext);
+
+  return (
+    <div style={contextBox}>
+      <div style={contextTag}>[theme-consumer] (client, reads context)</div>
+      <div style={{ marginTop: 6, color: '#111827' }} data-testid="theme-value">
+        theme from context: <strong>{theme ?? '(no context)'}</strong>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-context.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-context.ts
@@ -1,0 +1,7 @@
+'use client';
+
+// REAL — the React context shared by theme-provider and theme-consumer.
+// Kept in its own module so both client bloks import the same context object.
+import { createContext } from 'react';
+
+export const ThemeContext = createContext<string | null>(null);

--- a/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-provider.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_bloks/theme-provider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+// REAL — client blok that provides a context value derived from its blok, then
+// renders a server subtree as children. A client descendant (theme-consumer)
+// nested beneath the intervening server blok reads the value, proving client
+// context propagates through server components and updates on each edit.
+import type { BlokProps } from '../_sdk/types';
+import { ThemeContext } from './theme-context';
+import { contextBox, contextTag } from './styles';
+
+export function ThemeProvider({ blok, children }: BlokProps) {
+  const theme = String(blok.theme ?? '');
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      <div style={contextBox}>
+        <div style={contextTag}>[theme-provider] (client) — provides theme &quot;{theme}&quot;</div>
+        <div style={{ marginTop: 8 }}>{children}</div>
+      </div>
+    </ThemeContext.Provider>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/live-preview-island.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/live-preview-island.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+// REAL — the client island. Subscribes to live-preview updates and re-invokes
+// the `render` server action for each new story, swapping the returned RSC
+// payload into a stable state slot. Client islands inside the payload keep
+// their position and type across swaps, so React reconciles them in place and
+// their local state survives.
+//
+// The ONLY stubbed seam here is the import of `subscribeToLivePreview`. In
+// production it is `onStoryblokEditorEvent` from `@storyblok/live-preview`,
+// which has the same `(story) => void` callback / cleanup contract.
+import { useEffect, useState, type ReactNode } from 'react';
+import { subscribeToLivePreview } from '../_stub/bridge';
+import type { Story } from './types';
+
+type Props = {
+  initial: ReactNode;
+  render: (story: Story) => Promise<ReactNode>;
+};
+
+export function LivePreviewIsland({ initial, render }: Props) {
+  const [payload, setPayload] = useState<ReactNode>(initial);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToLivePreview(async (story) => {
+      setPayload(await render(story));
+    });
+    return unsubscribe;
+  }, [render]);
+
+  return <div data-testid="payload-slot">{payload}</div>;
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/storyblok-component.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/storyblok-component.tsx
@@ -1,0 +1,47 @@
+// REAL — the recursive resolver. Walks a nested story top-down in a single
+// server render pass: looks up `blok.component` in the registry and renders
+// `<Component blok={blok}>{children}</Component>`, where `children` is the
+// pre-rendered nested `body`.
+//
+// Pre-rendering `body` on the server and handing it down as `children` is what
+// lets server and client bloks nest arbitrarily: a client blok always receives
+// already-rendered server children (the only legal server-in-client direction),
+// composing to any depth. The `components` map is threaded explicitly — no
+// module globals (React context is not readable from server components anyway).
+import type { ComponentsMap, SbBlok } from './types';
+
+const unknownBox: React.CSSProperties = {
+  padding: 12,
+  border: '1px dashed #b91c1c',
+  borderRadius: 6,
+  color: '#7f1d1d',
+  fontFamily: 'monospace',
+  fontSize: 12,
+};
+
+export function StoryblokServerComponent({
+  blok,
+  components,
+}: {
+  blok: SbBlok;
+  components: ComponentsMap;
+}) {
+  const Component = components[blok.component];
+
+  if (!Component) {
+    return <div style={unknownBox}>[unknown blok: {blok.component}]</div>;
+  }
+
+  const body = Array.isArray(blok.body) ? (blok.body as SbBlok[]) : [];
+  const children = body.length
+    ? body.map((child) => (
+        <StoryblokServerComponent
+          key={child._uid}
+          blok={child}
+          components={components}
+        />
+      ))
+    : undefined;
+
+  return <Component blok={blok}>{children}</Component>;
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/storyblok-view.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/storyblok-view.tsx
@@ -1,0 +1,21 @@
+// REAL — the RSC entry point. Renders the story once on the server; in live
+// preview it mounts the client island that re-renders on each bridge event.
+import type { ReactNode } from 'react';
+import { LivePreviewIsland } from './live-preview-island';
+import type { Story } from './types';
+
+type Props = {
+  story: Story;
+  render: (story: Story) => Promise<ReactNode>;
+  livePreview: boolean;
+};
+
+export async function StoryblokView({ story, render, livePreview }: Props) {
+  const initial = await render(story);
+
+  if (!livePreview) {
+    return <>{initial}</>;
+  }
+
+  return <LivePreviewIsland initial={initial} render={render} />;
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_sdk/types.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_sdk/types.ts
@@ -1,0 +1,27 @@
+// REAL — mirrors the planned @storyblok/react v2 public types.
+// Shapes match the canonical Storyblok story/blok JSON (capi-client
+// generated `BlokContent`: `_uid`, `component`, plus arbitrary fields).
+import type { ComponentType, ReactNode } from 'react';
+
+// A single content block. Nested blocks live in array fields (here: `body`).
+export type SbBlok = {
+  _uid: string;
+  component: string;
+  [field: string]: unknown;
+};
+
+// A story as delivered by the client. `content` is the root blok.
+export type Story = {
+  name: string;
+  content: SbBlok;
+};
+
+// Every registered blok component receives its blok and any pre-rendered
+// nested bloks as `children`.
+export type BlokProps = {
+  blok: SbBlok;
+  children?: ReactNode;
+};
+
+// The registry: component name -> React component (server or client).
+export type ComponentsMap = Record<string, ComponentType<BlokProps>>;

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/bridge-controls.tsx
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/bridge-controls.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+// STUB — the edit control for the faked bridge. Stands in for the Storyblok
+// visual editor: edit the story JSON, press Submit, and it emits a bridge
+// `input` event with the new story through the same path the real editor uses.
+// Not part of the real SDK; deleted together with `bridge.ts` in production.
+import { useState } from 'react';
+import { emitStoryUpdate } from './bridge';
+import type { Story } from '../_sdk/types';
+
+const panel: React.CSSProperties = {
+  margin: '16px 0',
+  padding: 16,
+  border: '2px dashed #6b7280',
+  borderRadius: 8,
+  background: '#f9fafb',
+};
+
+const textarea: React.CSSProperties = {
+  width: '100%',
+  minHeight: 220,
+  fontFamily: 'ui-monospace, monospace',
+  fontSize: 12,
+  color: '#111827',
+  background: '#ffffff',
+  border: '1px solid #9ca3af',
+  borderRadius: 6,
+  padding: 10,
+  boxSizing: 'border-box',
+  resize: 'vertical',
+};
+
+const button: React.CSSProperties = {
+  marginTop: 10,
+  padding: '10px 18px',
+  background: '#2563eb',
+  color: '#ffffff',
+  border: 'none',
+  borderRadius: 8,
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+export function BridgeControls({ initialStory }: { initialStory: Story }) {
+  const [json, setJson] = useState(() => JSON.stringify(initialStory, null, 2));
+  const [error, setError] = useState<string | null>(null);
+
+  function submit() {
+    try {
+      const story = JSON.parse(json) as Story;
+      setError(null);
+      emitStoryUpdate(story);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }
+
+  return (
+    <div style={panel}>
+      <div style={{ fontFamily: 'monospace', fontSize: 12, color: '#374151', marginBottom: 8 }}>
+        [BridgeControls] (stub) — edit the story JSON and Submit to fake a
+        live-preview bridge update
+      </div>
+      <textarea
+        style={textarea}
+        value={json}
+        onChange={(e) => setJson(e.target.value)}
+        spellCheck={false}
+        data-testid="story-json"
+      />
+      <div>
+        <button style={button} onClick={submit} data-testid="submit-story">
+          Submit
+        </button>
+      </div>
+      {error && (
+        <div style={{ marginTop: 8, color: '#b91c1c', fontFamily: 'monospace', fontSize: 12 }}>
+          Invalid JSON: {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/bridge.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/bridge.ts
@@ -1,0 +1,25 @@
+// STUB #1 (of 2) — the live-preview bridge.
+//
+// Mimics `@storyblok/live-preview`'s `onStoryblokEditorEvent(cb): () => cleanup`
+// contract with a plain in-page event emitter. In production this file is
+// deleted and the island imports `onStoryblokEditorEvent` instead; the editor
+// iframe delivers `input` events with the updated story.
+import type { Story } from '../_sdk/types';
+
+type Listener = (story: Story) => void;
+
+const listeners = new Set<Listener>();
+
+// Real shape: subscribe a callback, get an unsubscribe function back.
+export function subscribeToLivePreview(callback: Listener): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+// Stub-only: the bridge controls call this to fake an editor `input` event.
+// The real bridge has no client-side emitter — the editor pushes the event.
+export function emitStoryUpdate(story: Story): void {
+  listeners.forEach((listener) => listener(story));
+}

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
@@ -48,6 +48,7 @@ export const initialStory: Story = {
             _uid: 'quote-1',
             component: 'server-quote',
             quote: 'A server component passed as children into a client one.',
+            authorId: 'author-1',
           },
         ],
       },

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/client-response.ts
@@ -1,0 +1,102 @@
+// STUB #2 (of 2) — the client response.
+//
+// The initial story the Storyblok client would return. In production this is
+// `await createStoryblokClient().getStory(slug)` (an HTTP call to the CAPI).
+// Here it is a hardcoded nested story whose `body` exercises every nesting
+// case the spike validates:
+//
+//   page (server)
+//    └ grid (server) ├ teaser (client)  └ feature (server)          client-in-server
+//    ├ client-card (client) └ server-quote (server)                 server-in-client (children)
+//    ├ server-section > client-panel > server-section > client-leaf deep alternation
+//    ├ theme-provider (client) └ server-section > theme-consumer     context through a server subtree
+//    ├ async-server-fetch (async, jsonplaceholder)                   async server component
+//    └ server-only-secret                                            process.env access
+import type { Story } from '../_sdk/types';
+
+export const initialStory: Story = {
+  name: 'home',
+  content: {
+    _uid: 'root',
+    component: 'page',
+    title: 'Storyblok live preview — RSC nesting probe',
+    body: [
+      {
+        _uid: 'grid-1',
+        component: 'grid',
+        heading: 'Grid (server) hosting mixed children',
+        body: [
+          {
+            _uid: 'teaser-1',
+            component: 'teaser',
+            headline: 'Teaser headline (client in server)',
+          },
+          {
+            _uid: 'feature-1',
+            component: 'feature',
+            name: 'Feature (server leaf)',
+            text: 'Rendered entirely on the server.',
+          },
+        ],
+      },
+      {
+        _uid: 'card-1',
+        component: 'client-card',
+        title: 'Client card wrapping a server blok',
+        body: [
+          {
+            _uid: 'quote-1',
+            component: 'server-quote',
+            quote: 'A server component passed as children into a client one.',
+          },
+        ],
+      },
+      {
+        _uid: 'sec-l1',
+        component: 'server-section',
+        heading: 'L1 server',
+        body: [
+          {
+            _uid: 'panel-l2',
+            component: 'client-panel',
+            label: 'L2 client',
+            body: [
+              {
+                _uid: 'sec-l3',
+                component: 'server-section',
+                heading: 'L3 server',
+                body: [
+                  {
+                    _uid: 'leaf-l4',
+                    component: 'client-leaf',
+                    label: 'L4 client',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        _uid: 'provider-1',
+        component: 'theme-provider',
+        theme: 'midnight',
+        body: [
+          {
+            _uid: 'sec-ctx',
+            component: 'server-section',
+            heading: 'Server subtree between provider and consumer',
+            body: [
+              {
+                _uid: 'consumer-1',
+                component: 'theme-consumer',
+              },
+            ],
+          },
+        ],
+      },
+      { _uid: 'async-1', component: 'async-server-fetch', postId: 1 },
+      { _uid: 'secret-1', component: 'server-only-secret' },
+    ],
+  },
+};

--- a/packages/react/playground/next-latest/src/app/experiment/_stub/server-db.ts
+++ b/packages/react/playground/next-latest/src/app/experiment/_stub/server-db.ts
@@ -1,0 +1,18 @@
+// STUB — simulated server-only DB. Module-level guard throws if this file
+// ever ends up in a client bundle (mimics what `server-only` would enforce
+// at build time). Async + artificial latency to mimic a real query.
+if (typeof window !== 'undefined') {
+  throw new Error('[server-db] imported on the client — server-only module');
+}
+
+type Author = { id: string; name: string; email: string };
+
+const authors: Record<string, Author> = {
+  'author-1': { id: 'author-1', name: 'Ada Lovelace', email: 'ada@example.com' },
+  'author-2': { id: 'author-2', name: 'Alan Turing', email: 'alan@example.com' },
+};
+
+export async function getAuthorById(id: string): Promise<Author | null> {
+  await new Promise((r) => setTimeout(r, 50));
+  return authors[id] ?? null;
+}


### PR DESCRIPTION
## What

A throwaway **spike** in `packages/react/playground/next-latest/src/app/experiment/` validating the v2 React SDK's central bet (`plans/architecture.md` §3.4/§5): a single `"use server"` `render(story)` action, re-invoked on each edit, can drive live-preview re-renders through arbitrarily nested **server/client** bloks resolved through a component **registry**.

## Approach

Registry-driven, with a crisp **real vs. stubbed** boundary — to make it production-real you swap exactly two things:

- **`_stub/`** (the only stubbed pieces): the **client response** (initial story JSON, normally a CAPI fetch) and the **live-preview bridge** (normally `@storyblok/live-preview`'s `onStoryblokEditorEvent`, here a JSON-textarea + Submit that fakes editor `input` events).
- **`_sdk/`** + **`_bloks/`** (real-SDK-shaped): `types`, the recursive resolver (`storyblok-component`), `StoryblokView`, the live-preview island, and the registered server/client bloks.

The resolver pre-renders nested `body` bloks on the server and passes them as `children`, which is what lets server and client bloks nest to any depth (the one legal server-in-client direction).

## Coverage

Seed story exercises client-in-server, server-in-client (via children), deep S>C>S>C alternation, client context through a server subtree, an async server component, and server-only (`process.env`) access.

## Verified

- SSR renders all bloks in `?lp=0` and `?lp=1`; island + JSON editor only in `?lp=1`.
- Editing the story JSON + Submit re-renders the whole nested tree (no stale values), context consumer updates, and **client state survives the RSC payload swap** (card toggle + leaf input). Clean console/dev log.

## Notes

- Pure playground; **no changes to any SDK package**, no real HTTP/bridge.
- `findings/`, `plans/`, `packages/schema/` are intentionally **not** part of this PR.