### PR TITLE
fix: simplify live preview typing and update Angular integration for generic API

### DIFF
--- a/packages/angular/src/lib/livepreview/livepreview.service.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.ts
@@ -69,9 +69,9 @@ export class LivePreviewService {
       ...(options ?? {}),
     };
 
-    return onStoryblokEditorEvent((story) => {
+    return onStoryblokEditorEvent<Story>((story) => {
       this.ngZone.run(() => {
-        callback(story as Story);
+        callback(story);
       });
     }, mergedConfig);
   }

--- a/packages/angular/src/lib/richtext/rich-text.component.spec.ts
+++ b/packages/angular/src/lib/richtext/rich-text.component.spec.ts
@@ -13,7 +13,7 @@ import type { RichTextComponentProps } from '../types';
   standalone: true,
   imports: [SbRichTextComponent],
   template: `<div class="custom-node">
-    <sb-rich-text [sbDocument]="data()?.content" />
+    <sb-rich-text [sbDocument]="data().content" />
   </div>`,
 })
 class MockCustomParagraphComponent {

--- a/packages/angular/src/lib/types.ts
+++ b/packages/angular/src/lib/types.ts
@@ -1,5 +1,10 @@
-import { ISbComponentType } from '@storyblok/live-preview';
 import { SbRichTextElement, SbRichTextProps } from '@storyblok/richtext/static';
+
+export interface ISbComponentType<T extends string> {
+  _uid?: string;
+  component?: T;
+  _editable?: string;
+}
 
 export type SbBlokKeyDataTypes = string | number | object | boolean | undefined;
 

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -19,21 +19,20 @@
     "live-preview",
     "storyblok"
   ],
+  "sideEffects": false,
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    },
+    ".": "./dist/index.mjs",
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.cts",
+  "types": "./dist/index.d.mts",
   "files": [
     "dist"
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "scripts": {
     "build": "tsdown",
@@ -50,9 +49,7 @@
   "devDependencies": {
     "@storyblok/eslint-config": "workspace:*",
     "@types/node": "^24.11.0",
-    "bumpp": "^10.4.1",
     "eslint": "^9.39.2",
-    "storyblok-js-client": "workspace:*",
     "tsdown": "^0.20.3",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/storyblok/monoblok/tree/main/packages/live-preview#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/storyblok/monoblok.git",
+    "url": "git+https://github.com/storyblok/monoblok.git",
     "directory": "packages/live-preview"
   },
   "bugs": {

--- a/packages/live-preview/src/index.ts
+++ b/packages/live-preview/src/index.ts
@@ -3,4 +3,3 @@ export { loadStoryblokBridge } from './loadStoryblokBridge';
 export { onStoryblokEditorEvent } from './onStoryblokEditorEvent';
 export { isInEditor } from './utils/isInEditor';
 export type { BridgeParams } from '@storyblok/preview-bridge';
-export type { ISbComponentType, ISbStoryData } from 'storyblok-js-client';

--- a/packages/live-preview/src/onStoryblokEditorEvent.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.ts
@@ -1,14 +1,15 @@
 import type { BridgeParams } from '@storyblok/preview-bridge';
-import type { ISbComponentType, ISbStoryData } from 'storyblok-js-client';
-
 import { loadStoryblokBridge } from './loadStoryblokBridge';
 import { canUseStoryblokBridge } from './utils/canUseStoryblokBridge';
 
 /**
+ * Base story type used internally.
+ */
+/**
  * Internal listener registry for Storyblok `input` events.
  * Each listener receives the updated story data from the Visual Editor.
  */
-const inputListeners = new Set<(story: ISbStoryData) => void>();
+const inputListeners = new Set<(story: unknown) => void>();
 
 /**
  * Tracks whether the Storyblok Preview Bridge event listeners
@@ -48,7 +49,7 @@ async function initializeBridge(bridgeOptions?: BridgeParams): Promise<void> {
 
       if (event.action === 'input' && event.story) {
         for (const listener of inputListeners) {
-          listener(event.story as ISbStoryData);
+          listener(event.story);
         }
         return;
       }
@@ -65,28 +66,15 @@ async function initializeBridge(bridgeOptions?: BridgeParams): Promise<void> {
 /**
  * Registers a callback for Storyblok Visual Editor live preview updates.
  *
- * This utility connects to the Storyblok Preview Bridge and listens
- * for Visual Editor events.
+ * The consumer provides the expected story type through the generic `T`.
  *
- * Behavior:
- * - **input** → Calls the provided callback with the updated story data.
- * - **change** → Reloads the page.
- * - **published** → Reloads the page.
- *
- * Multiple listeners can be registered simultaneously. Each call returns
- * a cleanup function that removes the registered listener.
- *
- * @typeParam T - The Storyblok component schema type.
+ * @typeParam T - Story type expected by the consumer.
  *
  * @param callback
  * Callback executed when the Visual Editor sends an `input` event.
  *
  * @param bridgeOptions
- * Optional configuration for the Storyblok Preview Bridge.
- * This configuration is applied **only during the first initialization**.
- *
- * @returns
- * A cleanup function that removes the registered listener.
+ * Optional configuration for the Preview Bridge.
  *
  * @example
  * ```ts
@@ -99,15 +87,15 @@ async function initializeBridge(bridgeOptions?: BridgeParams): Promise<void> {
  * ```
  */
 export async function onStoryblokEditorEvent<
-  T extends ISbComponentType<string> = ISbComponentType<string>,
+  T = unknown,
 >(
-  callback: (story: ISbStoryData<T>) => void,
+  callback: (story: T) => void,
   bridgeOptions?: BridgeParams,
 ): Promise<() => void> {
   await initializeBridge(bridgeOptions);
 
-  const listener = (story: ISbStoryData) => {
-    callback(story as ISbStoryData<T>);
+  const listener = (story: unknown) => {
+    callback(story as T);
   };
 
   inputListeners.add(listener);

--- a/packages/live-preview/src/onStoryblokEditorEvent.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.ts
@@ -3,9 +3,6 @@ import { loadStoryblokBridge } from './loadStoryblokBridge';
 import { canUseStoryblokBridge } from './utils/canUseStoryblokBridge';
 
 /**
- * Base story type used internally.
- */
-/**
  * Internal listener registry for Storyblok `input` events.
  * Each listener receives the updated story data from the Visual Editor.
  */

--- a/packages/live-preview/tsdown.config.ts
+++ b/packages/live-preview/tsdown.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   exports: true,
   sourcemap: true,
   dts: true,
-  attw: false,
+  attw: {
+    profile: 'esm-only',
+  },
   publint: true,
 });

--- a/packages/live-preview/tsdown.config.ts
+++ b/packages/live-preview/tsdown.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   exports: true,
   sourcemap: true,
   dts: true,
-  attw: true,
+  attw: false,
   publint: true,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,15 +660,9 @@ importers:
       '@types/node':
         specifier: ^24.11.0
         version: 24.11.0
-      bumpp:
-        specifier: ^10.4.1
-        version: 10.4.1(magicast@0.5.2)
       eslint:
         specifier: ^9.39.2
         version: 9.39.3(jiti@2.6.1)
-      storyblok-js-client:
-        specifier: workspace:*
-        version: link:../js-client
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.9.3)
@@ -7644,9 +7638,6 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  args-tokenizer@0.3.0:
-    resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
-
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -8056,11 +8047,6 @@ packages:
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
-
-  bumpp@10.4.1:
-    resolution: {integrity: sha512-X/bwWs5Gbb/D7rN4aHLB7zdjiA6nGdjckM1sTHhI9oovIbEw2L5pw5S4xzk8ZTeOZ8EnwU/Ze4SoZ6/Vr3pM2Q==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -17557,7 +17543,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -17624,7 +17610,7 @@ snapshots:
   '@eslint/eslintrc@3.3.4':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -21432,7 +21418,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 24.11.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -22618,8 +22604,6 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  args-tokenizer@0.3.0: {}
-
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -23394,22 +23378,6 @@ snapshots:
 
   builtin-modules@5.0.0: {}
 
-  bumpp@10.4.1(magicast@0.5.2):
-    dependencies:
-      ansis: 4.2.0
-      args-tokenizer: 0.3.0
-      c12: 3.3.3(magicast@0.5.2)
-      cac: 6.7.14
-      escalade: 3.2.0
-      jsonc-parser: 3.3.1
-      package-manager-detector: 1.6.0
-      semver: 7.7.4
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - magicast
-
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -24173,6 +24141,10 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -25632,7 +25604,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -26355,7 +26327,7 @@ snapshots:
 
   happy-dom@20.8.9:
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 24.11.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -26539,7 +26511,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -26556,7 +26528,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17543,7 +17543,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -17610,7 +17610,7 @@ snapshots:
   '@eslint/eslintrc@3.3.4':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -24142,10 +24142,6 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -25604,7 +25600,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -26511,7 +26507,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26528,7 +26524,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
This PR removes the dependency on `ISbStoryData` and simplifies the typing of `onStoryblokEditorEvent`.

The live preview package now uses a generic `unknown`-based story internally, and consumers define their own `Story` type.

We also enforce an **ESM-only build for the live preview package**, since it is browser-only.

### Changes

* Removed `ISbStoryData` dependency
* Made `onStoryblokEditorEvent` fully generic
* Angular SDK now defines `ISbComponentType` locally
* Adapted `onStoryblokEditorEvent<Story>((story) => ...)` usage
* Live preview package is now ESM-only (browser usage only)

### Usage

```ts
onStoryblokEditorEvent<Story>((story) => {
  console.log(story);
});
```

Fixes WDX-441