### PR TITLE
fix(cli,mapi-client): preserve image dimensions in asset URLs on push

### DIFF
--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -490,6 +490,34 @@ describe('assets push command', () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it('should carry the dimensions segment from the source filename into the create payload as `size`', async () => {
+    const targetSpace = '54321';
+    const asset = makeMockAsset({ filename: `https://a.storyblok.com/f/${DEFAULT_SPACE}/2048x1820/7fb286a4c5/photo.jpg` });
+    preconditions.canLoadAssets([asset]);
+    preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    expect(actions.createAsset).toHaveBeenCalledWith(expect.objectContaining({
+      size: '2048x1820',
+    }), expect.anything(), expect.anything());
+  });
+
+  it('should not set `size` when the source filename has no dimensions segment', async () => {
+    const targetSpace = '54321';
+    const asset = makeMockAsset({ filename: `https://a.storyblok.com/f/${DEFAULT_SPACE}/7fb286a4c5/photo.jpg` });
+    preconditions.canLoadAssets([asset]);
+    preconditions.canUpsertRemoteAssets([asset], { space: targetSpace });
+
+    await assetsCommand.parseAsync(['node', 'test', 'push', '--from', DEFAULT_SPACE, '--space', targetSpace]);
+
+    expect(actions.createAsset).toHaveBeenCalledWith(
+      expect.not.objectContaining({ size: expect.anything() }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it('should correctly resolve parent IDs even when child folders precede parents', async () => {
     const targetSpace = '54321';
     const numPairs = 10;

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -650,15 +650,8 @@ export const makeCleanupAssetFSTransport = (): CleanupAssetTransport =>
 const hasId = (a: unknown): a is { id: number } => {
   return !!a && typeof a === 'object' && 'id' in a && typeof (a as any).id === 'number';
 };
-const hasShortFilename = (a: unknown): a is { short_filename: string } => {
-  return !!a && typeof a === 'object' && 'short_filename' in a && typeof (a as any).short_filename === 'string';
-};
-const hasFilename = (a: unknown): a is { filename: string } => {
-  return !!a && typeof a === 'object' && 'filename' in a && typeof (a as any).filename === 'string';
-};
-const hasSize = (a: unknown): a is { size: string } => {
-  return !!a && typeof a === 'object' && 'size' in a && typeof (a as any).size === 'string';
-};
+const hasProp = <K extends string>(a: unknown, key: K): a is Record<K, string> =>
+  !!a && typeof a === 'object' && key in a && typeof (a as any)[key] === 'string';
 
 const processAsset = async ({
   localAsset,
@@ -726,7 +719,7 @@ const processAsset = async ({
     newRemoteAsset = { ...remoteAsset, ...updatePayload };
     status = 'updated';
   }
-  else if (hasShortFilename(localAsset)) {
+  else if (hasProp(localAsset, 'short_filename')) {
     // `internal_tags_list` is server-managed (read-only) and must not be sent.
     // `internal_tag_ids` is rewritten through `maps.assetInternalTagsByName` so
     // source-space IDs are translated to target-space IDs. When the
@@ -739,7 +732,7 @@ const processAsset = async ({
     // Storyblok only keeps the `<width>x<height>` folder in the CDN URL when it
     // was supplied at upload time; it is not derived server-side from the file.
     // Carry it over from the source asset's filename so pushed assets keep it.
-    const size = hasSize(rest) ? rest.size : (hasFilename(localAsset) ? extractAssetSizeFromFilename(localAsset.filename) : undefined);
+    const size = hasProp(rest, 'size') ? rest.size : (hasProp(localAsset, 'filename') ? extractAssetSizeFromFilename(localAsset.filename) : undefined);
     const createPayload = {
       ...rest,
       asset_folder_id: remoteFolderId,

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -13,7 +13,7 @@ import { getMapiClient } from '../../api';
 import { handleAPIError } from '../../utils/error/api-error';
 import { FetchError } from '../../utils/fetch';
 import { createPipelineBackpressureLock } from '../../utils/backpressure-lock';
-import { getAssetBinaryFilename, getAssetFilename, getFolderFilename, getSidecarFilename, isRemoteSource, loadSidecarAssetData } from './utils';
+import { extractAssetSizeFromFilename, getAssetBinaryFilename, getAssetFilename, getFolderFilename, getSidecarFilename, isRemoteSource, loadSidecarAssetData } from './utils';
 
 let _pipelineSlot: Sema | null = null;
 const getPipelineSlot = (): Sema => {
@@ -653,6 +653,12 @@ const hasId = (a: unknown): a is { id: number } => {
 const hasShortFilename = (a: unknown): a is { short_filename: string } => {
   return !!a && typeof a === 'object' && 'short_filename' in a && typeof (a as any).short_filename === 'string';
 };
+const hasFilename = (a: unknown): a is { filename: string } => {
+  return !!a && typeof a === 'object' && 'filename' in a && typeof (a as any).filename === 'string';
+};
+const hasSize = (a: unknown): a is { size: string } => {
+  return !!a && typeof a === 'object' && 'size' in a && typeof (a as any).size === 'string';
+};
 
 const processAsset = async ({
   localAsset,
@@ -730,10 +736,15 @@ const processAsset = async ({
     const mappedTagIds = 'internal_tag_ids' in localAsset
       ? resolveInternalTagIds(localAsset.internal_tag_ids)
       : undefined;
+    // Storyblok only keeps the `<width>x<height>` folder in the CDN URL when it
+    // was supplied at upload time; it is not derived server-side from the file.
+    // Carry it over from the source asset's filename so pushed assets keep it.
+    const size = hasSize(rest) ? rest.size : (hasFilename(localAsset) ? extractAssetSizeFromFilename(localAsset.filename) : undefined);
     const createPayload = {
       ...rest,
       asset_folder_id: remoteFolderId,
       ...(mappedTagIds !== undefined ? { internal_tag_ids: mappedTagIds } : {}),
+      ...(size !== undefined ? { size } : {}),
     } satisfies AssetUpload;
     newRemoteAsset = await transports.createAsset(createPayload, fileBuffer);
     status = 'created';

--- a/packages/cli/src/commands/assets/utils.test.ts
+++ b/packages/cli/src/commands/assets/utils.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
 import { vol } from 'memfs';
-import { collectAssetInternalTagNames, ensureAssetInternalTags, internalTagNamesFromAssets } from './utils';
+import { collectAssetInternalTagNames, ensureAssetInternalTags, extractAssetSizeFromFilename, internalTagNamesFromAssets } from './utils';
+
+describe('extractAssetSizeFromFilename', () => {
+  it('extracts the dimensions segment from a CDN URL', () => {
+    expect(extractAssetSizeFromFilename('https://a.storyblok.com/f/329189/2048x1820/7fb286a4c5/image.jpg')).toBe('2048x1820');
+  });
+
+  it('returns undefined when the URL has no dimensions segment', () => {
+    expect(extractAssetSizeFromFilename('https://a.storyblok.com/f/293255674717942/8ae82d3a12/image.jpg')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty or invalid filename', () => {
+    expect(extractAssetSizeFromFilename(undefined)).toBeUndefined();
+    expect(extractAssetSizeFromFilename('not-a-url')).toBeUndefined();
+  });
+});
 
 describe('internalTagNamesFromAssets', () => {
   it('collects unique tag names in first-seen order, ignoring blanks', () => {

--- a/packages/cli/src/commands/assets/utils.ts
+++ b/packages/cli/src/commands/assets/utils.ts
@@ -83,6 +83,25 @@ export const loadAssetFolderMap = async (manifestFile: string) => {
 };
 
 /**
+ * Extracts the `<width>x<height>` dimensions segment from an asset CDN URL,
+ * e.g. `https://a.storyblok.com/f/123/2048x1820/hash/image.jpg` -> `2048x1820`.
+ * Storyblok only keeps this segment in the path when it was supplied at
+ * upload time (see `getAssetSizeForUpload`); it is not derived from the file.
+ */
+export const extractAssetSizeFromFilename = (filename?: string): string | undefined => {
+  if (!filename) {
+    return undefined;
+  }
+  try {
+    const segments = new URL(filename).pathname.split('/');
+    return segments.find(segment => /^\d+x\d+$/.test(segment));
+  }
+  catch {
+    return undefined;
+  }
+};
+
+/**
  * Extracts the sanitized name and extension from an asset.
  * Uses short_filename if available, otherwise falls back to the filename basename.
  */

--- a/packages/mapi-client/src/resources/assets.test.ts
+++ b/packages/mapi-client/src/resources/assets.test.ts
@@ -19,6 +19,31 @@ beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
+const preconditions = {
+  canCreateAssetWithSize({ space = '123' }: { space?: string } = {}) {
+    let signedBody: { filename?: string; size?: string } | undefined;
+    server.use(
+      http.post(`https://mapi.storyblok.com/v1/spaces/${space}/assets`, async ({ request }) => {
+        signedBody = await request.json() as { filename?: string; size?: string };
+        return HttpResponse.json({
+          id: 1,
+          post_url: 'https://s3.amazonaws.com/a.storyblok.com',
+          fields: { key: `f/${space}/${signedBody.size}/hash/${signedBody.filename}` },
+        });
+      }),
+      http.post('https://s3.amazonaws.com/a.storyblok.com', () => HttpResponse.json({})),
+      http.get(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:asset_id/finish_upload`, () => HttpResponse.json({})),
+      http.get(`https://mapi.storyblok.com/v1/spaces/${space}/assets/:asset_id`, () => HttpResponse.json({
+        id: 1,
+        filename: `https://a.storyblok.com/f/${space}/2048x1820/hash/hero.png`,
+      })),
+    );
+    return {
+      getSignedBody: () => signedBody,
+    };
+  },
+};
+
 describe('assets.list()', () => {
   it('should successfully retrieve multiple assets', async () => {
     const client = createManagementApiClient({
@@ -72,6 +97,25 @@ describe('assets.list()', () => {
 
     expect(result.error).toBeUndefined();
     expect(resolvedSpaceId).toBe('999');
+  });
+});
+
+describe('assets.create()', () => {
+  it('forwards the `size` field to the sign request so the CDN URL keeps its dimensions', async () => {
+    const { getSignedBody } = preconditions.canCreateAssetWithSize();
+    const client = createManagementApiClient({
+      personalAccessToken: 'test-token',
+      spaceId: 123,
+      region: 'eu',
+      rateLimit: false,
+    });
+
+    await client.assets.create({
+      body: { short_filename: 'hero.png', size: '2048x1820' },
+      file: new ArrayBuffer(0),
+    });
+
+    expect(getSignedBody()?.size).toBe('2048x1820');
   });
 });
 

--- a/packages/mapi-client/src/resources/assets.ts
+++ b/packages/mapi-client/src/resources/assets.ts
@@ -151,6 +151,8 @@ export function createAssetsResource(deps: MapiResourceDeps) {
           short_filename: body.short_filename,
           asset_folder_id: body.asset_folder_id,
           is_private: body.is_private,
+          size: body.size,
+          validate_upload: body.validate_upload,
         },
         file,
         signal,


### PR DESCRIPTION
Assets migrated between spaces with `storyblok assets push` lost the `<width>x<height>` dimensions folder in their CDN URL (e.g. `.../f/SPACE/2048x1820/hash/image.jpg` became `.../f/SPACE/hash/image.jpg`), even when the source asset had it.

Root cause: Storyblok's backend only appends the dimensions folder to the S3 key when the sign request (`POST /v1/spaces/{id}/assets`) includes a `size` field — it does not derive it from the actual image. Two gaps combined to drop it:

- `@storyblok/management-api-client`'s `assets.create()` explicitly whitelisted only `short_filename`, `asset_folder_id`, `is_private` when calling `upload()`, silently discarding `size` (and `validate_upload`) even though both are part of its declared input type.
- The CLI's `assets push` never derived a `size` for pushed assets in the first place.

## Changes

- `packages/mapi-client/src/resources/assets.ts`: `create()` now forwards `size`/`validate_upload` to the sign request.
- `packages/cli/src/commands/assets/streams.ts`: when creating a pushed asset, reuse the dimensions already present in the source asset's filename URL (parsed via a new `extractAssetSizeFromFilename` helper) so pushed assets keep them.
- Added regression tests in both packages.

## Test plan

- [x] `pnpm nx run @storyblok/management-api-client:test` — 104 tests pass, including new `assets.create()` size-forwarding test
- [x] `pnpm nx run storyblok:test` — 726+ tests pass, including new push-command regression tests
- [x] `pnpm nx run storyblok:test:types` / `@storyblok/management-api-client:typecheck` — clean
- [x] Lint clean on both packages
- [x] Manually reproduced end-to-end against seeded QA spaces: created a UI-style asset with `size=2048x1820`, pulled and pushed it with the built CLI — confirmed the target asset's filename retains `2048x1820` (previously dropped before this fix)

Fixes WDX-480