### PR TITLE
fix(cli): use glob matching for datasources push --filter

### DIFF
--- a/packages/cli/src/commands/datasources/push/README.md
+++ b/packages/cli/src/commands/datasources/push/README.md
@@ -39,7 +39,7 @@ This will upload a single datasource and its entries from:
 |--------|-------------|---------|
 | `-s, --space <space>` | (Required) The ID of the space to push datasources to | - |
 | `-f, --from <from>` | Source space ID to read datasources from | Target space ID |
-| `--fi, --filter <filter>` | Filter to apply to datasources by their name (e.g., "color" will match datasources containing "color") | - |
+| `--fi, --filter <filter>` | Glob pattern to filter datasources by their name (e.g., "color*" will match all datasources starting with "color"). Filters without glob characters match as substrings (e.g., "color" will match datasources containing "color") | - |
 | `--sf, --separate-files` | Read from separate files instead of consolidated files | `false` |
 | `--su, --suffix <suffix>` | Suffix to add to the files names | - |
 | `-p, --path <path>` | Custom path to read the files from | `.storyblok/datasources` |
@@ -72,7 +72,7 @@ Reads from:
 
 3. Push datasources with filter:
 ```bash
-storyblok datasources push --space 12345 --filter "color"
+storyblok datasources push --space 12345 --filter "color*"
 ```
 Reads from:
 ```
@@ -218,7 +218,7 @@ storyblok datasources push --space 67890 --from 12345
 ### Update specific datasources
 ```bash
 # Push only color-related datasources
-storyblok datasources push --space 12345 --filter "color"
+storyblok datasources push --space 12345 --filter "color*"
 ```
 
 ### Work with separate files

--- a/packages/cli/src/commands/datasources/push/index.test.ts
+++ b/packages/cli/src/commands/datasources/push/index.test.ts
@@ -157,6 +157,55 @@ describe('push datasources', () => {
     });
   });
 
+  describe('--filter option', () => {
+    const datasources: SpaceDatasource[] = [
+      { ...mockDatasource, id: 1, name: 'colors-dark', slug: 'colors-dark' },
+      { ...mockDatasource, id: 2, name: 'colors-light', slug: 'colors-light' },
+      { ...mockDatasource, id: 3, name: 'internal-tags', slug: 'internal-tags' },
+    ];
+
+    beforeEach(() => {
+      vi.mocked(upsertDatasource).mockResolvedValue({ id: 1, name: 'test', slug: 'test', created_at: '', updated_at: '' });
+      vi.mocked(fetchDatasources).mockResolvedValue([]);
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify(datasources),
+      });
+    });
+
+    it('should match datasources by glob pattern', async () => {
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345', '--filter', 'colors-*']);
+
+      expect(upsertDatasource).toHaveBeenCalledTimes(2);
+      expect(upsertDatasource).toHaveBeenCalledWith('12345', expect.objectContaining({ name: 'colors-dark' }), undefined);
+      expect(upsertDatasource).toHaveBeenCalledWith('12345', expect.objectContaining({ name: 'colors-light' }), undefined);
+    });
+
+    it('should support negation patterns', async () => {
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345', '--filter', '!internal-*']);
+
+      expect(upsertDatasource).toHaveBeenCalledTimes(2);
+      expect(upsertDatasource).toHaveBeenCalledWith('12345', expect.objectContaining({ name: 'colors-dark' }), undefined);
+      expect(upsertDatasource).toHaveBeenCalledWith('12345', expect.objectContaining({ name: 'colors-light' }), undefined);
+    });
+
+    it('should fall back to substring matching when the filter contains no glob characters', async () => {
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345', '--filter', 'olor']);
+
+      expect(upsertDatasource).toHaveBeenCalledTimes(2);
+      expect(upsertDatasource).toHaveBeenCalledWith('12345', expect.objectContaining({ name: 'colors-dark' }), undefined);
+      expect(upsertDatasource).toHaveBeenCalledWith('12345', expect.objectContaining({ name: 'colors-light' }), undefined);
+    });
+
+    it('should error when no datasources match the pattern', async () => {
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345', '--filter', 'nonexistent-*']);
+
+      expect(upsertDatasource).not.toHaveBeenCalled();
+      expect(konsola.error).toHaveBeenCalledWith('No datasources found matching pattern "nonexistent-*".', null, {
+        header: true,
+      });
+    });
+  });
+
   describe('entry sync', () => {
     const localDatasource: SpaceDatasource = {
       id: 1,

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { minimatch } from 'minimatch';
 import { colorPalette, commands } from '../../../constants';
 import { CommandError, handleError, konsola, requireAuthentication } from '../../../utils';
 import { datasourcesCommand } from '../command';
@@ -78,7 +79,10 @@ pushCmd
         }
       }
       else if (filter) {
-        spaceState.local.datasources = spaceState.local.datasources.filter(datasource => datasource.name.includes(filter));
+        // Fall back to substring matching when the filter contains no glob special characters (backward compatibility)
+        const isGlobPattern = /[*?[\]{}!]/.test(filter);
+        spaceState.local.datasources = spaceState.local.datasources.filter(datasource =>
+          isGlobPattern ? minimatch(datasource.name, filter) : datasource.name.includes(filter));
         if (!spaceState.local.datasources.length) {
           handleError(new CommandError(`No datasources found matching pattern "${filter}".`), verbose);
           return;


### PR DESCRIPTION
## Summary

The `--filter` option of `storyblok datasources push` is documented as a glob pattern but was implemented as a plain substring match (`String.prototype.includes`), so glob tokens like `*`, `?`, and `!` negation were silently ignored. This PR switches the filter to `minimatch`, matching the existing `components push` implementation.

For backward compatibility, filters without glob special characters (`* ? [ ] { } !`) keep the old substring matching, so existing usage like `--filter color` continues to match `colors`.

## Changes

- `packages/cli/src/commands/datasources/push/index.ts`: use `minimatch` when the filter contains glob special characters, fall back to substring matching otherwise
- `packages/cli/src/commands/datasources/push/index.test.ts`: regression tests for glob matching, negation patterns, substring fallback, and the no-match error
- `packages/cli/src/commands/datasources/push/README.md`: document glob semantics and the substring fallback

## Test plan

- [x] `pnpm vitest run src/commands/datasources/push/index.test.ts` (17/17 passing)
- [x] `pnpm nx run-many -t lint,test:types -p storyblok`
- [x] Manual check: `storyblok datasources push --space <id> --filter '!internal-*'` excludes matching datasources (the #634 reproduction)

Fixes WDX-442
Fixes #634