### PR TITLE
fix(astro): correct package module entry

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -43,7 +43,7 @@
     "./StoryblokServerData.astro": "./dist/components/StoryblokServerData.astro"
   },
   "main": "./dist/storyblok-astro.es.js",
-  "module": "./dist/storyblok-astro.js",
+  "module": "./dist/storyblok-astro.es.js",
   "types": "./dist/index.d.ts",
   "files": [
     "*.d.ts",


### PR DESCRIPTION
## Summary
- Point `@storyblok/astro`'s `module` field at the generated ES bundle.

## Why
The published `@storyblok/astro@9.0.12` package declares:

```json
"module": "./dist/storyblok-astro.js"
```

but the npm tarball does not include `dist/storyblok-astro.js`. It does include `dist/storyblok-astro.es.js`, which is already used by `main` and `exports["."].import`.

The Vite library config uses `fileName: format => storyblok-astro.${format}.js`, so the ES build output is `storyblok-astro.es.js`.

## Validation
- `git diff --check HEAD~1..HEAD`
- Packed and inspected `@storyblok/astro@9.0.12`: `dist/storyblok-astro.js` is absent, while `dist/storyblok-astro.es.js` and `dist/storyblok-astro.umd.js` are present.
- Confirmed the patched `module` target resolves to a file that exists in the published tarball.

I did not run the full monorepo build locally because this is a package metadata-only change and the tarball inspection directly verifies the broken and corrected entry target.