### PR TITLE
fix(schema): accept component description in generated block schemas

### DIFF
--- a/packages/cli/src/commands/schema/push/actions.test.ts
+++ b/packages/cli/src/commands/schema/push/actions.test.ts
@@ -11,6 +11,7 @@ describe('toComponentCreate', () => {
       id: 99,
       name: 'page',
       display_name: 'Page',
+      description: 'A test block',
       created_at: '2024-01-01',
       updated_at: '2024-01-01',
       is_root: true,
@@ -28,6 +29,7 @@ describe('toComponentCreate', () => {
     expect(result).toEqual({
       name: 'page',
       display_name: 'Page',
+      description: 'A test block',
       color: '',
       icon: '',
       preview_field: '',
@@ -51,7 +53,7 @@ describe('toComponentCreate', () => {
       created_at: '',
       updated_at: '',
       schema: {},
-      // display_name, color, icon, preview_field intentionally absent
+      // display_name, description, color, icon, preview_field intentionally absent
     } as unknown as Component;
 
     const result = toComponentCreate(component);
@@ -59,6 +61,7 @@ describe('toComponentCreate', () => {
     expect(result).toMatchObject({
       name: 'hero',
       display_name: '',
+      description: '',
       color: '',
       icon: '',
       preview_field: '',

--- a/packages/cli/src/commands/schema/push/diff-schema.test.ts
+++ b/packages/cli/src/commands/schema/push/diff-schema.test.ts
@@ -123,6 +123,40 @@ describe('diffSchema', () => {
     expect(result.diffs[0].action).toBe('update');
   });
 
+  it('should not show diff when remote has an empty description and local does not set it', () => {
+    const localComp = makeComponent('test', { title: { type: 'text', pos: 0 } });
+    const remoteComp = { ...makeComponent('test', { title: { type: 'text', pos: 0 } }), description: '' };
+
+    const local: SchemaData = { components: [localComp], componentFolders: [], datasources: [] };
+    const remote: RemoteSchemaData = {
+      components: new Map([['test', remoteComp]]),
+      componentFolders: new Map(),
+      datasources: new Map(),
+    };
+
+    const result = diffSchema(local, remote);
+
+    expect(result.unchanged).toBe(1);
+    expect(result.updates).toBe(0);
+  });
+
+  it('should show diff when local removes a remote description', () => {
+    const localComp = makeComponent('test', { title: { type: 'text', pos: 0 } });
+    const remoteComp = { ...makeComponent('test', { title: { type: 'text', pos: 0 } }), description: 'A test block' };
+
+    const local: SchemaData = { components: [localComp], componentFolders: [], datasources: [] };
+    const remote: RemoteSchemaData = {
+      components: new Map([['test', remoteComp]]),
+      componentFolders: new Map(),
+      datasources: new Map(),
+    };
+
+    const result = diffSchema(local, remote);
+
+    expect(result.updates).toBe(1);
+    expect(result.diffs[0].action).toBe('update');
+  });
+
   it('should treat datasource without dimensions as unchanged when remote has empty dimensions', () => {
     const local: SchemaData = {
       components: [],

--- a/packages/cli/src/commands/schema/transform.ts
+++ b/packages/cli/src/commands/schema/transform.ts
@@ -28,6 +28,7 @@ function buildComponentPayload(input: unknown) {
     // removing a field from the local schema actually clears it on the API.
     // (Root-level fields are additive on MAPI update — omitting preserves the old value.)
     display_name: typeof input.display_name === 'string' ? input.display_name : '',
+    description: typeof input.description === 'string' ? input.description : '',
     color: typeof input.color === 'string' ? input.color : '',
     icon: typeof input.icon === 'string' ? input.icon : '',
     preview_field: typeof input.preview_field === 'string' ? input.preview_field : '',

--- a/packages/cli/src/commands/schema/utils.ts
+++ b/packages/cli/src/commands/schema/utils.ts
@@ -53,6 +53,7 @@ export const DATASOURCE_DEFAULTS: Record<string, unknown> = {
 
 export const COMPONENT_DEFAULTS: Record<string, unknown> = {
   display_name: '',
+  description: '',
   color: '',
   icon: '',
   preview_field: '',

--- a/packages/openapi/resources/mapi/components/component-create.yaml
+++ b/packages/openapi/resources/mapi/components/component-create.yaml
@@ -11,6 +11,11 @@ properties:
       - string
       - "null"
     description: Name that will be used in the editor interface
+  description:
+    type:
+      - string
+      - "null"
+    description: Description shown in the editor interface
   schema:
     type: object
     description: Component schema definition containing fields and their configurations

--- a/packages/openapi/resources/mapi/components/component-update.yaml
+++ b/packages/openapi/resources/mapi/components/component-update.yaml
@@ -9,6 +9,11 @@ properties:
       - string
       - "null"
     description: Name that will be used in the editor interface
+  description:
+    type:
+      - string
+      - "null"
+    description: Description shown in the editor interface
   schema:
     type: object
     description: Component schema definition containing fields and their configurations

--- a/packages/openapi/resources/mapi/components/component.yaml
+++ b/packages/openapi/resources/mapi/components/component.yaml
@@ -19,6 +19,11 @@ properties:
       - string
       - "null"
     description: Name that will be used in the editor interface
+  description:
+    type:
+      - string
+      - "null"
+    description: Description shown in the editor interface
   created_at:
     readOnly: true
     type: string

--- a/packages/schema/src/helpers/define-block.test-d.ts
+++ b/packages/schema/src/helpers/define-block.test-d.ts
@@ -42,6 +42,13 @@ describe('defineBlock', () => {
     const pageBlock = defineBlock({ name: 'page', component_group_uuid: 'shared-group', schema: [] });
     expectTypeOf(pageBlock.component_group_uuid).toEqualTypeOf<'shared-group'>();
   });
+
+  it('should accept a string or null description', () => {
+    const testBlock = defineBlock({ name: 'test', description: 'A test block', schema: [] });
+    const nullDescriptionBlock = defineBlock({ name: 'test', description: null, schema: [] });
+    expectTypeOf(testBlock.description).toEqualTypeOf<string | null | undefined>();
+    expectTypeOf(nullDescriptionBlock.description).toEqualTypeOf<string | null | undefined>();
+  });
 });
 
 const schema = [


### PR DESCRIPTION
Fixes WDX-453: `storyblok schema init` on a space with a user-created block emits a top-level `description` field that the generated `@storyblok/schema` types rejected, so the bootstrapped schema failed to type check.

Root cause: the MAPI returns a top-level `description` on components (`null` when never set, `''` for UI-created blocks), but the component schemas in `@storyblok/openapi` didn't declare it. With `strictObjects: true` codegen, `defineBlock()` rejected the excess property. Default blocks were unaffected only because their `description: null` is dropped by `stripKeys` during init.

## Changes

- **`@storyblok/openapi`**: declare `description` (`string | null`) on `Component`, `ComponentCreate`, and `ComponentUpdate` — this propagates through codegen to `@storyblok/schema` and `@storyblok/management-api-client` (generated artifacts are gitignored, nothing to commit there).
- **CLI `schema push`**: add `description: ''` to `COMPONENT_DEFAULTS` so remote `null`/`''` vs. local-unset produces no diff, and always send `description` in `buildComponentPayload` so removing a local description resets it remotely (root-level MAPI component updates are additive — omitted keys are preserved).
- Tests: type tests for `defineBlock` description, init codegen preservation, diff normalization/edit/removal cases, push payload assertions.

Fixes WDX-453