### PR TITLE
feat(schema): custom field plugins with Standard Schema validators

### DIFF
--- a/packages/capi-client/playground/integration-tests/test/types/stories.test-d.ts
+++ b/packages/capi-client/playground/integration-tests/test/types/stories.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest';
-import { defineBlock, defineField } from '@storyblok/schema';
+import { defineBlock, defineField, defineSchema, type Schema as InferSchema, type PluginFieldValue } from '@storyblok/schema';
+import { storyblokColorField } from '@storyblok/schema/field-plugins';
 
 import { createApiClient, type Story } from '@storyblok/api-client';
 
@@ -407,6 +408,42 @@ describe('defineBlock result from mapi shape used in capi withTypes', () => {
         // product is the only root component
         expectTypeOf(story.content.component).toEqualTypeOf<'product'>();
       }
+    }
+  });
+});
+
+describe('createApiClient with .withTypes() — field plugins', () => {
+  const _themedComponent = defineBlock({
+    name: 'themed',
+    is_root: true,
+    fields: [
+      defineField('bg', { type: 'custom', field_type: 'storyblok-colorpicker' }),
+      defineField('legacy', { type: 'custom', field_type: 'unregistered-plugin' }),
+    ],
+  });
+  const _schema = defineSchema({
+    blocks: { themedComponent: _themedComponent },
+    fieldPlugins: { storyblokColorField },
+  });
+  type Schema = InferSchema<typeof _schema>;
+
+  it('resolves a registered custom field to the validator output merged with the plugin envelope', async () => {
+    const client = createApiClient({ accessToken: 'test-token' }).withTypes<Schema>();
+    const result = await client.stories.get('home');
+    if (result.data && result.data.story.content.component === 'themed') {
+      expectTypeOf<NonNullable<typeof result.data.story.content.bg>>().toEqualTypeOf<{
+        color: string;
+        plugin: string;
+        _uid?: string;
+      }>();
+    }
+  });
+
+  it('leaves an unregistered custom field as PluginFieldValue', async () => {
+    const client = createApiClient({ accessToken: 'test-token' }).withTypes<Schema>();
+    const result = await client.stories.get('home');
+    if (result.data && result.data.story.content.component === 'themed') {
+      expectTypeOf<NonNullable<typeof result.data.story.content.legacy>>().toEqualTypeOf<PluginFieldValue>();
     }
   });
 });

--- a/packages/capi-client/src/client.ts
+++ b/packages/capi-client/src/client.ts
@@ -163,6 +163,9 @@ type ResolveComponents<T extends StoryblokTypesConfig> =
     : T extends { blocks: infer B extends Component } ? B
       : never;
 
+/** Extracts the `fieldType → value` plugin map from a Schema, defaulting to an empty map. */
+type ResolveFieldPlugins<T> = T extends { fieldPlugins: infer P } ? P : Record<never, never>;
+
 /**
  * The return type of `createApiClient`, parameterised by `TComponents` and `InlineRelations`
  * so that `.withTypes<T>()` can change the story response types without touching the
@@ -170,10 +173,11 @@ type ResolveComponents<T extends StoryblokTypesConfig> =
  */
 export type ContentApiClient<
   TComponents extends Component = Component,
+  TFieldPlugins = Record<never, never>,
   InlineRelations extends boolean = false,
   ThrowOnError extends boolean = false,
 > = Omit<ReturnType<typeof createApiClientBase>, 'stories' | 'withTypes'> & {
-  stories: ReturnType<typeof createStoriesResource<TComponents, InlineRelations, ThrowOnError>>;
+  stories: ReturnType<typeof createStoriesResource<TComponents, TFieldPlugins, InlineRelations, ThrowOnError>>;
   /**
    * Returns the same client instance cast to a version that narrows story content
    * to the provided component types. No runtime cost — the type parameter is erased.
@@ -190,7 +194,7 @@ export type ContentApiClient<
    * // story.content is now typed as a discriminated union
    * ```
    */
-  withTypes: <T extends StoryblokTypesConfig>() => ContentApiClient<ResolveComponents<T>, InlineRelations, ThrowOnError>;
+  withTypes: <T extends StoryblokTypesConfig>() => ContentApiClient<ResolveComponents<T>, ResolveFieldPlugins<T>, InlineRelations, ThrowOnError>;
 };
 
 // ---------------------------------------------------------------------------
@@ -382,7 +386,7 @@ export const createApiClientBase = <
     throttleManager,
   };
 
-  const stories = createStoriesResource<Component, InlineRelations, ThrowOnError>({
+  const stories = createStoriesResource<Component, Record<never, never>, InlineRelations, ThrowOnError>({
     ...resourceDeps,
     inlineRelations,
   });
@@ -431,12 +435,12 @@ export const createApiClient = <
   InlineRelations extends boolean = false,
 >(
   config: ContentApiClientConfig<ThrowOnError, InlineRelations>,
-): ContentApiClient<Component, InlineRelations, ThrowOnError> => {
+): ContentApiClient<Component, Record<never, never>, InlineRelations, ThrowOnError> => {
   const base = createApiClientBase(config);
-  const self: ContentApiClient<Component, InlineRelations, ThrowOnError> = {
+  const self: ContentApiClient<Component, Record<never, never>, InlineRelations, ThrowOnError> = {
     ...base,
-    withTypes<T extends StoryblokTypesConfig>(): ContentApiClient<ResolveComponents<T>, InlineRelations, ThrowOnError> {
-      return self as unknown as ContentApiClient<ResolveComponents<T>, InlineRelations, ThrowOnError>;
+    withTypes<T extends StoryblokTypesConfig>(): ContentApiClient<ResolveComponents<T>, ResolveFieldPlugins<T>, InlineRelations, ThrowOnError> {
+      return self as unknown as ContentApiClient<ResolveComponents<T>, ResolveFieldPlugins<T>, InlineRelations, ThrowOnError>;
     },
   };
   return self;

--- a/packages/capi-client/src/generated/types/field.ts
+++ b/packages/capi-client/src/generated/types/field.ts
@@ -32,15 +32,15 @@ type IsBaseBlock<T> = [Block] extends [T] ? true : false;
  * required (`required: true`) from optional fields. Each `F` is a member of the
  * field union, so it provably satisfies `FieldValue`'s `Field` constraint.
  */
-type ContentFields<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks> | null }
+type ContentFields<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /** Input (write) variant of {@link ContentFields}, resolving each field via {@link FieldValueInput}. */
-type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks> | null }
+type ContentFieldsInput<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /**
@@ -49,33 +49,34 @@ type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
  * runtime shape (any block, `_editable` optional). With a schema-typed
  * `TBlock`, fields are narrowed per the block's `fields`.
  */
-export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid: string; component: TBlock['name']; _editable?: string }
-        & ContentFields<TBlock['fields'], TBlocks>
+        & ContentFields<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 /** Input variant of {@link BlockContent} for write operations (creating/updating stories via the MAPI). `_uid` is optional. */
-export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentInputBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid?: string; component: TBlock['name']; _editable?: string }
-        & ContentFieldsInput<TBlock['fields'], TBlocks>
+        & ContentFieldsInput<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 export type BlocksFieldValue<
   TBlock extends Block = Block,
   TBlocks = NoBlocks,
-> = BlockContent<TBlock, TBlocks>[];
+  TFieldPlugins = Record<never, never>,
+> = BlockContent<TBlock, TBlocks, TFieldPlugins>[];
 
 /** Union of all valid Storyblok field type discriminants (e.g., `text`, `bloks`). */
 export type FieldType = Field['type'];
@@ -113,10 +114,24 @@ type ApplyAllow<TField, TBlocks> = TField extends { allow: ReadonlyArray<infer T
     ? IsNestable<TBlocks> extends true ? TBlocks : never
     : never;
 
+/**
+ * Resolves a `custom` field to its registered plugin value. When the field's
+ * `field_type` is a key of `TFieldPlugins`, the validator output is merged with
+ * the plugin envelope (`plugin`, optional `_uid`); otherwise it falls back to
+ * the untyped {@link PluginFieldValue}. Same shape for read and write.
+ */
+type ResolveCustom<TField, TFieldPlugins> =
+  TField extends { field_type: infer F extends string }
+    ? F extends keyof TFieldPlugins
+      ? Prettify<TFieldPlugins[F] & { plugin: string; _uid?: string }>
+      : PluginFieldValue
+    : PluginFieldValue;
+
 /** Resolves a field definition to its runtime content value type (read). */
 export type FieldValue<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -124,15 +139,18 @@ export type FieldValue<
     ? [TBlocks] extends [never]
         ? BlockContentBase[]
         : [TBlocks] extends [Block]
-            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;
 
 /** Resolves a field definition to its input value type (write). */
 export type FieldValueInput<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -140,7 +158,9 @@ export type FieldValueInput<
     ? [TBlocks] extends [never]
         ? BlockContentInputBase[]
         : [TBlocks] extends [Block]
-            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentInputBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;

--- a/packages/capi-client/src/generated/types/story.ts
+++ b/packages/capi-client/src/generated/types/story.ts
@@ -15,18 +15,20 @@ type NoBlocks = false;
 type CapiStoryWithSchemaContent<
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
-> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks> }>;
+  TFieldPlugins = Record<never, never>,
+> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks, TFieldPlugins> }>;
 
 /** A Storyblok CDN (CAPI) story. */
 export type Story<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks>
+    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;

--- a/packages/capi-client/src/resources/stories.ts
+++ b/packages/capi-client/src/resources/stories.ts
@@ -50,8 +50,8 @@ type ResolvedFieldsFor<R extends string, ComponentName extends string> =
   Extract<ParseRelations<R>, { component: ComponentName }>['field'];
 
 /** A resolved relation: a full story typed to the component union. */
-type ResolvedRelation<TComponents extends Component> =
-  { [K in TComponents as K['name']]: Story<K, TComponents> }[TComponents['name']];
+type ResolvedRelation<TComponents extends Component, TFieldPlugins = Record<never, never>> =
+  { [K in TComponents as K['name']]: Story<K, TFieldPlugins, TComponents> }[TComponents['name']];
 
 /**
  * Given a story type and a set of resolved field names, replaces
@@ -61,9 +61,10 @@ type WithResolvedRelations<
   TStory,
   TComponents extends Component,
   Fields extends string,
+  TFieldPlugins = Record<never, never>,
 > = TStory extends { content: infer C } ? Omit<TStory, 'content'> & {
   content: {
-    [K in keyof C]: K extends Fields ? ResolvedRelation<TComponents> : C[K]
+    [K in keyof C]: K extends Fields ? ResolvedRelation<TComponents, TFieldPlugins> : C[K]
   };
 }
   : TStory;
@@ -83,7 +84,7 @@ type WithResolvedRelations<
  * a distributive conditional + default-parameter pattern would collapse
  * both parameters to the distributed single member after inlining.
  *
- * The mapped type `{ [K in TComponents as K["name"]]: Story<K, TComponents> }`
+ * The mapped type `{ [K in TComponents as K["name"]]: Story<K, TFieldPlugins, TComponents> }`
  * iterates each union member as `K` while keeping `TComponents` as the full union
  * for nested blok field resolution. The final indexed access
  * `[TComponents["name"]]` produces the discriminated union of all story types.
@@ -92,32 +93,36 @@ type StoryResult<
   TComponents extends Component,
   InlineRelations extends boolean,
   ResolveRelationsRaw extends string | undefined = undefined,
+  TFieldPlugins = Record<never, never>,
 > =
   Component extends TComponents
     ? InlineRelations extends true ? StoryWithInlinedRelations : Story // fallback
     : ResolveRelationsRaw extends string
       ? {
           [K in RootComponents<TComponents> as K['name']]: WithResolvedRelations<
-            Story<K, TComponents>,
+            Story<K, TFieldPlugins, TComponents>,
             TComponents,
-            ResolvedFieldsFor<ResolveRelationsRaw, K['name']>
+            ResolvedFieldsFor<ResolveRelationsRaw, K['name']>,
+            TFieldPlugins
           >
         }[RootComponents<TComponents>['name']]
-      : Story<TComponents>;
+      : Story<TComponents, TFieldPlugins>;
 
 type GetResponse<
   TComponents extends Component,
   InlineRelations extends boolean,
   ResolveRelationsRaw extends string | undefined = undefined,
+  TFieldPlugins = Record<never, never>,
 > = Omit<GetStoryByIdResponses[200], 'story'> & {
-  story: StoryResult<TComponents, InlineRelations, ResolveRelationsRaw>;
+  story: StoryResult<TComponents, InlineRelations, ResolveRelationsRaw, TFieldPlugins>;
 };
 type ListResponse<
   TComponents extends Component,
   InlineRelations extends boolean,
   ResolveRelationsRaw extends string | undefined = undefined,
+  TFieldPlugins = Record<never, never>,
 > = Omit<ListStoriesResponses[200], 'stories'> & {
-  stories: Array<StoryResult<TComponents, InlineRelations, ResolveRelationsRaw>>;
+  stories: Array<StoryResult<TComponents, InlineRelations, ResolveRelationsRaw, TFieldPlugins>>;
 };
 
 /**
@@ -151,6 +156,7 @@ export interface StoriesResourceDeps<DefaultThrowOnError extends boolean = false
 
 export function createStoriesResource<
   TComponents extends Component = Component,
+  TFieldPlugins = Record<never, never>,
   InlineRelations extends boolean = false,
   DefaultThrowOnError extends boolean = false,
 >(
@@ -165,7 +171,7 @@ export function createStoriesResource<
     >(
       identifier: StoryIdentifier,
       options: { query?: Omit<NonNullable<GetStoryByIdData['query']>, 'resolve_relations'> & { resolve_relations?: ResolveRelationsStr }; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } = {},
-    ): Promise<ApiResponse<GetResponse<TComponents, InlineRelations, ResolveRelationsStr>, ThrowOnError>> => {
+    ): Promise<ApiResponse<GetResponse<TComponents, InlineRelations, ResolveRelationsStr, TFieldPlugins>, ThrowOnError>> => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
       const typedQuery = (query ?? {}) as NonNullable<GetStoryByIdData['query']>;
       const resolvedQuery = typeof identifier === 'string' && UUID_RE.test(identifier) && !typedQuery.find_by
@@ -181,7 +187,7 @@ export function createStoriesResource<
             signal,
             ...(throwOnError === undefined ? {} : { throwOnError }),
             ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}),
-          }))) satisfies ApiResponse<GetResponse<TComponents, InlineRelations, ResolveRelationsStr>, ThrowOnError>;
+          }))) satisfies ApiResponse<GetResponse<TComponents, InlineRelations, ResolveRelationsStr, TFieldPlugins>, ThrowOnError>;
 
         if (!inlineRelations || response.data === undefined) {
           return response;
@@ -210,7 +216,7 @@ export function createStoriesResource<
       const ResolveRelationsStr extends string | undefined = undefined,
     >(
       options: { query?: Omit<NonNullable<ListStoriesData['query']>, 'resolve_relations'> & { resolve_relations?: ResolveRelationsStr }; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } = {},
-    ): Promise<ApiResponse<ListResponse<TComponents, InlineRelations, ResolveRelationsStr>, ThrowOnError>> => {
+    ): Promise<ApiResponse<ListResponse<TComponents, InlineRelations, ResolveRelationsStr, TFieldPlugins>, ThrowOnError>> => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
       const typedQuery = (query ?? {}) as NonNullable<ListStoriesData['query']>;
       const requestPath = '/v2/cdn/stories';
@@ -222,7 +228,7 @@ export function createStoriesResource<
             signal,
             ...(throwOnError === undefined ? {} : { throwOnError }),
             ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}),
-          }))) satisfies ApiResponse<ListResponse<TComponents, InlineRelations, ResolveRelationsStr>, ThrowOnError>;
+          }))) satisfies ApiResponse<ListResponse<TComponents, InlineRelations, ResolveRelationsStr, TFieldPlugins>, ThrowOnError>;
 
         if (!inlineRelations || response.data === undefined) {
           return response;

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -125,6 +125,7 @@ describe('generateSchemaFile', () => {
 
     const result = generateSchemaFile(components, datasources, groupPaths);
 
+    expect(result).toContain('import { defineSchema } from \'@storyblok/schema\';');
     expect(result).toContain('import type { Schema as InferSchema, Story as InferStory } from \'@storyblok/schema\';');
     expect(result).toContain('import { pageBlock } from \'./blocks/page\';');
     // Grouped block imported from its group subdirectory (segment verbatim)
@@ -132,7 +133,8 @@ describe('generateSchemaFile', () => {
     expect(result).toContain('import { teaserListBlock } from \'./blocks/teaser-list\';');
     expect(result).toContain('import { categoriesDatasource } from \'./datasources/categories\';');
 
-    expect(result).toContain('export const schema = {');
+    expect(result).toContain('export const schema = defineSchema({');
+    expect(result).toContain('});');
     expect(result).toContain('  blocks: {');
     expect(result).toContain('    pageBlock,');
     expect(result).toContain('  datasources: {');

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -198,7 +198,8 @@ export function generateSchemaFile(
 ): string {
   const lines: string[] = [];
 
-  // Import Schema and Story type helpers
+  // Import the defineSchema helper and the Schema/Story type helpers
+  lines.push('import { defineSchema } from \'@storyblok/schema\';');
   lines.push('import type { Schema as InferSchema, Story as InferStory } from \'@storyblok/schema\';');
   lines.push('import type { MapiStory as InferStoryMapi } from \'@storyblok/schema\';');
   lines.push('');
@@ -224,7 +225,7 @@ export function generateSchemaFile(
   lines.push('');
 
   // Export schema object
-  lines.push('export const schema = {');
+  lines.push('export const schema = defineSchema({');
 
   if (components.length > 0) {
     lines.push('  blocks: {');
@@ -244,7 +245,7 @@ export function generateSchemaFile(
     lines.push('  },');
   }
 
-  lines.push('};');
+  lines.push('});');
   lines.push('');
 
   // Schema and Blocks types derived via Schema helper

--- a/packages/cli/src/commands/schema/init/index.test.ts
+++ b/packages/cli/src/commands/schema/init/index.test.ts
@@ -186,7 +186,7 @@ describe('schema init command', () => {
     const schemaFile = files.find(f => f.endsWith('/schema.ts'));
     expect(schemaFile).toBeDefined();
     const schemaContent = vol.readFileSync(schemaFile!, 'utf-8') as string;
-    expect(schemaContent).toContain('export const schema = {');
+    expect(schemaContent).toContain('export const schema = defineSchema({');
     expect(schemaContent).toContain('pageBlock,');
     expect(schemaContent).toContain('InferSchema<typeof schema>');
     expect(schemaContent).toContain('export type Story = InferStory');

--- a/packages/live-preview/src/generated/types/field.ts
+++ b/packages/live-preview/src/generated/types/field.ts
@@ -32,15 +32,15 @@ type IsBaseBlock<T> = [Block] extends [T] ? true : false;
  * required (`required: true`) from optional fields. Each `F` is a member of the
  * field union, so it provably satisfies `FieldValue`'s `Field` constraint.
  */
-type ContentFields<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks> | null }
+type ContentFields<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /** Input (write) variant of {@link ContentFields}, resolving each field via {@link FieldValueInput}. */
-type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks> | null }
+type ContentFieldsInput<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /**
@@ -49,33 +49,34 @@ type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
  * runtime shape (any block, `_editable` optional). With a schema-typed
  * `TBlock`, fields are narrowed per the block's `fields`.
  */
-export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid: string; component: TBlock['name']; _editable?: string }
-        & ContentFields<TBlock['fields'], TBlocks>
+        & ContentFields<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 /** Input variant of {@link BlockContent} for write operations (creating/updating stories via the MAPI). `_uid` is optional. */
-export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentInputBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid?: string; component: TBlock['name']; _editable?: string }
-        & ContentFieldsInput<TBlock['fields'], TBlocks>
+        & ContentFieldsInput<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 export type BlocksFieldValue<
   TBlock extends Block = Block,
   TBlocks = NoBlocks,
-> = BlockContent<TBlock, TBlocks>[];
+  TFieldPlugins = Record<never, never>,
+> = BlockContent<TBlock, TBlocks, TFieldPlugins>[];
 
 /** Union of all valid Storyblok field type discriminants (e.g., `text`, `bloks`). */
 export type FieldType = Field['type'];
@@ -113,10 +114,24 @@ type ApplyAllow<TField, TBlocks> = TField extends { allow: ReadonlyArray<infer T
     ? IsNestable<TBlocks> extends true ? TBlocks : never
     : never;
 
+/**
+ * Resolves a `custom` field to its registered plugin value. When the field's
+ * `field_type` is a key of `TFieldPlugins`, the validator output is merged with
+ * the plugin envelope (`plugin`, optional `_uid`); otherwise it falls back to
+ * the untyped {@link PluginFieldValue}. Same shape for read and write.
+ */
+type ResolveCustom<TField, TFieldPlugins> =
+  TField extends { field_type: infer F extends string }
+    ? F extends keyof TFieldPlugins
+      ? Prettify<TFieldPlugins[F] & { plugin: string; _uid?: string }>
+      : PluginFieldValue
+    : PluginFieldValue;
+
 /** Resolves a field definition to its runtime content value type (read). */
 export type FieldValue<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -124,15 +139,18 @@ export type FieldValue<
     ? [TBlocks] extends [never]
         ? BlockContentBase[]
         : [TBlocks] extends [Block]
-            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;
 
 /** Resolves a field definition to its input value type (write). */
 export type FieldValueInput<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -140,7 +158,9 @@ export type FieldValueInput<
     ? [TBlocks] extends [never]
         ? BlockContentInputBase[]
         : [TBlocks] extends [Block]
-            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentInputBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;

--- a/packages/live-preview/src/generated/types/story.ts
+++ b/packages/live-preview/src/generated/types/story.ts
@@ -15,18 +15,20 @@ type NoBlocks = false;
 type CapiStoryWithSchemaContent<
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
-> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks> }>;
+  TFieldPlugins = Record<never, never>,
+> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks, TFieldPlugins> }>;
 
 /** A Storyblok CDN (CAPI) story. */
 export type Story<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks>
+    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;

--- a/packages/mapi-client/playground/integration-tests/test/types/stories.test-d.ts
+++ b/packages/mapi-client/playground/integration-tests/test/types/stories.test-d.ts
@@ -1,5 +1,6 @@
-import { defineBlock, defineField } from '@storyblok/schema';
-import { createManagementApiClient, type Story as StoryMapi } from '@storyblok/management-api-client';
+import { defineBlock, defineField, defineSchema, type Schema as InferSchema } from '@storyblok/schema';
+import { storyblokColorField } from '@storyblok/schema/field-plugins';
+import { createManagementApiClient, type PluginFieldValue, type Story as StoryMapi } from '@storyblok/management-api-client';
 import { describe, expectTypeOf, it } from 'vitest';
 
 // Nestable block — not a root story type
@@ -268,6 +269,42 @@ describe('withTypes() write-body narrowing', () => {
       if (story.content.component === 'page') {
         expectTypeOf(story.content.headline).toEqualTypeOf<string | null | undefined>();
       }
+    }
+  });
+});
+
+describe('createManagementApiClient with .withTypes() — field plugins', () => {
+  const _themedComponent = defineBlock({
+    name: 'themed',
+    is_root: true,
+    fields: [
+      defineField('bg', { type: 'custom', field_type: 'storyblok-colorpicker' }),
+      defineField('legacy', { type: 'custom', field_type: 'unregistered-plugin' }),
+    ],
+  });
+  const _schema = defineSchema({
+    blocks: { themedComponent: _themedComponent },
+    fieldPlugins: { storyblokColorField },
+  });
+  type Schema = InferSchema<typeof _schema>;
+
+  it('resolves a registered custom field to the validator output merged with the plugin envelope', async () => {
+    const client = createManagementApiClient(CLIENT_CONFIG).withTypes<Schema>();
+    const result = await client.stories.get(123);
+    if (result.data?.story && result.data.story.content.component === 'themed') {
+      expectTypeOf<NonNullable<typeof result.data.story.content.bg>>().toEqualTypeOf<{
+        color: string;
+        plugin: string;
+        _uid?: string;
+      }>();
+    }
+  });
+
+  it('leaves an unregistered custom field as PluginFieldValue', async () => {
+    const client = createManagementApiClient(CLIENT_CONFIG).withTypes<Schema>();
+    const result = await client.stories.get(123);
+    if (result.data?.story && result.data.story.content.component === 'themed') {
+      expectTypeOf<NonNullable<typeof result.data.story.content.legacy>>().toEqualTypeOf<PluginFieldValue>();
     }
   });
 });

--- a/packages/mapi-client/src/client.ts
+++ b/packages/mapi-client/src/client.ts
@@ -317,6 +317,9 @@ type ResolveComponents<T extends StoryblokTypesConfig> =
     : T extends { blocks: infer B extends Block } ? B
       : never;
 
+/** Extracts the `fieldType → value` plugin map from a Schema, defaulting to an empty map. */
+type ResolveFieldPlugins<T> = T extends { fieldPlugins: infer P } ? P : Record<never, never>;
+
 /**
  * The return type of `createManagementApiClient`, parameterised by `TBlocks` so that
  * `.stories` methods can narrow story content types without touching the runtime object.
@@ -324,10 +327,11 @@ type ResolveComponents<T extends StoryblokTypesConfig> =
  */
 export type ManagementApiClient<
   TBlocks extends Block = Block,
+  TFieldPlugins = Record<never, never>,
   DefaultThrowOnError extends boolean = false,
 > = ReturnType<typeof buildResources<DefaultThrowOnError>> & {
   components: ReturnType<typeof createComponentsResource<DefaultThrowOnError>>;
-  stories: ReturnType<typeof createStoriesResource<TBlocks, DefaultThrowOnError>>;
+  stories: ReturnType<typeof createStoriesResource<TBlocks, TFieldPlugins, DefaultThrowOnError>>;
   /**
    * Returns the same client instance cast to a version that narrows story content
    * to the provided component types. No runtime cost — type parameter is erased.
@@ -343,21 +347,21 @@ export type ManagementApiClient<
    *   .withTypes<Schema>();
    * ```
    */
-  withTypes: <T extends StoryblokTypesConfig>() => ManagementApiClient<ResolveComponents<T>, DefaultThrowOnError>;
+  withTypes: <T extends StoryblokTypesConfig>() => ManagementApiClient<ResolveComponents<T>, ResolveFieldPlugins<T>, DefaultThrowOnError>;
 };
 
 export const createManagementApiClient = <
   DefaultThrowOnError extends boolean = false,
 >(
   config: ManagementApiClientConfig<DefaultThrowOnError>,
-): ManagementApiClient<Block, DefaultThrowOnError> => {
+): ManagementApiClient<Block, Record<never, never>, DefaultThrowOnError> => {
   const { deps, resources } = createManagementApiClientBase(config);
-  const self: ManagementApiClient<Block, DefaultThrowOnError> = {
+  const self: ManagementApiClient<Block, Record<never, never>, DefaultThrowOnError> = {
     ...resources,
     components: createComponentsResource<DefaultThrowOnError>(deps),
-    stories: createStoriesResource<Block, DefaultThrowOnError>(deps),
+    stories: createStoriesResource<Block, Record<never, never>, DefaultThrowOnError>(deps),
     withTypes<T extends StoryblokTypesConfig>() {
-      return self as unknown as ManagementApiClient<ResolveComponents<T>, DefaultThrowOnError>;
+      return self as unknown as ManagementApiClient<ResolveComponents<T>, ResolveFieldPlugins<T>, DefaultThrowOnError>;
     },
   };
   return self;

--- a/packages/mapi-client/src/generated/types/field.ts
+++ b/packages/mapi-client/src/generated/types/field.ts
@@ -32,15 +32,15 @@ type IsBaseBlock<T> = [Block] extends [T] ? true : false;
  * required (`required: true`) from optional fields. Each `F` is a member of the
  * field union, so it provably satisfies `FieldValue`'s `Field` constraint.
  */
-type ContentFields<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks> | null }
+type ContentFields<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /** Input (write) variant of {@link ContentFields}, resolving each field via {@link FieldValueInput}. */
-type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks> | null }
+type ContentFieldsInput<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /**
@@ -49,33 +49,34 @@ type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
  * runtime shape (any block, `_editable` optional). With a schema-typed
  * `TBlock`, fields are narrowed per the block's `fields`.
  */
-export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid: string; component: TBlock['name']; _editable?: string }
-        & ContentFields<TBlock['fields'], TBlocks>
+        & ContentFields<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 /** Input variant of {@link BlockContent} for write operations (creating/updating stories via the MAPI). `_uid` is optional. */
-export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentInputBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid?: string; component: TBlock['name']; _editable?: string }
-        & ContentFieldsInput<TBlock['fields'], TBlocks>
+        & ContentFieldsInput<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 export type BlocksFieldValue<
   TBlock extends Block = Block,
   TBlocks = NoBlocks,
-> = BlockContent<TBlock, TBlocks>[];
+  TFieldPlugins = Record<never, never>,
+> = BlockContent<TBlock, TBlocks, TFieldPlugins>[];
 
 /** Union of all valid Storyblok field type discriminants (e.g., `text`, `bloks`). */
 export type FieldType = Field['type'];
@@ -113,10 +114,24 @@ type ApplyAllow<TField, TBlocks> = TField extends { allow: ReadonlyArray<infer T
     ? IsNestable<TBlocks> extends true ? TBlocks : never
     : never;
 
+/**
+ * Resolves a `custom` field to its registered plugin value. When the field's
+ * `field_type` is a key of `TFieldPlugins`, the validator output is merged with
+ * the plugin envelope (`plugin`, optional `_uid`); otherwise it falls back to
+ * the untyped {@link PluginFieldValue}. Same shape for read and write.
+ */
+type ResolveCustom<TField, TFieldPlugins> =
+  TField extends { field_type: infer F extends string }
+    ? F extends keyof TFieldPlugins
+      ? Prettify<TFieldPlugins[F] & { plugin: string; _uid?: string }>
+      : PluginFieldValue
+    : PluginFieldValue;
+
 /** Resolves a field definition to its runtime content value type (read). */
 export type FieldValue<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -124,15 +139,18 @@ export type FieldValue<
     ? [TBlocks] extends [never]
         ? BlockContentBase[]
         : [TBlocks] extends [Block]
-            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;
 
 /** Resolves a field definition to its input value type (write). */
 export type FieldValueInput<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -140,7 +158,9 @@ export type FieldValueInput<
     ? [TBlocks] extends [never]
         ? BlockContentInputBase[]
         : [TBlocks] extends [Block]
-            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentInputBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;

--- a/packages/mapi-client/src/generated/types/mapi-story.ts
+++ b/packages/mapi-client/src/generated/types/mapi-story.ts
@@ -25,42 +25,47 @@ type MapiStoryWithSchemaContent<
   TStory extends MapiStoryGenerated | StoryCreateGenerated | StoryUpdateGenerated,
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = RootBlock extends TBlock
   ? TStory
   : Override<TStory, {
     content: TStory extends StoryCreateGenerated | StoryUpdateGenerated
-      ? BlockContentInput<TBlock, TBlocks>
-      : BlockContent<TBlock, TBlocks>;
+      ? BlockContentInput<TBlock, TBlocks, TFieldPlugins>
+      : BlockContent<TBlock, TBlocks, TFieldPlugins>;
   }>;
 
 type MakeMapiStory<
   TStory extends MapiStoryGenerated | StoryCreateGenerated | StoryUpdateGenerated,
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? MapiStoryWithSchemaContent<TStory, TBlockOrBlocks, TBlocks>
+    ? MapiStoryWithSchemaContent<TStory, TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? MapiStoryWithSchemaContent<TStory, Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? MapiStoryWithSchemaContent<TStory, Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;
 
 /** A Storyblok MAPI story. */
 export type MapiStory<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<MapiStoryGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<MapiStoryGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;
 
 /** Payload for creating a story via the MAPI. */
 export type StoryCreate<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<StoryCreateGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<StoryCreateGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;
 
 /** Payload for updating a story via the MAPI. */
 export type StoryUpdate<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<StoryUpdateGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<StoryUpdateGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;

--- a/packages/mapi-client/src/generated/types/story.ts
+++ b/packages/mapi-client/src/generated/types/story.ts
@@ -15,18 +15,20 @@ type NoBlocks = false;
 type CapiStoryWithSchemaContent<
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
-> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks> }>;
+  TFieldPlugins = Record<never, never>,
+> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks, TFieldPlugins> }>;
 
 /** A Storyblok CDN (CAPI) story. */
 export type Story<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks>
+    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;

--- a/packages/mapi-client/src/resources/stories.ts
+++ b/packages/mapi-client/src/resources/stories.ts
@@ -29,76 +29,77 @@ export type StoryListQuery = NonNullable<ListStoriesData['query']>;
  * Component union, or falls back to the generated `MapiStory` when no components
  * are provided (i.e. `TComponents` is the default base `Component` type).
  */
-type StoryResult<TComponents extends Component> =
+type StoryResult<TComponents extends Component, TFieldPlugins = Record<never, never>> =
   Component extends TComponents
     ? MapiStory
-    : MapiStory<TComponents>;
+    : MapiStory<TComponents, TFieldPlugins>;
 
-type GetResponse<TComponents extends Component> =
-  Omit<GetStoryByIdResponses[200], 'story'> & { story?: StoryResult<TComponents> };
+type GetResponse<TComponents extends Component, TFieldPlugins = Record<never, never>> =
+  Omit<GetStoryByIdResponses[200], 'story'> & { story?: StoryResult<TComponents, TFieldPlugins> };
 
-type ListResponse<TComponents extends Component> =
-  Omit<ListStoriesResponses[200], 'stories'> & { stories?: Array<StoryResult<TComponents>> };
+type ListResponse<TComponents extends Component, TFieldPlugins = Record<never, never>> =
+  Omit<ListStoriesResponses[200], 'stories'> & { stories?: Array<StoryResult<TComponents, TFieldPlugins>> };
 
-type CreateResponse<TComponents extends Component> =
-  Omit<CreateStoryResponses[201], 'story'> & { story?: StoryResult<TComponents> };
+type CreateResponse<TComponents extends Component, TFieldPlugins = Record<never, never>> =
+  Omit<CreateStoryResponses[201], 'story'> & { story?: StoryResult<TComponents, TFieldPlugins> };
 
-type UpdateResponse<TComponents extends Component> =
-  Omit<UpdateStoryResponses[200], 'story'> & { story?: StoryResult<TComponents> };
+type UpdateResponse<TComponents extends Component, TFieldPlugins = Record<never, never>> =
+  Omit<UpdateStoryResponses[200], 'story'> & { story?: StoryResult<TComponents, TFieldPlugins> };
 
-type DuplicateResponse<TComponents extends Component> =
-  Omit<DuplicateStoryResponses[200], 'story'> & { story?: StoryResult<TComponents> };
+type DuplicateResponse<TComponents extends Component, TFieldPlugins = Record<never, never>> =
+  Omit<DuplicateStoryResponses[200], 'story'> & { story?: StoryResult<TComponents, TFieldPlugins> };
 
-type PublishResponse<TComponents extends Component> =
-  Omit<PublishStoryResponses[200], 'story'> & { story?: StoryResult<TComponents> };
+type PublishResponse<TComponents extends Component, TFieldPlugins = Record<never, never>> =
+  Omit<PublishStoryResponses[200], 'story'> & { story?: StoryResult<TComponents, TFieldPlugins> };
 
-type CreateBody<TComponents extends Component> =
+type CreateBody<TComponents extends Component, TFieldPlugins = Record<never, never>> =
   Component extends TComponents
     ? CreateStoryData['body']
     : Omit<UpdateStoryRequest, 'story'> & {
-      story: StoryCreate<TComponents>;
+      story: StoryCreate<TComponents, TFieldPlugins>;
     };
 
-type UpdateBody<TComponents extends Component> =
+type UpdateBody<TComponents extends Component, TFieldPlugins = Record<never, never>> =
   Component extends TComponents
     ? UpdateStoryData['body']
     : Omit<UpdateStoryRequest, 'story'> & {
-      story: StoryUpdate<TComponents>;
+      story: StoryUpdate<TComponents, TFieldPlugins>;
     };
 
 export function createStoriesResource<
   TComponents extends Component = Component,
+  TFieldPlugins = Record<never, never>,
   DefaultThrowOnError extends boolean = false,
 >(deps: MapiResourceDeps<DefaultThrowOnError>) {
   const { client, spaceId, wrapRequest } = deps;
   const getSpaceId = (path?: SpaceIdPathOverride['path']) => resolveSpaceId(spaceId, path);
 
   return {
-    list<ThrowOnError extends boolean = DefaultThrowOnError>(options: { query?: ListStoriesData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<ListResponse<TComponents>, ThrowOnError>> {
+    list<ThrowOnError extends boolean = DefaultThrowOnError>(options: { query?: ListStoriesData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<ListResponse<TComponents, TFieldPlugins>, ThrowOnError>> {
       const { query, signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
-      return wrapRequest<ListResponse<TComponents>, ThrowOnError>(() =>
+      return wrapRequest<ListResponse<TComponents, TFieldPlugins>, ThrowOnError>(() =>
         mapi.listStories({ client, path: { space_id: resolvedSpaceId }, query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
-    get<ThrowOnError extends boolean = DefaultThrowOnError>(storyId: number, options: { query?: GetStoryByIdData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<GetResponse<TComponents>, ThrowOnError>> {
+    get<ThrowOnError extends boolean = DefaultThrowOnError>(storyId: number, options: { query?: GetStoryByIdData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<GetResponse<TComponents, TFieldPlugins>, ThrowOnError>> {
       const { query, signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
-      return wrapRequest<GetResponse<TComponents>, ThrowOnError>(() =>
+      return wrapRequest<GetResponse<TComponents, TFieldPlugins>, ThrowOnError>(() =>
         mapi.getStoryById({ client, path: { space_id: resolvedSpaceId, id: storyId }, query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
-    create<ThrowOnError extends boolean = DefaultThrowOnError>(options: { body: CreateBody<TComponents>; query?: CreateStoryData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride): Promise<ApiResponse<CreateResponse<TComponents>, ThrowOnError>> {
+    create<ThrowOnError extends boolean = DefaultThrowOnError>(options: { body: CreateBody<TComponents, TFieldPlugins>; query?: CreateStoryData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride): Promise<ApiResponse<CreateResponse<TComponents, TFieldPlugins>, ThrowOnError>> {
       const { body, query, signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
-      return wrapRequest<CreateResponse<TComponents>, ThrowOnError>(() =>
+      return wrapRequest<CreateResponse<TComponents, TFieldPlugins>, ThrowOnError>(() =>
         mapi.createStory({ client, path: { space_id: resolvedSpaceId }, body: body as CreateStoryData['body'], query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
     update<ThrowOnError extends boolean = DefaultThrowOnError>(
       storyId: number,
-      options: { body: UpdateBody<TComponents>; query?: UpdateStoryData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
-    ): Promise<ApiResponse<UpdateResponse<TComponents>, ThrowOnError>> {
+      options: { body: UpdateBody<TComponents, TFieldPlugins>; query?: UpdateStoryData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
+    ): Promise<ApiResponse<UpdateResponse<TComponents, TFieldPlugins>, ThrowOnError>> {
       const { body, query, signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
-      return wrapRequest<UpdateResponse<TComponents>, ThrowOnError>(() =>
+      return wrapRequest<UpdateResponse<TComponents, TFieldPlugins>, ThrowOnError>(() =>
         mapi.updateStory({ client, path: { space_id: resolvedSpaceId, id: storyId }, body: body as UpdateStoryData['body'], query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
     delete<ThrowOnError extends boolean = DefaultThrowOnError>(storyId: number, options: { signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {}): Promise<ApiResponse<DeleteStoryResponses[200], ThrowOnError>> {
@@ -110,19 +111,19 @@ export function createStoriesResource<
     duplicate<ThrowOnError extends boolean = DefaultThrowOnError>(
       storyId: number,
       options: { body: DuplicateStoryData['body']; query?: DuplicateStoryData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
-    ): Promise<ApiResponse<DuplicateResponse<TComponents>, ThrowOnError>> {
+    ): Promise<ApiResponse<DuplicateResponse<TComponents, TFieldPlugins>, ThrowOnError>> {
       const { body, query, signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
-      return wrapRequest<DuplicateResponse<TComponents>, ThrowOnError>(() =>
+      return wrapRequest<DuplicateResponse<TComponents, TFieldPlugins>, ThrowOnError>(() =>
         mapi.duplicateStory({ client, path: { space_id: resolvedSpaceId, id: storyId }, body, query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
     publish<ThrowOnError extends boolean = DefaultThrowOnError>(
       storyId: number,
       options: { query?: PublishStoryData['query']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride = {},
-    ): Promise<ApiResponse<PublishResponse<TComponents>, ThrowOnError>> {
+    ): Promise<ApiResponse<PublishResponse<TComponents, TFieldPlugins>, ThrowOnError>> {
       const { query, signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
-      return wrapRequest<PublishResponse<TComponents>, ThrowOnError>(() =>
+      return wrapRequest<PublishResponse<TComponents, TFieldPlugins>, ThrowOnError>(() =>
         mapi.publishStory({ client, path: { space_id: resolvedSpaceId, id: storyId }, query, signal, ...(throwOnError === undefined ? {} : { throwOnError }), ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}) }), throwOnError);
     },
     versions<ThrowOnError extends boolean = DefaultThrowOnError>(

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -21,11 +21,22 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
+    "./field-plugins": {
+      "import": "./dist/field-plugins/index.mjs",
+      "require": "./dist/field-plugins/index.cjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
+  "typesVersions": {
+    "*": {
+      "field-plugins": [
+        "./dist/field-plugins/index.d.cts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/schema/playground/astro/src/components/storyblok/hero.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/hero.astro
@@ -1,21 +1,29 @@
 ---
 import type { BlockContent } from '@storyblok/schema';
-import type { Blocks } from '../../schema/schema';
+import type { Blocks, FieldPlugins } from '../../schema/schema';
 import type { heroBlock } from '../../schema/blocks/hero';
 
-type HeroContent = BlockContent<typeof heroBlock, Blocks>;
+// Passing `FieldPlugins` as the third argument resolves the registered
+// `storyblok-colorpicker` custom field to `{ color: string; plugin: string }`.
+type HeroContent = BlockContent<typeof heroBlock, Blocks, FieldPlugins>;
 
 interface Props {
   blok: HeroContent;
 }
 
 const { blok } = Astro.props;
+
+// `blok.accent_color` is fully typed thanks to the registered color plugin.
+const accentColor = blok.accent_color?.color;
 ---
 
 <section class="relative flex min-h-[60vh] items-center bg-gray-900 px-6 py-24 text-white">
   <div class="mx-auto max-w-4xl">
     {blok.eyebrow && (
-      <p class="mb-4 text-sm font-semibold tracking-widest text-indigo-400 uppercase">
+      <p
+        class="mb-4 text-sm font-semibold tracking-widest text-indigo-400 uppercase"
+        style={accentColor ? `color: ${accentColor}` : undefined}
+      >
         {blok.eyebrow}
       </p>
     )}

--- a/packages/schema/playground/astro/src/schema/blocks/hero.ts
+++ b/packages/schema/playground/astro/src/schema/blocks/hero.ts
@@ -9,5 +9,6 @@ export const heroBlock = defineBlock({
     eyebrowField,
     { ...headlineField, required: true },
     defineField('image', { type: 'asset', filetypes: ['images'] }),
+    defineField('accent_color', { type: 'custom', field_type: 'storyblok-colorpicker' }),
   ],
 });

--- a/packages/schema/playground/astro/src/schema/schema.ts
+++ b/packages/schema/playground/astro/src/schema/schema.ts
@@ -1,4 +1,6 @@
+import { defineSchema } from '@storyblok/schema';
 import type { Schema as InferSchema, Story as InferStory, MapiStory as InferStoryMapi } from '@storyblok/schema';
+import { storyblokColorField } from '@storyblok/schema/field-plugins';
 
 import { articleBlock } from './blocks/article';
 import { bannerBlock } from './blocks/banner';
@@ -14,7 +16,7 @@ import { teaserBlock } from './blocks/teaser';
 import { pageBlock } from './blocks/page';
 import { bannerThemesDatasource, faqCategoriesDatasource } from './datasources';
 
-export const schema = {
+export const schema = defineSchema({
   blocks: {
     pageBlock,
     heroBlock,
@@ -35,9 +37,13 @@ export const schema = {
     bannerThemesDatasource,
     faqCategoriesDatasource,
   },
-};
+  fieldPlugins: {
+    storyblokColorField,
+  },
+});
 
 export type Schema = InferSchema<typeof schema>;
 export type Blocks = Schema['blocks'];
-export type Story = InferStory<Blocks>;
-export type StoryMapi = InferStoryMapi<Blocks>;
+export type FieldPlugins = Schema['fieldPlugins'];
+export type Story = InferStory<Blocks, FieldPlugins>;
+export type StoryMapi = InferStoryMapi<Blocks, FieldPlugins>;

--- a/packages/schema/playground/astro/src/seeds/stories/about.ts
+++ b/packages/schema/playground/astro/src/seeds/stories/about.ts
@@ -3,9 +3,9 @@ import { pageBlock } from '../../schema/blocks/page';
 import { heroBlock } from '../../schema/blocks/hero';
 import { introBlock } from '../../schema/blocks/intro';
 import { mediaBlock } from '../../schema/blocks/media';
-import type { Blocks } from '../../schema/schema';
+import type { Blocks, FieldPlugins } from '../../schema/schema';
 
-export function createAboutStory(mediaAsset: Asset): StoryCreate<Blocks> {
+export function createAboutStory(mediaAsset: Asset): StoryCreate<Blocks, FieldPlugins> {
   return {
     name: 'About',
     slug: 'about',
@@ -19,6 +19,8 @@ export function createAboutStory(mediaAsset: Asset): StoryCreate<Blocks> {
           eyebrow: 'About this project',
           headline: 'A monorepo playground for Storyblok packages.',
           image: null,
+          // Typed on write via the registered `storyblok-colorpicker` plugin.
+          accent_color: { plugin: 'storyblok-colorpicker', color: '#34d399' },
         },
         {
           component: mediaBlock.name,

--- a/packages/schema/playground/astro/src/seeds/stories/home.ts
+++ b/packages/schema/playground/astro/src/seeds/stories/home.ts
@@ -5,9 +5,9 @@ import { introBlock } from '../../schema/blocks/intro';
 import { mediaBlock } from '../../schema/blocks/media';
 import { teaserBlock } from '../../schema/blocks/teaser';
 import { teaserListBlock } from '../../schema/blocks/teaser-list';
-import type { Blocks } from '../../schema/schema';
+import type { Blocks, FieldPlugins } from '../../schema/schema';
 
-export function createHomeStory(mediaAsset: Asset): StoryCreate<Blocks> {
+export function createHomeStory(mediaAsset: Asset): StoryCreate<Blocks, FieldPlugins> {
   return {
     name: 'Home',
     slug: 'home',
@@ -21,6 +21,8 @@ export function createHomeStory(mediaAsset: Asset): StoryCreate<Blocks> {
           eyebrow: 'Built with Storyblok',
           headline: 'Code-driven content, fully typed.',
           image: null,
+          // Typed on write via the registered `storyblok-colorpicker` plugin.
+          accent_color: { plugin: 'storyblok-colorpicker', color: '#818cf8' },
         },
         {
           component: introBlock.name,

--- a/packages/schema/playground/vanilla/app/validate.ts
+++ b/packages/schema/playground/vanilla/app/validate.ts
@@ -48,7 +48,36 @@ for (const issue of bad.issues) {
   console.log(`${issue.severity} [${issue.code}] ${issue.path.join('.')}: ${issue.message}`);
 }
 
-// ── 4. createStoryValidator — hand the validator to a framework ──────────────
+// ── 4. validateStory — custom field plugins ──────────────────────────────────
+//
+// `hero.accent_color` is a `custom` field whose `field_type` matches the
+// registered `storyblokColorField` plugin. `validateStory` runs the plugin's
+// Standard Schema validator against the value, so a malformed color is caught
+// here — not at push time or in the browser.
+
+const validColor = validateStory({
+  content: {
+    component: 'page',
+    title: 'Colors',
+    body: [{ component: 'hero', headline: 'Welcome', accent_color: { plugin: 'storyblok-colorpicker', color: '#0ea5e9' } }],
+  },
+}, schema);
+console.log(`valid color ok: ${validColor.ok}`); // true
+
+const badColor = validateStory({
+  content: {
+    component: 'page',
+    title: 'Colors',
+    // `color` must be a string → the plugin validator flags it as invalid_value.
+    body: [{ component: 'hero', headline: 'Welcome', accent_color: { plugin: 'storyblok-colorpicker', color: 12345 } }],
+  },
+}, schema);
+console.log(`bad color ok: ${badColor.ok}`); // false
+for (const issue of badColor.issues) {
+  console.log(`${issue.severity} [${issue.code}] ${issue.path.join('.')}: ${issue.message}`);
+}
+
+// ── 5. createStoryValidator — hand the validator to a framework ──────────────
 //
 // `createStoryValidator` returns a Standard Schema, so any Standard-Schema-aware
 // library validates stories for you — you never touch the `['~standard']`

--- a/packages/schema/playground/vanilla/base/blocks/hero.ts
+++ b/packages/schema/playground/vanilla/base/blocks/hero.ts
@@ -11,5 +11,6 @@ export const heroBlock = defineBlock({
     defineField('image', { type: 'asset', filetypes: ['images'] }),
     defineField('cta_label', { type: 'text', max_length: 40 }),
     defineField('cta_link', { type: 'multilink' }),
+    defineField('accent_color', { type: 'custom', field_type: 'storyblok-colorpicker' }),
   ],
 });

--- a/packages/schema/playground/vanilla/base/schema.ts
+++ b/packages/schema/playground/vanilla/base/schema.ts
@@ -1,4 +1,6 @@
+import { defineSchema } from '@storyblok/schema';
 import type { Schema as InferSchema, Story as InferStory, MapiStory } from '@storyblok/schema';
+import { storyblokColorField } from '@storyblok/schema/field-plugins';
 import { pageBlock } from './blocks/page';
 import { articleBlock } from './blocks/article';
 import { heroBlock } from './blocks/hero';
@@ -9,12 +11,16 @@ import { blogTagsDatasource, colorsDatasource, iconsDatasource } from './datasou
 
 export const contentTypes = { pageBlock, articleBlock };
 
-export const schema = {
+export const schema = defineSchema({
   blocks: { ...contentTypes, heroBlock, featureCardBlock, kitchenSinkBlock, emptyBlock },
   datasources: { iconsDatasource, colorsDatasource, blogTagsDatasource },
-};
+  // Register the official Colorpicker plugin so `custom` fields with
+  // `field_type: 'storyblok-colorpicker'` are typed and runtime-validated.
+  fieldPlugins: { storyblokColorField },
+});
 
 export type Schema = InferSchema<typeof schema>;
 export type Blocks = Schema['blocks'];
-export type Story = InferStory<Blocks>;
-export type StoryMapi = MapiStory<Blocks>;
+export type FieldPlugins = Schema['fieldPlugins'];
+export type Story = InferStory<Blocks, FieldPlugins>;
+export type StoryMapi = MapiStory<Blocks, FieldPlugins>;

--- a/packages/schema/src/field-plugins/index.ts
+++ b/packages/schema/src/field-plugins/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Official Storyblok field plugins for `@storyblok/schema`. Each plugin is a
+ * {@link defineFieldPlugin} result backed by a hand-written Standard Schema
+ * validator; import individually so unused plugins tree-shake away.
+ */
+
+export { storyblokColorField } from './storyblok-color-field';
+export type { StoryblokColorFieldValue } from './storyblok-color-field';

--- a/packages/schema/src/field-plugins/storyblok-color-field.test.ts
+++ b/packages/schema/src/field-plugins/storyblok-color-field.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { storyblokColorField } from './storyblok-color-field';
+
+describe('storyblokColorField', () => {
+  it('registers the storyblok-colorpicker field type', () => {
+    expect(storyblokColorField.fieldType).toBe('storyblok-colorpicker');
+  });
+
+  it('accepts a value with a string color', async () => {
+    const result = await storyblokColorField.value['~standard'].validate({ color: '#ffffff' });
+    expect(result).toEqual({ value: { color: '#ffffff' } });
+  });
+
+  it('reports an issue for a malformed value', async () => {
+    const result = await storyblokColorField.value['~standard'].validate({ color: 123 });
+    expect('issues' in result).toBe(true);
+  });
+});

--- a/packages/schema/src/field-plugins/storyblok-color-field.ts
+++ b/packages/schema/src/field-plugins/storyblok-color-field.ts
@@ -1,0 +1,35 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { defineFieldPlugin } from '../helpers/define-field-plugin';
+import { isRecord } from '../utils/is-record';
+
+/** Value stored by Storyblok's official Colorpicker field plugin. */
+export interface StoryblokColorFieldValue {
+  color: string;
+}
+
+/**
+ * Hand-written [Standard Schema](https://standardschema.dev) validator for
+ * {@link StoryblokColorFieldValue}. Implemented directly (no external validator)
+ * so the package stays validator-agnostic and adds no runtime dependency.
+ */
+const storyblokColorFieldValue: StandardSchemaV1<StoryblokColorFieldValue> = {
+  '~standard': {
+    version: 1,
+    vendor: 'storyblok-schema',
+    validate(value) {
+      if (isRecord(value) && typeof value.color === 'string') {
+        return { value: { color: value.color } };
+      }
+      return { issues: [{ message: 'Expected an object with a string `color` property.' }] };
+    },
+  },
+};
+
+/**
+ * Official Storyblok Colorpicker field plugin (`storyblok-colorpicker`).
+ * Register it in a schema's `fieldPlugins` to type matching custom fields.
+ */
+export const storyblokColorField = defineFieldPlugin({
+  fieldType: 'storyblok-colorpicker',
+  value: storyblokColorFieldValue,
+});

--- a/packages/schema/src/field-plugins/storyblok-color-field.ts
+++ b/packages/schema/src/field-plugins/storyblok-color-field.ts
@@ -20,7 +20,7 @@ const storyblokColorFieldValue: StandardSchemaV1<StoryblokColorFieldValue> = {
       if (isRecord(value) && typeof value.color === 'string') {
         return { value: { color: value.color } };
       }
-      return { issues: [{ message: 'Expected an object with a string `color` property.' }] };
+      return { issues: [{ message: 'Expected a string `color` property.', path: ['color'] }] };
     },
   },
 };

--- a/packages/schema/src/generated/types/field.ts
+++ b/packages/schema/src/generated/types/field.ts
@@ -32,15 +32,15 @@ type IsBaseBlock<T> = [Block] extends [T] ? true : false;
  * required (`required: true`) from optional fields. Each `F` is a member of the
  * field union, so it provably satisfies `FieldValue`'s `Field` constraint.
  */
-type ContentFields<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks> | null }
+type ContentFields<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /** Input (write) variant of {@link ContentFields}, resolving each field via {@link FieldValueInput}. */
-type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks> | null }
+type ContentFieldsInput<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /**
@@ -49,33 +49,34 @@ type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
  * runtime shape (any block, `_editable` optional). With a schema-typed
  * `TBlock`, fields are narrowed per the block's `fields`.
  */
-export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid: string; component: TBlock['name']; _editable?: string }
-        & ContentFields<TBlock['fields'], TBlocks>
+        & ContentFields<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 /** Input variant of {@link BlockContent} for write operations (creating/updating stories via the MAPI). `_uid` is optional. */
-export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentInputBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid?: string; component: TBlock['name']; _editable?: string }
-        & ContentFieldsInput<TBlock['fields'], TBlocks>
+        & ContentFieldsInput<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 export type BlocksFieldValue<
   TBlock extends Block = Block,
   TBlocks = NoBlocks,
-> = BlockContent<TBlock, TBlocks>[];
+  TFieldPlugins = Record<never, never>,
+> = BlockContent<TBlock, TBlocks, TFieldPlugins>[];
 
 /** Union of all valid Storyblok field type discriminants (e.g., `text`, `bloks`). */
 export type FieldType = Field['type'];
@@ -113,10 +114,24 @@ type ApplyAllow<TField, TBlocks> = TField extends { allow: ReadonlyArray<infer T
     ? IsNestable<TBlocks> extends true ? TBlocks : never
     : never;
 
+/**
+ * Resolves a `custom` field to its registered plugin value. When the field's
+ * `field_type` is a key of `TFieldPlugins`, the validator output is merged with
+ * the plugin envelope (`plugin`, optional `_uid`); otherwise it falls back to
+ * the untyped {@link PluginFieldValue}. Same shape for read and write.
+ */
+type ResolveCustom<TField, TFieldPlugins> =
+  TField extends { field_type: infer F extends string }
+    ? F extends keyof TFieldPlugins
+      ? Prettify<TFieldPlugins[F] & { plugin: string; _uid?: string }>
+      : PluginFieldValue
+    : PluginFieldValue;
+
 /** Resolves a field definition to its runtime content value type (read). */
 export type FieldValue<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -124,15 +139,18 @@ export type FieldValue<
     ? [TBlocks] extends [never]
         ? BlockContentBase[]
         : [TBlocks] extends [Block]
-            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;
 
 /** Resolves a field definition to its input value type (write). */
 export type FieldValueInput<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -140,7 +158,9 @@ export type FieldValueInput<
     ? [TBlocks] extends [never]
         ? BlockContentInputBase[]
         : [TBlocks] extends [Block]
-            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentInputBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;

--- a/packages/schema/src/generated/types/mapi-story.ts
+++ b/packages/schema/src/generated/types/mapi-story.ts
@@ -25,42 +25,47 @@ type MapiStoryWithSchemaContent<
   TStory extends MapiStoryGenerated | StoryCreateGenerated | StoryUpdateGenerated,
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = RootBlock extends TBlock
   ? TStory
   : Override<TStory, {
     content: TStory extends StoryCreateGenerated | StoryUpdateGenerated
-      ? BlockContentInput<TBlock, TBlocks>
-      : BlockContent<TBlock, TBlocks>;
+      ? BlockContentInput<TBlock, TBlocks, TFieldPlugins>
+      : BlockContent<TBlock, TBlocks, TFieldPlugins>;
   }>;
 
 type MakeMapiStory<
   TStory extends MapiStoryGenerated | StoryCreateGenerated | StoryUpdateGenerated,
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? MapiStoryWithSchemaContent<TStory, TBlockOrBlocks, TBlocks>
+    ? MapiStoryWithSchemaContent<TStory, TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? MapiStoryWithSchemaContent<TStory, Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? MapiStoryWithSchemaContent<TStory, Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;
 
 /** A Storyblok MAPI story. */
 export type MapiStory<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<MapiStoryGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<MapiStoryGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;
 
 /** Payload for creating a story via the MAPI. */
 export type StoryCreate<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<StoryCreateGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<StoryCreateGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;
 
 /** Payload for updating a story via the MAPI. */
 export type StoryUpdate<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<StoryUpdateGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<StoryUpdateGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;

--- a/packages/schema/src/generated/types/story.ts
+++ b/packages/schema/src/generated/types/story.ts
@@ -15,18 +15,20 @@ type NoBlocks = false;
 type CapiStoryWithSchemaContent<
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
-> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks> }>;
+  TFieldPlugins = Record<never, never>,
+> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks, TFieldPlugins> }>;
 
 /** A Storyblok CDN (CAPI) story. */
 export type Story<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks>
+    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;

--- a/packages/schema/src/helpers/define-field-plugin.test-d.ts
+++ b/packages/schema/src/helpers/define-field-plugin.test-d.ts
@@ -1,0 +1,23 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { z } from 'zod';
+import { describe, expectTypeOf, it } from 'vitest';
+import { defineFieldPlugin } from './define-field-plugin';
+
+describe('defineFieldPlugin type inference', () => {
+  it('infers the fieldType literal from the single argument', () => {
+    const colorPicker = defineFieldPlugin({
+      fieldType: 'my-custom-color-picker',
+      value: z.object({ color: z.string(), alpha: z.number() }),
+    });
+    expectTypeOf(colorPicker.fieldType).toEqualTypeOf<'my-custom-color-picker'>();
+  });
+
+  it('retains the validator so its output type is recoverable', () => {
+    const _colorPicker = defineFieldPlugin({
+      fieldType: 'my-custom-color-picker',
+      value: z.object({ color: z.string(), alpha: z.number() }),
+    });
+    type Output = StandardSchemaV1.InferOutput<typeof _colorPicker['value']>;
+    expectTypeOf<Output>().toEqualTypeOf<{ color: string; alpha: number }>();
+  });
+});

--- a/packages/schema/src/helpers/define-field-plugin.test.ts
+++ b/packages/schema/src/helpers/define-field-plugin.test.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import { describe, expect, it } from 'vitest';
+import { defineFieldPlugin } from './define-field-plugin';
+
+describe('defineFieldPlugin', () => {
+  it('returns the config unchanged (identity helper)', () => {
+    const value = z.object({ color: z.string() });
+    const plugin = defineFieldPlugin({ fieldType: 'my-color', value });
+    expect(plugin.fieldType).toBe('my-color');
+    expect(plugin.value).toBe(value);
+  });
+});

--- a/packages/schema/src/helpers/define-field-plugin.ts
+++ b/packages/schema/src/helpers/define-field-plugin.ts
@@ -1,0 +1,35 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
+/**
+ * Binds a Storyblok custom field `field_type` to a
+ * [Standard Schema](https://standardschema.dev) validator. The validator (`S`,
+ * retained on `value`) supplies both the static value type
+ * (`StandardSchemaV1.InferOutput<S>`) and a runtime handle, so a single
+ * declaration serves types and (future) runtime validation.
+ */
+export interface FieldPlugin<
+  F extends string = string,
+  S extends StandardSchemaV1 = StandardSchemaV1,
+> {
+  fieldType: F;
+  value: S;
+}
+
+/**
+ * Declares a custom field plugin: both the `fieldType` literal and the value
+ * type infer from the single argument. `value` accepts any Standard Schema
+ * validator (Zod, Valibot, ArkType, or hand-written) and is retained for
+ * runtime use. A thin, strongly-typed identity helper — it does not validate.
+ *
+ * @example
+ * const colorPicker = defineFieldPlugin({
+ *   fieldType: 'my-custom-color-picker',
+ *   value: z.object({ color: z.string(), alpha: z.number() }),
+ * });
+ */
+export function defineFieldPlugin<
+  const F extends string,
+  S extends StandardSchemaV1,
+>(config: { fieldType: F; value: S }): FieldPlugin<F, S> {
+  return config;
+}

--- a/packages/schema/src/helpers/define-schema.test-d.ts
+++ b/packages/schema/src/helpers/define-schema.test-d.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { describe, expectTypeOf, it } from 'vitest';
+import { defineBlock } from './define-block';
+import { defineField } from './define-field';
+import { defineFieldPlugin } from './define-field-plugin';
+import { defineSchema } from './define-schema';
+import type { Schema } from './schema-type';
+
+const pageBlock = defineBlock({
+  name: 'page',
+  is_root: true,
+  fields: [defineField('headline', { type: 'text' })],
+});
+
+const colorPicker = defineFieldPlugin({
+  fieldType: 'my-color',
+  value: z.object({ color: z.string(), alpha: z.number() }),
+});
+
+describe('defineSchema', () => {
+  it('derives a fieldType → validator-output map keyed by fieldType, not the record label', () => {
+    const _schema = defineSchema({ blocks: { pageBlock }, fieldPlugins: { colorPicker } });
+    type Map = Schema<typeof _schema>['fieldPlugins'];
+    // keyed by the plugin's `fieldType` ('my-color'), not the record label ('colorPicker')
+    expectTypeOf<keyof Map>().toEqualTypeOf<'my-color'>();
+    expectTypeOf<Map['my-color']>().toEqualTypeOf<{ color: string; alpha: number }>();
+  });
+
+  it('derives an empty field-plugin map when none are registered', () => {
+    const _schema = defineSchema({ blocks: { pageBlock } });
+    expectTypeOf<Schema<typeof _schema>['fieldPlugins']>().toEqualTypeOf<Record<never, never>>();
+  });
+});

--- a/packages/schema/src/helpers/define-schema.ts
+++ b/packages/schema/src/helpers/define-schema.ts
@@ -3,7 +3,7 @@ import type { Datasource } from './define-datasource';
 import type { FieldPlugin } from './define-field-plugin';
 
 /** Minimal shape accepted by {@link defineSchema}; extra keys pass through unchanged. */
-interface SchemaConfig {
+export interface SchemaConfig {
   blocks: Record<string, Block>;
   datasources?: Record<string, Datasource>;
   fieldPlugins?: Record<string, FieldPlugin>;

--- a/packages/schema/src/helpers/define-schema.ts
+++ b/packages/schema/src/helpers/define-schema.ts
@@ -1,0 +1,27 @@
+import type { Block } from './define-block';
+import type { Datasource } from './define-datasource';
+import type { FieldPlugin } from './define-field-plugin';
+
+/** Minimal shape accepted by {@link defineSchema}; extra keys pass through unchanged. */
+interface SchemaConfig {
+  blocks: Record<string, Block>;
+  datasources?: Record<string, Datasource>;
+  fieldPlugins?: Record<string, FieldPlugin>;
+}
+
+/**
+ * Typed identity wrapper for a schema object, consistent with the other
+ * `define*` helpers. Preserves the exact literal shape via `const` inference so
+ * {@link Schema} can derive block, datasource, and field-plugin types from
+ * `typeof schema`. Does not validate or transform.
+ *
+ * @example
+ * export const schema = defineSchema({
+ *   blocks: { pageBlock, heroBlock },
+ *   datasources: { colorsDatasource },
+ *   fieldPlugins: { colorPicker },
+ * });
+ */
+export function defineSchema<const T extends SchemaConfig>(schema: T): T {
+  return schema;
+}

--- a/packages/schema/src/helpers/field-plugins.test-d.ts
+++ b/packages/schema/src/helpers/field-plugins.test-d.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { describe, expectTypeOf, it } from 'vitest';
+import type { BlockContentInput, PluginFieldValue } from '../generated/types/field';
+import type { Story } from '../generated/types/story';
+import { defineBlock } from './define-block';
+import { defineField } from './define-field';
+import { defineFieldPlugin } from './define-field-plugin';
+import { defineSchema } from './define-schema';
+import type { Schema } from './schema-type';
+
+const colorPicker = defineFieldPlugin({
+  fieldType: 'my-color',
+  value: z.object({ color: z.string(), alpha: z.number() }),
+});
+
+interface ColorEnvelope {
+  color: string;
+  alpha: number;
+  plugin: string;
+  _uid?: string;
+}
+
+describe('custom field plugin resolution (read + write share one type)', () => {
+  const heroBlock = defineBlock({
+    name: 'hero',
+    is_root: true,
+    fields: [
+      defineField('bg', { type: 'custom', field_type: 'my-color' }),
+      defineField('legacy', { type: 'custom', field_type: 'unregistered-plugin' }),
+    ],
+  });
+
+  const _schema = defineSchema({ blocks: { heroBlock }, fieldPlugins: { colorPicker } });
+  type S = Schema<typeof _schema>;
+  type HeroStory = Story<S['blocks'], S['fieldPlugins']>;
+
+  it('resolves a registered custom field to the validator output merged with the plugin envelope', () => {
+    expectTypeOf<NonNullable<HeroStory['content']['bg']>>().toEqualTypeOf<ColorEnvelope>();
+  });
+
+  it('leaves an unregistered custom field as PluginFieldValue', () => {
+    expectTypeOf<NonNullable<HeroStory['content']['legacy']>>().toEqualTypeOf<PluginFieldValue>();
+  });
+
+  it('resolves to the same envelope on the write (input) side', () => {
+    type HeroInput = BlockContentInput<typeof heroBlock, false, S['fieldPlugins']>;
+    expectTypeOf<NonNullable<HeroInput['bg']>>().toEqualTypeOf<ColorEnvelope>();
+  });
+
+  it('falls back to PluginFieldValue for every custom field when no plugins are registered', () => {
+    const _bareSchema = defineSchema({ blocks: { heroBlock } });
+    type Bare = Schema<typeof _bareSchema>;
+    type BareStory = Story<Bare['blocks'], Bare['fieldPlugins']>;
+    expectTypeOf<NonNullable<BareStory['content']['bg']>>().toEqualTypeOf<PluginFieldValue>();
+  });
+});
+
+describe('custom field plugin resolution inside nested bloks', () => {
+  const cardBlock = defineBlock({
+    name: 'card',
+    fields: [defineField('bg', { type: 'custom', field_type: 'my-color' })],
+  });
+
+  const pageBlock = defineBlock({
+    name: 'page',
+    is_root: true,
+    fields: [defineField('body', { type: 'bloks', allow: ['card'] })],
+  });
+
+  const _schema = defineSchema({ blocks: { pageBlock, cardBlock }, fieldPlugins: { colorPicker } });
+  type S = Schema<typeof _schema>;
+  type PageStory = Story<S['blocks'], S['fieldPlugins']>;
+
+  it('threads the plugin map into nested block content', () => {
+    type CardContent = Extract<NonNullable<PageStory['content']['body']>[number], { component: 'card' }>;
+    expectTypeOf<NonNullable<CardContent['bg']>>().toEqualTypeOf<ColorEnvelope>();
+  });
+});

--- a/packages/schema/src/helpers/schema-type.ts
+++ b/packages/schema/src/helpers/schema-type.ts
@@ -1,5 +1,16 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { Block } from './define-block';
 import type { Datasource } from './define-datasource';
+import type { FieldPlugin } from './define-field-plugin';
+
+/**
+ * Derives a `fieldType → validator output` map from a `fieldPlugins` record.
+ * Record keys are cosmetic labels; the map is keyed by each plugin's
+ * `fieldType`. Resolves to `{}` when no plugins are registered.
+ */
+type FieldPluginMap<TPlugins> = TPlugins extends Record<string, FieldPlugin>
+  ? { [K in keyof TPlugins as TPlugins[K]['fieldType']]: StandardSchemaV1.InferOutput<TPlugins[K]['value']> }
+  : Record<never, never>;
 
 /**
  * Derives a schema types interface from a schema object.
@@ -27,10 +38,12 @@ export interface Schema<
   T extends {
     blocks: Record<string, Block>;
     datasources?: Record<string, Datasource>;
+    fieldPlugins?: Record<string, FieldPlugin>;
   },
 > {
   blocks: T['blocks'][keyof T['blocks']];
   datasources: T['datasources'] extends Record<string, Datasource>
     ? T['datasources'][keyof T['datasources']]
     : never;
+  fieldPlugins: FieldPluginMap<T['fieldPlugins']>;
 }

--- a/packages/schema/src/helpers/schema-type.ts
+++ b/packages/schema/src/helpers/schema-type.ts
@@ -1,7 +1,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import type { Block } from './define-block';
 import type { Datasource } from './define-datasource';
 import type { FieldPlugin } from './define-field-plugin';
+import type { SchemaConfig } from './define-schema';
 
 /**
  * Derives a `fieldType → validator output` map from a `fieldPlugins` record.
@@ -22,25 +22,21 @@ type FieldPluginMap<TPlugins> = TPlugins extends Record<string, FieldPlugin>
  *
  * @example
  * ```ts
+ * import { defineSchema } from '@storyblok/schema';
  * import type { Schema as InferSchema } from '@storyblok/schema';
  *
- * export const schema = {
+ * export const schema = defineSchema({
  *   blocks: { pageBlock, heroBlock },
  *   datasources: { colorsDatasource },
- * };
+ *   fieldPlugins: { storyblokColorField },
+ * });
  *
  * export type Schema = InferSchema<typeof schema>;
  * export type Blocks = Schema['blocks'];
- * export type Datasources = Schema['datasources'];
+ * export type FieldPlugins = Schema['fieldPlugins'];
  * ```
  */
-export interface Schema<
-  T extends {
-    blocks: Record<string, Block>;
-    datasources?: Record<string, Datasource>;
-    fieldPlugins?: Record<string, FieldPlugin>;
-  },
-> {
+export interface Schema<T extends SchemaConfig> {
   blocks: T['blocks'][keyof T['blocks']];
   datasources: T['datasources'] extends Record<string, Datasource>
     ? T['datasources'][keyof T['datasources']]

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -22,6 +22,7 @@ export type { Datasource } from './helpers/define-datasource';
 
 // Field
 export { defineField } from './helpers/define-field';
+
 export type {
   AssetFieldValue,
   BlockContent,
@@ -38,8 +39,12 @@ export type {
   RichtextFieldValue,
   TableFieldValue,
 } from './helpers/define-field';
+// Field plugin
+export { defineFieldPlugin } from './helpers/define-field-plugin';
+export type { FieldPlugin } from './helpers/define-field-plugin';
 
-// Schema type helper
+// Schema
+export { defineSchema } from './helpers/define-schema';
 export type { Schema } from './helpers/schema-type';
 
 // Validators (Zod-powered, non-throwing)

--- a/packages/schema/src/validators/shapes.ts
+++ b/packages/schema/src/validators/shapes.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { FieldType } from '../generated/types/field';
 
 export { isRecord } from '../utils/is-record';
@@ -13,6 +14,8 @@ export { isRecord } from '../utils/is-record';
 export interface SchemaFieldLike {
   name: string;
   type: FieldType;
+  /** `custom`: the field plugin discriminant, matched against registered `fieldPlugins`. */
+  field_type?: string;
   required?: boolean;
   /** Normalized block-name references for `bloks` fields. */
   allow?: readonly string[];
@@ -58,10 +61,17 @@ export interface SchemaDatasourceLike {
   slug?: string;
 }
 
-/** The schema object accepted by the validators: blocks (required) and datasources (optional). */
+/** A field plugin registration (`defineFieldPlugin` result). */
+export interface FieldPluginLike {
+  fieldType: string;
+  value: StandardSchemaV1;
+}
+
+/** The schema object accepted by the validators: blocks (required), datasources and field plugins (optional). */
 export interface SchemaLike {
   blocks: Record<string, SchemaBlockLike> | readonly SchemaBlockLike[];
   datasources?: Record<string, SchemaDatasourceLike> | readonly SchemaDatasourceLike[];
+  fieldPlugins?: Record<string, FieldPluginLike> | readonly FieldPluginLike[];
 }
 
 /** Normalizes a record-or-array of entities to an array of values. */

--- a/packages/schema/src/validators/validate-schema.test.ts
+++ b/packages/schema/src/validators/validate-schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { storyblokColorField } from '../field-plugins/storyblok-color-field';
 import { defineBlock } from '../helpers/define-block';
 import { defineDatasource } from '../helpers/define-datasource';
 import { defineField } from '../helpers/define-field';
@@ -77,5 +78,19 @@ describe('validateSchema', () => {
     const result = validateSchema({ blocks: [block] });
     expect(result.ok).toBe(false);
     expect(codesFor(result)).toContain('invalid_field');
+  });
+
+  it('flags a custom field referencing an unregistered field plugin', () => {
+    const block = defineBlock({ name: 'hero', fields: [defineField('bg', { type: 'custom', field_type: 'storyblok-colorpicker' })] });
+    const result = validateSchema({ blocks: [block] });
+    expect(result.ok).toBe(false);
+    expect(codesFor(result)).toContain('unresolved_field_plugin');
+  });
+
+  it('resolves a custom field to a registered field plugin', () => {
+    const block = defineBlock({ name: 'hero', fields: [defineField('bg', { type: 'custom', field_type: 'storyblok-colorpicker' })] });
+    const result = validateSchema({ blocks: [block], fieldPlugins: { storyblokColorField } });
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
   });
 });

--- a/packages/schema/src/validators/validate-schema.ts
+++ b/packages/schema/src/validators/validate-schema.ts
@@ -6,7 +6,8 @@ import { isRecord, toValues } from './shapes';
  * Validates a schema definition without throwing. Checks structural identity
  * (duplicate block names, field names, and datasource slugs) and cross-references
  * (every `allow` entry resolves to a defined block; every field `datasource`
- * resolves to a defined datasource).
+ * resolves to a defined datasource; every `custom` field's `field_type`
+ * resolves to a registered field plugin).
  *
  * @example
  * const result = validateSchema({ blocks: { hero }, datasources: { colors } });
@@ -16,6 +17,15 @@ export function validateSchema(schema: SchemaLike): ValidationResult {
   const issues: ValidationIssue[] = [];
   const blocks = toValues(schema.blocks);
   const datasources = toValues(schema.datasources);
+  const fieldPlugins = toValues(schema.fieldPlugins);
+
+  const fieldPluginTypes = new Set<string>();
+  for (const plugin of fieldPlugins) {
+    const fieldType = plugin?.fieldType;
+    if (typeof fieldType === 'string') {
+      fieldPluginTypes.add(fieldType);
+    }
+  }
 
   const datasourceSlugs = new Set<string>();
   for (const datasource of datasources) {
@@ -116,6 +126,17 @@ export function validateSchema(schema: SchemaLike): ValidationResult {
           path: ['blocks', blockName, fieldName ?? '', 'datasource'],
           entity: `block:${blockName}`,
           message: `Field "${fieldName}" references unknown datasource "${datasource}".`,
+        });
+      }
+
+      const fieldType = field.field_type;
+      if (field.type === 'custom' && typeof fieldType === 'string' && !fieldPluginTypes.has(fieldType)) {
+        issues.push({
+          severity: 'error',
+          code: 'unresolved_field_plugin',
+          path: ['blocks', blockName, fieldName ?? '', 'field_type'],
+          entity: `block:${blockName}`,
+          message: `Field "${fieldName}" references unregistered field plugin "${fieldType}".`,
         });
       }
     }

--- a/packages/schema/src/validators/validate-story.test.ts
+++ b/packages/schema/src/validators/validate-story.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import { defineBlock } from '../helpers/define-block';
 import { defineField } from '../helpers/define-field';
+import { defineFieldPlugin } from '../helpers/define-field-plugin';
 import { validateStory } from './validate-story';
 
 const teaser = defineBlock({ name: 'teaser', fields: [defineField('text', { type: 'text' })] });
@@ -80,6 +82,90 @@ describe('validateStory', () => {
     expect(result.ok).toBe(false);
     const unknown = result.issues.find(i => i.code === 'unknown_component');
     expect(unknown?.path).toEqual(['content', 'body', 0, 'component']);
+  });
+
+  describe('custom field plugins', () => {
+    const colorPlugin = defineFieldPlugin({
+      fieldType: 'storyblok-colorpicker',
+      value: z.object({ color: z.string() }),
+    });
+    const pageWithPlugin = defineBlock({
+      name: 'page',
+      is_root: true,
+      fields: [
+        defineField('headline', { type: 'text', required: true }),
+        defineField('accent', { type: 'custom', field_type: 'storyblok-colorpicker' }),
+      ],
+    });
+    const pluginSchema = { blocks: { page: pageWithPlugin }, fieldPlugins: { colorPlugin } };
+
+    it('accepts a registered plugin value that matches its validator', () => {
+      const result = validateStory({
+        content: {
+          component: 'page',
+          headline: 'Hi',
+          accent: { plugin: 'storyblok-colorpicker', _uid: 'abc-123', color: '#fff' },
+        },
+      }, pluginSchema);
+      expect(result.ok).toBe(true);
+      expect(result.issues).toEqual([]);
+    });
+
+    it('errors on a registered plugin value with the wrong inner type', () => {
+      const result = validateStory({
+        content: {
+          component: 'page',
+          headline: 'Hi',
+          accent: { plugin: 'storyblok-colorpicker', _uid: 'abc-123', color: 12345 },
+        },
+      }, pluginSchema);
+      expect(result.ok).toBe(false);
+      const colorIssue = result.issues.find(i => i.code === 'invalid_value');
+      expect(colorIssue?.path).toEqual(['content', 'accent', 'color']);
+    });
+
+    it('checks only the envelope for an unregistered field_type', () => {
+      const pageWithUnknownPlugin = defineBlock({
+        name: 'page',
+        is_root: true,
+        fields: [
+          defineField('headline', { type: 'text', required: true }),
+          defineField('accent', { type: 'custom', field_type: 'unregistered-plugin' }),
+        ],
+      });
+      const result = validateStory({
+        content: {
+          component: 'page',
+          headline: 'Hi',
+          accent: { plugin: 'unregistered-plugin', _uid: 'abc-123', color: 12345 },
+        },
+      }, { blocks: { page: pageWithUnknownPlugin }, fieldPlugins: { colorPlugin } });
+      expect(result.ok).toBe(true);
+    });
+
+    it('errors when the envelope plugin key is missing', () => {
+      const result = validateStory({
+        content: {
+          component: 'page',
+          headline: 'Hi',
+          accent: { color: '#fff' },
+        },
+      }, pluginSchema);
+      expect(result.ok).toBe(false);
+      expect(codesFor(result)).toContain('invalid_value');
+    });
+
+    it('accepts a non-UUID _uid string (envelope relaxation)', () => {
+      const result = validateStory({
+        content: {
+          component: 'page',
+          headline: 'Hi',
+          accent: { plugin: 'storyblok-colorpicker', _uid: 'not-a-uuid', color: '#fff' },
+        },
+      }, pluginSchema);
+      expect(result.ok).toBe(true);
+      expect(result.issues).toEqual([]);
+    });
   });
 });
 

--- a/packages/schema/src/validators/validate-story.test.ts
+++ b/packages/schema/src/validators/validate-story.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { defineBlock } from '../helpers/define-block';
 import { defineField } from '../helpers/define-field';
 import { defineFieldPlugin } from '../helpers/define-field-plugin';
+import { storyblokColorField } from '../field-plugins/storyblok-color-field';
 import { validateStory } from './validate-story';
 
 const teaser = defineBlock({ name: 'teaser', fields: [defineField('text', { type: 'text' })] });
@@ -165,6 +167,39 @@ describe('validateStory', () => {
       }, pluginSchema);
       expect(result.ok).toBe(true);
       expect(result.issues).toEqual([]);
+    });
+
+    it('reports the `color` sub-path for the shipped storyblokColorField plugin', () => {
+      const result = validateStory({
+        content: {
+          component: 'page',
+          headline: 'Hi',
+          accent: { plugin: 'storyblok-colorpicker', _uid: 'abc-123', color: 123 },
+        },
+      }, { blocks: { page: pageWithPlugin }, fieldPlugins: { storyblokColorField } });
+      expect(result.ok).toBe(false);
+      const colorIssue = result.issues.find(i => i.code === 'invalid_value');
+      expect(colorIssue?.path).toEqual(['content', 'accent', 'color']);
+    });
+
+    it('errors instead of silently passing when a plugin ships an async validator', () => {
+      const asyncValue: StandardSchemaV1<{ color: string }> = {
+        '~standard': {
+          version: 1,
+          vendor: 'test',
+          validate: () => Promise.resolve({ value: { color: 'x' } }),
+        },
+      };
+      const asyncPlugin = defineFieldPlugin({ fieldType: 'storyblok-colorpicker', value: asyncValue });
+      const result = validateStory({
+        content: {
+          component: 'page',
+          headline: 'Hi',
+          accent: { plugin: 'storyblok-colorpicker', _uid: 'abc-123', color: 'x' },
+        },
+      }, { blocks: { page: pageWithPlugin }, fieldPlugins: { asyncPlugin } });
+      expect(result.ok).toBe(false);
+      expect(codesFor(result)).toContain('async_validator_unsupported');
     });
   });
 });

--- a/packages/schema/src/validators/validate-story.ts
+++ b/packages/schema/src/validators/validate-story.ts
@@ -30,8 +30,18 @@ function checkValue(
   issues: ValidationIssue[],
 ): void {
   const result = schema['~standard'].validate(value);
-  // The Zod schemas are synchronous; a thenable result would indicate misuse.
+  // `validateStory` is synchronous. The internal Zod schemas never return a
+  // thenable, but a registered field plugin may ship an async validator — which
+  // cannot be awaited here. Surface it as an error instead of silently passing,
+  // which would report a false `ok: true`.
   if (result instanceof Promise) {
+    issues.push({
+      severity: 'error',
+      code: 'async_validator_unsupported',
+      path,
+      entity,
+      message: 'Field plugin validator is asynchronous; validateStory runs synchronously and cannot await it.',
+    });
     return;
   }
   if (result.issues) {

--- a/packages/schema/src/validators/validate-story.ts
+++ b/packages/schema/src/validators/validate-story.ts
@@ -1,10 +1,10 @@
+import { z } from 'zod';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { SchemaBlockLike, SchemaFieldLike, SchemaLike } from './shapes';
 import type { ValidationIssue, ValidationResult } from './types';
 import {
   zAssetFieldValue,
   zMultilinkFieldValue,
-  zPluginFieldValue,
   zRichtextFieldValue,
   zTableFieldValue,
 } from './internal-schemas';
@@ -12,6 +12,14 @@ import { isRecord, toValues } from './shapes';
 
 /** Field-content keys that are not user-defined fields. */
 const RESERVED_KEYS = new Set(['_uid', 'component', '_editable']);
+
+/**
+ * Relaxed plugin envelope used by the `custom` case. Mirrors the generated
+ * `zPluginFieldValue` but relaxes `_uid` from a UUID to a plain string, matching
+ * the CMS, which persists arbitrary `_uid` strings. Kept local so a codegen
+ * regenerate cannot revert it.
+ */
+const zPluginEnvelope = z.object({ plugin: z.string(), _uid: z.optional(z.string()) });
 
 /** Maps a Standard Schema validator to a {@link ValidationIssue} reporter at `path`. */
 function checkValue(
@@ -46,6 +54,7 @@ function validateFieldValue(
   field: SchemaFieldLike,
   value: unknown,
   blocksByName: Map<string, SchemaBlockLike>,
+  fieldPluginsByType: Map<string, StandardSchemaV1>,
   path: (string | number)[],
   entity: string,
   issues: ValidationIssue[],
@@ -70,11 +79,20 @@ function validateFieldValue(
       break;
     case 'richtext':
       checkValue(zRichtextFieldValue, value, path, entity, issues);
-      validateRichtextBloks(value, blocksByName, path, issues);
+      validateRichtextBloks(value, blocksByName, fieldPluginsByType, path, issues);
       break;
-    case 'custom':
-      checkValue(zPluginFieldValue, value, path, entity, issues);
+    case 'custom': {
+      checkValue(zPluginEnvelope, value, path, entity, issues);
+      const validator = field.field_type ? fieldPluginsByType.get(field.field_type) : undefined;
+      if (validator && isRecord(value)) {
+        // Envelope keys sit alongside the plugin's own keys; strip them so the
+        // plugin validator sees only its value. Sibling keys keep issue paths
+        // accurate (an issue at ['color'] maps to [...path, 'color']).
+        const { plugin: _plugin, _uid, ...pluginValue } = value;
+        checkValue(validator, pluginValue, path, entity, issues);
+      }
       break;
+    }
     case 'bloks':
       if (!Array.isArray(value)) {
         pushTypeIssue(value, 'array', path, entity, issues);
@@ -95,7 +113,7 @@ function validateFieldValue(
             message: `Component "${item.component}" is not allowed in field "${field.name}"; allowed: ${field.allow.join(', ')}.`,
           });
         }
-        validateBlokContent(item, blocksByName, [...path, index], issues);
+        validateBlokContent(item, blocksByName, fieldPluginsByType, [...path, index], issues);
       });
       break;
     case 'text':
@@ -254,6 +272,7 @@ function pushTypeIssue(
 function validateRichtextBloks(
   value: unknown,
   blocksByName: Map<string, SchemaBlockLike>,
+  fieldPluginsByType: Map<string, StandardSchemaV1>,
   path: (string | number)[],
   issues: ValidationIssue[],
 ): void {
@@ -266,12 +285,12 @@ function validateRichtextBloks(
     }
     if (node.type === 'blok' && isRecord(node.attrs) && Array.isArray(node.attrs.body)) {
       node.attrs.body.forEach((blok, blokIndex) =>
-        validateBlokContent(blok, blocksByName, [...path, 'content', index, 'attrs', 'body', blokIndex], issues),
+        validateBlokContent(blok, blocksByName, fieldPluginsByType, [...path, 'content', index, 'attrs', 'body', blokIndex], issues),
       );
     }
     else if (Array.isArray(node.content)) {
       // Recurse into nested marks/nodes that may themselves embed bloks.
-      validateRichtextBloks(node, blocksByName, [...path, 'content', index], issues);
+      validateRichtextBloks(node, blocksByName, fieldPluginsByType, [...path, 'content', index], issues);
     }
   });
 }
@@ -280,6 +299,7 @@ function validateRichtextBloks(
 function validateBlokContent(
   content: unknown,
   blocksByName: Map<string, SchemaBlockLike>,
+  fieldPluginsByType: Map<string, StandardSchemaV1>,
   path: (string | number)[],
   issues: ValidationIssue[],
 ): void {
@@ -337,7 +357,7 @@ function validateBlokContent(
       }
       continue;
     }
-    validateFieldValue(field, value, blocksByName, [...path, field.name], entity, issues);
+    validateFieldValue(field, value, blocksByName, fieldPluginsByType, [...path, field.name], entity, issues);
   }
 }
 
@@ -353,7 +373,10 @@ function validateBlokContent(
 export function validateStory(story: unknown, schema: SchemaLike): ValidationResult {
   const issues: ValidationIssue[] = [];
   const blocksByName = new Map(toValues(schema.blocks).map(block => [block.name, block]));
+  const fieldPluginsByType = new Map(
+    toValues(schema.fieldPlugins).map(plugin => [plugin.fieldType, plugin.value]),
+  );
   const content = isRecord(story) ? story.content : undefined;
-  validateBlokContent(content, blocksByName, ['content'], issues);
+  validateBlokContent(content, blocksByName, fieldPluginsByType, ['content'], issues);
   return { ok: issues.every(issue => issue.severity !== 'error'), issues };
 }

--- a/packages/schema/tsdown.config.ts
+++ b/packages/schema/tsdown.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
   exports: true,
   publint: true,
   entry: {
-    index: './src/index.ts',
+    'index': './src/index.ts',
+    'field-plugins/index': './src/field-plugins/index.ts',
   },
   outDir: './dist',
   format: ['esm', 'cjs'],

--- a/tools/openapi-codegen/templates/field.ts
+++ b/tools/openapi-codegen/templates/field.ts
@@ -29,15 +29,15 @@ type IsBaseBlock<T> = [Block] extends [T] ? true : false;
  * required (`required: true`) from optional fields. Each `F` is a member of the
  * field union, so it provably satisfies `FieldValue`'s `Field` constraint.
  */
-type ContentFields<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks> | null }
+type ContentFields<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValue<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValue<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /** Input (write) variant of {@link ContentFields}, resolving each field via {@link FieldValueInput}. */
-type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
-  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks> }
-  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks> | null }
+type ContentFieldsInput<TFields extends BlockFields, TBlocks, TFieldPlugins = Record<never, never>> = Prettify<
+  { [F in TFields[number] as F extends { required: true } ? F['name'] : never]: FieldValueInput<F, TBlocks, TFieldPlugins> }
+  & { [F in TFields[number] as F extends { required: true } ? never : F['name']]?: FieldValueInput<F, TBlocks, TFieldPlugins> | null }
 >;
 
 /**
@@ -46,33 +46,34 @@ type ContentFieldsInput<TFields extends BlockFields, TBlocks> = Prettify<
  * runtime shape (any block, `_editable` optional). With a schema-typed
  * `TBlock`, fields are narrowed per the block's `fields`.
  */
-export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContent<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid: string; component: TBlock['name']; _editable?: string }
-        & ContentFields<TBlock['fields'], TBlocks>
+        & ContentFields<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 /** Input variant of {@link BlockContent} for write operations (creating/updating stories via the MAPI). `_uid` is optional. */
-export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks> =
+export type BlockContentInput<TBlock extends Block = Block, TBlocks = NoBlocks, TFieldPlugins = Record<never, never>> =
   IsBaseBlock<TBlock> extends true
     ? BlockContentInputBase
     // distribute over each member of the `TBlock` union
     : TBlock extends any
       ? Prettify<
         { _uid?: string; component: TBlock['name']; _editable?: string }
-        & ContentFieldsInput<TBlock['fields'], TBlocks>
+        & ContentFieldsInput<TBlock['fields'], TBlocks, TFieldPlugins>
       >
       : never;
 
 export type BlocksFieldValue<
   TBlock extends Block = Block,
   TBlocks = NoBlocks,
-> = BlockContent<TBlock, TBlocks>[];
+  TFieldPlugins = Record<never, never>,
+> = BlockContent<TBlock, TBlocks, TFieldPlugins>[];
 
 /** Union of all valid Storyblok field type discriminants (e.g., `text`, `bloks`). */
 export type FieldType = Field['type'];
@@ -110,10 +111,24 @@ type ApplyAllow<TField, TBlocks> = TField extends { allow: ReadonlyArray<infer T
     ? IsNestable<TBlocks> extends true ? TBlocks : never
     : never;
 
+/**
+ * Resolves a `custom` field to its registered plugin value. When the field's
+ * `field_type` is a key of `TFieldPlugins`, the validator output is merged with
+ * the plugin envelope (`plugin`, optional `_uid`); otherwise it falls back to
+ * the untyped {@link PluginFieldValue}. Same shape for read and write.
+ */
+type ResolveCustom<TField, TFieldPlugins> =
+  TField extends { field_type: infer F extends string }
+    ? F extends keyof TFieldPlugins
+      ? Prettify<TFieldPlugins[F] & { plugin: string; _uid?: string }>
+      : PluginFieldValue
+    : PluginFieldValue;
+
 /** Resolves a field definition to its runtime content value type (read). */
 export type FieldValue<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -121,15 +136,18 @@ export type FieldValue<
     ? [TBlocks] extends [never]
         ? BlockContentBase[]
         : [TBlocks] extends [Block]
-            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContent<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;
 
 /** Resolves a field definition to its input value type (write). */
 export type FieldValueInput<
   TField extends Field = Field,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = Prettify<
   TField extends { type: 'bloks' }
     // guard `never` first: `[never] extends [Block]` is structurally true, so an
@@ -137,7 +155,9 @@ export type FieldValueInput<
     ? [TBlocks] extends [never]
         ? BlockContentInputBase[]
         : [TBlocks] extends [Block]
-            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks>[]
+            ? BlockContentInput<ApplyAllow<TField, TBlocks>, TBlocks, TFieldPlugins>[]
             : BlockContentInputBase[]
-    : FieldTypeValueMap[TField['type']]
+    : TField extends { type: 'custom' }
+      ? ResolveCustom<TField, TFieldPlugins>
+      : FieldTypeValueMap[TField['type']]
 >;

--- a/tools/openapi-codegen/templates/mapi-story.ts
+++ b/tools/openapi-codegen/templates/mapi-story.ts
@@ -22,42 +22,47 @@ type MapiStoryWithSchemaContent<
   TStory extends MapiStoryGenerated | StoryCreateGenerated | StoryUpdateGenerated,
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
+  TFieldPlugins = Record<never, never>,
 > = RootBlock extends TBlock
   ? TStory
   : Override<TStory, {
     content: TStory extends StoryCreateGenerated | StoryUpdateGenerated
-      ? BlockContentInput<TBlock, TBlocks>
-      : BlockContent<TBlock, TBlocks>;
+      ? BlockContentInput<TBlock, TBlocks, TFieldPlugins>
+      : BlockContent<TBlock, TBlocks, TFieldPlugins>;
   }>;
 
 type MakeMapiStory<
   TStory extends MapiStoryGenerated | StoryCreateGenerated | StoryUpdateGenerated,
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? MapiStoryWithSchemaContent<TStory, TBlockOrBlocks, TBlocks>
+    ? MapiStoryWithSchemaContent<TStory, TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? MapiStoryWithSchemaContent<TStory, Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? MapiStoryWithSchemaContent<TStory, Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;
 
 /** A Storyblok MAPI story. */
 export type MapiStory<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<MapiStoryGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<MapiStoryGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;
 
 /** Payload for creating a story via the MAPI. */
 export type StoryCreate<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<StoryCreateGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<StoryCreateGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;
 
 /** Payload for updating a story via the MAPI. */
 export type StoryUpdate<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
-> = MakeMapiStory<StoryUpdateGenerated, TBlockOrBlocks, TBlocks>;
+> = MakeMapiStory<StoryUpdateGenerated, TBlockOrBlocks, TFieldPlugins, TBlocks>;

--- a/tools/openapi-codegen/templates/story.ts
+++ b/tools/openapi-codegen/templates/story.ts
@@ -12,18 +12,20 @@ type NoBlocks = false;
 type CapiStoryWithSchemaContent<
   TBlock extends RootBlock = RootBlock,
   TBlocks = NoBlocks,
-> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks> }>;
+  TFieldPlugins = Record<never, never>,
+> = Override<CapiStoryGenerated, { content: BlockContent<TBlock, TBlocks, TFieldPlugins> }>;
 
 /** A Storyblok CDN (CAPI) story. */
 export type Story<
   TBlockOrBlocks extends RootBlock | Block = RootBlock,
+  TFieldPlugins = Record<never, never>,
   TBlocks = NoBlocks,
 > = Prettify<
   // caller passed root block(s) directly → use them as the content type
   [TBlockOrBlocks] extends [RootBlock]
-    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks>
+    ? CapiStoryWithSchemaContent<TBlockOrBlocks, TBlocks, TFieldPlugins>
     // caller passed the full block union → derive root blocks, thread the union as the registry
     : TBlocks extends NoBlocks
-      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks>
+      ? CapiStoryWithSchemaContent<Extract<TBlockOrBlocks, RootBlock>, TBlockOrBlocks, TFieldPlugins>
       : never
 >;


### PR DESCRIPTION
Lets a schema **register** its custom field plugins via a [Standard Schema](https://standardschema.dev) validator (Zod, Valibot, ArkType, or hand-written). A registered `field_type` then resolves to `validatorOutput & { plugin: string; _uid?: string }` for both **read and write**; unregistered custom fields keep today's `PluginFieldValue`. Non-breaking — the default plugin map is empty.

## How

- **New API in `@storyblok/schema`:** `defineFieldPlugin`, `defineSchema`, and `InferSchema` deriving a `fieldType → InferOutput<validator>` map, threaded end-to-end through a new `TFieldPlugins` generic — across `@storyblok/schema` **and** the capi/mapi clients' `withTypes` plumbing.
- **New tree-shakeable entrypoint** `@storyblok/schema/field-plugins`, shipping one official hand-written plugin, `storyblokColorField` (`field_type: 'storyblok-colorpicker'`, value `{ color: string }`), with no zod runtime dependency.
- **Shared codegen templates** (`tools/openapi-codegen/templates/{field,story,mapi-story}.ts`) carry the resolution logic; all four consumers regenerated (`schema`, `api-client`, `management-api-client`, `live-preview`).

Fixes WDX-454