### PR TITLE
fix(readme): replace 404 docs links in alpha packages

### DIFF
--- a/packages/capi-client/README.md
+++ b/packages/capi-client/README.md
@@ -38,7 +38,9 @@
 
 ## Documentation
 
-For complete documentation, please visit [package reference](https://www.storyblok.com/docs/libraries/js/api-client)
+<!-- TODO: restore docs link once live — https://www.storyblok.com/docs/libraries/js/api-client (docs #536/#548) -->
+
+Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/main/packages/capi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/main/packages/schema/playground/astro).
 
 ## Contributing
 

--- a/packages/capi-client/README.md
+++ b/packages/capi-client/README.md
@@ -40,7 +40,7 @@
 
 <!-- TODO: restore docs link once live — https://www.storyblok.com/docs/libraries/js/api-client (docs #536/#548) -->
 
-Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/main/packages/capi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/main/packages/schema/playground/astro).
+Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/alpha/packages/capi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/alpha/packages/schema/playground/astro).
 
 ## Contributing
 

--- a/packages/mapi-client/README.md
+++ b/packages/mapi-client/README.md
@@ -40,7 +40,7 @@
 
 <!-- TODO: restore docs link once live — https://www.storyblok.com/docs/libraries/js/management-api-client (docs #536/#548) -->
 
-Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/main/packages/mapi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/main/packages/schema/playground/astro).
+Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/alpha/packages/mapi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/alpha/packages/schema/playground/astro).
 
 ## Contributing
 

--- a/packages/mapi-client/README.md
+++ b/packages/mapi-client/README.md
@@ -38,7 +38,9 @@
 
 ## Documentation
 
-For complete documentation, please visit [package reference](https://www.storyblok.com/docs/libraries/js/management-api-client)
+<!-- TODO: restore docs link once live — https://www.storyblok.com/docs/libraries/js/management-api-client (docs #536/#548) -->
+
+Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/main/packages/mapi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/main/packages/schema/playground/astro).
 
 ## Contributing
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -38,7 +38,7 @@
 
 <!-- TODO: restore docs link once live — https://www.storyblok.com/docs/packages/storyblok-schema (docs #536/#548) -->
 
-Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/main/packages/schema) or explore a runnable example in the [Astro playground](https://github.com/storyblok/monoblok/tree/main/packages/schema/playground/astro).
+Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/alpha/packages/schema) or explore a runnable example in the [Astro playground](https://github.com/storyblok/monoblok/tree/alpha/packages/schema/playground/astro).
 
 ## Contributing
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -36,7 +36,9 @@
 
 ## Documentation
 
-For complete documentation, please visit [package reference](https://www.storyblok.com/docs/packages/storyblok-schema)
+<!-- TODO: restore docs link once live — https://www.storyblok.com/docs/packages/storyblok-schema (docs #536/#548) -->
+
+Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/main/packages/schema) or explore a runnable example in the [Astro playground](https://github.com/storyblok/monoblok/tree/main/packages/schema/playground/astro).
 
 ## Contributing
 


### PR DESCRIPTION
The README "package reference" links in three alpha packages point to docs pages that aren't live yet, so anyone reading the package on npm clicks through to a **404**:

- `@storyblok/schema` → `…/docs/packages/storyblok-schema`
- `@storyblok/api-client` (`capi-client`) → `…/docs/libraries/js/api-client`
- `@storyblok/management-api-client` (`mapi-client`) → `…/docs/libraries/js/management-api-client`

The docs pages are in flight (docs #536/#548) and will land soon — this is a temporary gap, not a broken pattern (existing packages link the same way and resolve fine).

## Fix

Until the docs pages go live, point the Documentation section at targets that resolve today:

- the **GitHub package source** for each package, and
- the **runnable Astro playground** (`packages/schema/playground/astro`), which exercises both the API client and the management API client.

A non-rendering `<!-- TODO -->` marker above each section records the eventual docs URL so the swap-back is trivial once #536/#548 land.