### PR TITLE
fix(richtext): require content on doc root, keep it optional on child nodes

### DIFF
--- a/packages/richtext/src/static/generate/richtext-type.ts
+++ b/packages/richtext/src/static/generate/richtext-type.ts
@@ -36,7 +36,14 @@ function nodeShape(schema: Schema, name: string): string {
   const type = schema.nodes[name];
   const hasText = name === 'text' ? 'text: string;' : '';
   let children = '';
-  if (type.isBlock || name === 'doc' || type.spec.content || type.isInline) {
+  // The root `doc` node is the document body and always carries a `content`
+  // array, so it is required. Every other node may legitimately omit `content`,
+  // for example an empty paragraph or a leaf node like `image`, so for those it
+  // stays optional, matching what the Storyblok API actually returns. See #16.
+  if (name === 'doc') {
+    children = 'content: SbRichTextNode[];';
+  }
+  else if (type.isBlock || type.spec.content || type.isInline) {
     children = 'content?: SbRichTextNode[];';
   }
   return `{ type: '${name}'; attrs?: TiptapNodeAttributes['${name}']; ${children} marks?: SbRichTextMark[]; ${hasText} _key?: string; context?: TContext; }`;

--- a/packages/richtext/src/static/normalize-nodes.ts
+++ b/packages/richtext/src/static/normalize-nodes.ts
@@ -36,8 +36,9 @@ function addKeys(
       ...mark,
       _key: generateKey(mark.type),
     })),
-    content: node.content
-      ? addKeys(node.content, generateKey)
-      : undefined,
+    // Only re-attach `content` when the node actually has it. The root `doc`
+    // node always carries `content`, while leaf and empty nodes legitimately
+    // omit it, so we must not force `content: undefined` onto them.
+    ...(node.content ? { content: addKeys(node.content, generateKey) } : {}),
   }));
 }

--- a/packages/richtext/src/static/types.type-test.ts
+++ b/packages/richtext/src/static/types.type-test.ts
@@ -1,0 +1,44 @@
+/**
+ * Compile-time regression tests for the `SbRichTextNode` / `SbRichTextDoc`
+ * contract reported in https://github.com/storyblok/monoblok/issues/16.
+ *
+ * The Storyblok API returns the root `doc` node with a `content` array, but
+ * nested nodes (empty paragraphs, leaf nodes) may omit `content` entirely.
+ * The types must mirror that: `content` is required on the document root and
+ * optional on every other node.
+ *
+ * These assertions are checked by `pnpm test:types` (`tsc --noEmit`) and are
+ * intentionally never executed at runtime.
+ */
+import type { SbRichTextDoc, SbRichTextNode } from './index';
+
+// A `doc` with a `content` array is valid.
+export const docWithContent: SbRichTextDoc = {
+  type: 'doc',
+  content: [],
+};
+
+// The document root must include `content`.
+// @ts-expect-error - `content` is required on the `doc` node.
+export const docWithoutContent: SbRichTextDoc = {
+  type: 'doc',
+};
+
+// Nested nodes may omit `content`. This is the exact case from #16 that the
+// previous type wrongly rejected.
+export const docWithContentlessChildren: SbRichTextDoc = {
+  type: 'doc',
+  content: [
+    { type: 'paragraph' },
+    { type: 'horizontal_rule' },
+    {
+      type: 'bullet_list',
+      content: [{ type: 'list_item' }],
+    },
+  ],
+};
+
+// A bare nested node without `content` is assignable to `SbRichTextNode`.
+export const contentlessNode: SbRichTextNode = {
+  type: 'paragraph',
+};


### PR DESCRIPTION
## Summary

Make `content` required on the root `doc` node and keep it optional on every other node in the generated `SbRichTextNode` type, so the types match what the Storyblok API actually returns. Also stop `normalizeNodes` from forcing `content: undefined` onto nodes that have none, and add a compile-time regression assertion checked by the existing `test:types` target.

## Root cause

The richtext node type is generated by `packages/richtext/src/static/generate/richtext-type.ts`, which emitted `content?: SbRichTextNode[]` for every node. As a result `content` was optional everywhere, including the document root. The Storyblok API always returns the root `doc` with a `content` array, while nested nodes (empty paragraphs, leaf nodes such as `image`) may omit `content` entirely.

## Note

Tightening `doc.content` from optional to required is a minor breaking change for code that builds `{ type: 'doc' }` literals without `content`. It matches both the issue's stated expectation and the API response, but I am happy to scope this down to only relax sub-nodes if you would prefer to avoid the breaking change.

Fixes #16