### PR TITLE
chore: base blitz worktrees on latest origin/main

### DIFF
--- a/.agents/skills/blitz/SKILL.md
+++ b/.agents/skills/blitz/SKILL.md
@@ -42,6 +42,8 @@ Create worktrees **only when multiple issues are confirmed for implementation**:
 - Single issue: work in the current tree (no worktree needed)
 - Multiple issues: create a worktree per issue for parallel work
 
+Each new worktree branch starts from the latest `origin/main`: the script fetches `origin/main` and bases new branches on it, so worktrees never inherit unrelated work from whatever is currently checked out.
+
 Use the bundled script:
 ```bash
 bash .claude/skills/blitz/scripts/monotree.sh add <branch-name>

--- a/.agents/skills/blitz/SKILL.md
+++ b/.agents/skills/blitz/SKILL.md
@@ -46,9 +46,9 @@ Each new worktree branch starts from the latest `origin/main`: the script fetche
 
 Use the bundled script:
 ```bash
-bash .claude/skills/blitz/scripts/monotree.sh add <branch-name>
-bash .claude/skills/blitz/scripts/monotree.sh remove <branch-name>
-bash .claude/skills/blitz/scripts/monotree.sh list
+bash .agents/skills/blitz/scripts/monotree.sh add <branch-name>
+bash .agents/skills/blitz/scripts/monotree.sh remove <branch-name>
+bash .agents/skills/blitz/scripts/monotree.sh list
 ```
 
 **IMPORTANT:** Create worktrees **sequentially**, one at a time. The script runs `git worktree add`, `pnpm install`, and `pnpm nx build` which are not safe to run in parallel (git index locks, pnpm store contention, Nx cache races). Wait for each to complete before starting the next.

--- a/.agents/skills/blitz/scripts/monotree.sh
+++ b/.agents/skills/blitz/scripts/monotree.sh
@@ -25,7 +25,10 @@ add_worktree() {
   if git show-ref --verify --quiet "refs/heads/$name" 2>/dev/null; then
     git worktree add "$worktree_path" "$name"
   else
-    git worktree add "$worktree_path" -b "$name"
+    # Branch new worktrees from the latest origin/main so each starts clean,
+    # regardless of what's currently checked out in the main repo.
+    git fetch origin main
+    git worktree add "$worktree_path" -b "$name" origin/main
   fi
 
   cd "$worktree_path" || exit 1


### PR DESCRIPTION
## What

`monotree.sh add` now fetches `origin/main` and bases new worktree branches on it, instead of branching from whatever is currently checked out in the main repo.

## Why

When blitzing issues, each worktree should start from a clean, up-to-date baseline. Branching off the current HEAD risked inheriting unrelated in-progress work into a fresh worktree.

## Changes

- `monotree.sh`: `git fetch origin main` + `git worktree add ... -b <name> origin/main` for new branches. Existing-branch reuse is unchanged.
- `blitz/SKILL.md`: documents the origin/main basing behavior in Phase 3.