### PR TITLE
feat(experiments): A/B testing support in MAPI + CDN clients (WDX-439)

### DIFF
--- a/packages/capi-client/src/index.ts
+++ b/packages/capi-client/src/index.ts
@@ -16,6 +16,7 @@ import { createLinksResource } from './resources/links';
 import { createTagsResource } from './resources/tags';
 import { createDatasourcesResource } from './resources/datasources';
 import { createDatasourceEntriesResource } from './resources/datasource-entries';
+import { createExperimentsResource } from './resources/experiments';
 import { createSpacesResource } from './resources/spaces';
 
 type Prettify<T> = {
@@ -319,6 +320,7 @@ export const createApiClient = <
   return {
     datasourceEntries: createDatasourceEntriesResource(resourceDeps),
     datasources: createDatasourcesResource(resourceDeps),
+    experiments: createExperimentsResource(resourceDeps),
     flushCache,
     get: getRequest,
     interceptors: client.interceptors,

--- a/packages/capi-client/src/resources/experiments.test.ts
+++ b/packages/capi-client/src/resources/experiments.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { fromOpenApi } from '@msw/source/open-api';
+import { readFileSync } from 'node:fs';
+import { join } from 'pathe';
+import { fileURLToPath } from 'node:url';
+import { createApiClient } from '../index';
+
+const openapiSpecPath = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../node_modules/@storyblok/openapi/dist/capi/experiments.yaml',
+);
+const openapiSpec = readFileSync(openapiSpecPath, 'utf-8');
+const handlers = await fromOpenApi(openapiSpec);
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('experiments.list()', () => {
+  it('should return experiments array', async () => {
+    const client = createApiClient({
+      accessToken: 'test-token',
+    });
+
+    const result = await client.experiments.list();
+
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.data?.experiments)).toBe(true);
+  });
+
+  it('should expose variants with their story mappings', async () => {
+    server.use(
+      http.get('https://api.storyblok.com/v2/cdn/experiments', () => {
+        return HttpResponse.json({
+          experiments: [
+            {
+              id: 1,
+              name: 'homepage_hero_test',
+              display_name: 'Homepage Hero Test',
+              story_ids: [101],
+              variants: [
+                {
+                  name: 'control',
+                  display_name: 'Control',
+                  public_id: 'var_control',
+                  weight: 50,
+                  is_control: true,
+                  story_mappings: [
+                    { original_story_id: 101, original_slug: 'home', variant_story_id: null, variant_slug: null },
+                  ],
+                },
+                {
+                  name: 'variant_a',
+                  display_name: 'Variant A',
+                  public_id: 'var_a',
+                  weight: 50,
+                  is_control: false,
+                  story_mappings: [
+                    { original_story_id: 101, original_slug: 'home', variant_story_id: 202, variant_slug: 'home-variant-a' },
+                  ],
+                },
+              ],
+            },
+          ],
+          cv: 1700000000,
+        });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: 'test-token',
+    });
+
+    const result = await client.experiments.list();
+
+    expect(result.error).toBeUndefined();
+    const experiment = result.data?.experiments[0];
+    expect(experiment?.variants).toHaveLength(2);
+    expect(experiment?.variants[1]?.story_mappings[0]?.variant_slug).toBe('home-variant-a');
+  });
+
+  it('should return error on 401', async () => {
+    server.use(
+      http.get('https://api.storyblok.com/v2/cdn/experiments', () => {
+        return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: 'invalid-token',
+    });
+
+    const result = await client.experiments.list();
+
+    expect(result.error).toBeDefined();
+    expect(result.data).toBeUndefined();
+    expect(result.response.status).toBe(401);
+  });
+});

--- a/packages/capi-client/src/resources/experiments.ts
+++ b/packages/capi-client/src/resources/experiments.ts
@@ -1,0 +1,42 @@
+import { list as listExperimentsApi } from '../generated/experiments/sdk.gen';
+import type { ListData as ExperimentsListData, ListResponses as ExperimentsListResponses } from '../generated/experiments/types.gen';
+import type { ApiResponse, FetchOptions, ResourceDeps } from '../types';
+
+export function createExperimentsResource(deps: ResourceDeps) {
+  const { client, requestWithCache, asApiResponse, throttleManager } = deps;
+
+  return {
+    /**
+     * Retrieve all running experiments for the space.
+     *
+     * Each experiment lists its variants and their `story_mappings`, which map an
+     * `original_story_id`/`original_slug` to a `variant_story_id`/`variant_slug`.
+     * The CDN has no per-story variant filter, so the typical flow is:
+     *
+     * 1. `experiments.list()` to fetch the running experiments.
+     * 2. Pick a variant deterministically (e.g. hash the visitor id against the
+     *    variant `public_id`/`weight`) for the experiment that maps the story you
+     *    are rendering.
+     * 3. Fetch that variant's own `variant_slug` via the `stories` resource (the
+     *    control variant resolves back to the `original_slug`).
+     *
+     * See `@storyblok/experiments` for variant assignment and tracking helpers.
+     */
+    list: async <ThrowOnError extends boolean = false>(
+      options: { query?: ExperimentsListData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } = {},
+    ): Promise<ApiResponse<ExperimentsListResponses[200], ThrowOnError>> => {
+      const { query = {}, signal, throwOnError, fetchOptions } = options;
+      const requestPath = '/v2/cdn/experiments';
+      return requestWithCache<ExperimentsListResponses[200], ThrowOnError>('GET', requestPath, query, (requestQuery: Record<string, unknown>) => {
+        return throttleManager.execute(requestPath, requestQuery, () =>
+          asApiResponse<ExperimentsListResponses[200], ThrowOnError>(listExperimentsApi({
+            client,
+            query: requestQuery,
+            signal,
+            ...(throwOnError === undefined ? {} : { throwOnError }),
+            ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}),
+          })));
+      });
+    },
+  };
+}

--- a/packages/mapi-client/src/index.ts
+++ b/packages/mapi-client/src/index.ts
@@ -10,6 +10,7 @@ import { createComponentFoldersResource } from './resources/component-folders';
 import { createComponentsResource } from './resources/components';
 import { createDatasourceEntriesResource } from './resources/datasource-entries';
 import { createDatasourcesResource } from './resources/datasources';
+import { createExperimentsResource } from './resources/experiments';
 import { createInternalTagsResource } from './resources/internal-tags';
 import { createPresetsResource } from './resources/presets';
 import { createSpacesResource } from './resources/spaces';
@@ -171,6 +172,7 @@ export const createManagementApiClient = (config: ManagementApiClientConfig) => 
     components: createComponentsResource(deps),
     datasourceEntries: createDatasourceEntriesResource(deps),
     datasources: createDatasourcesResource(deps),
+    experiments: createExperimentsResource(deps),
     delete: httpDelete,
     get: httpGet,
     patch: httpPatch,

--- a/packages/mapi-client/src/resources/experiments.test.ts
+++ b/packages/mapi-client/src/resources/experiments.test.ts
@@ -161,6 +161,22 @@ describe('experiments.stories', () => {
     expect(result.error).toBeUndefined();
     expect(captured).toMatchObject({ experiment_story: { story_id: 999 } });
   });
+
+  it('delete() should DELETE the experiment story path', async () => {
+    let calledPath: string | undefined;
+    server.use(
+      http.delete(`${BASE}/:experiment_id/stories/:story_id`, ({ request }) => {
+        calledPath = new URL(request.url).pathname;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const result = await createClient().experiments.stories.delete(55, 999);
+
+    expect(result.error).toBeUndefined();
+    expect(result.response.status).toBe(204);
+    expect(calledPath).toBe('/v1/spaces/123/experiments/55/stories/999');
+  });
 });
 
 describe('experiments.storyMappings', () => {

--- a/packages/mapi-client/src/resources/experiments.test.ts
+++ b/packages/mapi-client/src/resources/experiments.test.ts
@@ -1,0 +1,235 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { fromOpenApi } from '@msw/source/open-api';
+import { readFileSync } from 'node:fs';
+import { join } from 'pathe';
+import { fileURLToPath } from 'node:url';
+import { createManagementApiClient } from '../index';
+
+const openapiSpecPath = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../node_modules/@storyblok/openapi/dist/mapi/experiments.yaml',
+);
+const openapiSpec = readFileSync(openapiSpecPath, 'utf-8');
+const handlers = await fromOpenApi(openapiSpec);
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const createClient = (token = 'test-token') =>
+  createManagementApiClient({
+    personalAccessToken: token,
+    spaceId: 123,
+    region: 'eu',
+    rateLimit: false,
+  });
+
+const BASE = 'https://mapi.storyblok.com/v1/spaces/123/experiments';
+
+describe('experiments.list()', () => {
+  it('should retrieve experiments', async () => {
+    const result = await createClient().experiments.list();
+
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.data?.experiments)).toBe(true);
+  });
+
+  it('should return error on 401', async () => {
+    server.use(
+      http.get(BASE, () => HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })),
+    );
+
+    const result = await createClient('invalid-token').experiments.list();
+
+    expect(result.error).toBeDefined();
+    expect(result.data).toBeUndefined();
+    expect(result.response.status).toBe(401);
+  });
+});
+
+describe('experiments.get()', () => {
+  it('should retrieve a single experiment by id', async () => {
+    let calledPath: string | undefined;
+    server.use(
+      http.get(`${BASE}/:experiment_id`, ({ request }) => {
+        calledPath = new URL(request.url).pathname;
+        return HttpResponse.json({ experiment: { id: 55, name: 'hero_test', display_name: 'Hero Test', status: 'running', experiment_variants: [] } });
+      }),
+    );
+
+    const result = await createClient().experiments.get(55);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.experiment?.id).toBe(55);
+    expect(calledPath).toBe('/v1/spaces/123/experiments/55');
+  });
+});
+
+describe('experiments.create()', () => {
+  it('should POST the experiment envelope and return the created experiment', async () => {
+    let captured: unknown;
+    server.use(
+      http.post(BASE, async ({ request }) => {
+        captured = await request.json();
+        return HttpResponse.json({ experiment: { id: 55, name: 'hero_test', display_name: 'Hero Test', status: 'draft' } }, { status: 201 });
+      }),
+    );
+
+    const result = await createClient().experiments.create({
+      body: {
+        experiment: {
+          name: 'hero_test',
+          display_name: 'Hero Test',
+          experiment_variants_attributes: [
+            { name: 'control', display_name: 'Control', is_control: true, weight: 50 },
+            { name: 'variant_a', display_name: 'Variant A', weight: 50 },
+          ],
+        },
+      },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.experiment?.id).toBe(55);
+    expect(captured).toMatchObject({ experiment: { name: 'hero_test' } });
+  });
+});
+
+describe('experiments.remove()', () => {
+  it('should DELETE the experiment and resolve with no error', async () => {
+    server.use(
+      http.delete(`${BASE}/:experiment_id`, () => new HttpResponse(null, { status: 204 })),
+    );
+
+    const result = await createClient().experiments.remove(55);
+
+    expect(result.error).toBeUndefined();
+    expect(result.response.status).toBe(204);
+  });
+});
+
+describe('experiments lifecycle', () => {
+  it('activate() should PUT to /activate', async () => {
+    let calledPath: string | undefined;
+    server.use(
+      http.put(`${BASE}/:experiment_id/activate`, ({ request }) => {
+        calledPath = new URL(request.url).pathname;
+        return HttpResponse.json({ experiment: { id: 55, status: 'running' } });
+      }),
+    );
+
+    const result = await createClient().experiments.activate(55);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.experiment?.status).toBe('running');
+    expect(calledPath).toBe('/v1/spaces/123/experiments/55/activate');
+  });
+
+  it('completeWithWinner() should PATCH with the variant_id query param', async () => {
+    let variantIdParam: string | null = null;
+    server.use(
+      http.patch(`${BASE}/:experiment_id/complete_with_winner`, ({ request }) => {
+        variantIdParam = new URL(request.url).searchParams.get('variant_id');
+        return HttpResponse.json({ experiment: { id: 55, status: 'completed', winning_variant_id: 77 } });
+      }),
+    );
+
+    const result = await createClient().experiments.completeWithWinner(55, 77);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.experiment?.winning_variant_id).toBe(77);
+    expect(variantIdParam).toBe('77');
+  });
+});
+
+describe('experiments.stories', () => {
+  it('create() should POST the experiment_story envelope', async () => {
+    let captured: unknown;
+    server.use(
+      http.post(`${BASE}/:experiment_id/stories`, async ({ request }) => {
+        captured = await request.json();
+        return HttpResponse.json({ experiment: { id: 55, story_ids: [999] } }, { status: 201 });
+      }),
+    );
+
+    const result = await createClient().experiments.stories.create(55, {
+      body: { experiment_story: { story_id: 999 } },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(captured).toMatchObject({ experiment_story: { story_id: 999 } });
+  });
+});
+
+describe('experiments.storyMappings', () => {
+  it('create() should POST to the nested variants path with the mapping envelope', async () => {
+    let calledPath: string | undefined;
+    let captured: unknown;
+    server.use(
+      http.post(`${BASE}/:experiment_id/variants/:variant_id/story_mappings`, async ({ request }) => {
+        calledPath = new URL(request.url).pathname;
+        captured = await request.json();
+        return HttpResponse.json({ story_mapping: { original_story_id: 999, variant_story_id: 1001 } }, { status: 201 });
+      }),
+    );
+
+    const result = await createClient().experiments.storyMappings.create(55, 77, {
+      body: { story_mapping: { original_story_id: 999 } },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(calledPath).toBe('/v1/spaces/123/experiments/55/variants/77/story_mappings');
+    expect(captured).toMatchObject({ story_mapping: { original_story_id: 999 } });
+    expect(result.data?.story_mapping?.variant_story_id).toBe(1001);
+  });
+
+  it('remove() should DELETE the deeply nested mapping path', async () => {
+    let calledPath: string | undefined;
+    server.use(
+      http.delete(`${BASE}/:experiment_id/variants/:variant_id/story_mappings/:original_story_id`, ({ request }) => {
+        calledPath = new URL(request.url).pathname;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const result = await createClient().experiments.storyMappings.remove(55, 77, 999);
+
+    expect(result.error).toBeUndefined();
+    expect(result.response.status).toBe(204);
+    expect(calledPath).toBe('/v1/spaces/123/experiments/55/variants/77/story_mappings/999');
+  });
+});
+
+describe('experiments.results', () => {
+  it('push() should POST the charts payload', async () => {
+    let captured: { charts?: unknown[] } | undefined;
+    server.use(
+      http.post(`${BASE}/:experiment_id/results`, async ({ request }) => {
+        captured = (await request.json()) as { charts?: unknown[] };
+        return HttpResponse.json({ experiment_result: { id: 1, experiment_id: 55, charts: captured?.charts ?? [] } });
+      }),
+    );
+
+    const result = await createClient().experiments.results.push(55, {
+      body: { charts: [{ kind: 'text', body: 'Variant A wins.' }] },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(captured?.charts).toHaveLength(1);
+    expect(result.data?.experiment_result?.experiment_id).toBe(55);
+  });
+
+  it('get() should retrieve the experiment result', async () => {
+    server.use(
+      http.get(`${BASE}/:experiment_id/results`, () =>
+        HttpResponse.json({ experiment_result: { id: 1, experiment_id: 55, charts: [] } })),
+    );
+
+    const result = await createClient().experiments.results.get(55);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.experiment_result?.id).toBe(1);
+  });
+});

--- a/packages/mapi-client/src/resources/experiments.test.ts
+++ b/packages/mapi-client/src/resources/experiments.test.ts
@@ -97,13 +97,13 @@ describe('experiments.create()', () => {
   });
 });
 
-describe('experiments.remove()', () => {
+describe('experiments.delete()', () => {
   it('should DELETE the experiment and resolve with no error', async () => {
     server.use(
       http.delete(`${BASE}/:experiment_id`, () => new HttpResponse(null, { status: 204 })),
     );
 
-    const result = await createClient().experiments.remove(55);
+    const result = await createClient().experiments.delete(55);
 
     expect(result.error).toBeUndefined();
     expect(result.response.status).toBe(204);
@@ -185,7 +185,7 @@ describe('experiments.storyMappings', () => {
     expect(result.data?.story_mapping?.variant_story_id).toBe(1001);
   });
 
-  it('remove() should DELETE the deeply nested mapping path', async () => {
+  it('delete() should DELETE the deeply nested mapping path', async () => {
     let calledPath: string | undefined;
     server.use(
       http.delete(`${BASE}/:experiment_id/variants/:variant_id/story_mappings/:original_story_id`, ({ request }) => {
@@ -194,7 +194,7 @@ describe('experiments.storyMappings', () => {
       }),
     );
 
-    const result = await createClient().experiments.storyMappings.remove(55, 77, 999);
+    const result = await createClient().experiments.storyMappings.delete(55, 77, 999);
 
     expect(result.error).toBeUndefined();
     expect(result.response.status).toBe(204);

--- a/packages/mapi-client/src/resources/experiments.ts
+++ b/packages/mapi-client/src/resources/experiments.ts
@@ -59,7 +59,7 @@ export function createExperimentsResource(deps: MapiResourceDeps) {
       return wrapRequest<UpdateResponses[200], ThrowOnError>(() =>
         experimentsApi.update({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
-    remove<ThrowOnError extends boolean = false>(experimentId: number | string, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<DeleteResponses[204], ThrowOnError>> {
+    delete<ThrowOnError extends boolean = false>(experimentId: number | string, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<DeleteResponses[204], ThrowOnError>> {
       const { signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
       return wrapRequest<DeleteResponses[204], ThrowOnError>(() =>
@@ -116,7 +116,7 @@ export function createExperimentsResource(deps: MapiResourceDeps) {
         return wrapRequest<CreateExperimentStoryResponses[201], ThrowOnError>(() =>
           experimentsApi.createExperimentStory({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
       },
-      remove<ThrowOnError extends boolean = false>(
+      delete<ThrowOnError extends boolean = false>(
         experimentId: number | string,
         storyId: number | string,
         options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {},
@@ -138,7 +138,7 @@ export function createExperimentsResource(deps: MapiResourceDeps) {
         return wrapRequest<CreateStoryMappingResponses[201], ThrowOnError>(() =>
           experimentsApi.createStoryMapping({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId, variant_id: variantId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
       },
-      remove<ThrowOnError extends boolean = false>(
+      delete<ThrowOnError extends boolean = false>(
         experimentId: number | string,
         variantId: number | string,
         originalStoryId: number | string,

--- a/packages/mapi-client/src/resources/experiments.ts
+++ b/packages/mapi-client/src/resources/experiments.ts
@@ -1,0 +1,171 @@
+import * as experimentsApi from '../generated/experiments/sdk.gen';
+import type {
+  ActivateData,
+  ActivateResponses,
+  CompleteResponses,
+  CompleteWithWinnerResponses,
+  CreateData,
+  CreateExperimentStoryData,
+  CreateExperimentStoryResponses,
+  CreateResponses,
+  CreateStoryMappingData,
+  CreateStoryMappingResponses,
+  DeleteExperimentStoryResponses,
+  DeleteResponses,
+  DeleteStoryMappingResponses,
+  GetResponses,
+  GetResultsResponses,
+  ListData,
+  ListResponses,
+  PauseResponses,
+  PushResultsData,
+  PushResultsResponses,
+  SelectWinnerResponses,
+  UpdateData,
+  UpdateResponses,
+} from '../generated/experiments/types.gen';
+import type { ApiResponse, FetchOptions, MapiResourceDeps } from '../index';
+import { resolveSpaceId, type SpaceIdPathOverride } from './shared';
+
+export function createExperimentsResource(deps: MapiResourceDeps) {
+  const { client, spaceId, wrapRequest } = deps;
+  const getSpaceId = (path?: SpaceIdPathOverride['path']) => resolveSpaceId(spaceId, path);
+
+  return {
+    list<ThrowOnError extends boolean = false>(options: { query?: ListData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<ListResponses[200], ThrowOnError>> {
+      const { query, signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<ListResponses[200], ThrowOnError>(() =>
+        experimentsApi.list({ client, path: { space_id: resolvedSpaceId }, query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    get<ThrowOnError extends boolean = false>(experimentId: number | string, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<GetResponses[200], ThrowOnError>> {
+      const { signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<GetResponses[200], ThrowOnError>(() =>
+        experimentsApi.get({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    create<ThrowOnError extends boolean = false>(options: { body: CreateData['body']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride): Promise<ApiResponse<CreateResponses[201], ThrowOnError>> {
+      const { body, signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<CreateResponses[201], ThrowOnError>(() =>
+        experimentsApi.create({ client, path: { space_id: resolvedSpaceId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    update<ThrowOnError extends boolean = false>(
+      experimentId: number | string,
+      options: { body: UpdateData['body']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
+    ): Promise<ApiResponse<UpdateResponses[200], ThrowOnError>> {
+      const { body, signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<UpdateResponses[200], ThrowOnError>(() =>
+        experimentsApi.update({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    remove<ThrowOnError extends boolean = false>(experimentId: number | string, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<DeleteResponses[204], ThrowOnError>> {
+      const { signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<DeleteResponses[204], ThrowOnError>(() =>
+        experimentsApi.delete_({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    activate<ThrowOnError extends boolean = false>(
+      experimentId: number | string,
+      options: { query?: ActivateData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {},
+    ): Promise<ApiResponse<ActivateResponses[200], ThrowOnError>> {
+      const { query, signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<ActivateResponses[200], ThrowOnError>(() =>
+        experimentsApi.activate({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    pause<ThrowOnError extends boolean = false>(experimentId: number | string, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<PauseResponses[200], ThrowOnError>> {
+      const { signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<PauseResponses[200], ThrowOnError>(() =>
+        experimentsApi.pause({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    complete<ThrowOnError extends boolean = false>(experimentId: number | string, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<CompleteResponses[200], ThrowOnError>> {
+      const { signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<CompleteResponses[200], ThrowOnError>(() =>
+        experimentsApi.complete({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    completeWithWinner<ThrowOnError extends boolean = false>(
+      experimentId: number | string,
+      variantId: number,
+      options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {},
+    ): Promise<ApiResponse<CompleteWithWinnerResponses[200], ThrowOnError>> {
+      const { signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<CompleteWithWinnerResponses[200], ThrowOnError>(() =>
+        experimentsApi.completeWithWinner({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, query: { variant_id: variantId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    selectWinner<ThrowOnError extends boolean = false>(
+      experimentId: number | string,
+      variantId: number,
+      options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {},
+    ): Promise<ApiResponse<SelectWinnerResponses[200], ThrowOnError>> {
+      const { signal, path, throwOnError, fetchOptions } = options;
+      const resolvedSpaceId = getSpaceId(path);
+      return wrapRequest<SelectWinnerResponses[200], ThrowOnError>(() =>
+        experimentsApi.selectWinner({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, query: { variant_id: variantId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+    },
+    stories: {
+      create<ThrowOnError extends boolean = false>(
+        experimentId: number | string,
+        options: { body: CreateExperimentStoryData['body']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
+      ): Promise<ApiResponse<CreateExperimentStoryResponses[201], ThrowOnError>> {
+        const { body, signal, path, throwOnError, fetchOptions } = options;
+        const resolvedSpaceId = getSpaceId(path);
+        return wrapRequest<CreateExperimentStoryResponses[201], ThrowOnError>(() =>
+          experimentsApi.createExperimentStory({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+      },
+      remove<ThrowOnError extends boolean = false>(
+        experimentId: number | string,
+        storyId: number | string,
+        options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {},
+      ): Promise<ApiResponse<DeleteExperimentStoryResponses[204], ThrowOnError>> {
+        const { signal, path, throwOnError, fetchOptions } = options;
+        const resolvedSpaceId = getSpaceId(path);
+        return wrapRequest<DeleteExperimentStoryResponses[204], ThrowOnError>(() =>
+          experimentsApi.deleteExperimentStory({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId, story_id: storyId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+      },
+    },
+    storyMappings: {
+      create<ThrowOnError extends boolean = false>(
+        experimentId: number | string,
+        variantId: number | string,
+        options: { body: CreateStoryMappingData['body']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
+      ): Promise<ApiResponse<CreateStoryMappingResponses[201], ThrowOnError>> {
+        const { body, signal, path, throwOnError, fetchOptions } = options;
+        const resolvedSpaceId = getSpaceId(path);
+        return wrapRequest<CreateStoryMappingResponses[201], ThrowOnError>(() =>
+          experimentsApi.createStoryMapping({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId, variant_id: variantId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+      },
+      remove<ThrowOnError extends boolean = false>(
+        experimentId: number | string,
+        variantId: number | string,
+        originalStoryId: number | string,
+        options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {},
+      ): Promise<ApiResponse<DeleteStoryMappingResponses[204], ThrowOnError>> {
+        const { signal, path, throwOnError, fetchOptions } = options;
+        const resolvedSpaceId = getSpaceId(path);
+        return wrapRequest<DeleteStoryMappingResponses[204], ThrowOnError>(() =>
+          experimentsApi.deleteStoryMapping({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId, variant_id: variantId, original_story_id: originalStoryId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+      },
+    },
+    results: {
+      get<ThrowOnError extends boolean = false>(experimentId: number | string, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<GetResultsResponses[200], ThrowOnError>> {
+        const { signal, path, throwOnError, fetchOptions } = options;
+        const resolvedSpaceId = getSpaceId(path);
+        return wrapRequest<GetResultsResponses[200], ThrowOnError>(() =>
+          experimentsApi.getResults({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+      },
+      push<ThrowOnError extends boolean = false>(
+        experimentId: number | string,
+        options: { body: PushResultsData['body']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
+      ): Promise<ApiResponse<PushResultsResponses[200], ThrowOnError>> {
+        const { body, signal, path, throwOnError, fetchOptions } = options;
+        const resolvedSpaceId = getSpaceId(path);
+        return wrapRequest<PushResultsResponses[200], ThrowOnError>(() =>
+          experimentsApi.pushResults({ client, path: { space_id: resolvedSpaceId, experiment_id: experimentId }, body, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
+      },
+    },
+  };
+}

--- a/packages/openapi/redocly.yaml
+++ b/packages/openapi/redocly.yaml
@@ -73,6 +73,14 @@ apis:
     root: resources/mapi/users/main.yaml
     output: ./dist/mapi/users.yaml
     title: Users
+  experiments:
+    root: resources/mapi/experiments/main.yaml
+    output: ./dist/mapi/experiments.yaml
+    title: Experiments
+  experiments-capi:
+    root: resources/capi/experiments/main.yaml
+    output: ./dist/capi/experiments.yaml
+    title: Experiments
 
 
 # Linting rules

--- a/packages/openapi/resources/capi/experiments/main.yaml
+++ b/packages/openapi/resources/capi/experiments/main.yaml
@@ -1,0 +1,130 @@
+openapi: 3.1.1
+info:
+  title: Storyblok Experiments Delivery API
+  version: 1.0.0
+  description: API for delivering running Storyblok A/B testing experiments
+servers:
+  $ref: ../shared/servers.yaml
+security:
+  $ref: ../shared/security.yaml
+paths:
+  /v2/cdn/experiments:
+    get:
+      operationId: list
+      summary: Retrieve Running Experiments
+      description: Returns an array of all running experiments for the space, including their variants and story mappings. Only experiments in the running status are exposed.
+      parameters:
+        - name: cv
+          in: query
+          required: false
+          description: Cached version Unix timestamp for cache invalidation
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Array of running experiments
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiments
+                properties:
+                  experiments:
+                    type: array
+                    description: Array of running experiment objects
+                    items:
+                      $ref: '#/components/schemas/Experiment'
+                  cv:
+                    type: integer
+                    description: Cache version Unix timestamp
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+components:
+  securitySchemes:
+    $ref: ../shared/security-schemes.yaml#/securitySchemes
+  schemas:
+    Experiment:
+      type: object
+      description: A running A/B testing experiment
+      required:
+        - id
+        - name
+        - display_name
+        - story_ids
+        - variants
+      properties:
+        id:
+          type: integer
+          description: Numeric ID of the experiment
+        name:
+          type: string
+          description: Internal name (lowercase, numbers, underscores)
+        display_name:
+          type: string
+          description: Human-readable display name
+        story_ids:
+          type: array
+          description: IDs of original stories assigned to this experiment
+          items:
+            type: integer
+        variants:
+          type: array
+          description: Variants belonging to this experiment
+          items:
+            $ref: '#/components/schemas/ExperimentVariant'
+    ExperimentVariant:
+      type: object
+      description: A variant within a running experiment
+      required:
+        - name
+        - display_name
+        - public_id
+        - weight
+        - is_control
+        - story_mappings
+      properties:
+        name:
+          type: string
+          description: Internal name (lowercase, numbers, underscores)
+        display_name:
+          type: string
+          description: Human-readable display name
+        public_id:
+          type: string
+          description: Public identifier used for stable bucketing
+        weight:
+          type: integer
+          description: Traffic weight percentage (0-100)
+        is_control:
+          type: boolean
+          description: Whether this is the control variant
+        story_mappings:
+          type: array
+          description: Mappings between original stories and their variant copies
+          items:
+            type: object
+            required:
+              - original_story_id
+              - original_slug
+              - variant_story_id
+              - variant_slug
+            properties:
+              original_story_id:
+                type: integer
+                description: ID of the original story
+              original_slug:
+                type:
+                  - string
+                  - "null"
+                description: Full slug of the original story
+              variant_story_id:
+                type:
+                  - integer
+                  - "null"
+                description: ID of the variant story copy
+              variant_slug:
+                type:
+                  - string
+                  - "null"
+                description: Full slug of the variant story copy

--- a/packages/openapi/resources/mapi/experiments/main.yaml
+++ b/packages/openapi/resources/mapi/experiments/main.yaml
@@ -1,0 +1,883 @@
+openapi: 3.1.1
+info:
+  title: Storyblok Experiments API
+  version: 1.0.0
+  description: API for managing Storyblok A/B testing experiments
+servers:
+  $ref: ../shared/servers.yaml
+security:
+  $ref: ../shared/security.yaml
+paths:
+  /v1/spaces/{space_id}/experiments:
+    get:
+      operationId: list
+      summary: Retrieve Multiple Experiments
+      description: Returns an array of experiment objects for the space.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - name: by_status
+          in: query
+          required: false
+          description: Filter experiments by status
+          schema:
+            type: string
+            enum:
+              - draft
+              - running
+              - paused
+              - completed
+        - name: by_story_id
+          in: query
+          required: false
+          description: Filter experiments that include the given original story id
+          schema:
+            type: integer
+        - name: by_variant_story_id
+          in: query
+          required: false
+          description: Filter experiments that include the given variant story id
+          schema:
+            type: integer
+        - name: page
+          in: query
+          required: false
+          description: Page number for pagination
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          required: false
+          description: Number of experiments per page
+          schema:
+            type: integer
+            default: 25
+      responses:
+        '200':
+          description: List of experiments
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiments
+                properties:
+                  experiments:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExperimentDetail'
+        '400':
+          $ref: ../../shared/responses.yaml#/BadRequest
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+    post:
+      operationId: create
+      summary: Create an Experiment
+      description: Creates a new experiment with its variants.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - experiment
+              properties:
+                experiment:
+                  $ref: '#/components/schemas/ExperimentCreate'
+      responses:
+        '201':
+          description: Experiment created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiment
+                properties:
+                  experiment:
+                    $ref: '#/components/schemas/ExperimentDetail'
+        '400':
+          $ref: ../../shared/responses.yaml#/BadRequest
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '422':
+          description: Unprocessable entity - validation errors
+  /v1/spaces/{space_id}/experiments/{experiment_id}:
+    get:
+      operationId: get
+      summary: Retrieve a Single Experiment
+      description: Returns a single experiment object by its numeric id.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      responses:
+        '200':
+          description: Experiment details
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiment
+                properties:
+                  experiment:
+                    $ref: '#/components/schemas/ExperimentDetail'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+    put:
+      operationId: update
+      summary: Update an Experiment
+      description: Updates an experiment and its variants. The experiment name cannot be changed after creation.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - experiment
+              properties:
+                experiment:
+                  $ref: '#/components/schemas/ExperimentUpdate'
+      responses:
+        '200':
+          description: Experiment updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiment
+                properties:
+                  experiment:
+                    $ref: '#/components/schemas/ExperimentDetail'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - validation errors
+    delete:
+      operationId: delete
+      summary: Delete an Experiment
+      description: Deletes an experiment. Only draft or completed experiments can be deleted.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      responses:
+        '204':
+          description: Experiment deleted
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '403':
+          description: Forbidden - only draft or completed experiments can be deleted
+        '404':
+          description: Experiment not found
+  /v1/spaces/{space_id}/experiments/{experiment_id}/activate:
+    put:
+      operationId: activate
+      summary: Activate an Experiment
+      description: Activates (starts or resumes) an experiment, moving it to the running status.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+        - name: end_date
+          in: query
+          required: false
+          description: Optional scheduled end date for the experiment (ISO 8601)
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          $ref: '#/components/responses/ExperimentResponse'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - invalid status transition
+  /v1/spaces/{space_id}/experiments/{experiment_id}/pause:
+    put:
+      operationId: pause
+      summary: Pause an Experiment
+      description: Pauses a running experiment.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ExperimentResponse'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - invalid status transition
+  /v1/spaces/{space_id}/experiments/{experiment_id}/complete:
+    put:
+      operationId: complete
+      summary: Complete an Experiment
+      description: Completes an experiment without selecting a winner.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ExperimentResponse'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - invalid status transition
+  /v1/spaces/{space_id}/experiments/{experiment_id}/complete_with_winner:
+    patch:
+      operationId: completeWithWinner
+      summary: Complete an Experiment with a Winner
+      description: Selects a winning variant and completes the experiment.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+        - $ref: '#/components/parameters/variant_id_query'
+      responses:
+        '200':
+          $ref: '#/components/responses/ExperimentResponse'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - validation errors
+  /v1/spaces/{space_id}/experiments/{experiment_id}/select_winner:
+    patch:
+      operationId: selectWinner
+      summary: Select a Winning Variant
+      description: Selects a winning variant without completing the experiment.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+        - $ref: '#/components/parameters/variant_id_query'
+      responses:
+        '200':
+          $ref: '#/components/responses/ExperimentResponse'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - validation errors
+  /v1/spaces/{space_id}/experiments/{experiment_id}/stories:
+    post:
+      operationId: createExperimentStory
+      summary: Link a Story to an Experiment
+      description: Adds an original story to the experiment.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - experiment_story
+              properties:
+                experiment_story:
+                  type: object
+                  required:
+                    - story_id
+                  properties:
+                    story_id:
+                      type: integer
+                      description: ID of the story to link
+      responses:
+        '201':
+          description: Story linked
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiment
+                properties:
+                  experiment:
+                    $ref: '#/components/schemas/ExperimentDetail'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - validation errors
+  /v1/spaces/{space_id}/experiments/{experiment_id}/stories/{story_id}:
+    delete:
+      operationId: deleteExperimentStory
+      summary: Unlink a Story from an Experiment
+      description: Removes an original story from the experiment.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+        - $ref: ../shared/parameters.yaml#/story_id
+      responses:
+        '204':
+          description: Story unlinked
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment or story not found
+        '422':
+          description: Unprocessable entity - validation errors
+  /v1/spaces/{space_id}/experiments/{experiment_id}/variants/{variant_id}/story_mappings:
+    post:
+      operationId: createStoryMapping
+      summary: Create a Variant Story Mapping
+      description: Maps an original story to a variant, optionally duplicating it into a new variant story.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+        - $ref: '#/components/parameters/variant_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - story_mapping
+              properties:
+                story_mapping:
+                  type: object
+                  required:
+                    - original_story_id
+                  properties:
+                    original_story_id:
+                      type: integer
+                      description: ID of the original story to map
+                    variant_story_id:
+                      type:
+                        - integer
+                        - "null"
+                      description: ID of an existing story to link as the variant. Omit to duplicate the original.
+      responses:
+        '201':
+          description: Story mapping created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - story_mapping
+                properties:
+                  story_mapping:
+                    $ref: '#/components/schemas/StoryMapping'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment or variant not found
+        '422':
+          description: Unprocessable entity - validation errors
+  /v1/spaces/{space_id}/experiments/{experiment_id}/variants/{variant_id}/story_mappings/{original_story_id}:
+    delete:
+      operationId: deleteStoryMapping
+      summary: Delete a Variant Story Mapping
+      description: Removes the mapping between an original story and a variant.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+        - $ref: '#/components/parameters/variant_id'
+        - name: original_story_id
+          in: path
+          required: true
+          description: ID of the original story whose mapping should be removed
+          schema:
+            oneOf:
+              - type: integer
+              - type: string
+      responses:
+        '204':
+          description: Story mapping deleted
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Mapping not found
+  /v1/spaces/{space_id}/experiments/{experiment_id}/results:
+    get:
+      operationId: getResults
+      summary: Retrieve Experiment Results
+      description: Returns the pre-computed result charts for an experiment. Responds with 204 when no results have been pushed yet.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      responses:
+        '200':
+          description: Experiment results
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiment_result
+                properties:
+                  experiment_result:
+                    $ref: '#/components/schemas/ExperimentResult'
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+    post:
+      operationId: pushResults
+      summary: Push Experiment Results
+      description: Stores up to 20 pre-computed result charts for an experiment.
+      parameters:
+        - $ref: ../shared/parameters.yaml#/space_id
+        - $ref: '#/components/parameters/experiment_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - charts
+              properties:
+                charts:
+                  type: array
+                  maxItems: 20
+                  description: Pre-computed chart snapshots (max 20)
+                  items:
+                    $ref: '#/components/schemas/Chart'
+      responses:
+        '200':
+          description: Experiment results stored
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experiment_result
+                properties:
+                  experiment_result:
+                    $ref: '#/components/schemas/ExperimentResult'
+        '400':
+          $ref: ../../shared/responses.yaml#/BadRequest
+        '401':
+          $ref: ../../shared/responses.yaml#/Unauthorized
+        '404':
+          description: Experiment not found
+        '422':
+          description: Unprocessable entity - validation errors
+components:
+  securitySchemes:
+    $ref: ../shared/security-schemes.yaml#/securitySchemes
+  parameters:
+    experiment_id:
+      name: experiment_id
+      in: path
+      required: true
+      description: The numeric ID of the experiment
+      schema:
+        oneOf:
+          - type: integer
+          - type: string
+    variant_id:
+      name: variant_id
+      in: path
+      required: true
+      description: The numeric ID of the experiment variant
+      schema:
+        oneOf:
+          - type: integer
+          - type: string
+    variant_id_query:
+      name: variant_id
+      in: query
+      required: true
+      description: The numeric ID of the winning variant
+      schema:
+        type: integer
+  responses:
+    ExperimentResponse:
+      description: Experiment details
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - experiment
+            properties:
+              experiment:
+                $ref: '#/components/schemas/ExperimentDetail'
+  schemas:
+    Experiment:
+      type: object
+      description: An A/B testing experiment
+      required:
+        - id
+        - name
+        - display_name
+        - status
+        - created_at
+        - updated_at
+        - story_ids
+      properties:
+        id:
+          type: integer
+          description: Numeric ID of the experiment
+        name:
+          type: string
+          maxLength: 100
+          description: Internal name (lowercase letters, numbers, underscores)
+        display_name:
+          type: string
+          maxLength: 255
+          description: Human-readable display name
+        description:
+          type:
+            - string
+            - "null"
+          description: Optional description of the experiment
+        status:
+          type: string
+          description: Current status of the experiment
+          enum:
+            - draft
+            - running
+            - paused
+            - completed
+        started_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Timestamp when the experiment was first activated
+        ended_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Timestamp when the experiment was completed
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+        story_ids:
+          type: array
+          description: IDs of original stories assigned to this experiment
+          items:
+            type: integer
+        winning_variant_id:
+          type:
+            - integer
+            - "null"
+          description: ID of the winning variant (set when completed with a winner)
+    StoryMapping:
+      type: object
+      description: Mapping between an original story and its variant copy
+      properties:
+        experiment_variant_id:
+          type: integer
+          description: ID of the variant this mapping belongs to
+        original_story_id:
+          type: integer
+          description: ID of the original story
+        variant_story_id:
+          type:
+            - integer
+            - "null"
+          description: ID of the variant story copy
+        original_slug:
+          type:
+            - string
+            - "null"
+          description: Full slug of the original story
+        variant_slug:
+          type:
+            - string
+            - "null"
+          description: Full slug of the variant story copy
+        variant_story:
+          type:
+            - object
+            - "null"
+          additionalProperties: true
+          description: The variant story object, when expanded
+    ExperimentVariant:
+      type: object
+      description: A variant within an experiment
+      required:
+        - id
+        - name
+        - display_name
+        - public_id
+        - weight
+        - is_control
+        - story_mappings
+      properties:
+        id:
+          type: integer
+          description: Numeric ID of the variant
+        name:
+          type: string
+          maxLength: 100
+          description: Internal name (lowercase, numbers, underscores)
+        display_name:
+          type: string
+          maxLength: 255
+          description: Human-readable display name
+        public_id:
+          type: string
+          maxLength: 20
+          description: Public identifier used for stable bucketing
+        weight:
+          type: integer
+          description: Traffic weight percentage (0-100)
+        is_control:
+          type: boolean
+          description: Whether this is the control variant
+        story_mappings:
+          type: array
+          description: Story-level variant mappings
+          items:
+            $ref: '#/components/schemas/StoryMapping'
+    ExperimentDetail:
+      allOf:
+        - $ref: '#/components/schemas/Experiment'
+        - type: object
+          required:
+            - experiment_variants
+          properties:
+            experiment_variants:
+              type: array
+              description: Variants belonging to this experiment
+              items:
+                $ref: '#/components/schemas/ExperimentVariant'
+            experiment_assigned_metrics:
+              type: array
+              description: Metrics assigned to this experiment
+              items:
+                type: object
+                additionalProperties: true
+    ExperimentCreate:
+      type: object
+      description: Input for creating an experiment
+      required:
+        - name
+        - display_name
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          description: Internal name (lowercase letters, numbers, underscores only)
+        display_name:
+          type: string
+          maxLength: 255
+          description: Human-readable display name
+        description:
+          type: string
+          description: Optional description of the experiment
+        story_ids:
+          type: array
+          description: IDs of stories to assign to this experiment
+          items:
+            type: integer
+        experiment_variants_attributes:
+          type: array
+          description: Variants to create with the experiment
+          items:
+            type: object
+            required:
+              - name
+              - display_name
+            properties:
+              name:
+                type: string
+                maxLength: 100
+              display_name:
+                type: string
+                maxLength: 255
+              weight:
+                type: integer
+                minimum: 0
+                maximum: 100
+              is_control:
+                type: boolean
+    ExperimentUpdate:
+      type: object
+      description: Input for updating an experiment
+      properties:
+        display_name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        story_ids:
+          type: array
+          items:
+            type: integer
+        experiment_variants_attributes:
+          type: array
+          description: Variants to add, update, or remove
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: ID of an existing variant (required for update or delete)
+              name:
+                type: string
+                maxLength: 100
+              display_name:
+                type: string
+                maxLength: 255
+              weight:
+                type: integer
+                minimum: 0
+                maximum: 100
+              is_control:
+                type: boolean
+              _destroy:
+                type: boolean
+                description: Set to true to remove this variant
+    BarChart:
+      type: object
+      description: Bar chart with variant comparison data
+      required:
+        - kind
+        - labels
+        - series
+      properties:
+        kind:
+          type: string
+          enum:
+            - bar
+        title:
+          type:
+            - string
+            - "null"
+        xLabel:
+          type:
+            - string
+            - "null"
+        yLabel:
+          type:
+            - string
+            - "null"
+        labels:
+          type: array
+          items:
+            type: string
+        series:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChartSeries'
+    LineChart:
+      type: object
+      description: Line chart for time-series data
+      required:
+        - kind
+        - labels
+        - series
+      properties:
+        kind:
+          type: string
+          enum:
+            - line
+        title:
+          type:
+            - string
+            - "null"
+        xLabel:
+          type:
+            - string
+            - "null"
+        yLabel:
+          type:
+            - string
+            - "null"
+        labels:
+          type: array
+          items:
+            type: string
+        series:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChartSeries'
+    TextChart:
+      type: object
+      description: Text-only block for insights or summary copy
+      required:
+        - kind
+        - body
+      properties:
+        kind:
+          type: string
+          enum:
+            - text
+        title:
+          type:
+            - string
+            - "null"
+        body:
+          type: string
+          description: Insight text content
+    ChartSeries:
+      type: object
+      required:
+        - label
+        - data
+      properties:
+        label:
+          type: string
+          description: Series label
+        data:
+          type: array
+          description: Numeric data points aligned with labels
+          items:
+            type: number
+    Chart:
+      description: A result chart. The kind field determines the chart type.
+      oneOf:
+        - $ref: '#/components/schemas/BarChart'
+        - $ref: '#/components/schemas/LineChart'
+        - $ref: '#/components/schemas/TextChart'
+    ExperimentResult:
+      type: object
+      description: Pre-computed result charts for an experiment
+      required:
+        - id
+        - experiment_id
+        - charts
+        - pushed_at
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: integer
+        experiment_id:
+          type: integer
+        charts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Chart'
+        pushed_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time

--- a/packages/openapi/resources/mapi/experiments/main.yaml
+++ b/packages/openapi/resources/mapi/experiments/main.yaml
@@ -429,6 +429,8 @@ paths:
                 properties:
                   experiment_result:
                     $ref: '#/components/schemas/ExperimentResult'
+        '204':
+          description: No results have been pushed yet
         '401':
           $ref: ../../shared/responses.yaml#/Unauthorized
         '404':


### PR DESCRIPTION
Adds A/B testing **experiment** support to `@storyblok/management-api-client` (MAPI) and `@storyblok/api-client` (CDN), so consumers can manage and read experiments today.

## MAPI surface (`client.experiments`)

- `list / get / create / update / remove`
- Lifecycle: `activate / pause / complete` (PUT), `completeWithWinner / selectWinner` (PATCH, `variant_id` query)
- `stories.{create, remove}` — link/unlink original stories
- `storyMappings.{create, remove}` — variant story mappings (`/variants/{variant_id}/story_mappings/{original_story_id}`)
- `results.{get, push}` — bar/line/text result charts

## CDN surface (`client.experiments`)

- `list()` over `GET /v2/cdn/experiments`, returning running experiments with variants + story mappings. JSDoc documents the list → pick variant → fetch `variant_slug` flow (pairs with `@storyblok/experiments`).

Fixes WDX-439