### PR TITLE
fix(cli): support non-EU regions when creating spaces

### DIFF
--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vites
 import open from 'open';
 import { createEnvFile, extractPortFromTopics, fetchBlueprintRepositories, generateProject, generateSpaceUrl, handleEnvFileCreation, openSpaceInBrowser, repositoryToTemplate } from './actions';
 import * as filesystem from '../../utils/filesystem';
+import type { RegionCode } from '../../constants';
+import { appDomains } from '../../constants';
 
 vi.mock('node:child_process');
 vi.mock('node:fs/promises', () => ({
@@ -331,40 +333,41 @@ describe('create actions', () => {
   });
 
   describe('generateSpaceUrl', () => {
-    it('should generate correct URL for EU region', () => {
-      const url = generateSpaceUrl(12345, 'eu');
-      expect(url).toBe('https://app.storyblok.com/#/me/spaces/12345/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create');
-    });
+    const regionDomains = (Object.keys(appDomains) as RegionCode[]).map(region => ({
+      region,
+      expectedDomain: appDomains[region],
+    }));
 
-    it('should generate correct URL for US region', () => {
-      const url = generateSpaceUrl(67890, 'us');
-      expect(url).toBe('https://app-us.storyblok.com/#/me/spaces/67890/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create');
-    });
+    it.each(regionDomains)(
+      'should generate correct URL for $region region',
+      ({ region, expectedDomain }) => {
+        const spaceId = 12345;
 
-    it('should generate correct URL for China region', () => {
-      const url = generateSpaceUrl(11111, 'cn');
-      expect(url).toBe('https://app.storyblokchina.cn/#/me/spaces/11111/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create');
-    });
-
-    it('should generate correct URL for Canada region', () => {
-      const url = generateSpaceUrl(22222, 'ca');
-      expect(url).toBe('https://app-ca.storyblok.com/#/me/spaces/22222/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create');
-    });
-
-    it('should generate correct URL for Asia Pacific region', () => {
-      const url = generateSpaceUrl(33333, 'ap');
-      expect(url).toBe('https://app-ap.storyblok.com/#/me/spaces/33333/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create');
-    });
+        expect(generateSpaceUrl(spaceId, region)).toBe(
+          `https://${expectedDomain}/#/me/spaces/${spaceId}/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create`,
+        );
+      },
+    );
   });
 
   describe('openSpaceInBrowser', () => {
-    it('should open space URL in browser successfully', async () => {
-      mockedOpen.mockResolvedValue({} as any);
+    const regionDomains = (Object.keys(appDomains) as RegionCode[]).map(region => ({
+      region,
+      expectedDomain: appDomains[region],
+    }));
 
-      await expect(openSpaceInBrowser(12345, 'eu')).resolves.toBeUndefined();
+    it.each(regionDomains)(
+      'should open the correct URL for $region region',
+      async ({ region, expectedDomain }) => {
+        mockedOpen.mockResolvedValue({} as any);
 
-      expect(mockedOpen).toHaveBeenCalledWith('https://app.storyblok.com/#/me/spaces/12345/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create');
-    });
+        await expect(openSpaceInBrowser(98765, region)).resolves.toBeUndefined();
+
+        expect(mockedOpen).toHaveBeenCalledWith(
+          `https://${expectedDomain}/#/me/spaces/98765/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create`,
+        );
+      },
+    );
 
     it('should handle errors when opening browser fails', async () => {
       const openError = new Error('Failed to open browser');
@@ -373,14 +376,6 @@ describe('create actions', () => {
       await expect(openSpaceInBrowser(12345, 'us')).rejects.toThrow(
         'Failed to open space in browser: Failed to open browser',
       );
-    });
-
-    it('should open correct URL for different regions', async () => {
-      mockedOpen.mockResolvedValue({} as any);
-
-      await openSpaceInBrowser(98765, 'cn');
-
-      expect(mockedOpen).toHaveBeenCalledWith('https://app.storyblokchina.cn/#/me/spaces/98765/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create');
     });
   });
 });

--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -343,20 +343,23 @@ describe('create actions', () => {
   });
 
   describe('openSpaceInBrowser', () => {
-    const regionDomains = (Object.keys(appDomains) as RegionCode[]).map(region => ({
-      region,
-      expectedDomain: appDomains[region],
-    }));
+    const testCases = [
+      { region: 'eu', spaceId: 12345 },
+      { region: 'us', spaceId: 67890 },
+      { region: 'cn', spaceId: 11111 },
+      { region: 'ca', spaceId: 22222 },
+      { region: 'ap', spaceId: 33333 },
+    ] satisfies Array<{ region: RegionCode; spaceId: number }>;
 
-    it.each(regionDomains)(
-      'should open the correct URL for $region region',
-      async ({ region, expectedDomain }) => {
+    it.each(testCases)(
+      'should open the correct URL for %s region',
+      async ({ region, spaceId }) => {
         mockedOpen.mockResolvedValue({} as any);
 
-        await expect(openSpaceInBrowser(98765, region)).resolves.toBeUndefined();
+        await expect(openSpaceInBrowser(spaceId, region)).resolves.toBeUndefined();
 
         expect(mockedOpen).toHaveBeenCalledWith(
-          `https://${expectedDomain}/#/me/spaces/98765/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create`,
+          `https://${appDomains[region]}/#/me/spaces/${spaceId}/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create`,
         );
       },
     );

--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import { vol } from 'memfs';
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 import open from 'open';
-import { createEnvFile, extractPortFromTopics, fetchBlueprintRepositories, generateProject, generateSpaceUrl, handleEnvFileCreation, openSpaceInBrowser, repositoryToTemplate } from './actions';
+import { createEnvFile, extractPortFromTopics, fetchBlueprintRepositories, generateProject, handleEnvFileCreation, openSpaceInBrowser, repositoryToTemplate } from './actions';
 import * as filesystem from '../../utils/filesystem';
 import type { RegionCode } from '../../constants';
 import { appDomains } from '../../constants';
@@ -332,22 +332,14 @@ describe('create actions', () => {
     });
   });
 
-  describe('generateSpaceUrl', () => {
-    const regionDomains = (Object.keys(appDomains) as RegionCode[]).map(region => ({
-      region,
-      expectedDomain: appDomains[region],
-    }));
-
-    it.each(regionDomains)(
-      'should generate correct URL for $region region',
-      ({ region, expectedDomain }) => {
-        const spaceId = 12345;
-
-        expect(generateSpaceUrl(spaceId, region)).toBe(
-          `https://${expectedDomain}/#/me/spaces/${spaceId}/dashboard?utm_source=storyblok-cli&utm_medium=cli&utm_campaign=create`,
-        );
-      },
-    );
+  it('should contain the correct region domains', () => {
+    expect(appDomains).toEqual({
+      eu: 'app.storyblok.com',
+      us: 'app.storyblok.com',
+      cn: 'app.storyblokchina.cn/fe/editor_v2',
+      ca: 'app.storyblok.com',
+      ap: 'app.storyblok.com',
+    });
   });
 
   describe('openSpaceInBrowser', () => {

--- a/packages/cli/src/commands/spaces/actions.ts
+++ b/packages/cli/src/commands/spaces/actions.ts
@@ -29,10 +29,13 @@ export const fetchSpace = async (spaceId: string): Promise<Space | undefined> =>
  */
 export const createSpace = async (space: SpaceCreate): Promise<Space | undefined> => {
   try {
+    const { in_org, assign_partner, ...spaceData } = space;
     const client = getMapiClient();
     const { data } = await client.spaces.create({
       body: {
-        space,
+        space: spaceData,
+        ...(in_org && { in_org }),
+        ...(assign_partner && { assign_partner }),
       },
     });
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -69,10 +69,10 @@ export const managementApiRegions: Record<RegionCode, string> = {
 
 export const appDomains: Record<RegionCode, string> = {
   eu: 'app.storyblok.com',
-  us: 'app-us.storyblok.com',
-  cn: 'app.storyblokchina.cn',
-  ca: 'app-ca.storyblok.com',
-  ap: 'app-ap.storyblok.com',
+  us: 'app.storyblok.com',
+  cn: 'app.storyblokchina.cn/fe/editor_v2',
+  ca: 'app.storyblok.com',
+  ap: 'app.storyblok.com',
 } as const;
 
 export const regionNames: Record<RegionCode, string> = {


### PR DESCRIPTION
This PR fixes issues related to space creation in the CLI when working with regions other than the EU.

### Changes

* Use the correct organisation settings when creating new spaces.
* Fix app domain resolution when generating URLs for newly created spaces.
* Update URL generation logic so the CLI opens the correct regional Storyblok app after space creation.


Fixes WDX-283
Fixes WDX-413