### PR TITLE
test(stories): handle shared-asset references in push/pull & migrations (WDX-411)

### DIFF
--- a/packages/cli/src/commands/stories/push/index.test.ts
+++ b/packages/cli/src/commands/stories/push/index.test.ts
@@ -830,6 +830,66 @@ describe('stories push command', () => {
       );
     });
 
+    it('should preserve shared-asset references and remap local ones on cross-space push', async () => {
+      const fromSpace = '54321';
+      const targetSpace = DEFAULT_SPACE;
+      const localOldId = 111;
+      const localNewId = 222;
+      const localOldFilename = 'https://a.storyblok.com/f/54321/500x500/local.png';
+      const localNewFilename = 'https://a.storyblok.com/f/12345/500x500/local.png';
+      const sharedId = 999111; // globally-unique shared asset id, never in the space manifest
+      const sharedFilename = 'https://a.storyblok.com/g/1/500x500/shared.png';
+      const storyA = makeMockStory({
+        slug: 'story-a',
+        content: {
+          _uid: randomUUID(),
+          component: 'page',
+          local_asset: { id: localOldId, filename: localOldFilename, fieldtype: 'asset' },
+          shared_asset: { id: sharedId, filename: sharedFilename, fieldtype: 'asset' },
+        },
+      });
+      preconditions.canLoadStories([storyA], fromSpace);
+      preconditions.canLoadComponents([
+        makeMockComponent({
+          name: 'page',
+          schema: {
+            local_asset: { type: 'asset' },
+            shared_asset: { type: 'asset' },
+          },
+        }),
+      ], fromSpace);
+      // The per-space asset manifest contains ONLY the local asset mapping; the
+      // shared asset is never present (separate namespace — WDX-411 invariant).
+      preconditions.canLoadAssetManifest([
+        {
+          old_id: localOldId,
+          new_id: localNewId,
+          old_filename: localOldFilename,
+          new_filename: localNewFilename,
+          created_at: new Date().toISOString(),
+        },
+      ], fromSpace);
+      const remoteStories = preconditions.canCreateStories([storyA]);
+      preconditions.canUpdateStories(remoteStories);
+
+      await storiesCommand.parseAsync(['node', 'test', 'push', '--space', targetSpace, '--from', fromSpace]);
+
+      const [storyARemote] = remoteStories;
+      expect(actions.updateStory).toHaveBeenCalledWith(targetSpace, storyARemote.id, expect.objectContaining({
+        story: expect.objectContaining({
+          content: expect.objectContaining({
+            // Local ref remapped through the target space manifest.
+            local_asset: { id: localNewId, filename: localNewFilename, fieldtype: 'asset' },
+            // Shared ref preserved verbatim (id + filename unchanged).
+            shared_asset: { id: sharedId, filename: sharedFilename, fieldtype: 'asset' },
+          }),
+        }),
+      }));
+      expect(console.info).toHaveBeenCalledWith(
+        expect.stringContaining('Push results: 1 story pushed, 0 stories failed'),
+      );
+    });
+
     it('should match existing stories by full_slug in a duplicated space', async () => {
       const sourceSpace = '99999';
       const targetSpace = DEFAULT_SPACE;

--- a/packages/cli/src/commands/stories/ref-mapper.test.ts
+++ b/packages/cli/src/commands/stories/ref-mapper.test.ts
@@ -112,6 +112,56 @@ describe('storyRefMapper', () => {
     expect(mappedStory.content.asset.filename).toBe(expectedCdnFilename);
   });
 
+  it('should pass shared-asset references through unchanged when the id is absent from the space manifest', () => {
+    const story: any = structuredClone(makeStoryWithAllFieldTypes());
+    // A shared asset uses a /g/{org_id}/ filename and is never in the space map.
+    story.content.asset.filename = 'https://a.storyblok.com/g/1/500x500/shared-image.png';
+    const sharedId = story.content.asset.id;
+    const sharedFilename = story.content.asset.filename;
+    // The per-space manifest only ever contains space-local assets.
+    const maps = { assets: new Map<number, any>(), stories: new Map() };
+
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
+
+    // id and filename preserved verbatim — no remap, no normalization rewrite.
+    expect(mappedStory.content.asset.id).toBe(sharedId);
+    expect(mappedStory.content.asset.filename).toBe(sharedFilename);
+  });
+
+  it('should remap a local asset while passing a shared asset through in the same story', () => {
+    const story: any = structuredClone(makeStoryWithAllFieldTypes());
+    const localOldId = story.content.bloks[0].bloks[0].asset.id;
+    const localNew = { id: getID(), filename: 'https://a.storyblok.com/f/12345/500x500/local-new.png' };
+    story.content.asset.filename = 'https://a.storyblok.com/g/1/500x500/shared-image.png';
+    const sharedId = story.content.asset.id;
+    const sharedFilename = story.content.asset.filename;
+    const assetMap = new Map<number, any>();
+    assetMap.set(localOldId, { new: localNew }); // local asset is in the space manifest
+    const maps = { assets: assetMap, stories: new Map() };
+
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
+
+    // Local ref remapped through the target space manifest.
+    expect(mappedStory.content.bloks[0].bloks[0].asset.id).toBe(localNew.id);
+    expect(mappedStory.content.bloks[0].bloks[0].asset.filename).toBe(localNew.filename);
+    // Shared ref untouched.
+    expect(mappedStory.content.asset.id).toBe(sharedId);
+    expect(mappedStory.content.asset.filename).toBe(sharedFilename);
+  });
+
+  it('should pass multiasset shared references through unchanged when absent from the manifest', () => {
+    const story: any = structuredClone(makeStoryWithAllFieldTypes());
+    story.content.multi_assets[0].filename = 'https://a.storyblok.com/g/1/500x500/shared-multi.png';
+    const sharedId = story.content.multi_assets[0].id;
+    const sharedFilename = story.content.multi_assets[0].filename;
+    const maps = { assets: new Map<number, any>(), stories: new Map() };
+
+    const mappedStory = storyRefMapper(story, { schemas: componentSchemas, maps });
+
+    expect(mappedStory.content.multi_assets[0].id).toBe(sharedId);
+    expect(mappedStory.content.multi_assets[0].filename).toBe(sharedFilename);
+  });
+
   it('should handle null parent_id for root-level stories', () => {
     const story = {
       name: 'Root Story',

--- a/packages/cli/src/commands/stories/ref-mapper.ts
+++ b/packages/cli/src/commands/stories/ref-mapper.ts
@@ -157,10 +157,19 @@ const bloksFieldRefMapper: RefMapper = (data, { schemas, maps, fieldRefMappers }
 /**
  * Asset field reference mapper.
  *
- * Normalizes asset filenames from S3 origin URLs to CDN URLs. The MAPI returns
- * asset filenames as S3 URLs (https://s3.amazonaws.com/a.storyblok.com/f/...)
- * but story content must reference the CDN URL (https://a.storyblok.com/f/...)
- * so that the Storyblok Image Service (/m/...) works correctly.
+ * Remaps an asset reference ONLY when its `id` is present in the per-space
+ * asset manifest (`maps.assets`). References absent from the manifest are
+ * passed through unchanged, preserving `id` and `filename` verbatim.
+ *
+ * Shared-asset references (`/g/{org_id}/…`) fall into this pass-through path:
+ * shared assets are never written into the per-space manifest (they live in a
+ * separate namespace, see assets pull/push), and their `id`s are globally
+ * unique, so they cannot collide with a space asset's `id`. A shared reference
+ * therefore keeps its `id`/`filename` across a cross-space push (WDX-411).
+ *
+ * For remapped (local) assets, normalizes the new filename from S3 origin URLs
+ * (https://s3.amazonaws.com/a.storyblok.com/f/...) to CDN URLs
+ * (https://a.storyblok.com/f/...) so the Storyblok Image Service (/m/...) works.
  */
 const assetFieldRefMapper: RefMapper = (data, { maps }) => {
   const mappedAsset = typeof data.id === 'number' ? maps.assets?.get(data.id) : undefined;

--- a/packages/migrations/src/map-refs.test.ts
+++ b/packages/migrations/src/map-refs.test.ts
@@ -65,6 +65,21 @@ describe('mapRefs', () => {
     expect(asRecord(asRecord(mappedStory.content).hero_image).id).toBe(20);
   });
 
+  it('should pass a shared-asset reference through unchanged when its id is absent from the asset map', () => {
+    const story = makeStory({
+      hero_image: {
+        fieldtype: 'asset',
+        id: 999111, // globally-unique shared asset id, not in the map
+        filename: 'https://a.storyblok.com/g/1/500x500/shared.png',
+      },
+    });
+    const maps = { assets: new Map<unknown, string | number>([[10, 20]]) }; // only a local id
+    const { mappedStory } = mapRefs(story as never, { schemas, maps });
+    const heroImage = asRecord(asRecord(mappedStory.content).hero_image);
+    expect(heroImage.id).toBe(999111);
+    expect(heroImage.filename).toBe('https://a.storyblok.com/g/1/500x500/shared.png');
+  });
+
   it('should traverse nested bloks recursively', () => {
     const story = makeStory({
       body: [

--- a/packages/migrations/src/map-refs.ts
+++ b/packages/migrations/src/map-refs.ts
@@ -227,6 +227,9 @@ const bloksFieldRefMapper: RefMapper = (
   );
 };
 
+// Remaps an asset reference only when its id is present in the asset map.
+// Absent ids (including shared assets, whose ids are globally unique and never
+// added to the per-space map) pass through unchanged, preserving id+filename.
 const assetFieldRefMapper: RefMapper = (data, { maps }) => {
   if (!isRecord(data)) {
     return data;


### PR DESCRIPTION
Locks in the contract that **shared-asset references** (`/g/{org_id}/…`) round-trip through story push/pull and migrations without being remapped or losing their `id`/`filename`.

## Why

WDX-411's behavior is already correct by WDX-408's architecture:
- Shared assets live in a **separate manifest namespace** (`.storyblok/assets/shared/{library_id}/…`) and are never written into the per-space manifest (`maps.assets`).
- Both ref-mappers (CLI `ref-mapper.ts`, migrations `map-refs.ts`) **pass an asset through unchanged when its `id` is absent** from the manifest.
- Asset `id`s are globally-unique snowflakes, so a shared asset's `id` can never collide with a space asset's `id` — the pass-through path is correct by construction.

So this PR adds **regression tests** that pin the contract and **documents the invariant** in the mappers. No behavioral production change.

## Changes

- `ref-mapper.ts` / `map-refs.ts`: invariant doc-comments only.
- `ref-mapper.test.ts`: shared pass-through (id+filename verbatim), combined local-remap + shared-passthrough, multiasset pass-through.
- `map-refs.test.ts`: migrations asset pass-through for ids absent from the map.
- `stories/push/index.test.ts`: end-to-end cross-space push — shared ref preserved, local ref remapped, manifest isolation.

Fixes DX-411