### PR TITLE
fix(cli): mark conditionally-returned StoryblokAsset fields as optional

### DIFF
--- a/packages/cli/src/types/storyblok.ts
+++ b/packages/cli/src/types/storyblok.ts
@@ -2,25 +2,28 @@ export type StoryblokPropertyType = 'asset' | 'multiasset' | 'multilink' | 'tabl
 
 export interface StoryblokAsset {
   alt: string | null;
-  copyright: string | null;
   fieldtype: 'asset';
   id: number;
   filename: string | null;
   name: string;
   title: string | null;
   focus: string | null;
-  meta_data: Record<string, any>;
-  source: string | null;
-  is_external_url: boolean;
-  is_private: boolean;
-  src: string;
-  updated_at: string;
+  // The properties below are only present in some asset responses (they
+  // depend on the asset itself, the space configuration and integrations such
+  // as Cloudinary), so they are optional to reflect the actual API payloads.
+  copyright?: string | null;
+  meta_data?: Record<string, any>;
+  source?: string | null;
+  is_external_url?: boolean;
+  is_private?: boolean;
+  src?: string;
+  updated_at?: string;
   // Cloudinary integration keys
-  width: number | null;
-  height: number | null;
-  aspect_ratio: number | null;
-  public_id: string | null;
-  content_type: string;
+  width?: number | null;
+  height?: number | null;
+  aspect_ratio?: number | null;
+  public_id?: string | null;
+  content_type?: string;
 }
 
 export interface StoryblokMultiasset extends Array<StoryblokAsset> {}


### PR DESCRIPTION
## What & why

The generated `StoryblokAsset` type (`packages/cli/src/types/storyblok.ts`) declares **every** property as required. However, several fields only appear in *some* asset responses depending on the asset, the space configuration, and integrations such as Cloudinary.

The two examples in #488 from the same space confirm this — `is_private` is present in one payload and absent in the other:

```jsonc
// no is_private
{ "id": 1, "alt": "", "name": "", "filename": "https://a.storyblok.com/f/...", "fieldtype": "asset", "meta_data": {}, "is_external_url": false }

// has is_private
{ "id": 2, "alt": "", "name": "", "filename": "https://a.storyblok.com/f/...", "fieldtype": "asset", "meta_data": {}, "is_private": false, "is_external_url": false }
```

Because this interface is read verbatim and emitted into the generated `storyblok.d.ts` (`generateStoryblokTypes` in `commands/types/generate/actions.ts`), consumers get a type that is stricter than the real API, forcing `// @ts-ignore` or unsafe casts when a field is missing.

This also already disagreed with the project's own JSON schema in `utils/storyblok-schemas.ts`, whose `required` list is only:

```
['id', 'fieldtype', 'filename', 'name', 'title', 'focus', 'alt']
```

## Change

Align the `StoryblokAsset` interface with that JSON schema by keeping the 7 core fields required and marking the remaining, conditionally-returned fields optional (`copyright`, `meta_data`, `source`, `is_external_url`, `is_private`, `src`, `updated_at`, and the Cloudinary keys `width`/`height`/`aspect_ratio`/`public_id`/`content_type`).

No runtime behavior changes — this is a type-only fix.

## Testing

From `packages/cli`:

- `pnpm nx run storyblok:test:types` (tsc --noEmit) — passes
- `pnpm nx run storyblok:lint` — passes
- `pnpm vitest run` — 717 passed, 1 todo, 1 skipped

Fixes #488
