### PR TITLE
fix(svelte): decouple teaser e2e from mutable blok _uid

### DIFF
--- a/packages/svelte/cypress/e2e/index.cy.ts
+++ b/packages/svelte/cypress/e2e/index.cy.ts
@@ -9,7 +9,10 @@ describe('@storyblok/svelte', () => {
   describe('Rendering Components', () => {
     it('The teaser blok is correctly rendered', () => {
       cy.visit('https://localhost:5173/');
-      cy.get('[data-blok-uid="141210018-97a0e33f-1e0b-4561-8193-4839a9f85cae"]').should('exist');
+      // Match the stable numeric blok `id` prefix rather than the full
+      // `data-blok-uid`: the trailing `_uid` is regenerated whenever the blok
+      // is edited in the space, which silently breaks an exact-match selector.
+      cy.get('[data-blok-uid^="141210018-"]').should('contain', 'First Teaser');
     });
   });
 });


### PR DESCRIPTION
Decouples the `@storyblok/svelte` Cypress e2e ("The teaser blok is correctly rendered") from the mutable blok `_uid`.

```ts
// before
cy.get('[data-blok-uid="141210018-97a0e33f-1e0b-4561-8193-4839a9f85cae"]').should('exist');
// after
cy.get('[data-blok-uid^="141210018-"]').should('contain', 'First Teaser');
```

## Why

The test asserted an exact `data-blok-uid`. That attribute is `${_editable.id}-${_editable.uid}`, and the trailing `_uid` is regenerated whenever the blok is edited in the space (delete/re-add keeps the numeric `id` but mints a new UUID). The live `home` story's teaser `_uid` has since changed from `97a0e33f-…` to `0365762c-…`, so the selector never matched — failing **deterministically** in CI.

It surfaced on unrelated PRs (e.g. #626) only because `nx run-many` pulls `@storyblok/svelte` into the affected graph, and its `test` target chains `test:unit && test:e2e`. The failure was **not** caused by those PRs.

## Fix

Match the stable numeric blok `id` prefix (`141210018-`) and assert on rendered content instead of the regenerating `_uid`.
