### PR TITLE
fix(astro): circular dependency through StoryblokComponent

### DIFF
--- a/packages/astro/cypress/e2e/index.cy.js
+++ b/packages/astro/cypress/e2e/index.cy.js
@@ -3,6 +3,7 @@ Tests:
 - Bridge should be loaded
 - storyblokEditable attributes are assigned
 - globally loaded component is rendered correctly
+- TDZ fix works for manually registered components
 */
 
 describe("@storyblok/astro", () => {
@@ -31,6 +32,26 @@ describe("@storyblok/astro", () => {
     cy.visit("http://localhost:4321/");
     cy.get("[data-test=custom-fallback-component]").should("exist");
   });
+
+  /**
+   * TDZ (Temporal Dead Zone) Test
+   *
+   * Verifies that manually-registered components don't cause
+   * "Cannot access 'X' before initialization" errors when:
+   * 1. A component is registered in astro.config.mjs
+   * 2. The same component is directly imported in a page
+   *
+   * If the page loads and renders correctly, the TDZ fix is working.
+   */
+  it("TDZ fix: directly imported components work alongside registration", () => {
+    cy.visit("http://localhost:4321/tdz-test");
+    // Page should load without TDZ errors
+    cy.contains("TDZ Test Page").should("exist");
+    cy.contains("If you can see this, the TDZ fix is working correctly.").should("exist");
+    // Directly imported Teaser component should render
+    cy.contains("Direct Import Test").should("exist");
+  });
+
   /* it("RichText Renderer renders embedded bloks correctly", () => {
     cy.visit("http://localhost:4321/");
     cy.get("[data-test=embedded-blok]").should("exist");

--- a/packages/astro/playground/test/src/pages/tdz-test.astro
+++ b/packages/astro/playground/test/src/pages/tdz-test.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * TDZ (Temporal Dead Zone) Test Page
+ *
+ * This page verifies that manually-registered components don't cause
+ * "Cannot access 'X' before initialization" errors during SSR builds.
+ *
+ * The TDZ issue occurs when:
+ * 1. A component is registered in astro.config.mjs: components: { teaser: '...' }
+ * 2. The same component is directly imported in a page (like below)
+ * 3. During bundling, the registration code may execute before the component is defined
+ *
+ * If this page builds successfully, the TDZ fix is working.
+ */
+import Teaser from '@shared/storyblok/Teaser.astro';
+import Grid from '@shared/storyblok/Grid.astro';
+---
+
+<html>
+  <head>
+    <title>TDZ Test</title>
+  </head>
+  <body>
+    <h1>TDZ Test Page</h1>
+    <p>If you can see this, the TDZ fix is working correctly.</p>
+
+    <!-- Direct usage of manually-registered components -->
+    <Teaser blok={{ component: 'teaser', headline: 'Direct Import Test', _uid: '1' }} />
+    <Grid blok={{ component: 'grid', columns: [], _uid: '2' }} />
+  </body>
+</html>

--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -3,14 +3,12 @@ import { normalizePath } from '../utils/normalizePath';
 import { toCamelCase } from '../utils/toCamelCase';
 import type { Plugin } from 'vite';
 
-// Virtual module identifiers for Vite's module system
 const VIRTUAL_MODULE_ID = 'virtual:import-storyblok-components';
 const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
+
 /**
- * Vite plugin that automatically imports Storyblok components from a specified directory
- * and merges them with optional user-provided component mappings.
- *
- * @returns Vite plugin object
+ * Vite plugin that auto-imports Storyblok components from a directory
+ * and merges them with user-provided component mappings.
  */
 export function vitePluginImportStoryblokComponents(
   components: Record<string, string>,
@@ -20,121 +18,75 @@ export function vitePluginImportStoryblokComponents(
 ): Plugin {
   return {
     name: 'vite-plugin-import-storyblok-components',
-    /**
-     * Resolves virtual module imports
-     */
+
     async resolveId(id: string) {
       if (id === VIRTUAL_MODULE_ID) {
         return RESOLVED_VIRTUAL_MODULE_ID;
       }
     },
 
-    /**
-     * Generates the virtual module content with dynamic imports
-     */
     async load(id: string) {
       if (id !== RESOLVED_VIRTUAL_MODULE_ID) {
         return;
       }
 
-      // Resolve fallback component import
-      const fallbackImport = await resolveFallbackComponent(
+      const fallbackRegistration = await resolveFallbackComponent(
         this,
         componentsDir,
         enableFallbackComponent,
         customFallbackComponent,
       );
 
-      const manualImports = await resolveUserComponents(
+      const manualRegistrations = await resolveUserComponents(
         this,
         components,
         componentsDir,
         enableFallbackComponent,
       );
 
-      // Generate the virtual module code
-      const moduleCode = generateModuleCode(
-        componentsDir,
-        fallbackImport,
-        manualImports,
-      );
-
       return {
-        code: moduleCode,
+        code: generateModuleCode(componentsDir, fallbackRegistration, manualRegistrations),
         moduleType: 'js',
       };
     },
   };
 }
-export interface ResolvedComponent {
-  componentName: string;
-  importPath: string;
+
+export interface ComponentRegistrationParts {
+  importStatement: string;
+  wrapperDefinition: string;
+  registrationCall: string;
 }
 
 /**
- * Generates the complete virtual module code including:
- * - Auto-imported components via glob
- * - User-provided component imports (via static imports at the top)
- * - Optional fallback component (via static import at the top)
- *
- * Static imports are placed at the very beginning of the module to ensure
- * they are hoisted correctly and available when registration code runs.
- *
- * @param componentsDir - Base directory of components
- * @param fallbackImport - Import statement for fallback (if any)
- * @param manualImports - Explicit imports generated from user-provided components
- * @returns Virtual module source code
+ * Generates the virtual module code with:
+ * - Static imports at the top for proper hoisting
+ * - Glob-imported components from storyblok folder
+ * - Manual and fallback component registrations
  */
 export function generateModuleCode(
   componentsDir: string,
-  fallbackImport: string,
-  manualImports: string[],
+  fallbackRegistration: ComponentRegistrationParts | null,
+  manualRegistrations: ComponentRegistrationParts[],
 ): string {
-  // Normalize components directory path for Vite globbing
   const normalizedComponentsDir = normalizePath(componentsDir);
-
-  // Only look into the storyblok folder
   const globPattern = `${normalizedComponentsDir}/storyblok/**/*.astro`;
 
-  // Extract import statements, wrapper definitions, and registration calls from manual imports
-  const importStatements: string[] = [];
-  const wrapperDefinitions: string[] = [];
-  const registrationCalls: string[] = [];
-
-  const parseLines = (code: string) => {
-    const lines = code.split('\n');
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('import ')) {
-        importStatements.push(trimmed);
-      }
-      else if (trimmed.startsWith('const ')) {
-        wrapperDefinitions.push(trimmed);
-      }
-      else if (trimmed.startsWith('registerComponent(')) {
-        registrationCalls.push(trimmed);
-      }
-    }
-  };
-
-  for (const importCode of manualImports) {
-    parseLines(importCode);
+  const allRegistrations = [...manualRegistrations];
+  if (fallbackRegistration) {
+    allRegistrations.push(fallbackRegistration);
   }
 
-  // Extract fallback import and registration
-  if (fallbackImport) {
-    parseLines(fallbackImport);
-  }
+  const importStatements = allRegistrations.map(r => r.importStatement);
+  const wrapperDefinitions = allRegistrations.map(r => r.wrapperDefinition);
+  const registrationCalls = allRegistrations.map(r => r.registrationCall);
 
   return `
-    // Static imports - placed at the top for proper hoisting
     import { toCamelCase } from '@storyblok/astro';
     ${importStatements.join('\n    ')}
 
-    // Dynamically import all Storyblok components using Vite's glob import
     const modules = import.meta.glob('${globPattern}', { eager: true });
 
-    // Process imported modules into a components object
     const storyblokComponents = {};
     const createComponentLoader = (module) => {
       return async () => module?.default ?? module;
@@ -147,7 +99,6 @@ export function generateModuleCode(
       });
     };
 
-    // Register glob-imported components from storyblok folder
     for (const filePath in modules) {
       const fileName = filePath.split('/').pop();
       const componentName = toCamelCase(fileName?.replace(/\\.[^/.]+$/, '') ?? '');
@@ -156,13 +107,10 @@ export function generateModuleCode(
       }
     }
 
-    // Component wrappers with getters to defer access and avoid TDZ issues
     ${wrapperDefinitions.join('\n    ')}
 
-    // Register manual and fallback components
     ${registrationCalls.join('\n    ')}
 
-    // Export the components object for use in Storyblok initialization
     export { storyblokComponents };
   `.trim();
 }
@@ -172,21 +120,18 @@ async function resolveFallbackComponent(
   componentsDir: string,
   enableFallbackComponent: boolean,
   customFallbackComponent?: string,
-): Promise<string> {
+): Promise<ComponentRegistrationParts | null> {
   if (!enableFallbackComponent) {
-    return '';
+    return null;
   }
   if (!customFallbackComponent) {
-    return createComponentRegistrationCode({
+    return createComponentRegistrationParts({
       componentName: 'FallbackComponent',
       importPath: '@storyblok/astro/FallbackComponent.astro',
     });
   }
 
-  const componentPath = getComponentFullPath(
-    componentsDir,
-    customFallbackComponent,
-  );
+  const componentPath = getComponentFullPath(componentsDir, customFallbackComponent);
   const resolved = await ctx.resolve(componentPath);
   if (!resolved) {
     throw new Error(
@@ -194,27 +139,19 @@ async function resolveFallbackComponent(
     );
   }
 
-  return createComponentRegistrationCode({
+  return createComponentRegistrationParts({
     componentName: 'FallbackComponent',
     importPath: resolved.id,
   });
 }
-/**
- * Resolves user-provided Storyblok components into import statements.
- *
- * @param ctx - Vite plugin context (`this` in load hook)
- * @param components - User-specified mapping of blok names to component paths
- * @param componentsDir - Base directory for components
- * @param enableFallback - Whether to silently skip unresolved components
- * @returns Array of import and registration code strings
- */
+
 async function resolveUserComponents(
   ctx: any,
   components: Record<string, string>,
   componentsDir: string,
   enableFallback: boolean,
-): Promise<string[]> {
-  const resolvedComponents: string[] = [];
+): Promise<ComponentRegistrationParts[]> {
+  const resolvedComponents: ComponentRegistrationParts[] = [];
 
   for (const [blokName, componentPath] of Object.entries(components)) {
     const fullPath = getComponentFullPath(componentsDir, componentPath);
@@ -229,7 +166,7 @@ async function resolveUserComponents(
       continue;
     };
     const componentName = toCamelCase(blokName);
-    resolvedComponents.push(createComponentRegistrationCode({
+    resolvedComponents.push(createComponentRegistrationParts({
       componentName,
       importPath: resolved.id,
     }));
@@ -237,22 +174,6 @@ async function resolveUserComponents(
   return resolvedComponents;
 }
 
-/**
- * Builds the full normalized path to an Astro component file.
- *
- * - Ensures both the components directory and the component path
- *   are normalized (leading slash, no trailing slash, no duplicates).
- * - Concatenates them into a single path.
- * - Ensures the `.astro` extension is present.
- *
- * @param componentsDir - Base directory where Astro components live
- * @param componentPath - Relative path (or subpath) to the component
- * @returns Full normalized path ending with `.astro`
- *
- * @example
- * getComponentFullPath("components", "ui/Button");
- * // "/components/ui/Button.astro"
- */
 function getComponentFullPath(
   componentsDir: string,
   componentPath: string,
@@ -262,32 +183,29 @@ function getComponentFullPath(
   return normalizeAstroExtension(fullComponentPath);
 }
 
-interface CreateComponentRegistrationCodeOptions {
+interface CreateComponentRegistrationPartsOptions {
   componentName: string;
   importPath: string;
 }
 
 /**
- * Generates import and registration code for a component.
- * Uses a unique variable name based on the component name to avoid conflicts.
+ * Generates structured registration parts for a component.
  *
- * IMPORTANT: We wrap each import in an object with a getter to avoid TDZ errors.
- * When Vite bundles modules, the order of code execution can cause
- * "Cannot access 'X' before initialization" errors if we directly reference
- * the imported component. By wrapping it in an object with a getter,
- * the actual access is deferred until the component is needed.
+ * Uses a getter wrapper to avoid TDZ (Temporal Dead Zone) errors.
+ * When Vite bundles modules, direct references to imported components
+ * can cause "Cannot access 'X' before initialization" errors.
+ * The getter defers access until the component is actually needed.
  */
-function createComponentRegistrationCode({
+export function createComponentRegistrationParts({
   componentName,
   importPath,
-}: CreateComponentRegistrationCodeOptions): string {
-  // Use a unique variable name to avoid conflicts between components
+}: CreateComponentRegistrationPartsOptions): ComponentRegistrationParts {
   const varName = `__${componentName}_component__`;
-  // Wrap in an object with a getter to defer access and avoid TDZ issues
   const wrapperName = `__${componentName}_wrapper__`;
-  return `
-import ${varName} from '${importPath}';
-const ${wrapperName} = { get default() { return ${varName}; } };
-registerComponent('${componentName}', ${wrapperName});
-`.trim();
+
+  return {
+    importStatement: `import ${varName} from '${importPath}';`,
+    wrapperDefinition: `const ${wrapperName} = { get default() { return ${varName}; } };`,
+    registrationCall: `registerComponent('${componentName}', ${wrapperName});`,
+  };
 }

--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -96,35 +96,34 @@ export function generateModuleCode(
   // Only look into the storyblok folder
   const globPattern = `${normalizedComponentsDir}/storyblok/**/*.astro`;
 
-  // Extract import statements and registration calls from manual imports
+  // Extract import statements, wrapper definitions, and registration calls from manual imports
   const importStatements: string[] = [];
+  const wrapperDefinitions: string[] = [];
   const registrationCalls: string[] = [];
 
-  for (const importCode of manualImports) {
-    const lines = importCode.split('\n');
+  const parseLines = (code: string) => {
+    const lines = code.split('\n');
     for (const line of lines) {
       const trimmed = line.trim();
       if (trimmed.startsWith('import ')) {
         importStatements.push(trimmed);
       }
+      else if (trimmed.startsWith('const ')) {
+        wrapperDefinitions.push(trimmed);
+      }
       else if (trimmed.startsWith('registerComponent(')) {
         registrationCalls.push(trimmed);
       }
     }
+  };
+
+  for (const importCode of manualImports) {
+    parseLines(importCode);
   }
 
   // Extract fallback import and registration
   if (fallbackImport) {
-    const lines = fallbackImport.split('\n');
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('import ')) {
-        importStatements.push(trimmed);
-      }
-      else if (trimmed.startsWith('registerComponent(')) {
-        registrationCalls.push(trimmed);
-      }
-    }
+    parseLines(fallbackImport);
   }
 
   return `
@@ -156,6 +155,9 @@ export function generateModuleCode(
         registerComponent(componentName, modules[filePath]);
       }
     }
+
+    // Component wrappers with getters to defer access and avoid TDZ issues
+    ${wrapperDefinitions.join('\n    ')}
 
     // Register manual and fallback components
     ${registrationCalls.join('\n    ')}
@@ -268,6 +270,12 @@ interface CreateComponentRegistrationCodeOptions {
 /**
  * Generates import and registration code for a component.
  * Uses a unique variable name based on the component name to avoid conflicts.
+ *
+ * IMPORTANT: We wrap each import in an object with a getter to avoid TDZ errors.
+ * When Vite bundles modules, the order of code execution can cause
+ * "Cannot access 'X' before initialization" errors if we directly reference
+ * the imported component. By wrapping it in an object with a getter,
+ * the actual access is deferred until the component is needed.
  */
 function createComponentRegistrationCode({
   componentName,
@@ -275,8 +283,11 @@ function createComponentRegistrationCode({
 }: CreateComponentRegistrationCodeOptions): string {
   // Use a unique variable name to avoid conflicts between components
   const varName = `__${componentName}_component__`;
+  // Wrap in an object with a getter to defer access and avoid TDZ issues
+  const wrapperName = `__${componentName}_wrapper__`;
   return `
 import ${varName} from '${importPath}';
-registerComponent('${componentName}', ${varName});
+const ${wrapperName} = { get default() { return ${varName}; } };
+registerComponent('${componentName}', ${wrapperName});
 `.trim();
 }

--- a/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
+++ b/packages/astro/src/vite-plugins/vite-plugin-import-storyblok-components.ts
@@ -66,18 +66,26 @@ export function vitePluginImportStoryblokComponents(
     },
   };
 }
+export interface ResolvedComponent {
+  componentName: string;
+  importPath: string;
+}
+
 /**
  * Generates the complete virtual module code including:
  * - Auto-imported components via glob
- * - User-provided component imports
- * - Optional fallback component
+ * - User-provided component imports (via static imports at the top)
+ * - Optional fallback component (via static import at the top)
+ *
+ * Static imports are placed at the very beginning of the module to ensure
+ * they are hoisted correctly and available when registration code runs.
  *
  * @param componentsDir - Base directory of components
  * @param fallbackImport - Import statement for fallback (if any)
  * @param manualImports - Explicit imports generated from user-provided components
  * @returns Virtual module source code
  */
-function generateModuleCode(
+export function generateModuleCode(
   componentsDir: string,
   fallbackImport: string,
   manualImports: string[],
@@ -88,12 +96,45 @@ function generateModuleCode(
   // Only look into the storyblok folder
   const globPattern = `${normalizedComponentsDir}/storyblok/**/*.astro`;
 
+  // Extract import statements and registration calls from manual imports
+  const importStatements: string[] = [];
+  const registrationCalls: string[] = [];
+
+  for (const importCode of manualImports) {
+    const lines = importCode.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('import ')) {
+        importStatements.push(trimmed);
+      }
+      else if (trimmed.startsWith('registerComponent(')) {
+        registrationCalls.push(trimmed);
+      }
+    }
+  }
+
+  // Extract fallback import and registration
+  if (fallbackImport) {
+    const lines = fallbackImport.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('import ')) {
+        importStatements.push(trimmed);
+      }
+      else if (trimmed.startsWith('registerComponent(')) {
+        registrationCalls.push(trimmed);
+      }
+    }
+  }
+
   return `
-    // Import utilities and fallback component
+    // Static imports - placed at the top for proper hoisting
     import { toCamelCase } from '@storyblok/astro';
+    ${importStatements.join('\n    ')}
 
     // Dynamically import all Storyblok components using Vite's glob import
     const modules = import.meta.glob('${globPattern}', { eager: true });
+
     // Process imported modules into a components object
     const storyblokComponents = {};
     const createComponentLoader = (module) => {
@@ -106,19 +147,19 @@ function generateModuleCode(
         get: () => createComponentLoader(component),
       });
     };
+
+    // Register glob-imported components from storyblok folder
     for (const filePath in modules) {
-      // Extract component name from file path (remove extension)
       const fileName = filePath.split('/').pop();
-      const componentName = toCamelCase(fileName?.replace(/\.[^/.]+$/, '') ?? '');
+      const componentName = toCamelCase(fileName?.replace(/\\.[^/.]+$/, '') ?? '');
       if (componentName) {
         registerComponent(componentName, modules[filePath]);
       }
     }
-    
-    // Manual components
-    ${manualImports.join('\n\n')}
-    // Add fallback component if enabled
-    ${fallbackImport}    
+
+    // Register manual and fallback components
+    ${registrationCalls.join('\n    ')}
+
     // Export the components object for use in Storyblok initialization
     export { storyblokComponents };
   `.trim();
@@ -163,7 +204,7 @@ async function resolveFallbackComponent(
  * @param components - User-specified mapping of blok names to component paths
  * @param componentsDir - Base directory for components
  * @param enableFallback - Whether to silently skip unresolved components
- * @returns Object containing import statements
+ * @returns Array of import and registration code strings
  */
 async function resolveUserComponents(
   ctx: any,
@@ -224,12 +265,18 @@ interface CreateComponentRegistrationCodeOptions {
   importPath: string;
 }
 
+/**
+ * Generates import and registration code for a component.
+ * Uses a unique variable name based on the component name to avoid conflicts.
+ */
 function createComponentRegistrationCode({
   componentName,
   importPath,
 }: CreateComponentRegistrationCodeOptions): string {
+  // Use a unique variable name to avoid conflicts between components
+  const varName = `__${componentName}_component__`;
   return `
-  import ${componentName} from '${importPath}';
-  registerComponent('${componentName}', ${componentName});
+import ${varName} from '${importPath}';
+registerComponent('${componentName}', ${varName});
 `.trim();
 }

--- a/packages/astro/tests/vite-plugin-import-storyblok-components.test.ts
+++ b/packages/astro/tests/vite-plugin-import-storyblok-components.test.ts
@@ -1,10 +1,40 @@
 import { describe, expect, it } from 'vitest';
-import { generateModuleCode } from '../src/vite-plugins/vite-plugin-import-storyblok-components';
+import { createComponentRegistrationParts, generateModuleCode } from '../src/vite-plugins/vite-plugin-import-storyblok-components';
 
 describe('vite-plugin-import-storyblok-components', () => {
+  describe('createComponentRegistrationParts', () => {
+    it('generates structured parts with wrapper for TDZ avoidance', () => {
+      const parts = createComponentRegistrationParts({
+        componentName: 'Card',
+        importPath: '/src/components/Card.astro',
+      });
+
+      expect(parts.importStatement).toBe(`import __Card_component__ from '/src/components/Card.astro';`);
+      expect(parts.wrapperDefinition).toBe(`const __Card_wrapper__ = { get default() { return __Card_component__; } };`);
+      expect(parts.registrationCall).toBe(`registerComponent('Card', __Card_wrapper__);`);
+    });
+
+    it('uses unique variable names based on component name', () => {
+      const cardParts = createComponentRegistrationParts({
+        componentName: 'Card',
+        importPath: '/src/Card.astro',
+      });
+      const heroParts = createComponentRegistrationParts({
+        componentName: 'Hero',
+        importPath: '/src/Hero.astro',
+      });
+
+      // Variable names should be unique per component
+      expect(cardParts.importStatement).toContain('__Card_component__');
+      expect(heroParts.importStatement).toContain('__Hero_component__');
+      expect(cardParts.wrapperDefinition).toContain('__Card_wrapper__');
+      expect(heroParts.wrapperDefinition).toContain('__Hero_wrapper__');
+    });
+  });
+
   describe('generateModuleCode', () => {
     it('generates valid module code without manual components', () => {
-      const code = generateModuleCode('/src/components', '', []);
+      const code = generateModuleCode('/src/components', null, []);
 
       expect(code).toContain('import { toCamelCase }');
       expect(code).toContain('import.meta.glob');
@@ -12,26 +42,38 @@ describe('vite-plugin-import-storyblok-components', () => {
     });
 
     it('generates valid module code with manual components', () => {
-      const manualImports = [
-        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
-        `import __hero_component__ from '/src/components/Hero.astro';\nregisterComponent('hero', __hero_component__);`,
+      const manualRegistrations = [
+        createComponentRegistrationParts({
+          componentName: 'card',
+          importPath: '/src/components/Card.astro',
+        }),
+        createComponentRegistrationParts({
+          componentName: 'hero',
+          importPath: '/src/components/Hero.astro',
+        }),
       ];
 
-      const code = generateModuleCode('/src/components', '', manualImports);
+      const code = generateModuleCode('/src/components', null, manualRegistrations);
 
-      expect(code).toContain('import __card_component__ from \'/src/components/Card.astro\'');
-      expect(code).toContain('registerComponent(\'card\', __card_component__)');
-      expect(code).toContain('import __hero_component__ from \'/src/components/Hero.astro\'');
-      expect(code).toContain('registerComponent(\'hero\', __hero_component__)');
+      expect(code).toContain(`import __card_component__ from '/src/components/Card.astro'`);
+      expect(code).toContain(`const __card_wrapper__ = { get default() { return __card_component__; } }`);
+      expect(code).toContain(`registerComponent('card', __card_wrapper__)`);
+      expect(code).toContain(`import __hero_component__ from '/src/components/Hero.astro'`);
+      expect(code).toContain(`const __hero_wrapper__ = { get default() { return __hero_component__; } }`);
+      expect(code).toContain(`registerComponent('hero', __hero_wrapper__)`);
     });
 
     it('generates valid module code with fallback component', () => {
-      const fallbackImport = `import __FallbackComponent_component__ from '@storyblok/astro/FallbackComponent.astro';\nregisterComponent('FallbackComponent', __FallbackComponent_component__);`;
+      const fallbackRegistration = createComponentRegistrationParts({
+        componentName: 'FallbackComponent',
+        importPath: '@storyblok/astro/FallbackComponent.astro',
+      });
 
-      const code = generateModuleCode('/src/components', fallbackImport, []);
+      const code = generateModuleCode('/src/components', fallbackRegistration, []);
 
-      expect(code).toContain('import __FallbackComponent_component__ from \'@storyblok/astro/FallbackComponent.astro\'');
-      expect(code).toContain('registerComponent(\'FallbackComponent\', __FallbackComponent_component__)');
+      expect(code).toContain(`import __FallbackComponent_component__ from '@storyblok/astro/FallbackComponent.astro'`);
+      expect(code).toContain(`const __FallbackComponent_wrapper__ = { get default() { return __FallbackComponent_component__; } }`);
+      expect(code).toContain(`registerComponent('FallbackComponent', __FallbackComponent_wrapper__)`);
     });
 
     /**
@@ -39,11 +81,14 @@ describe('vite-plugin-import-storyblok-components', () => {
      * to ensure proper hoisting behavior and avoid TDZ issues.
      */
     it('places static imports at the top of the module', () => {
-      const manualImports = [
-        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
+      const manualRegistrations = [
+        createComponentRegistrationParts({
+          componentName: 'card',
+          importPath: '/src/components/Card.astro',
+        }),
       ];
 
-      const code = generateModuleCode('/src/components', '', manualImports);
+      const code = generateModuleCode('/src/components', null, manualRegistrations);
 
       // All imports should be at the top, before any other code
       const toCamelCaseImportIndex = code.indexOf('import { toCamelCase }');
@@ -59,16 +104,38 @@ describe('vite-plugin-import-storyblok-components', () => {
       expect(cardImportIndex).toBeLessThan(modulesDefIndex);
     });
 
-    it('places registration calls after registerComponent is defined', () => {
-      const manualImports = [
-        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
+    it('places wrapper definitions before registration calls', () => {
+      const manualRegistrations = [
+        createComponentRegistrationParts({
+          componentName: 'card',
+          importPath: '/src/components/Card.astro',
+        }),
       ];
 
-      const code = generateModuleCode('/src/components', '', manualImports);
+      const code = generateModuleCode('/src/components', null, manualRegistrations);
+
+      // Wrapper definitions should come before registration calls
+      const wrapperDefIndex = code.indexOf('const __card_wrapper__');
+      const registerCallIndex = code.indexOf(`registerComponent('card', __card_wrapper__)`);
+
+      expect(wrapperDefIndex).toBeGreaterThan(-1);
+      expect(registerCallIndex).toBeGreaterThan(-1);
+      expect(wrapperDefIndex).toBeLessThan(registerCallIndex);
+    });
+
+    it('places registration calls after registerComponent is defined', () => {
+      const manualRegistrations = [
+        createComponentRegistrationParts({
+          componentName: 'card',
+          importPath: '/src/components/Card.astro',
+        }),
+      ];
+
+      const code = generateModuleCode('/src/components', null, manualRegistrations);
 
       // registerComponent definition should come before registration calls
       const registerComponentDefIndex = code.indexOf('const registerComponent = ');
-      const registerCallIndex = code.indexOf('registerComponent(\'card\'');
+      const registerCallIndex = code.indexOf(`registerComponent('card'`);
 
       expect(registerComponentDefIndex).toBeGreaterThan(-1);
       expect(registerCallIndex).toBeGreaterThan(-1);
@@ -76,27 +143,55 @@ describe('vite-plugin-import-storyblok-components', () => {
     });
 
     it('uses glob pattern for auto-discovered components', () => {
-      const code = generateModuleCode('/src/components', '', []);
+      const code = generateModuleCode('/src/components', null, []);
 
       // Should use import.meta.glob for components in storyblok folder
-      expect(code).toContain('import.meta.glob(\'/src/components/storyblok/**/*.astro\'');
+      expect(code).toContain(`import.meta.glob('/src/components/storyblok/**/*.astro'`);
       expect(code).toContain('eager: true');
     });
 
     it('registers glob components before manual components', () => {
-      const manualImports = [
-        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
+      const manualRegistrations = [
+        createComponentRegistrationParts({
+          componentName: 'card',
+          importPath: '/src/components/Card.astro',
+        }),
       ];
 
-      const code = generateModuleCode('/src/components', '', manualImports);
+      const code = generateModuleCode('/src/components', null, manualRegistrations);
 
       // Glob components registration loop should come before manual registration
       const globLoopIndex = code.indexOf('for (const filePath in modules)');
-      const manualRegisterIndex = code.indexOf('registerComponent(\'card\'');
+      const manualRegisterIndex = code.indexOf(`registerComponent('card'`);
 
       expect(globLoopIndex).toBeGreaterThan(-1);
       expect(manualRegisterIndex).toBeGreaterThan(-1);
       expect(globLoopIndex).toBeLessThan(manualRegisterIndex);
+    });
+
+    /**
+     * This test verifies that the TDZ fix is properly applied:
+     * components are registered with wrapper objects that use getters,
+     * not with the raw imported component reference.
+     */
+    it('registers components using wrapper with getter (TDZ fix)', () => {
+      const manualRegistrations = [
+        createComponentRegistrationParts({
+          componentName: 'card',
+          importPath: '/src/components/Card.astro',
+        }),
+      ];
+
+      const code = generateModuleCode('/src/components', null, manualRegistrations);
+
+      // Should NOT register with the raw component
+      expect(code).not.toContain(`registerComponent('card', __card_component__)`);
+
+      // Should register with the wrapper that has a getter
+      expect(code).toContain(`registerComponent('card', __card_wrapper__)`);
+
+      // The wrapper should use a getter to defer access
+      expect(code).toContain(`const __card_wrapper__ = { get default() { return __card_component__; } }`);
     });
   });
 });

--- a/packages/astro/tests/vite-plugin-import-storyblok-components.test.ts
+++ b/packages/astro/tests/vite-plugin-import-storyblok-components.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { generateModuleCode } from '../src/vite-plugins/vite-plugin-import-storyblok-components';
+
+describe('vite-plugin-import-storyblok-components', () => {
+  describe('generateModuleCode', () => {
+    it('generates valid module code without manual components', () => {
+      const code = generateModuleCode('/src/components', '', []);
+
+      expect(code).toContain('import { toCamelCase }');
+      expect(code).toContain('import.meta.glob');
+      expect(code).toContain('export { storyblokComponents }');
+    });
+
+    it('generates valid module code with manual components', () => {
+      const manualImports = [
+        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
+        `import __hero_component__ from '/src/components/Hero.astro';\nregisterComponent('hero', __hero_component__);`,
+      ];
+
+      const code = generateModuleCode('/src/components', '', manualImports);
+
+      expect(code).toContain('import __card_component__ from \'/src/components/Card.astro\'');
+      expect(code).toContain('registerComponent(\'card\', __card_component__)');
+      expect(code).toContain('import __hero_component__ from \'/src/components/Hero.astro\'');
+      expect(code).toContain('registerComponent(\'hero\', __hero_component__)');
+    });
+
+    it('generates valid module code with fallback component', () => {
+      const fallbackImport = `import __FallbackComponent_component__ from '@storyblok/astro/FallbackComponent.astro';\nregisterComponent('FallbackComponent', __FallbackComponent_component__);`;
+
+      const code = generateModuleCode('/src/components', fallbackImport, []);
+
+      expect(code).toContain('import __FallbackComponent_component__ from \'@storyblok/astro/FallbackComponent.astro\'');
+      expect(code).toContain('registerComponent(\'FallbackComponent\', __FallbackComponent_component__)');
+    });
+
+    /**
+     * This test verifies that static imports are placed at the top of the module
+     * to ensure proper hoisting behavior and avoid TDZ issues.
+     */
+    it('places static imports at the top of the module', () => {
+      const manualImports = [
+        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
+      ];
+
+      const code = generateModuleCode('/src/components', '', manualImports);
+
+      // All imports should be at the top, before any other code
+      const toCamelCaseImportIndex = code.indexOf('import { toCamelCase }');
+      const cardImportIndex = code.indexOf('import __card_component__');
+      const modulesDefIndex = code.indexOf('const modules = import.meta.glob');
+
+      expect(toCamelCaseImportIndex).toBeGreaterThan(-1);
+      expect(cardImportIndex).toBeGreaterThan(-1);
+      expect(modulesDefIndex).toBeGreaterThan(-1);
+
+      // Both imports should come before the modules definition
+      expect(toCamelCaseImportIndex).toBeLessThan(modulesDefIndex);
+      expect(cardImportIndex).toBeLessThan(modulesDefIndex);
+    });
+
+    it('places registration calls after registerComponent is defined', () => {
+      const manualImports = [
+        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
+      ];
+
+      const code = generateModuleCode('/src/components', '', manualImports);
+
+      // registerComponent definition should come before registration calls
+      const registerComponentDefIndex = code.indexOf('const registerComponent = ');
+      const registerCallIndex = code.indexOf('registerComponent(\'card\'');
+
+      expect(registerComponentDefIndex).toBeGreaterThan(-1);
+      expect(registerCallIndex).toBeGreaterThan(-1);
+      expect(registerComponentDefIndex).toBeLessThan(registerCallIndex);
+    });
+
+    it('uses glob pattern for auto-discovered components', () => {
+      const code = generateModuleCode('/src/components', '', []);
+
+      // Should use import.meta.glob for components in storyblok folder
+      expect(code).toContain('import.meta.glob(\'/src/components/storyblok/**/*.astro\'');
+      expect(code).toContain('eager: true');
+    });
+
+    it('registers glob components before manual components', () => {
+      const manualImports = [
+        `import __card_component__ from '/src/components/Card.astro';\nregisterComponent('card', __card_component__);`,
+      ];
+
+      const code = generateModuleCode('/src/components', '', manualImports);
+
+      // Glob components registration loop should come before manual registration
+      const globLoopIndex = code.indexOf('for (const filePath in modules)');
+      const manualRegisterIndex = code.indexOf('registerComponent(\'card\'');
+
+      expect(globLoopIndex).toBeGreaterThan(-1);
+      expect(manualRegisterIndex).toBeGreaterThan(-1);
+      expect(globLoopIndex).toBeLessThan(manualRegisterIndex);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
         version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       '@astrojs/vercel':
         specifier: ^11.0.0
-        version: 11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
+        version: 11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
       '@astrojs/vue':
         specifier: ^7.0.0
         version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
@@ -16945,10 +16945,10 @@ snapshots:
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
 
-  '@astrojs/vercel@11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
+  '@astrojs/vercel@11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
-      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
+      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
       '@vercel/functions': 3.4.3
       '@vercel/nft': 1.3.2(rollup@4.60.2)
       '@vercel/routing-utils': 5.3.3
@@ -23141,10 +23141,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+      next: 16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react: 19.2.4
       svelte: 5.55.0
       vue: 3.5.30(typescript@6.0.3)
@@ -29829,33 +29829,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
-    dependencies:
-      '@next/env': 16.1.6
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001775
-      postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
-      '@opentelemetry/api': 1.9.0
-      sass: 1.99.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    optional: true
-
   next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
     dependencies:
       '@next/env': 16.1.6
@@ -32996,14 +32969,6 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@babel/core': 7.29.7
-
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.4
-    optionalDependencies:
-      '@babel/core': 7.29.0
-    optional: true
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
         version: 24.11.0
       astro:
         specifier: ^7.0.0
-        version: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       cypress:
         specifier: ^14.3.3
         version: 14.5.4
@@ -191,16 +191,16 @@ importers:
         version: 6.0.0(@types/node@24.11.0)(@types/react-dom@19.2.3(@types/react@19.1.4))(@types/react@19.1.4)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/svelte':
         specifier: ^9.0.0
-        version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+        version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       '@astrojs/vue':
         specifier: ^7.0.0
-        version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
+        version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
         specifier: ^7.0.0
-        version: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -225,19 +225,19 @@ importers:
         version: 6.0.0(@types/node@24.11.0)(@types/react-dom@19.2.3(@types/react@19.1.4))(@types/react@19.1.4)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/svelte':
         specifier: ^9.0.0
-        version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+        version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       '@astrojs/vercel':
         specifier: ^11.0.0
-        version: 11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
+        version: 11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
       '@astrojs/vue':
         specifier: ^7.0.0
-        version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
+        version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
         specifier: ^7.0.0
-        version: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -262,16 +262,16 @@ importers:
         version: 6.0.0(@types/node@24.11.0)(@types/react-dom@19.2.3(@types/react@19.1.4))(@types/react@19.1.4)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/svelte':
         specifier: ^9.0.0
-        version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+        version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       '@astrojs/vue':
         specifier: ^7.0.0
-        version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
+        version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
       '@storyblok/astro':
         specifier: workspace:*
         version: link:../..
       astro:
         specifier: ^7.0.0
-        version: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1961,6 +1961,9 @@ packages:
 
   '@astrojs/internal-helpers@0.10.0':
     resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
+
+  '@astrojs/markdown-remark@7.2.0':
+    resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
   '@astrojs/markdown-satteri@0.3.2':
     resolution: {integrity: sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==}
@@ -8242,6 +8245,9 @@ packages:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
 
+  array-iterate@2.0.1:
+    resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -10889,11 +10895,23 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -12159,6 +12177,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-definitions@6.0.0:
+    resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -13114,6 +13135,9 @@ packages:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
+  parse-latin@7.0.0:
+    resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
+
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
@@ -13964,6 +13988,9 @@ packages:
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
@@ -13974,6 +14001,22 @@ packages:
     resolution: {integrity: sha512-HOVRcicehCgoCsPFOu0iCBlEC8GDOoKS5s6ICkWmqomGEoZtRQ88D3RCsI5MciSU8vAQU+aWZW2z57NQNNb74w==}
     engines: {node: ^20.9.0 || >=22.0.0}
     hasBin: true
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-smartypants@3.0.2:
+    resolution: {integrity: sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==}
+    engines: {node: '>=16.0.0'}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   request-progress@3.0.0:
     resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
@@ -14031,8 +14074,17 @@ packages:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
     engines: {node: '>=4'}
 
+  retext-latin@4.0.0:
+    resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
+
   retext-smartypants@6.2.0:
     resolution: {integrity: sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==}
+
+  retext-stringify@4.0.0:
+    resolution: {integrity: sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==}
+
+  retext@9.0.0:
+    resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -14773,11 +14825,6 @@ packages:
     resolution: {integrity: sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==}
     engines: {node: '>=18'}
 
-  svgo@4.0.0:
-    resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -15276,17 +15323,29 @@ packages:
     resolution: {integrity: sha512-njnL6sp8lEA8QQbZrt+52p/g4X0rw3bnGGmUcJnt1jeG8+iiqO779aGz0PirCtydAIVcuTBRlJ52F0u46z309Q==}
     engines: {node: '>=18.12.0'}
 
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
+  unist-util-modify-children@4.0.0:
+    resolution: {integrity: sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==}
+
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-children@3.0.0:
+    resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
 
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
@@ -16795,6 +16854,29 @@ snapshots:
       smol-toml: 1.6.0
       unified: 11.0.5
 
+  '@astrojs/markdown-remark@7.2.0':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@astrojs/markdown-satteri@0.3.2':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
@@ -16832,10 +16914,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@9.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)':
+  '@astrojs/svelte@9.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      astro: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       svelte: 5.55.0
       svelte2tsx: 0.7.57(svelte@5.55.0)(typescript@6.0.3)
       typescript: 6.0.3
@@ -16863,14 +16945,14 @@ snapshots:
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
 
-  '@astrojs/vercel@11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
+  '@astrojs/vercel@11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
-      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
+      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
       '@vercel/functions': 3.4.3
       '@vercel/nft': 1.3.2(rollup@4.60.2)
       '@vercel/routing-utils': 5.3.3
-      astro: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       esbuild: 0.28.1
       tinyglobby: 0.2.17
     transitivePeerDependencies:
@@ -16886,12 +16968,12 @@ snapshots:
       - vue
       - vue-router
 
-  '@astrojs/vue@7.0.0(@types/node@24.11.0)(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)':
+  '@astrojs/vue@7.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)':
     dependencies:
       '@vitejs/plugin-vue': 6.0.7(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@6.0.3))
       '@vue/compiler-sfc': 3.5.30
-      astro: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite: 8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-vue-devtools: 8.1.1(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@6.0.3))
       vue: 3.5.30(typescript@6.0.3)
@@ -23059,10 +23141,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      next: 16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react: 19.2.4
       svelte: 5.55.0
       vue: 3.5.30(typescript@6.0.3)
@@ -23959,6 +24041,9 @@ snapshots:
       is-string: 1.1.1
       math-intrinsics: 1.1.0
 
+  array-iterate@2.0.1:
+    optional: true
+
   array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
@@ -24071,7 +24156,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler-rs': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.0
@@ -24130,6 +24215,7 @@ snapshots:
       yargs-parser: 22.0.0
       zod: 4.3.6
     optionalDependencies:
+      '@astrojs/markdown-remark': 7.2.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -27584,9 +27670,31 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+    optional: true
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+    optional: true
 
   hast-util-to-html@9.0.5:
     dependencies:
@@ -27601,6 +27709,25 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+    optional: true
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+    optional: true
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -28908,6 +29035,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-definitions@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
+    optional: true
+
   mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -29694,6 +29828,33 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
+    dependencies:
+      '@next/env': 16.1.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001775
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.1.6
+      '@next/swc-darwin-x64': 16.1.6
+      '@next/swc-linux-arm64-gnu': 16.1.6
+      '@next/swc-linux-arm64-musl': 16.1.6
+      '@next/swc-linux-x64-gnu': 16.1.6
+      '@next/swc-linux-x64-musl': 16.1.6
+      '@next/swc-win32-arm64-msvc': 16.1.6
+      '@next/swc-win32-x64-msvc': 16.1.6
+      '@opentelemetry/api': 1.9.0
+      sass: 1.99.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    optional: true
 
   next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
     dependencies:
@@ -30799,6 +30960,16 @@ snapshots:
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
+  parse-latin@7.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      '@types/unist': 3.0.3
+      nlcst-to-string: 4.0.0
+      unist-util-modify-children: 4.0.0
+      unist-util-visit-children: 3.0.0
+      vfile: 6.0.3
+    optional: true
+
   parse-ms@4.0.0: {}
 
   parse-node-version@1.0.1: {}
@@ -31126,7 +31297,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
-      svgo: 4.0.0
+      svgo: 4.0.1
 
   postcss-unique-selectors@7.0.4(postcss@8.5.6):
     dependencies:
@@ -31712,6 +31883,13 @@ snapshots:
       hast-util-from-html: 2.0.3
       unified: 11.0.5
 
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+    optional: true
+
   rehype-stringify@10.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -31756,6 +31934,52 @@ snapshots:
       - '@types/node'
       - supports-color
       - typescript
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+    optional: true
+
+  remark-smartypants@3.0.2:
+    dependencies:
+      retext: 9.0.0
+      retext-smartypants: 6.2.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+    optional: true
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+    optional: true
 
   request-progress@3.0.0:
     dependencies:
@@ -31807,11 +32031,33 @@ snapshots:
 
   ret@0.2.2: {}
 
+  retext-latin@4.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      parse-latin: 7.0.0
+      unified: 11.0.5
+    optional: true
+
   retext-smartypants@6.2.0:
     dependencies:
       '@types/nlcst': 2.0.3
       nlcst-to-string: 4.0.0
       unist-util-visit: 5.1.0
+
+  retext-stringify@4.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      nlcst-to-string: 4.0.0
+      unified: 11.0.5
+    optional: true
+
+  retext@9.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      retext-latin: 4.0.0
+      retext-stringify: 4.0.0
+      unified: 11.0.5
+    optional: true
 
   retry@0.13.1: {}
 
@@ -32751,6 +32997,14 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
+    optional: true
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -32854,16 +33108,6 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.21
       zimmerframe: 1.1.4
-
-  svgo@4.0.0:
-    dependencies:
-      commander: 11.1.0
-      css-select: 5.2.2
-      css-tree: 3.1.0
-      css-what: 6.2.2
-      csso: 5.0.5
-      picocolors: 1.1.1
-      sax: 1.5.0
 
   svgo@4.0.1:
     dependencies:
@@ -33493,13 +33737,31 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
 
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+    optional: true
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
 
+  unist-util-modify-children@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      array-iterate: 2.0.1
+    optional: true
+
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
+    optional: true
 
   unist-util-stringify-position@2.0.3:
     dependencies:
@@ -33508,6 +33770,11 @@ snapshots:
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-visit-children@3.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+    optional: true
 
   unist-util-visit-parents@6.0.2:
     dependencies:


### PR DESCRIPTION
This PR fixes the TDZ (`ReferenceError`) caused by circular dependencies when Storyblok components are imported directly and also render `<StoryblokComponent />` internally.

It also adds both unit and Cypress tests to cover this scenario and help prevent future regressions.

Fixes #547.
