### PR TITLE
fix(cli): replace Angular env placeholders with actual values

### DIFF
--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -1,22 +1,13 @@
 import { spawn } from 'node:child_process';
-import fs from 'node:fs/promises';
 import { vol } from 'memfs';
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 import open from 'open';
 import { createEnvFile, extractPortFromTopics, fetchBlueprintRepositories, generateProject, handleEnvFileCreation, openSpaceInBrowser, repositoryToTemplate, updateAngularEnvironmentFiles } from './actions';
-import * as filesystem from '../../utils/filesystem';
 import type { RegionCode } from '../../constants';
 import { appDomains } from '../../constants';
 
 vi.mock('node:child_process');
-vi.mock('node:fs/promises', () => ({
-  default: {
-    access: vi.fn(),
-    readFile: vi.fn(),
-  },
-}));
 vi.mock('open');
-vi.mock('../../utils/filesystem');
 vi.mock('../../github', () => ({
   createOctokit: vi.fn(),
 }));
@@ -34,9 +25,6 @@ vi.mock('../../utils/ui', () => ({
 
 const mockedSpawn = vi.mocked(spawn);
 const mockedOpen = open as MockedFunction<typeof open>;
-const mockedSaveToFile = filesystem.saveToFile as MockedFunction<typeof filesystem.saveToFile>;
-const mockedFsAccess = vi.mocked(fs.access);
-const mockedFsReadFile = vi.mocked(fs.readFile);
 
 // Import the mocked modules
 const { createOctokit } = await import('../../github');
@@ -50,10 +38,7 @@ describe('create actions', () => {
 
   describe('generateProject', () => {
     it('should generate project successfully when directory does not exist', async () => {
-      const accessError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
-      accessError.code = 'ENOENT';
-      mockedFsAccess.mockRejectedValueOnce(accessError);
-
+      // Directory does not exist - vol is empty
       const mockProcess = {
         on: vi.fn((event: string, callback: (code: number) => void) => {
           if (event === 'close') {
@@ -65,7 +50,6 @@ describe('create actions', () => {
 
       await expect(generateProject('react', 'my-project', '/test/path')).resolves.toBeUndefined();
 
-      expect(mockedFsAccess).toHaveBeenCalledWith('/test/path/my-project');
       expect(mockedSpawn).toHaveBeenCalledWith(
         'npx',
         ['degit', 'storyblok/blueprint-core-react', '/test/path/my-project'],
@@ -77,37 +61,22 @@ describe('create actions', () => {
     });
 
     it('should throw FileSystemError when directory already exists', async () => {
-      mockedFsAccess.mockResolvedValueOnce(undefined);
+      // Create existing directory in memfs
+      vol.fromJSON({
+        '/test/path/existing-project/.gitkeep': '',
+      });
 
-      await expect(generateProject('vue', 'existing-project')).rejects.toThrow(
+      await expect(generateProject('vue', 'existing-project', '/test/path')).rejects.toThrow(
         expect.objectContaining({
           name: 'File System Error',
           errorId: 'directory_not_empty',
           code: 'ENOTEMPTY',
         }),
       );
-
-      expect(mockedFsAccess).toHaveBeenCalledWith(expect.stringContaining('existing-project'));
-    });
-
-    it('should handle filesystem errors other than ENOENT', async () => {
-      const accessError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
-      accessError.code = 'EACCES';
-      mockedFsAccess.mockRejectedValueOnce(accessError);
-
-      await expect(generateProject('svelte', 'test-project')).rejects.toThrow(
-        expect.objectContaining({
-          name: 'File System Error',
-          errorId: 'permission_denied',
-        }),
-      );
     });
 
     it('should handle spawn process failure', async () => {
-      const accessError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
-      accessError.code = 'ENOENT';
-      mockedFsAccess.mockRejectedValueOnce(accessError);
-
+      // Directory does not exist - vol is empty
       const mockProcess = {
         on: vi.fn((event: string, callback: (code: number) => void) => {
           if (event === 'close') {
@@ -117,16 +86,13 @@ describe('create actions', () => {
       };
       mockedSpawn.mockReturnValue(mockProcess as any);
 
-      await expect(generateProject('react', 'failed-project')).rejects.toThrow(
+      await expect(generateProject('react', 'failed-project', '/test/path')).rejects.toThrow(
         'Failed to clone template. Process exited with code 1',
       );
     });
 
     it('should handle spawn process error', async () => {
-      const accessError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
-      accessError.code = 'ENOENT';
-      mockedFsAccess.mockRejectedValueOnce(accessError);
-
+      // Directory does not exist - vol is empty
       const mockProcess = {
         on: vi.fn((event: string, callback: (error: Error) => void) => {
           if (event === 'error') {
@@ -136,16 +102,13 @@ describe('create actions', () => {
       };
       mockedSpawn.mockReturnValue(mockProcess as any);
 
-      await expect(generateProject('react', 'error-project')).rejects.toThrow(
+      await expect(generateProject('react', 'error-project', '/test/path')).rejects.toThrow(
         'Failed to spawn degit process: spawn failed',
       );
     });
 
     it('should use current working directory as default target path', async () => {
-      const accessError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
-      accessError.code = 'ENOENT';
-      mockedFsAccess.mockRejectedValueOnce(accessError);
-
+      // Directory does not exist - vol is empty
       const mockProcess = {
         on: vi.fn((event: string, callback: (code: number) => void) => {
           if (event === 'close') {
@@ -159,7 +122,14 @@ describe('create actions', () => {
 
       await generateProject('react', 'my-project');
 
-      expect(mockedFsAccess).toHaveBeenCalledWith('/current/dir/my-project');
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        'npx',
+        ['degit', 'storyblok/blueprint-core-react', '/current/dir/my-project'],
+        {
+          stdio: 'inherit',
+          shell: true,
+        },
+      );
 
       vi.mocked(process.cwd).mockRestore();
     });
@@ -167,18 +137,20 @@ describe('create actions', () => {
 
   describe('createEnvFile', () => {
     it('should create .env file successfully with access token only', async () => {
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/.gitkeep': '',
+      });
 
       await createEnvFile('/test/project', { STORYBLOK_DELIVERY_API_TOKEN: 'test-token-123' });
 
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN=test-token-123'),
-      );
+      const content = vol.readFileSync('/test/project/.env', 'utf-8');
+      expect(content).toContain('STORYBLOK_DELIVERY_API_TOKEN=test-token-123');
     });
 
     it('should create .env file with additional variables', async () => {
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/.gitkeep': '',
+      });
 
       const additionalVars = {
         CUSTOM_VAR: 'custom-value',
@@ -187,36 +159,20 @@ describe('create actions', () => {
 
       await createEnvFile('/test/project', { STORYBLOK_DELIVERY_API_TOKEN: 'test-token-123' }, additionalVars);
 
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringMatching(/STORYBLOK_DELIVERY_API_TOKEN=test-token-123/),
-      );
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringMatching(/CUSTOM_VAR=custom-value/),
-      );
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringMatching(/ANOTHER_VAR=another-value/),
-      );
-    });
-
-    it('should handle filesystem errors when creating .env file', async () => {
-      const saveError = new Error('Permission denied');
-      mockedSaveToFile.mockRejectedValue(saveError);
-
-      await expect(createEnvFile('/test/project', { STORYBLOK_DELIVERY_API_TOKEN: 'test-token-123' })).rejects.toThrow(
-        'Failed to create .env file: Permission denied',
-      );
+      const content = vol.readFileSync('/test/project/.env', 'utf-8');
+      expect(content).toMatch(/STORYBLOK_DELIVERY_API_TOKEN=test-token-123/);
+      expect(content).toMatch(/CUSTOM_VAR=custom-value/);
+      expect(content).toMatch(/ANOTHER_VAR=another-value/);
     });
 
     it('should create proper .env file content structure', async () => {
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/.gitkeep': '',
+      });
 
       await createEnvFile('/test/project', { STORYBLOK_DELIVERY_API_TOKEN: 'test-token-123' }, { CUSTOM: 'value' });
 
-      const [[, content]] = mockedSaveToFile.mock.calls;
-
+      const content = vol.readFileSync('/test/project/.env', 'utf-8');
       expect(content).toMatch(/^# Storyblok Configuration/);
       expect(content).toMatch(/STORYBLOK_DELIVERY_API_TOKEN=test-token-123/);
       expect(content).toMatch(/# Additional Configuration/);
@@ -226,32 +182,29 @@ describe('create actions', () => {
 
   describe('handleEnvFileCreation', () => {
     it('should create .env file with token and region successfully', async () => {
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/.gitkeep': '',
+      });
 
       const result = await handleEnvFileCreation('/test/project', 'test-token-123', 'us');
 
       expect(result).toBe(true);
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN=test-token-123'),
-      );
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringContaining('STORYBLOK_REGION=us'),
-      );
+      const content = vol.readFileSync('/test/project/.env', 'utf-8');
+      expect(content).toContain('STORYBLOK_DELIVERY_API_TOKEN=test-token-123');
+      expect(content).toContain('STORYBLOK_REGION=us');
       expect(mockedUI.ok).toHaveBeenCalledWith(expect.stringContaining('Created .env file with'), true);
     });
 
     it('should create .env file with only token', async () => {
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/.gitkeep': '',
+      });
 
       const result = await handleEnvFileCreation('/test/project', 'test-token-456');
 
       expect(result).toBe(true);
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN=test-token-456'),
-      );
+      const content = vol.readFileSync('/test/project/.env', 'utf-8');
+      expect(content).toContain('STORYBLOK_DELIVERY_API_TOKEN=test-token-456');
       expect(mockedUI.ok).toHaveBeenCalledWith(
         expect.stringContaining('Created .env file with'),
         true,
@@ -259,15 +212,15 @@ describe('create actions', () => {
     });
 
     it('should create .env file with only region', async () => {
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/.gitkeep': '',
+      });
 
       const result = await handleEnvFileCreation('/test/project', undefined, 'ap');
 
       expect(result).toBe(true);
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringContaining('STORYBLOK_REGION=ap'),
-      );
+      const content = vol.readFileSync('/test/project/.env', 'utf-8');
+      expect(content).toContain('STORYBLOK_REGION=ap');
       expect(mockedUI.ok).toHaveBeenCalledWith(expect.stringContaining('Created .env file with'), true);
     });
 
@@ -276,61 +229,6 @@ describe('create actions', () => {
 
       expect(result).toBe(true);
       expect(mockedUI.info).toHaveBeenCalledWith('No environment variables to write');
-      expect(mockedSaveToFile).not.toHaveBeenCalled();
-    });
-
-    it('should handle errors gracefully and return false', async () => {
-      const saveError = new Error('Permission denied');
-      mockedSaveToFile.mockRejectedValue(saveError);
-
-      const result = await handleEnvFileCreation('/test/project', 'test-token-789', 'eu');
-
-      expect(result).toBe(false);
-      expect(mockedUI.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to create .env file: Permission denied'),
-      );
-      expect(mockedUI.info).toHaveBeenCalledWith(
-        expect.stringContaining('You can manually add STORYBLOK_DELIVERY_API_TOKEN'),
-      );
-      expect(mockedUI.info).toHaveBeenCalledWith(
-        expect.stringContaining('You can manually add STORYBLOK_REGION'),
-      );
-    });
-
-    it('should show only token message when only token fails', async () => {
-      const saveError = new Error('Disk full');
-      mockedSaveToFile.mockRejectedValue(saveError);
-
-      const result = await handleEnvFileCreation('/test/project', 'test-token');
-
-      expect(result).toBe(false);
-      expect(mockedUI.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to create .env file'),
-      );
-      expect(mockedUI.info).toHaveBeenCalledWith(
-        expect.stringContaining('You can manually add STORYBLOK_DELIVERY_API_TOKEN'),
-      );
-      expect(mockedUI.info).not.toHaveBeenCalledWith(
-        expect.stringContaining('You can manually add STORYBLOK_REGION'),
-      );
-    });
-
-    it('should show only region message when only region fails', async () => {
-      const saveError = new Error('Access denied');
-      mockedSaveToFile.mockRejectedValue(saveError);
-
-      const result = await handleEnvFileCreation('/test/project', undefined, 'ca');
-
-      expect(result).toBe(false);
-      expect(mockedUI.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to create .env file'),
-      );
-      expect(mockedUI.info).not.toHaveBeenCalledWith(
-        expect.stringContaining('You can manually add STORYBLOK_DELIVERY_API_TOKEN'),
-      );
-      expect(mockedUI.info).toHaveBeenCalledWith(
-        expect.stringContaining('You can manually add STORYBLOK_REGION'),
-      );
     });
   });
 
@@ -342,74 +240,71 @@ describe('create actions', () => {
 };`;
 
     it('should replace both token and region placeholders', async () => {
-      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/src/environments/environment.ts': angularEnvTemplate,
+        '/test/project/src/environments/environment.development.ts': angularEnvTemplate,
+      });
 
-      await updateAngularEnvironmentFiles('/test/project', 'my-actual-token', 'eu');
+      const result = await updateAngularEnvironmentFiles('/test/project', 'my-actual-token', 'eu');
 
-      // Should be called twice (environment.ts and environment.development.ts)
-      expect(mockedSaveToFile).toHaveBeenCalledTimes(2);
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
+      expect(result.updatedFiles).toEqual([
         '/test/project/src/environments/environment.ts',
-        expect.stringContaining('accessToken: \'my-actual-token\''),
-      );
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/src/environments/environment.ts',
-        expect.stringContaining('region: \'eu\''),
-      );
+        '/test/project/src/environments/environment.development.ts',
+      ]);
+
+      const envContent = vol.readFileSync('/test/project/src/environments/environment.ts', 'utf-8');
+      expect(envContent).toContain('accessToken: \'my-actual-token\'');
+      expect(envContent).toContain('region: \'eu\'');
+
+      const devEnvContent = vol.readFileSync('/test/project/src/environments/environment.development.ts', 'utf-8');
+      expect(devEnvContent).toContain('accessToken: \'my-actual-token\'');
+      expect(devEnvContent).toContain('region: \'eu\'');
     });
 
     it('should replace only token placeholder when region not provided', async () => {
-      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/src/environments/environment.ts': angularEnvTemplate,
+        '/test/project/src/environments/environment.development.ts': angularEnvTemplate,
+      });
 
       await updateAngularEnvironmentFiles('/test/project', 'my-token');
 
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.stringContaining('accessToken: \'my-token\''),
-      );
+      const content = vol.readFileSync('/test/project/src/environments/environment.ts', 'utf-8');
+      expect(content).toContain('accessToken: \'my-token\'');
       // Region placeholder should remain unchanged
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.stringContaining('STORYBLOK_REGION'),
-      );
+      expect(content).toContain('STORYBLOK_REGION');
     });
 
     it('should replace only region placeholder when token not provided', async () => {
-      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/src/environments/environment.ts': angularEnvTemplate,
+        '/test/project/src/environments/environment.development.ts': angularEnvTemplate,
+      });
 
       await updateAngularEnvironmentFiles('/test/project', undefined, 'us');
 
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.stringContaining('region: \'us\''),
-      );
+      const content = vol.readFileSync('/test/project/src/environments/environment.ts', 'utf-8');
+      expect(content).toContain('region: \'us\'');
       // Token placeholder should remain unchanged
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN'),
-      );
+      expect(content).toContain('STORYBLOK_DELIVERY_API_TOKEN');
     });
 
-    it('should skip missing environment files silently', async () => {
-      const enoentError = new Error('File not found') as NodeJS.ErrnoException;
-      enoentError.code = 'ENOENT';
-      mockedFsReadFile.mockRejectedValue(enoentError);
+    it('should skip missing environment files silently and return empty array', async () => {
+      // No files exist in memfs
+      const result = await updateAngularEnvironmentFiles('/test/project', 'token', 'eu');
 
-      await expect(updateAngularEnvironmentFiles('/test/project', 'token', 'eu')).resolves.toBeUndefined();
-      expect(mockedSaveToFile).not.toHaveBeenCalled();
+      expect(result.updatedFiles).toEqual([]);
     });
 
-    it('should throw error for non-ENOENT filesystem errors', async () => {
-      const permissionError = new Error('Permission denied') as NodeJS.ErrnoException;
-      permissionError.code = 'EACCES';
-      mockedFsReadFile.mockRejectedValue(permissionError);
+    it('should return only the files that exist', async () => {
+      vol.fromJSON({
+        '/test/project/src/environments/environment.ts': angularEnvTemplate,
+        // environment.development.ts does not exist
+      });
 
-      await expect(updateAngularEnvironmentFiles('/test/project', 'token', 'eu'))
-        .rejects
-        .toThrow('Failed to update environment.ts: Permission denied');
+      const result = await updateAngularEnvironmentFiles('/test/project', 'token', 'eu');
+
+      expect(result.updatedFiles).toEqual(['/test/project/src/environments/environment.ts']);
     });
   });
 
@@ -421,8 +316,10 @@ describe('create actions', () => {
 };`;
 
     it('should update Angular environment files when template is angular', async () => {
-      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/src/environments/environment.ts': angularEnvTemplate,
+        '/test/project/src/environments/environment.development.ts': angularEnvTemplate,
+      });
 
       const result = await handleEnvFileCreation('/test/project', 'my-token', 'eu', 'angular');
 
@@ -431,11 +328,10 @@ describe('create actions', () => {
         expect.stringContaining('Updated Angular environment files'),
         true,
       );
-      // Should NOT create .env file
-      expect(mockedSaveToFile).not.toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.any(String),
-      );
+      // Verify files were actually updated
+      const content = vol.readFileSync('/test/project/src/environments/environment.ts', 'utf-8');
+      expect(content).toContain('accessToken: \'my-token\'');
+      expect(content).toContain('region: \'eu\'');
     });
 
     it('should return true and log info when no vars provided for angular', async () => {
@@ -445,29 +341,26 @@ describe('create actions', () => {
       expect(mockedUI.info).toHaveBeenCalledWith('No environment variables to write');
     });
 
-    it('should handle Angular env file errors gracefully', async () => {
-      const permissionError = new Error('Permission denied') as NodeJS.ErrnoException;
-      permissionError.code = 'EACCES';
-      mockedFsReadFile.mockRejectedValue(permissionError);
-
+    it('should log info when environment files do not exist', async () => {
+      // No Angular environment files exist
       const result = await handleEnvFileCreation('/test/project', 'token', 'eu', 'angular');
 
-      expect(result).toBe(false);
-      expect(mockedUI.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to update Angular environment files'),
+      expect(result).toBe(true);
+      expect(mockedUI.info).toHaveBeenCalledWith(
+        'No Angular environment files found to update',
       );
     });
 
     it('should create .env file for non-angular templates', async () => {
-      mockedSaveToFile.mockResolvedValue(undefined);
+      vol.fromJSON({
+        '/test/project/.gitkeep': '',
+      });
 
       const result = await handleEnvFileCreation('/test/project', 'token', 'eu', 'react');
 
       expect(result).toBe(true);
-      expect(mockedSaveToFile).toHaveBeenCalledWith(
-        '/test/project/.env',
-        expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN=token'),
-      );
+      const content = vol.readFileSync('/test/project/.env', 'utf-8');
+      expect(content).toContain('STORYBLOK_DELIVERY_API_TOKEN=token');
     });
   });
 

--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import { vol } from 'memfs';
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 import open from 'open';
-import { createEnvFile, extractPortFromTopics, fetchBlueprintRepositories, generateProject, handleEnvFileCreation, openSpaceInBrowser, repositoryToTemplate } from './actions';
+import { createEnvFile, extractPortFromTopics, fetchBlueprintRepositories, generateProject, handleEnvFileCreation, openSpaceInBrowser, repositoryToTemplate, updateAngularEnvironmentFiles } from './actions';
 import * as filesystem from '../../utils/filesystem';
 import type { RegionCode } from '../../constants';
 import { appDomains } from '../../constants';
@@ -12,6 +12,7 @@ vi.mock('node:child_process');
 vi.mock('node:fs/promises', () => ({
   default: {
     access: vi.fn(),
+    readFile: vi.fn(),
   },
 }));
 vi.mock('open');
@@ -35,6 +36,7 @@ const mockedSpawn = vi.mocked(spawn);
 const mockedOpen = open as MockedFunction<typeof open>;
 const mockedSaveToFile = filesystem.saveToFile as MockedFunction<typeof filesystem.saveToFile>;
 const mockedFsAccess = vi.mocked(fs.access);
+const mockedFsReadFile = vi.mocked(fs.readFile);
 
 // Import the mocked modules
 const { createOctokit } = await import('../../github');
@@ -328,6 +330,143 @@ describe('create actions', () => {
       );
       expect(mockedUI.info).toHaveBeenCalledWith(
         expect.stringContaining('You can manually add STORYBLOK_REGION'),
+      );
+    });
+  });
+
+  describe('updateAngularEnvironmentFiles', () => {
+    const angularEnvTemplate = `export const environment = {
+  production: true,
+  accessToken: 'STORYBLOK_DELIVERY_API_TOKEN', // Replace with your Storyblok Delivery API token
+  region: 'STORYBLOK_REGION', // Replace with your Storyblok region
+};`;
+
+    it('should replace both token and region placeholders', async () => {
+      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
+      mockedSaveToFile.mockResolvedValue(undefined);
+
+      await updateAngularEnvironmentFiles('/test/project', 'my-actual-token', 'eu');
+
+      // Should be called twice (environment.ts and environment.development.ts)
+      expect(mockedSaveToFile).toHaveBeenCalledTimes(2);
+      expect(mockedSaveToFile).toHaveBeenCalledWith(
+        '/test/project/src/environments/environment.ts',
+        expect.stringContaining('accessToken: \'my-actual-token\''),
+      );
+      expect(mockedSaveToFile).toHaveBeenCalledWith(
+        '/test/project/src/environments/environment.ts',
+        expect.stringContaining('region: \'eu\''),
+      );
+    });
+
+    it('should replace only token placeholder when region not provided', async () => {
+      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
+      mockedSaveToFile.mockResolvedValue(undefined);
+
+      await updateAngularEnvironmentFiles('/test/project', 'my-token');
+
+      expect(mockedSaveToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('accessToken: \'my-token\''),
+      );
+      // Region placeholder should remain unchanged
+      expect(mockedSaveToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('STORYBLOK_REGION'),
+      );
+    });
+
+    it('should replace only region placeholder when token not provided', async () => {
+      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
+      mockedSaveToFile.mockResolvedValue(undefined);
+
+      await updateAngularEnvironmentFiles('/test/project', undefined, 'us');
+
+      expect(mockedSaveToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('region: \'us\''),
+      );
+      // Token placeholder should remain unchanged
+      expect(mockedSaveToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN'),
+      );
+    });
+
+    it('should skip missing environment files silently', async () => {
+      const enoentError = new Error('File not found') as NodeJS.ErrnoException;
+      enoentError.code = 'ENOENT';
+      mockedFsReadFile.mockRejectedValue(enoentError);
+
+      await expect(updateAngularEnvironmentFiles('/test/project', 'token', 'eu')).resolves.toBeUndefined();
+      expect(mockedSaveToFile).not.toHaveBeenCalled();
+    });
+
+    it('should throw error for non-ENOENT filesystem errors', async () => {
+      const permissionError = new Error('Permission denied') as NodeJS.ErrnoException;
+      permissionError.code = 'EACCES';
+      mockedFsReadFile.mockRejectedValue(permissionError);
+
+      await expect(updateAngularEnvironmentFiles('/test/project', 'token', 'eu'))
+        .rejects
+        .toThrow('Failed to update environment.ts: Permission denied');
+    });
+  });
+
+  describe('handleEnvFileCreation for Angular', () => {
+    const angularEnvTemplate = `export const environment = {
+  production: true,
+  accessToken: 'STORYBLOK_DELIVERY_API_TOKEN',
+  region: 'STORYBLOK_REGION',
+};`;
+
+    it('should update Angular environment files when template is angular', async () => {
+      mockedFsReadFile.mockResolvedValue(angularEnvTemplate);
+      mockedSaveToFile.mockResolvedValue(undefined);
+
+      const result = await handleEnvFileCreation('/test/project', 'my-token', 'eu', 'angular');
+
+      expect(result).toBe(true);
+      expect(mockedUI.ok).toHaveBeenCalledWith(
+        expect.stringContaining('Updated Angular environment files'),
+        true,
+      );
+      // Should NOT create .env file
+      expect(mockedSaveToFile).not.toHaveBeenCalledWith(
+        '/test/project/.env',
+        expect.any(String),
+      );
+    });
+
+    it('should return true and log info when no vars provided for angular', async () => {
+      const result = await handleEnvFileCreation('/test/project', undefined, undefined, 'angular');
+
+      expect(result).toBe(true);
+      expect(mockedUI.info).toHaveBeenCalledWith('No environment variables to write');
+    });
+
+    it('should handle Angular env file errors gracefully', async () => {
+      const permissionError = new Error('Permission denied') as NodeJS.ErrnoException;
+      permissionError.code = 'EACCES';
+      mockedFsReadFile.mockRejectedValue(permissionError);
+
+      const result = await handleEnvFileCreation('/test/project', 'token', 'eu', 'angular');
+
+      expect(result).toBe(false);
+      expect(mockedUI.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to update Angular environment files'),
+      );
+    });
+
+    it('should create .env file for non-angular templates', async () => {
+      mockedSaveToFile.mockResolvedValue(undefined);
+
+      const result = await handleEnvFileCreation('/test/project', 'token', 'eu', 'react');
+
+      expect(result).toBe(true);
+      expect(mockedSaveToFile).toHaveBeenCalledWith(
+        '/test/project/.env',
+        expect.stringContaining('STORYBLOK_DELIVERY_API_TOKEN=token'),
       );
     });
   });

--- a/packages/cli/src/commands/create/actions.ts
+++ b/packages/cli/src/commands/create/actions.ts
@@ -121,15 +121,16 @@ ${Object.entries(storyblokVars).map(([key, value]) => `${key}=${value}`).join('\
  * @param projectPath - The absolute path to the project directory
  * @param token - The Storyblok access token
  * @param region - The Storyblok region code
- * @returns Promise<void>
+ * @returns Object containing array of files that were actually updated
  */
 export const updateAngularEnvironmentFiles = async (
   projectPath: string,
   token?: string,
   region?: RegionCode,
-): Promise<void> => {
+): Promise<{ updatedFiles: string[] }> => {
   const environmentsDir = join(projectPath, 'src', 'environments');
   const envFiles = ['environment.ts', 'environment.development.ts'];
+  const updatedFiles: string[] = [];
 
   for (const envFile of envFiles) {
     const filePath = join(environmentsDir, envFile);
@@ -145,6 +146,7 @@ export const updateAngularEnvironmentFiles = async (
       }
 
       await saveToFile(filePath, content);
+      updatedFiles.push(filePath);
     }
     catch (error) {
       const fsError = error as NodeJS.ErrnoException;
@@ -155,6 +157,8 @@ export const updateAngularEnvironmentFiles = async (
       throw new Error(`Failed to update ${envFile}: ${(error as Error).message}`);
     }
   }
+
+  return { updatedFiles };
 };
 
 // Helper to create .env file (or Angular environment files) and handle errors
@@ -166,7 +170,13 @@ export async function handleEnvFileCreation(resolvedPath: string, token?: string
       return true;
     }
     try {
-      await updateAngularEnvironmentFiles(resolvedPath, token, region);
+      const { updatedFiles } = await updateAngularEnvironmentFiles(resolvedPath, token, region);
+
+      if (updatedFiles.length === 0) {
+        ui.info('No Angular environment files found to update');
+        return true;
+      }
+
       const writtenVars = [token && 'accessToken', region && 'region'].filter(Boolean).join(', ');
       ui.ok(`Updated Angular environment files with: ${writtenVars}`, true);
       return true;

--- a/packages/cli/src/commands/create/actions.ts
+++ b/packages/cli/src/commands/create/actions.ts
@@ -115,8 +115,79 @@ ${Object.entries(storyblokVars).map(([key, value]) => `${key}=${value}`).join('\
   }
 };
 
-// Helper to create .env file and handle errors
-export async function handleEnvFileCreation(resolvedPath: string, token?: string, region?: RegionCode): Promise<boolean> {
+/**
+ * Updates Angular environment files with Storyblok configuration
+ * Angular uses TypeScript environment files instead of .env files
+ * @param projectPath - The absolute path to the project directory
+ * @param token - The Storyblok access token
+ * @param region - The Storyblok region code
+ * @returns Promise<void>
+ */
+export const updateAngularEnvironmentFiles = async (
+  projectPath: string,
+  token?: string,
+  region?: RegionCode,
+): Promise<void> => {
+  const environmentsDir = join(projectPath, 'src', 'environments');
+  const envFiles = ['environment.ts', 'environment.development.ts'];
+
+  for (const envFile of envFiles) {
+    const filePath = join(environmentsDir, envFile);
+    try {
+      let content = await fs.readFile(filePath, 'utf-8');
+
+      // Replace placeholder values with actual values
+      if (token) {
+        content = content.replaceAll('STORYBLOK_DELIVERY_API_TOKEN', token);
+      }
+      if (region) {
+        content = content.replaceAll('STORYBLOK_REGION', region);
+      }
+
+      await saveToFile(filePath, content);
+    }
+    catch (error) {
+      const fsError = error as NodeJS.ErrnoException;
+      // If file doesn't exist, skip it silently
+      if (fsError.code === 'ENOENT') {
+        continue;
+      }
+      throw new Error(`Failed to update ${envFile}: ${(error as Error).message}`);
+    }
+  }
+};
+
+// Helper to create .env file (or Angular environment files) and handle errors
+export async function handleEnvFileCreation(resolvedPath: string, token?: string, region?: RegionCode, template?: string): Promise<boolean> {
+  // Angular uses TypeScript environment files instead of .env
+  if (template === 'angular') {
+    if (!token && !region) {
+      ui.info('No environment variables to write');
+      return true;
+    }
+    try {
+      await updateAngularEnvironmentFiles(resolvedPath, token, region);
+      const writtenVars = [token && 'accessToken', region && 'region'].filter(Boolean).join(', ');
+      ui.ok(`Updated Angular environment files with: ${writtenVars}`, true);
+      return true;
+    }
+    catch (error) {
+      ui.warn(`Failed to update Angular environment files: ${(error as Error).message}`);
+      if (token) {
+        ui.info(
+          `You can manually add accessToken to src/environments/environment.ts and src/environments/environment.development.ts`,
+        );
+      }
+      if (region) {
+        ui.info(
+          `You can manually add region to src/environments/environment.ts and src/environments/environment.development.ts`,
+        );
+      }
+      return false;
+    }
+  }
+
+  // Default behavior for other frameworks: create .env file
   const envVars: Record<string, string> = {};
   if (token) {
     envVars.STORYBLOK_DELIVERY_API_TOKEN = token;

--- a/packages/cli/src/commands/create/index.test.ts
+++ b/packages/cli/src/commands/create/index.test.ts
@@ -143,7 +143,7 @@ describe('createCommand', () => {
       // Should generate project
       expect(generateProject).toHaveBeenCalledWith('react', 'my-project', expect.any(String));
       // Should create .env file with provided token and session region
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'eu', 'react');
       // Should NOT create space or open browser
       expect(createSpace).not.toHaveBeenCalled();
       expect(openSpaceInBrowser).not.toHaveBeenCalled();
@@ -167,7 +167,7 @@ describe('createCommand', () => {
       // Should generate project
       expect(generateProject).toHaveBeenCalledWith('react', 'my-project', expect.any(String));
       // Should create .env file with provided token and region
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'us');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'us', 'react');
       // Should NOT create space, require authentication, or prompt for login
       expect(createSpace).not.toHaveBeenCalled();
       expect(requireAuthentication).not.toHaveBeenCalled();
@@ -411,7 +411,7 @@ describe('createCommand', () => {
       });
 
       // Verify .env file creation
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu', 'react');
 
       // Verify browser opening
       expect(openSpaceInBrowser).toHaveBeenCalledWith(12345, 'eu');
@@ -470,7 +470,7 @@ describe('createCommand', () => {
       await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react']);
 
       // Should call handleEnvFileCreation
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu', 'react');
       // Should continue with browser opening even if .env creation fails
       expect(openSpaceInBrowser).toHaveBeenCalled();
     });
@@ -587,7 +587,7 @@ describe('createCommand', () => {
       await createCommand.parseAsync(['node', 'test', './projects/my-project', '--template', 'react']);
 
       expect(generateProject).toHaveBeenCalledWith('react', 'my-project', expect.stringContaining('projects'));
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.stringContaining('my-project'), 'space-token-123', 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.stringContaining('my-project'), 'space-token-123', 'eu', 'react');
     });
 
     it('should handle absolute paths correctly', async () => {
@@ -630,7 +630,7 @@ describe('createCommand', () => {
       // Verify space creation is skipped
       expect(createSpace).not.toHaveBeenCalled();
       // handleEnvFileCreation IS called with session region (eu from mock)
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'eu', 'react');
       expect(openSpaceInBrowser).not.toHaveBeenCalled();
 
       // Verify success message still shows
@@ -665,7 +665,7 @@ describe('createCommand', () => {
       // Verify space-related operations are skipped
       expect(createSpace).not.toHaveBeenCalled();
       // handleEnvFileCreation IS called with session region (eu from mock)
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'eu', 'vue');
       expect(openSpaceInBrowser).not.toHaveBeenCalled();
     });
 
@@ -1081,7 +1081,7 @@ describe('createCommand', () => {
       await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react', '--token', 'my-access-token', '--region', 'us']);
 
       // Should create .env file with provided token and region
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'us');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'us', 'react');
     });
 
     it('should validate region and show error for invalid region', async () => {
@@ -1117,7 +1117,7 @@ describe('createCommand', () => {
 
         expect(handleError).not.toHaveBeenCalled();
         expect(generateProject).toHaveBeenCalled();
-        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'token', region);
+        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'token', region, 'react');
       }
     });
 
@@ -1135,7 +1135,7 @@ describe('createCommand', () => {
       await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react']);
 
       // Should create .env file with space token and session region (eu by default in tests)
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu', 'react');
     });
 
     it('should not include region in .env when --token is provided without --region', async () => {
@@ -1148,7 +1148,7 @@ describe('createCommand', () => {
       await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react', '--token', 'my-access-token']);
 
       // Should create .env file with session region (eu from mock) when --region not provided
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-access-token', 'eu', 'react');
     });
 
     it('should work with --region and --skip-space flags together', async () => {
@@ -1165,7 +1165,7 @@ describe('createCommand', () => {
 
       // Should not create space but should call handleEnvFileCreation with only the region (no token)
       expect(createSpace).not.toHaveBeenCalled();
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'ca');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'ca', 'react');
     });
 
     it('should throw error when provided region does not match user account region during space creation', async () => {
@@ -1206,7 +1206,7 @@ describe('createCommand', () => {
       expect(handleError).not.toHaveBeenCalled();
       expect(generateProject).toHaveBeenCalled();
       expect(createSpace).toHaveBeenCalled();
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'space-token-123', 'eu', 'react');
     });
 
     it('should not throw region mismatch error when --token is provided with different region', async () => {
@@ -1222,7 +1222,7 @@ describe('createCommand', () => {
       // Should proceed without region mismatch error
       expect(handleError).not.toHaveBeenCalled();
       expect(generateProject).toHaveBeenCalled();
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-token', 'us');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-token', 'us', 'react');
 
       // Should not create space
       expect(createSpace).not.toHaveBeenCalled();
@@ -1244,7 +1244,7 @@ describe('createCommand', () => {
 
       // Should not create space but should call handleEnvFileCreation with undefined token and region
       expect(createSpace).not.toHaveBeenCalled();
-      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'us');
+      expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'us', 'react');
     });
 
     describe('session region fallback behavior', () => {
@@ -1258,7 +1258,7 @@ describe('createCommand', () => {
 
         await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react', '--token', 'my-token']);
 
-        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-token', 'us');
+        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-token', 'us', 'react');
       });
 
       it('should use CA session region as fallback when no --region provided with --skip-space', async () => {
@@ -1271,7 +1271,7 @@ describe('createCommand', () => {
 
         await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react', '--skip-space']);
 
-        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'ca');
+        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), undefined, 'ca', 'react');
       });
 
       it('should prioritize user-provided --region over session region', async () => {
@@ -1285,7 +1285,7 @@ describe('createCommand', () => {
         // User provides 'ap' region, should use that instead of 'us' session region
         await createCommand.parseAsync(['node', 'test', 'my-project', '--template', 'react', '--token', 'my-token', '--region', 'ap']);
 
-        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-token', 'ap');
+        expect(handleEnvFileCreation).toHaveBeenCalledWith(expect.any(String), 'my-token', 'ap', 'react');
       });
     });
   });

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -209,14 +209,14 @@ export const createCommand = program
       let userData: User;
       let whereToCreateSpace = 'personal';
       if (token) {
-        await handleEnvFileCreation(resolvedPath, token, options.region || region);
+        await handleEnvFileCreation(resolvedPath, token, options.region || region, technologyTemplate);
         showNextSteps(technologyTemplate!, finalProjectPath);
         return;
       }
       if (options.skipSpace) {
         // Only create .env file if region is available (useful for configuring SDK)
         if (options.region || region) {
-          await handleEnvFileCreation(resolvedPath, undefined, options.region || region);
+          await handleEnvFileCreation(resolvedPath, undefined, options.region || region, technologyTemplate);
         }
         showNextSteps(technologyTemplate!, finalProjectPath);
         return;
@@ -303,7 +303,7 @@ export const createCommand = program
 
         // Create .env file with the Storyblok token
         if (createdSpace?.first_token) {
-          await handleEnvFileCreation(resolvedPath, createdSpace.first_token, region!);
+          await handleEnvFileCreation(resolvedPath, createdSpace.first_token, region!, technologyTemplate);
         }
 
         // Open the space in the browser


### PR DESCRIPTION
## Summary

Updates Angular environment file handling in the `create` command to use simple string replacement for placeholders instead of regex-based value matching.

## Changes

- Add `updateAngularEnvironmentFiles` function for Angular-specific environment file handling
- Pass `template` parameter to `handleEnvFileCreation` to detect Angular projects
- Use `replaceAll` to replace `STORYBLOK_DELIVERY_API_TOKEN` and `STORYBLOK_REGION` placeholders with actual values

## Before

The Angular environment files kept the placeholder names as literal strings.

## After

```ts
// environment.ts
export const environment = {
  production: true,
  accessToken: 'actual-token-here', // Replace with your Storyblok Delivery API token
  region: 'eu', // Replace with your Storyblok region
};
```

## Related

Works with the Angular blueprint update: https://github.com/storyblok/blueprint-core-angular/pull/18