### PR TITLE
fix(cli): activate restrict_components on bloks fields when allow is used

### DIFF
--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -65,6 +65,53 @@ describe('generateComponentFile', () => {
     expect(result).not.toContain('datasource_slug');
   });
 
+  it('should drop restrict_components and restrict_type when they accompany a component_whitelist', () => {
+    const component = {
+      id: 1,
+      name: 'page',
+      created_at: '',
+      updated_at: '',
+      schema: {
+        body: {
+          type: 'bloks',
+          pos: 0,
+          component_whitelist: ['hero'],
+          restrict_components: true,
+          restrict_type: '',
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any);
+
+    expect(result).toContain('allow: [');
+    expect(result).not.toContain('restrict_components');
+    expect(result).not.toContain('restrict_type');
+  });
+
+  it('should keep restrict_components and restrict_type for group/tag restrictions', () => {
+    const component = {
+      id: 1,
+      name: 'page',
+      created_at: '',
+      updated_at: '',
+      schema: {
+        body: {
+          type: 'bloks',
+          pos: 0,
+          restrict_components: true,
+          restrict_type: 'groups',
+          component_group_whitelist: ['group-uuid'],
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any);
+
+    expect(result).toContain('restrict_components: true,');
+    expect(result).toContain('restrict_type: \'groups\',');
+  });
+
   it('should drop component_group_uuid by default (group encoded by directory)', () => {
     const component = {
       id: 1,

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -55,11 +55,21 @@ export function datasourceFileName(datasource: Pick<Datasource, 'name'> & { slug
  * Reverse of the push-time DSL→wire field mapping: renames the wire reference
  * keys back to their DSL form (`component_whitelist`→`allow`,
  * `datasource_slug`→`datasource`). The `source` selector is left untouched.
+ *
+ * `restrict_components: true` and `restrict_type: ''` are dropped alongside a
+ * `component_whitelist` — they're the wire byproduct `defineField`'s `allow`
+ * re-derives on push, not independent DSL state.
  */
 function toDslField(field: Record<string, unknown>): Record<string, unknown> {
-  const { component_whitelist, datasource_slug, ...rest } = field;
+  const { component_whitelist, datasource_slug, restrict_components, restrict_type, ...rest } = field;
   const out: Record<string, unknown> = { ...rest };
-  if (component_whitelist !== undefined) { out.allow = component_whitelist; }
+  if (component_whitelist !== undefined) {
+    out.allow = component_whitelist;
+  }
+  else {
+    if (restrict_components !== undefined) { out.restrict_components = restrict_components; }
+    if (restrict_type !== undefined) { out.restrict_type = restrict_type; }
+  }
   if (datasource_slug !== undefined) { out.datasource = datasource_slug; }
   return out;
 }

--- a/packages/cli/src/commands/schema/map-to-wire.test.ts
+++ b/packages/cli/src/commands/schema/map-to-wire.test.ts
@@ -9,9 +9,20 @@ describe('mapFieldToWire', () => {
     expect(value).toEqual({ type: 'text', pos: 0, max_length: 70 });
   });
 
-  it('renames allow to component_whitelist', () => {
+  it('renames allow to component_whitelist and activates the restriction on bloks fields', () => {
     const { value } = mapFieldToWire({ name: 'body', type: 'bloks', pos: 0, allow: ['hero', 'teaser'] });
-    expect(value).toEqual({ type: 'bloks', pos: 0, component_whitelist: ['hero', 'teaser'] });
+    expect(value).toEqual({
+      type: 'bloks',
+      pos: 0,
+      component_whitelist: ['hero', 'teaser'],
+      restrict_components: true,
+      restrict_type: '',
+    });
+  });
+
+  it('renames allow to component_whitelist without restriction flags on non-bloks fields', () => {
+    const { value } = mapFieldToWire({ name: 'link', type: 'multilink', pos: 0, allow: ['page'] });
+    expect(value).toEqual({ type: 'multilink', pos: 0, component_whitelist: ['page'] });
   });
 
   it('renames datasource to datasource_slug and keeps the source selector', () => {
@@ -38,7 +49,13 @@ describe('mapBlockToWire', () => {
       is_nestable: false,
       schema: {
         title: { type: 'text', pos: 0 },
-        body: { type: 'bloks', pos: 1, component_whitelist: ['hero'] },
+        body: {
+          type: 'bloks',
+          pos: 1,
+          component_whitelist: ['hero'],
+          restrict_components: true,
+          restrict_type: '',
+        },
       },
     });
   });

--- a/packages/cli/src/commands/schema/map-to-wire.ts
+++ b/packages/cli/src/commands/schema/map-to-wire.ts
@@ -5,7 +5,9 @@ import { isRecord } from './utils';
  * Maps a single content-shape DSL field to its MAPI wire form. The field's
  * `name` becomes the schema record key (returned separately); the DSL reference
  * keys are renamed to their wire equivalents:
- * - `allow` → `component_whitelist`
+ * - `allow` → `component_whitelist`, plus `restrict_components: true` and
+ *   `restrict_type: ''` on `bloks` fields so MAPI actually enforces the
+ *   whitelist (a bare `component_whitelist` is otherwise ignored)
  * - `datasource` → `datasource_slug` (the `source` selector passes through)
  *
  * Every other key (`type`, `pos`, `source`, `required`, validation options, and
@@ -15,7 +17,13 @@ export function mapFieldToWire(field: Record<string, unknown>): { name: string; 
   const { name, allow, datasource, ...rest } = field;
 
   const value: Record<string, unknown> = { ...rest };
-  if (allow !== undefined) { value.component_whitelist = allow; }
+  if (allow !== undefined) {
+    value.component_whitelist = allow;
+    if (rest.type === 'bloks') {
+      value.restrict_components = true;
+      value.restrict_type = '';
+    }
+  }
   if (datasource !== undefined) { value.datasource_slug = datasource; }
 
   // The wire `Field` is a loose, fully-optional index shape; the structural

--- a/packages/cli/src/commands/schema/push/load-schema.test.ts
+++ b/packages/cli/src/commands/schema/push/load-schema.test.ts
@@ -71,7 +71,13 @@ describe('classifyExports', () => {
     const { components } = classifyExports(moduleExports);
 
     expect(components[0].schema).toEqual({
-      body: { type: 'bloks', pos: 0, component_whitelist: ['hero', 'teaser'] },
+      body: {
+        type: 'bloks',
+        pos: 0,
+        component_whitelist: ['hero', 'teaser'],
+        restrict_components: true,
+        restrict_type: '',
+      },
       theme: { type: 'option', pos: 1, source: 'internal', datasource_slug: 'colors' },
     });
   });


### PR DESCRIPTION
- `defineField`'s `allow` on a `bloks` field mapped only to `component_whitelist` on push, which MAPI ignores unless `restrict_components: true` and `restrict_type: ''` are also set — so the whitelist was silently not enforced.
- `mapFieldToWire` now sets both flags alongside `component_whitelist` for `bloks` fields (left `multilink` untouched — it uses a separate `restrict_content_types` flag).
- `schema init`'s reverse wire→DSL mapping now strips `restrict_components`/`restrict_type` when they're the byproduct of a `component_whitelist` (re-derived from `allow` on push), but keeps them for group/tag-based restrictions, which have no DSL equivalent yet.

Fixes DX-481