### PR TITLE
fix(cli): schema/migrations DX improvements

### DIFF
--- a/packages/cli/src/commands/schema/init/index.test.ts
+++ b/packages/cli/src/commands/schema/init/index.test.ts
@@ -257,6 +257,16 @@ describe('schema init command', () => {
     expect(content).not.toContain('api-field-id');
   });
 
+  it('should list generated files as paths relative to the current working directory', async () => {
+    const comp = makeMockComponent({ name: 'hero' });
+    preconditions.hasRemoteSchema({ components: [comp] });
+
+    await schemaCommand.parseAsync(['node', 'test', 'init', '--space', DEFAULT_SPACE]);
+
+    expect(console.log).toHaveBeenCalledWith('  .storyblok/schema/components/hero.ts');
+    expect(console.log).toHaveBeenCalledWith('  .storyblok/schema/schema.ts');
+  });
+
   it('should refuse when the target directory is not empty', async () => {
     vol.fromJSON({
       '.storyblok/schema/components/existing.ts': '// existing',

--- a/packages/cli/src/commands/schema/init/index.ts
+++ b/packages/cli/src/commands/schema/init/index.ts
@@ -8,6 +8,7 @@ import { getReporter } from '../../../lib/reporter/reporter';
 import { getUI } from '../../../utils/ui';
 import { session } from '../../../session';
 import { schemaCommand } from '../command';
+import { displayPath } from '../utils';
 import type { SchemaInitOptions } from './constants';
 import { fetchRemoteSchema } from '../actions';
 import { writeSchemaFiles } from './actions';
@@ -47,10 +48,11 @@ schemaCommand
     }
 
     const targetPath = resolve(options.outDir);
+    const targetDisplayPath = displayPath(targetPath, options.outDir);
 
     if (!(await isTargetEmpty(targetPath))) {
       handleError(
-        new CommandError(`Target directory ${targetPath} is not empty. \`schema init\` is a one-time bootstrap and refuses to overwrite existing files. Use \`schema push\` for ongoing changes, or remove the directory to re-bootstrap.`),
+        new CommandError(`Target directory ${targetDisplayPath} is not empty. \`schema init\` is a one-time bootstrap and refuses to overwrite existing files. Use \`schema push\` for ongoing changes, or remove the directory to re-bootstrap.`),
         verbose,
       );
       return;
@@ -74,14 +76,14 @@ schemaCommand
       fetchSpinner.succeed(`Found: ${rawComponents.length} components, ${rawComponentFolders.length} component folders, ${rawDatasources.length} datasources`);
 
       // 2. Generate and write files
-      const writeSpinner = ui.createSpinner(`Generating TypeScript files to ${targetPath}...`);
+      const writeSpinner = ui.createSpinner(`Generating TypeScript files to ${targetDisplayPath}...`);
       const writtenFiles = await writeSchemaFiles(targetPath, rawComponents, rawComponentFolders, rawDatasources);
 
       summary.total = writtenFiles.length;
       summary.succeeded = writtenFiles.length;
 
       writeSpinner.succeed(`Generated ${writtenFiles.length} files`);
-      ui.list(writtenFiles);
+      ui.list(writtenFiles.map(file => displayPath(file, options.outDir)));
       ui.warn('`schema init` is a one-time bootstrap step for adopting an existing space. Review generated files before continuing.');
       ui.info('After bootstrapping, keep your local schema as the source of truth and use `schema push` for ongoing changes.');
       ui.info('Make sure `@storyblok/schema` is installed in the project that imports these files (e.g. `pnpm add @storyblok/schema`).');

--- a/packages/cli/src/commands/schema/push/index.ts
+++ b/packages/cli/src/commands/schema/push/index.ts
@@ -9,6 +9,7 @@ import { getUI } from '../../../utils/ui';
 import { session } from '../../../session';
 import { resolvePath } from '../../../utils/filesystem';
 import { schemaCommand } from '../command';
+import { displayPath } from '../utils';
 import type { SchemaPushOptions } from './constants';
 import type { SchemaData } from '../types';
 import { loadSchema } from './load-schema';
@@ -159,7 +160,9 @@ schemaCommand
                   timestamp: migrationTimestamp,
                   basePath: resolvedBase,
                 });
-                ui.log(`  Generated: ${path}`);
+                const migrationPath = displayPath(path, basePath);
+                logger.info('Migration generated', { component: comp.componentName, path: migrationPath });
+                ui.log(`  Generated: ${migrationPath}`);
               }
 
               ui.br();
@@ -198,7 +201,7 @@ schemaCommand
         remote: { components: rawComponents, componentFolders: rawComponentFolders, datasources: rawDatasources },
         changes: buildChangesetEntries(diffResult, resolved, remote, { delete: options.delete }),
       });
-      logger.info('Changeset saved', { path: changesetPath });
+      logger.info('Changeset saved', { path: displayPath(changesetPath, basePath) });
 
       // 9. Execute push (skipped when nothing to push)
       const nothingToPush = diffResult.creates === 0 && diffResult.updates === 0 && (!options.delete || diffResult.stale === 0);

--- a/packages/cli/src/commands/schema/push/migrations/generate.test.ts
+++ b/packages/cli/src/commands/schema/push/migrations/generate.test.ts
@@ -158,9 +158,9 @@ describe('writeMigrationFile', () => {
       timestamp,
     });
 
-    expect(path).toContain('migrations/12345/hero.2026-04-10T12-00-00-000Z.js');
+    expect(path).toContain('migrations/12345/hero.20260410120000.js');
     const files = vol.toJSON();
-    expect(Object.keys(files).some(f => f.includes('hero.2026-04-10T12-00-00-000Z.js'))).toBe(true);
+    expect(Object.keys(files).some(f => f.includes('hero.20260410120000.js'))).toBe(true);
   });
 
   it('should use custom base path when provided', async () => {
@@ -175,6 +175,6 @@ describe('writeMigrationFile', () => {
       basePath: 'custom/path',
     });
 
-    expect(path).toContain('custom/path/migrations/12345/hero.2026-04-10T12-00-00-000Z.js');
+    expect(path).toContain('custom/path/migrations/12345/hero.20260410120000.js');
   });
 });

--- a/packages/cli/src/commands/schema/push/write-local-components.ts
+++ b/packages/cli/src/commands/schema/push/write-local-components.ts
@@ -6,6 +6,7 @@ import type { UI } from '../../../utils/ui';
 import { directories } from '../../../constants';
 import { fileExists, resolveCommandPath, sanitizeFilename, saveToFile } from '../../../utils/filesystem';
 import type { DiffResult, SchemaData } from '../types';
+import { displayPath } from '../utils';
 
 const DEFAULT_GROUPS_FILENAME = 'groups.json';
 const CONSOLIDATED_COMPONENTS_FILENAME = 'components.json';
@@ -34,7 +35,7 @@ export async function writeLocalComponents({
   const consolidatedPath = join(componentsDir, CONSOLIDATED_COMPONENTS_FILENAME);
   if (await fileExists(consolidatedPath)) {
     ui.warn(
-      `A consolidated ${CONSOLIDATED_COMPONENTS_FILENAME} exists at ${componentsDir}. `
+      `A consolidated ${CONSOLIDATED_COMPONENTS_FILENAME} exists at ${displayPath(componentsDir, basePath)}. `
       + `Per-component files will still be written, but the consolidated file may shadow them when stories push validates schemas. `
       + `Delete it or run \`storyblok components pull --separate-files\` to regenerate.`,
     );
@@ -52,7 +53,7 @@ export async function writeLocalComponents({
   else if (await fileExists(groupsPath)) {
     try {
       await unlink(groupsPath);
-      logger.info('Removed stale local groups file', { path: groupsPath });
+      logger.info('Removed stale local groups file', { path: displayPath(groupsPath, basePath) });
     }
     catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -69,7 +70,7 @@ export async function writeLocalComponents({
       const filePath = join(componentsDir, `${sanitizeFilename(stale.name)}.json`);
       try {
         await unlink(filePath);
-        logger.info('Removed stale local component file', { path: filePath });
+        logger.info('Removed stale local component file', { path: displayPath(filePath, basePath) });
       }
       catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/packages/cli/src/commands/schema/rollback/index.ts
+++ b/packages/cli/src/commands/schema/rollback/index.ts
@@ -11,6 +11,7 @@ import { resolvePath } from '../../../utils/filesystem';
 import { schemaCommand } from '../command';
 import { fetchRemoteSchema } from '../actions';
 import { saveChangeset } from '../changeset';
+import { displayPath } from '../utils';
 import type { SchemaRollbackOptions } from './constants';
 import { buildRollbackOps, executeRollback, formatRollbackOutput, listChangesets, loadChangeset } from './actions';
 
@@ -156,7 +157,7 @@ schemaCommand
           ...(Object.keys(op.payload).length > 0 && { after: op.payload }),
         })),
       });
-      logger.info('Rollback changeset saved', { path: rollbackChangesetPath });
+      logger.info('Rollback changeset saved', { path: displayPath(rollbackChangesetPath, basePath) });
     }
     catch (maybeError) {
       summary.failed += 1;

--- a/packages/cli/src/commands/schema/utils.test.ts
+++ b/packages/cli/src/commands/schema/utils.test.ts
@@ -1,19 +1,37 @@
+import { join } from 'pathe';
 import { describe, expect, it } from 'vitest';
 
-import { applyDefaults, fileTimestamp, formatValue, stripKeys } from './utils';
+import { applyDefaults, displayPath, fileTimestamp, formatValue, stripKeys } from './utils';
 
 describe('fileTimestamp', () => {
-  it('should replace colons with hyphens', () => {
-    expect(fileTimestamp('2024-01-15T10:30:00')).toBe('2024-01-15T10-30-00');
+  it('should convert an ISO timestamp to compact YYYYMMDDHHmmss form', () => {
+    expect(fileTimestamp('2024-01-15T10:30:00')).toBe('20240115103000');
   });
 
-  it('should replace dots with hyphens', () => {
-    expect(fileTimestamp('2024-01-15T10:30:00.000Z')).toBe('2024-01-15T10-30-00-000Z');
+  it('should drop milliseconds and timezone suffix', () => {
+    expect(fileTimestamp('2024-01-15T10:30:00.123Z')).toBe('20240115103000');
   });
 
   it('should produce a filesystem-safe string', () => {
     const result = fileTimestamp('2024-01-15T10:30:00.000Z');
-    expect(result).not.toMatch(/[:.]/);
+    expect(result).toMatch(/^\d{14}$/);
+  });
+});
+
+describe('displayPath', () => {
+  it('should return a path relative to CWD by default', () => {
+    const filePath = join(process.cwd(), '.storyblok/migrations/12345/hero.20260430114254.js');
+    expect(displayPath(filePath)).toBe('.storyblok/migrations/12345/hero.20260430114254.js');
+  });
+
+  it('should return a path relative to CWD when the user path is relative', () => {
+    const filePath = join(process.cwd(), 'custom/migrations/12345/hero.js');
+    expect(displayPath(filePath, 'custom')).toBe('custom/migrations/12345/hero.js');
+  });
+
+  it('should keep the absolute path when the user passed an absolute path', () => {
+    const filePath = join(process.cwd(), 'storage/migrations/12345/hero.js');
+    expect(displayPath(filePath, process.cwd())).toBe(filePath);
   });
 });
 

--- a/packages/cli/src/commands/schema/utils.ts
+++ b/packages/cli/src/commands/schema/utils.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, relative } from 'pathe';
+
 /** Fields to strip from Component before serialization (read-only / API-assigned). */
 export const COMPONENT_STRIP_KEYS = new Set([
   'id',
@@ -113,9 +115,17 @@ export function formatValue(value: unknown, depth: number): string {
   return String(value);
 }
 
-/** Converts an ISO timestamp to a filesystem-safe string (replaces `:` and `.` with `-`). */
+/** Converts an ISO timestamp to a compact filesystem-safe form: `YYYYMMDDHHmmss` (e.g. `20260430114254`). */
 export function fileTimestamp(iso: string): string {
-  return iso.replace(/[:.]/g, '-');
+  return iso.replace(/\D/g, '').slice(0, 14);
+}
+
+/**
+ * Formats a file path for display: relative to CWD, unless the user explicitly
+ * passed an absolute `--path` (then the absolute path is kept as-is).
+ */
+export function displayPath(filePath: string, userPath?: string): string {
+  return userPath && isAbsolute(userPath) ? filePath : relative(process.cwd(), filePath);
 }
 
 /** Strips keys from an object, removing undefined and null values from optional fields. */


### PR DESCRIPTION
Small DX improvements to the `schema` / `migrations` CLI flow:

1. **Compact timestamps in generated filenames** — migration files and changesets now use a Laravel/Rails-style `YYYYMMDDHHmmss` suffix (`hero.20260611114309.js`, `changesets/20260611114309.json`) instead of the long ISO form (`hero.2026-04-30T11-42-54-732Z.js`), making `migrations run hero.20260611114309` practical to type.
2. **Log entry for generated migrations** — `schema push --migrations` now writes a `Migration generated` logger entry (component + path) and a UI `Generated: <path>` line per migration file.
3. **Relative paths in output** — migration, changeset, and rollback paths in UI and logger output are printed relative to the CWD via a new `displayPath` helper. An absolute user-provided `--path`/`--out-dir` keeps absolute output. Also applied to `schema init` (spinner, generated file list, non-empty-dir error).

Out of scope: `migrations generate` filename format, migrating previously generated ISO-named files.

Fixes WDX-437