### PR TITLE
chore: refine dependency rule to discourage fragile hand-rolling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 2. **Small diffs** - One logical change per commit
 3. **Plan first** - For non-trivial changes, write a plan before coding
 4. **Verify always** - Run lint/typecheck/tests before considering work done
-5. **No new deps** - Avoid adding dependencies unless strictly necessary
+5. **Deps: prefer none, don't hand-roll** - Write a few-line helper yourself. But don't reimplement error-prone functionality (parsing, crypto, dates, globbing). Use dependencies already in the lockfile; else add a small well-established dep or flag the tradeoff. Never hand-roll silently.
 6. **Reuse first** - Before implementing, search for existing utilities, helpers, and modules in the package. Prefer composing over writing new.
 
 ## Monorepo setup


### PR DESCRIPTION
## Summary

Rule 5 (`No new deps`) was binary: "avoid dependencies unless strictly necessary." With no counter-weight, agents resolve the ambiguity by hand-rolling error-prone functionality to comply, e.g. a regex-based YAML parser instead of using the `yaml` package (surfaced in #625 review comments).

This reframes the rule so it still discourages casual deps but names the opposite failure mode and gives a concrete decision procedure:

- Write trivial few-line helpers yourself.
- Don't reimplement error-prone functionality (parsing, crypto, dates, globbing).
- Prefer a dependency already in the lockfile (free); otherwise add a small well-established one, or flag the tradeoff rather than hand-rolling silently.

The examples carry the definition, so the vague "non-trivial" / "strictly necessary" wording is gone.