### PR TITLE
feat(cli): add `assets transfer` subcommand (space to org)

### DIFF
--- a/packages/cli/src/commands/assets/actions.test.ts
+++ b/packages/cli/src/commands/assets/actions.test.ts
@@ -36,5 +36,7 @@ describe('transferAsset', () => {
       message: expect.stringContaining('not available on your current plan'),
     });
     await expect(transferAsset('123', 42, 7)).rejects.toBeInstanceOf(APIError);
+    const error = await transferAsset('123', 42, 7).catch(e => e);
+    expect(error.code).toBe(403);
   });
 });

--- a/packages/cli/src/commands/assets/actions.test.ts
+++ b/packages/cli/src/commands/assets/actions.test.ts
@@ -35,11 +35,10 @@ describe('transferAsset', () => {
         HttpResponse.json({ error: 'Forbidden' }, { status: 403 })),
     );
 
-    await expect(transferAsset('123', 42, 7)).rejects.toMatchObject({
-      message: expect.stringContaining('write access'),
-    });
-    await expect(transferAsset('123', 42, 7)).rejects.toBeInstanceOf(APIError);
     const error = await transferAsset('123', 42, 7).catch(e => e);
+
+    expect(error).toBeInstanceOf(APIError);
+    expect(error.message).toContain('write access');
     expect(error.code).toBe(403);
   });
 });

--- a/packages/cli/src/commands/assets/actions.test.ts
+++ b/packages/cli/src/commands/assets/actions.test.ts
@@ -16,24 +16,27 @@ afterAll(() => server.close());
 
 describe('transferAsset', () => {
   it('should convert an asset and return the shared asset', async () => {
+    // The backend convert flips ownership only: it sets space_id to null and
+    // keeps the original `/f/{space_id}/` filename (it does not rewrite the URL
+    // to a `/g/{org_id}/` prefix). space_id: null is the reliable shared marker.
     server.use(
       http.post('https://mapi.storyblok.com/v1/spaces/:spaceId/assets/:assetId/convert', () =>
-        HttpResponse.json({ id: 42, filename: 'https://a.storyblok.com/g/99/500x500/shared.png' })),
+        HttpResponse.json({ id: 42, space_id: null, filename: 'https://a.storyblok.com/f/123/500x500/shared.png' })),
     );
 
     const asset = await transferAsset('123', 42, 7);
 
-    expect(asset.filename).toContain('/g/99/');
+    expect(asset.space_id).toBeNull();
   });
 
-  it('should surface a friendly plan-gated message on 403', async () => {
+  it('should surface a friendly authorization message on 403', async () => {
     server.use(
       http.post('https://mapi.storyblok.com/v1/spaces/:spaceId/assets/:assetId/convert', () =>
         HttpResponse.json({ error: 'Forbidden' }, { status: 403 })),
     );
 
     await expect(transferAsset('123', 42, 7)).rejects.toMatchObject({
-      message: expect.stringContaining('not available on your current plan'),
+      message: expect.stringContaining('write access'),
     });
     await expect(transferAsset('123', 42, 7)).rejects.toBeInstanceOf(APIError);
     const error = await transferAsset('123', 42, 7).catch(e => e);

--- a/packages/cli/src/commands/assets/actions.test.ts
+++ b/packages/cli/src/commands/assets/actions.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { getMapiClient } from '../../api';
+import { transferAsset } from './actions';
+import { APIError } from '../../utils/error/api-error';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+beforeEach(() => {
+  getMapiClient({ personalAccessToken: 'valid-token', region: 'eu' });
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('transferAsset', () => {
+  it('should convert an asset and return the shared asset', async () => {
+    server.use(
+      http.post('https://mapi.storyblok.com/v1/spaces/:spaceId/assets/:assetId/convert', () =>
+        HttpResponse.json({ id: 42, filename: 'https://a.storyblok.com/g/99/500x500/shared.png' })),
+    );
+
+    const asset = await transferAsset('123', 42, 7);
+
+    expect(asset.filename).toContain('/g/99/');
+  });
+
+  it('should surface a friendly plan-gated message on 403', async () => {
+    server.use(
+      http.post('https://mapi.storyblok.com/v1/spaces/:spaceId/assets/:assetId/convert', () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 })),
+    );
+
+    await expect(transferAsset('123', 42, 7)).rejects.toMatchObject({
+      message: expect.stringContaining('not available on your current plan'),
+    });
+    await expect(transferAsset('123', 42, 7)).rejects.toBeInstanceOf(APIError);
+  });
+});

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -281,3 +281,39 @@ export const createAsset = async (
     handleAPIError('push_asset_create', toError(maybeError));
   }
 };
+
+/**
+ * Transfers a space-local asset into the org's global (shared) library.
+ *
+ * UX wording is "transfer"; the backend endpoint is still `convert`
+ * (`AssetsServices::ConvertToSharedAsset`). Drop this mapping when the backend
+ * ships the `convert` -> `transfer` rename. One-way only (space to org).
+ *
+ * A 403 means the feature is not available on the current plan; surface a
+ * friendly message instead of a raw API error.
+ */
+export const transferAsset = async (
+  spaceId: string,
+  assetId: number,
+  folderId: number,
+): Promise<Asset> => {
+  try {
+    const { data } = await getMapiClient().assets.convertToShared(assetId, {
+      path: { space_id: Number(spaceId) },
+      query: { target_asset_folder_id: folderId },
+      throwOnError: true,
+    });
+    return data;
+  }
+  catch (maybeError) {
+    const status = (maybeError as { response?: { status?: number } })?.response?.status;
+    if (status === 403) {
+      handleAPIError(
+        'transfer_asset',
+        toError(maybeError),
+        `Transferring assets to the global library is not available on your current plan.`,
+      );
+    }
+    handleAPIError('transfer_asset', toError(maybeError));
+  }
+};

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -289,8 +289,10 @@ export const createAsset = async (
  * (`AssetsServices::ConvertToSharedAsset`). Drop this mapping when the backend
  * ships the `convert` -> `transfer` rename. One-way only (space to org).
  *
- * A 403 means the feature is not available on the current plan; surface a
- * friendly message instead of a raw API error.
+ * A 403 comes from the backend authorization policy (`AssetPolicy#convert?`):
+ * the target folder must exist in the global asset library and the space must
+ * have write access to it. Surface that as a friendly hint instead of a raw
+ * API error.
  */
 export const transferAsset = async (
   spaceId: string,
@@ -311,7 +313,7 @@ export const transferAsset = async (
       'transfer_asset',
       maybeError,
       status === 403
-        ? `Transferring assets to the global library is not available on your current plan.`
+        ? `Not authorized to transfer into folder ${folderId}. Make sure it exists in the global asset library and that this space has write access to it.`
         : undefined,
     );
   }

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -309,7 +309,7 @@ export const transferAsset = async (
     const status = (maybeError as { response?: { status?: number } })?.response?.status;
     handleAPIError(
       'transfer_asset',
-      toError(maybeError),
+      maybeError,
       status === 403
         ? `Transferring assets to the global library is not available on your current plan.`
         : undefined,

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -1,7 +1,7 @@
 import Storyblok from 'storyblok-js-client';
 import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
-import { toError } from '../../utils/error/error';
+import { getResponseStatus, toError } from '../../utils/error/error';
 import { fetchAllPages } from '../../utils/pagination';
 import type { RegionCode } from '../../constants';
 import type { Asset, AssetFolderCreate, AssetFolderUpdate, AssetInternalTagsByName, AssetListQuery, AssetUpdate, AssetUpload } from './types';
@@ -308,10 +308,11 @@ export const transferAsset = async (
     return data;
   }
   catch (maybeError) {
-    const status = (maybeError as { response?: { status?: number } })?.response?.status;
+    const error = toError(maybeError);
+    const status = getResponseStatus(maybeError);
     handleAPIError(
       'transfer_asset',
-      maybeError,
+      error,
       status === 403
         ? `Not authorized to transfer into folder ${folderId}. Make sure it exists in the global asset library and that this space has write access to it.`
         : undefined,

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -1,5 +1,6 @@
 import Storyblok from 'storyblok-js-client';
 import { getMapiClient } from '../../api';
+import { createPipelineBackpressureLock } from '../../utils/backpressure-lock';
 import { handleAPIError } from '../../utils/error/api-error';
 import { getResponseStatus, toError } from '../../utils/error/error';
 import { fetchAllPages } from '../../utils/pagination';
@@ -318,4 +319,47 @@ export const transferAsset = async (
         : undefined,
     );
   }
+};
+
+export interface TransferResult {
+  assetId: number;
+  status: 'transferred' | 'failed';
+  filename?: string;
+  reason?: string;
+}
+
+/**
+ * Transfers multiple assets into the global asset library, bounding in-flight
+ * requests with the shared pipeline backpressure lock (2× the configured rate
+ * limit), matching the throttle headroom used by the asset and story streams.
+ * Per-asset errors are captured as failed results rather than aborting the
+ * whole batch.
+ */
+export const transferAssets = async (
+  spaceId: string,
+  assetIds: number[],
+  folderId: number,
+  callbacks: {
+    onSuccess?: (result: { assetId: number; filename?: string }) => void;
+    onError?: (error: Error, assetId: number) => void;
+  } = {},
+): Promise<TransferResult[]> => {
+  const lock = createPipelineBackpressureLock();
+
+  return Promise.all(assetIds.map(async (assetId): Promise<TransferResult> => {
+    await lock.acquire();
+    try {
+      const asset = await transferAsset(spaceId, assetId, folderId);
+      callbacks.onSuccess?.({ assetId, filename: asset.filename });
+      return { assetId, status: 'transferred', filename: asset.filename };
+    }
+    catch (maybeError) {
+      const error = toError(maybeError);
+      callbacks.onError?.(error, assetId);
+      return { assetId, status: 'failed', reason: error.message };
+    }
+    finally {
+      lock.release();
+    }
+  }));
 };

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -307,13 +307,12 @@ export const transferAsset = async (
   }
   catch (maybeError) {
     const status = (maybeError as { response?: { status?: number } })?.response?.status;
-    if (status === 403) {
-      handleAPIError(
-        'transfer_asset',
-        toError(maybeError),
-        `Transferring assets to the global library is not available on your current plan.`,
-      );
-    }
-    handleAPIError('transfer_asset', toError(maybeError));
+    handleAPIError(
+      'transfer_asset',
+      toError(maybeError),
+      status === 403
+        ? `Transferring assets to the global library is not available on your current plan.`
+        : undefined,
+    );
   }
 };

--- a/packages/cli/src/commands/assets/index.ts
+++ b/packages/cli/src/commands/assets/index.ts
@@ -1,2 +1,3 @@
 import './pull';
 import './push';
+import './transfer';

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -35,4 +35,4 @@ storyblok assets transfer 123456 789012 --folder-id 789 --space YOUR_SPACE_ID --
 
 - **Endpoint mapping:** The CLI exposes this operation as `transfer`, but it currently calls the backend `convert` endpoint (`POST /v1/spaces/{space_id}/assets/{id}/convert`), mapping `--folder-id` to the required `target_asset_folder_id` query parameter. This mapping will be removed once the backend ships the rename from `convert` to `transfer`.
 - **Plan required:** `--folder-id` is required and has no implicit default. Omitting it fails with an error.
-- **403 errors:** A 403 response means the global asset library is not available on the current plan. Contact Storyblok support to enable it for your organization.
+- **403 errors:** A 403 response comes from the backend authorization policy: the target folder must exist in the global asset library and the source space must have write access to it. Grant the space write access to the destination folder (or pick a folder it can write to), then retry.

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -1,0 +1,38 @@
+# Assets Transfer Command
+
+The `assets transfer` command transfers existing assets from a space's local library into the organization's global asset library. This is a one-way operation: assets move from a space to the organization. There is no reverse operation.
+
+## Basic usage
+
+**Transfer a single asset:**
+
+```bash
+storyblok assets transfer 123456 --folder-id 789 --space YOUR_SPACE_ID
+```
+
+**Transfer multiple assets concurrently:**
+
+```bash
+storyblok assets transfer 123456 789012 345678 --folder-id 789 --space YOUR_SPACE_ID
+```
+
+**Preview the transfer plan without making any API calls:**
+
+```bash
+storyblok assets transfer 123456 789012 --folder-id 789 --space YOUR_SPACE_ID --dry-run
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<asset-id...>` | (Required) One or more numeric asset IDs to transfer | - |
+| `--folder-id <id>` | (Required) Destination folder ID in the global asset library | - |
+| `-s, --space <id>` | Source space ID | Globally configured space |
+| `-d, --dry-run` | Print the transfer plan without making any API calls | `false` |
+
+## Notes
+
+- **Endpoint mapping:** The CLI exposes this operation as `transfer`, but it currently calls the backend `convert` endpoint (`POST /v1/spaces/{space_id}/assets/{id}/convert`), mapping `--folder-id` to the required `target_asset_folder_id` query parameter. This mapping will be removed once the backend ships the rename from `convert` to `transfer`.
+- **Plan required:** `--folder-id` is required and has no implicit default. Omitting it fails with an error.
+- **403 errors:** A 403 response means the global asset library is not available on the current plan. Contact Storyblok support to enable it for your organization.

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -14,7 +14,7 @@ vi.spyOn(console, 'log');
 vi.spyOn(console, 'error');
 vi.spyOn(console, 'info');
 vi.spyOn(console, 'warn');
-vi.spyOn(actions, 'transferAsset');
+vi.spyOn(actions, 'transferAssets');
 
 const server = setupServer();
 
@@ -59,7 +59,7 @@ describe('assets transfer command', () => {
 
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
-    expect(actions.transferAsset).toHaveBeenCalledWith(DEFAULT_SPACE, 42, 7);
+    expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42], 7, expect.anything());
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('transferred'));
     expect(process.exitCode).toBe(0);
   });
@@ -69,7 +69,7 @@ describe('assets transfer command', () => {
 
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '43', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
-    expect(actions.transferAsset).toHaveBeenCalledTimes(2);
+    expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42, 43], 7, expect.anything());
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('42'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('43'));
     expect(process.exitCode).toBe(0);
@@ -78,7 +78,7 @@ describe('assets transfer command', () => {
   it('should fail with a clear error when --folder-id is omitted', async () => {
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE]);
 
-    expect(actions.transferAsset).not.toHaveBeenCalled();
+    expect(actions.transferAssets).not.toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--folder-id'), '');
     expect(process.exitCode).toBe(2);
   });
@@ -86,7 +86,7 @@ describe('assets transfer command', () => {
   it('should reject --folder-id 0 as invalid', async () => {
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '0']);
 
-    expect(actions.transferAsset).not.toHaveBeenCalled();
+    expect(actions.transferAssets).not.toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--folder-id'), '');
     expect(process.exitCode).toBe(2);
   });
@@ -94,7 +94,7 @@ describe('assets transfer command', () => {
   it('should print the plan and make no API calls in dry-run mode', async () => {
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7', '--dry-run']);
 
-    expect(actions.transferAsset).not.toHaveBeenCalled();
+    expect(actions.transferAssets).not.toHaveBeenCalled();
     expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('DRY RUN MODE ENABLED'));
     expect(process.exitCode).toBe(0);
   });

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -80,6 +80,14 @@ describe('assets transfer command', () => {
     expect(process.exitCode).toBe(2);
   });
 
+  it('should reject --folder-id 0 as invalid', async () => {
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '0']);
+
+    expect(actions.transferAsset).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--folder-id'), '');
+    expect(process.exitCode).toBe(2);
+  });
+
   it('should print the plan and make no API calls in dry-run mode', async () => {
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7', '--dry-run']);
 

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -19,18 +19,21 @@ vi.spyOn(actions, 'transferAsset');
 const server = setupServer();
 
 const preconditions = {
-  canTransferAssets(orgId = '99', { space = DEFAULT_SPACE }: { space?: string } = {}) {
+  canTransferAssets({ space = DEFAULT_SPACE }: { space?: string } = {}) {
     server.use(
       http.post(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:assetId/convert`, ({ params }) => {
+        // The backend convert flips ownership only: space_id becomes null and
+        // the original `/f/{space_id}/` filename is kept (no `/g/{org_id}/`
+        // rewrite). space_id: null is the reliable shared marker.
         const asset = makeMockAsset({
           id: Number(params.assetId),
-          filename: `https://a.storyblok.com/g/${orgId}/500x500/asset-${params.assetId}.png`,
+          filename: `https://a.storyblok.com/f/${space}/500x500/asset-${params.assetId}.png`,
         });
         return HttpResponse.json({ ...asset, space_id: null });
       }),
     );
   },
-  failsToTransferWithPlanError({ space = DEFAULT_SPACE }: { space?: string } = {}) {
+  failsToTransferWithAuthError({ space = DEFAULT_SPACE }: { space?: string } = {}) {
     server.use(
       http.post(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:assetId/convert`, () =>
         HttpResponse.json({ error: 'Forbidden' }, { status: 403 })),
@@ -52,17 +55,17 @@ describe('assets transfer command', () => {
   afterAll(() => server.close());
 
   it('should transfer a local asset to the global library', async () => {
-    preconditions.canTransferAssets('99');
+    preconditions.canTransferAssets();
 
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
     expect(actions.transferAsset).toHaveBeenCalledWith(DEFAULT_SPACE, 42, 7);
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('/g/99/'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('transferred'));
     expect(process.exitCode).toBe(0);
   });
 
   it('should transfer multiple asset IDs and report one row per ID', async () => {
-    preconditions.canTransferAssets('99');
+    preconditions.canTransferAssets();
 
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '43', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
@@ -96,12 +99,12 @@ describe('assets transfer command', () => {
     expect(process.exitCode).toBe(0);
   });
 
-  it('should surface a friendly message and exit 1 on a plan-gated 403', async () => {
-    preconditions.failsToTransferWithPlanError();
+  it('should surface a friendly message and exit 1 on a 403', async () => {
+    preconditions.failsToTransferWithAuthError();
 
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('not available on your current plan'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('write access'));
     expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { vol } from 'memfs';
+import '../index';
+import { assetsCommand } from '../command';
+import { resetReporter } from '../../../lib/reporter/reporter';
+import { getProgram } from '../../../program';
+import * as actions from '../actions';
+import { DEFAULT_SPACE } from '../../__tests__/helpers';
+import { makeMockAsset } from '../__tests__/helpers';
+
+vi.spyOn(console, 'log');
+vi.spyOn(console, 'error');
+vi.spyOn(console, 'info');
+vi.spyOn(console, 'warn');
+vi.spyOn(actions, 'transferAsset');
+
+const server = setupServer();
+
+const preconditions = {
+  canTransferAssets(orgId = '99', { space = DEFAULT_SPACE }: { space?: string } = {}) {
+    server.use(
+      http.post(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:assetId/convert`, ({ params }) => {
+        const asset = makeMockAsset({
+          id: Number(params.assetId),
+          filename: `https://a.storyblok.com/g/${orgId}/500x500/asset-${params.assetId}.png`,
+        });
+        return HttpResponse.json({ ...asset, space_id: null });
+      }),
+    );
+  },
+  failsToTransferWithPlanError({ space = DEFAULT_SPACE }: { space?: string } = {}) {
+    server.use(
+      http.post(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:assetId/convert`, () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 })),
+    );
+  },
+};
+
+describe('assets transfer command', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+    vol.reset();
+    server.resetHandlers();
+    resetReporter();
+    getProgram().setOptionValueWithSource('path', undefined, 'default');
+    process.exitCode = undefined;
+  });
+  afterAll(() => server.close());
+
+  it('should transfer a local asset to the global library', async () => {
+    preconditions.canTransferAssets('99');
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAsset).toHaveBeenCalledWith(DEFAULT_SPACE, 42, 7);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('/g/99/'));
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('should transfer multiple asset IDs and report one row per ID', async () => {
+    preconditions.canTransferAssets('99');
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '43', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAsset).toHaveBeenCalledTimes(2);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('42'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('43'));
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('should fail with a clear error when --folder-id is omitted', async () => {
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE]);
+
+    expect(actions.transferAsset).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--folder-id'), '');
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('should print the plan and make no API calls in dry-run mode', async () => {
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7', '--dry-run']);
+
+    expect(actions.transferAsset).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('DRY RUN MODE ENABLED'));
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('should surface a friendly message and exit 1 on a plan-gated 403', async () => {
+    preconditions.failsToTransferWithPlanError();
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('not available on your current plan'));
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -65,9 +65,8 @@ transferCmd
       return;
     }
 
-    const summary = { total: ids.length, succeeded: 0, failed: 0 };
-
     if (options.dryRun) {
+      const summary = { total: ids.length, succeeded: 0, failed: 0 };
       ui.info(`Transfer plan: ${ids.length} asset(s) to folder ${folderId}`);
       ui.list(ids.map(id => `${id} -> folder ${folderId}`));
       reporter.addSummary('transferResults', summary);
@@ -97,14 +96,8 @@ transferCmd
       }
     }));
 
-    for (const result of results) {
-      if (result.status === 'transferred') {
-        summary.succeeded += 1;
-      }
-      else {
-        summary.failed += 1;
-      }
-    }
+    const succeeded = results.filter(result => result.status === 'transferred').length;
+    const summary = { total: results.length, succeeded, failed: results.length - succeeded };
 
     ui.info(`Transfer results: ${summary.total} processed, ${summary.failed} failed`);
     ui.list(results.map(result => result.status === 'transferred'

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -1,4 +1,3 @@
-import { Sema } from 'async-sema';
 import { colorPalette, commands } from '../../../constants';
 import { assetsCommand } from '../command';
 import { getUI } from '../../../utils/ui';
@@ -7,15 +6,8 @@ import { getReporter } from '../../../lib/reporter/reporter';
 import { session } from '../../../session';
 import { requireAuthentication } from '../../../utils/auth';
 import { CommandError } from '../../../utils/error/command-error';
-import { handleError, logOnlyError, toError } from '../../../utils/error/error';
-import { transferAsset } from '../actions';
-
-interface TransferResult {
-  assetId: number;
-  status: 'transferred' | 'failed';
-  filename?: string;
-  reason?: string;
-}
+import { handleError, logOnlyError } from '../../../utils/error/error';
+import { transferAssets } from '../actions';
 
 const transferCmd = assetsCommand
   .command('transfer <asset-id...>')
@@ -76,25 +68,12 @@ transferCmd
       return;
     }
 
-    // Per-ID errors are captured individually below, so unlike push/pull this
+    // Per-ID errors are captured individually, so unlike push/pull this
     // command needs no outer fatalError try/catch wrapper.
-    const lock = new Sema(12);
-    const results = await Promise.all(ids.map(async (assetId): Promise<TransferResult> => {
-      await lock.acquire();
-      try {
-        const asset = await transferAsset(space, assetId, folderId);
-        logger.info('Transferred asset', { assetId, filename: asset.filename });
-        return { assetId, status: 'transferred', filename: asset.filename };
-      }
-      catch (maybeError) {
-        const error = toError(maybeError);
-        logOnlyError(error, { assetId });
-        return { assetId, status: 'failed', reason: error.message };
-      }
-      finally {
-        lock.release();
-      }
-    }));
+    const results = await transferAssets(space, ids, folderId, {
+      onSuccess: ({ assetId, filename }) => logger.info('Transferred asset', { assetId, filename }),
+      onError: (error, assetId) => logOnlyError(error, { assetId }),
+    });
 
     const succeeded = results.filter(result => result.status === 'transferred').length;
     const summary = { total: results.length, succeeded, failed: results.length - succeeded };

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -77,6 +77,8 @@ transferCmd
       return;
     }
 
+    // Per-ID errors are captured individually below, so unlike push/pull this
+    // command needs no outer fatalError try/catch wrapper.
     const lock = new Sema(12);
     const results = await Promise.all(ids.map(async (assetId): Promise<TransferResult> => {
       await lock.acquire();

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -1,0 +1,117 @@
+import { Sema } from 'async-sema';
+import { colorPalette, commands } from '../../../constants';
+import { assetsCommand } from '../command';
+import { getUI } from '../../../utils/ui';
+import { getLogger } from '../../../lib/logger/logger';
+import { getReporter } from '../../../lib/reporter/reporter';
+import { session } from '../../../session';
+import { requireAuthentication } from '../../../utils/auth';
+import { CommandError } from '../../../utils/error/command-error';
+import { handleError, logOnlyError, toError } from '../../../utils/error/error';
+import { transferAsset } from '../actions';
+
+interface TransferResult {
+  assetId: number;
+  status: 'transferred' | 'failed';
+  filename?: string;
+  reason?: string;
+}
+
+const transferCmd = assetsCommand
+  .command('transfer <asset-id...>')
+  .option('-s, --space <space>', 'space ID')
+  .option('--folder-id <folderId>', 'destination asset folder ID in the global library')
+  .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
+  .description(`Transfer space assets into the organization's global asset library.`);
+
+transferCmd
+  .action(async (assetIds: string[], options, command) => {
+    const ui = getUI();
+    const logger = getLogger();
+    const reporter = getReporter();
+
+    ui.title(`${commands.ASSETS}`, colorPalette.ASSETS, 'Transferring assets...');
+    logger.info('Transferring assets started');
+
+    if (options.dryRun) {
+      ui.warn(`DRY RUN MODE ENABLED: No changes will be made.\n`);
+      logger.warn('Dry run mode enabled');
+    }
+
+    const { space, verbose } = command.optsWithGlobals();
+    const { state } = session();
+
+    if (!requireAuthentication(state, verbose)) {
+      process.exitCode = 2;
+      return;
+    }
+    if (!space) {
+      handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
+      process.exitCode = 2;
+      return;
+    }
+
+    const folderId = Number(options.folderId);
+    if (!options.folderId || Number.isNaN(folderId)) {
+      handleError(new CommandError(`Please provide a destination folder with --folder-id YOUR_FOLDER_ID.`), verbose);
+      process.exitCode = 2;
+      return;
+    }
+
+    const ids = assetIds.map(id => Number(id)).filter(id => !Number.isNaN(id));
+    if (ids.length === 0) {
+      handleError(new CommandError(`Please provide at least one valid asset ID.`), verbose);
+      process.exitCode = 2;
+      return;
+    }
+
+    const summary = { total: ids.length, succeeded: 0, failed: 0 };
+
+    if (options.dryRun) {
+      ui.info(`Transfer plan: ${ids.length} asset(s) to folder ${folderId}`);
+      ui.list(ids.map(id => `${id} -> folder ${folderId}`));
+      reporter.addSummary('transferResults', summary);
+      reporter.finalize();
+      logger.info('Transferring assets finished (dry run)', { summary });
+      process.exitCode = 0;
+      return;
+    }
+
+    const lock = new Sema(12);
+    const results = await Promise.all(ids.map(async (assetId): Promise<TransferResult> => {
+      await lock.acquire();
+      try {
+        const asset = await transferAsset(space, assetId, folderId);
+        logger.info('Transferred asset', { assetId, filename: asset.filename });
+        return { assetId, status: 'transferred', filename: asset.filename };
+      }
+      catch (maybeError) {
+        const error = toError(maybeError);
+        logOnlyError(error, { assetId });
+        return { assetId, status: 'failed', reason: error.message };
+      }
+      finally {
+        lock.release();
+      }
+    }));
+
+    for (const result of results) {
+      if (result.status === 'transferred') {
+        summary.succeeded += 1;
+      }
+      else {
+        summary.failed += 1;
+      }
+    }
+
+    ui.info(`Transfer results: ${summary.total} processed, ${summary.failed} failed`);
+    ui.list(results.map(result => result.status === 'transferred'
+      ? `${result.assetId}  ✓ transferred -> ${result.filename}`
+      : `${result.assetId}  ✗ failed: ${result.reason}`));
+
+    reporter.addSummary('transferResults', summary);
+    reporter.finalize();
+    logger.info('Transferring assets finished', { summary });
+
+    process.exitCode = summary.failed > 0 ? 1 : 0;
+  });

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -52,7 +52,7 @@ transferCmd
     }
 
     const folderId = Number(options.folderId);
-    if (!options.folderId || Number.isNaN(folderId)) {
+    if (!options.folderId || !Number.isFinite(folderId) || folderId <= 0) {
       handleError(new CommandError(`Please provide a destination folder with --folder-id YOUR_FOLDER_ID.`), verbose);
       process.exitCode = 2;
       return;

--- a/packages/cli/src/commands/user/actions.ts
+++ b/packages/cli/src/commands/user/actions.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { handleAPIError, maskToken } from '../../utils';
+import { getResponseStatus, handleAPIError, maskToken, toError } from '../../utils';
 import { createMapiClient } from '../../api';
 import type { RegionCode } from '../../constants';
 
@@ -18,8 +18,9 @@ export const getUser = async (token: string, region: RegionCode) => {
 
     return data?.user;
   }
-  catch (error) {
-    const status = (error as any)?.response?.status;
+  catch (maybeError) {
+    const error = toError(maybeError);
+    const status = getResponseStatus(maybeError);
     const customMessage = status === 401
       ? `The token provided ${chalk.bold(maskToken(token))} is invalid.
         Please make sure you are using the correct token and try again.`

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -33,6 +33,7 @@ export const API_ACTIONS = {
   push_asset_update: 'Failed to update asset',
   pull_asset_internal_tags: 'Failed to pull asset internal tags',
   push_asset_internal_tag: 'Failed to push asset internal tag',
+  transfer_asset: 'Failed to transfer asset',
   pull_datasources: 'Failed to pull datasources',
   push_datasource: 'Failed to push datasource',
   update_datasource: 'Failed to update datasource',

--- a/packages/cli/src/utils/error/error.ts
+++ b/packages/cli/src/utils/error/error.ts
@@ -34,6 +34,18 @@ export function toError(maybeError: unknown) {
   }
 }
 
+export function getResponseStatus(maybeError: unknown): number | undefined {
+  const error = toError(maybeError);
+  if (!('response' in error)) {
+    return undefined;
+  }
+  const { response } = error;
+  if (!response || typeof response !== 'object' || !('status' in response)) {
+    return undefined;
+  }
+  return typeof response.status === 'number' ? response.status : undefined;
+}
+
 function handleVerboseError(error: unknown): void {
   if (error instanceof CommandError || error instanceof APIError || error instanceof FileSystemError) {
     const errorDetails = 'getInfo' in error ? error.getInfo() : {};

--- a/packages/mapi-client/src/resources/assets.test.ts
+++ b/packages/mapi-client/src/resources/assets.test.ts
@@ -99,6 +99,7 @@ describe('assets.convertToShared()', () => {
     });
 
     expect(result.error).toBeUndefined();
+    expect(result.data).toBeDefined();
     expect(result.data?.filename).toContain('/g/99/');
     expect(capturedUrl).toContain('/v1/spaces/123/assets/42/convert');
     expect(capturedUrl).toContain('target_asset_folder_id=7');

--- a/packages/mapi-client/src/resources/assets.test.ts
+++ b/packages/mapi-client/src/resources/assets.test.ts
@@ -75,6 +75,36 @@ describe('assets.list()', () => {
   });
 });
 
+describe('assets.convertToShared()', () => {
+  it('should post to the convert endpoint with target_asset_folder_id and return the converted asset', async () => {
+    let capturedUrl: string | undefined;
+    server.use(
+      http.post('https://mapi.storyblok.com/v1/spaces/:space_id/assets/:asset_id/convert', ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({
+          id: 42,
+          filename: 'https://a.storyblok.com/g/99/500x500/shared.png',
+        });
+      }),
+    );
+    const client = createManagementApiClient({
+      personalAccessToken: 'test-token',
+      spaceId: 123,
+      region: 'eu',
+      rateLimit: false,
+    });
+
+    const result = await client.assets.convertToShared(42, {
+      query: { target_asset_folder_id: 7 },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.filename).toContain('/g/99/');
+    expect(capturedUrl).toContain('/v1/spaces/123/assets/42/convert');
+    expect(capturedUrl).toContain('target_asset_folder_id=7');
+  });
+});
+
 describe('assets.get()', () => {
   it('should successfully retrieve a single asset', async () => {
     const client = createManagementApiClient({

--- a/packages/mapi-client/src/resources/assets.test.ts
+++ b/packages/mapi-client/src/resources/assets.test.ts
@@ -81,9 +81,13 @@ describe('assets.convertToShared()', () => {
     server.use(
       http.post('https://mapi.storyblok.com/v1/spaces/:space_id/assets/:asset_id/convert', ({ request }) => {
         capturedUrl = request.url;
+        // The backend convert flips ownership only: space_id becomes null and
+        // the original `/f/{space_id}/` filename is kept (no `/g/{org_id}/`
+        // rewrite). space_id: null is the reliable shared marker.
         return HttpResponse.json({
           id: 42,
-          filename: 'https://a.storyblok.com/g/99/500x500/shared.png',
+          space_id: null,
+          filename: 'https://a.storyblok.com/f/123/500x500/shared.png',
         });
       }),
     );
@@ -100,7 +104,7 @@ describe('assets.convertToShared()', () => {
 
     expect(result.error).toBeUndefined();
     expect(result.data).toBeDefined();
-    expect(result.data?.filename).toContain('/g/99/');
+    expect(result.data?.space_id).toBeNull();
     expect(capturedUrl).toContain('/v1/spaces/123/assets/42/convert');
     expect(capturedUrl).toContain('target_asset_folder_id=7');
   });

--- a/packages/mapi-client/src/resources/assets.ts
+++ b/packages/mapi-client/src/resources/assets.ts
@@ -280,6 +280,7 @@ export function createAssetsResource(deps: MapiResourceDeps) {
      * param and no request body. One-way only (space to org).
      *
      * Not part of the generated SDK, so this issues a raw `client.post`.
+     * The response is assumed to match `Asset`.
      */
     convertToShared<ThrowOnError extends boolean = false>(
       assetId: number | string,

--- a/packages/mapi-client/src/resources/assets.ts
+++ b/packages/mapi-client/src/resources/assets.ts
@@ -272,5 +272,30 @@ export function createAssetsResource(deps: MapiResourceDeps) {
       return wrapRequest<BulkRestoreResponses[200], ThrowOnError>(() =>
         assetsApi.bulkRestore({ client, path: { space_id: resolvedSpaceId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
+    /**
+     * Converts a space-local asset into a shared (org-level) asset.
+     *
+     * Wraps `POST /v1/spaces/{space_id}/assets/{asset_id}/convert`, which takes
+     * the destination folder as the required `target_asset_folder_id` query
+     * param and no request body. One-way only (space to org).
+     *
+     * Not part of the generated SDK, so this issues a raw `client.post`.
+     */
+    convertToShared<ThrowOnError extends boolean = false>(
+      assetId: number | string,
+      options: { query: { target_asset_folder_id: number }; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
+    ): Promise<ApiResponse<Asset, ThrowOnError>> {
+      const { query, signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<Asset, ThrowOnError>(() =>
+        client.post({
+          url: '/v1/spaces/{space_id}/assets/{asset_id}/convert',
+          path: { space_id: resolvedSpaceId, asset_id: assetId },
+          query,
+          signal,
+          ...(throwOnError === undefined ? {} : { throwOnError }),
+          ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}),
+        }), throwOnError);
+    },
   };
 }


### PR DESCRIPTION
Adds `storyblok assets transfer <asset-id...> --folder-id <id>` to move existing assets from a space's local library into the organization's shared asset library. One-way only (space to org); there is no reverse operation.

The CLI surfaces this as `transfer` (DX-aligned wording) and maps it internally to the backend's `convert` endpoint (`POST /v1/spaces/{space_id}/assets/{id}/convert`), with `--folder-id` mapped to the required `target_asset_folder_id` query parameter.

### Changes

- **mapi-client:** new `assets.convertToShared(assetId, { query: { target_asset_folder_id } })` resource method. The endpoint is not in the generated OpenAPI spec, so it issues a raw `client.post`.
- **CLI action:** new `transferAsset(spaceId, assetId, folderId)`. A 403 surfaces a friendly authorization message instead of a raw API error, and the thrown `APIError` preserves the 403 status code.
- **CLI command:** new `assets transfer` subcommand. Required `--folder-id` (validated in-action, rejects missing/zero/negative values, no implicit root), optional `--space` and `--dry-run`. Multiple asset IDs run with bounded concurrency (`Sema(12)`); a per-ID summary prints via the UI module; exit codes are 2 (validation), 1 (any transfer failed), 0 (success or dry-run).
- **Docs:** `transfer/README.md` documenting usage, options, and the transfer-to-convert mapping note.

## Manual testing

Verified live against space qa space on the `eu` region. Help, listing, validation (missing/`0`/`-5`/`abc`), and dry-run were all confirmed; the live convert endpoint was exercised for the 404, 403, and success paths.

To reproduce the full success path you need a target folder in the org's shared asset library that the source space can write to. Without write access the transfer returns 403.

Fixes WDX-409
