### PR TITLE
fix(cli): escape backslashes and newlines in schema init string values

### DIFF
--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -44,6 +44,49 @@ describe('generateComponentFile', () => {
     expect(result).not.toContain('created_at');
   });
 
+  it('should escape backslashes and newlines in field values so the output round-trips', () => {
+    const component = {
+      id: 1,
+      name: 'vimeo-video',
+      created_at: '',
+      updated_at: '',
+      description: 'The identifier can be found here:\nhttps://vimeo.com/<id>',
+      schema: {
+        videoId: {
+          type: 'text',
+          pos: 0,
+          regex: String.raw`^\s*\b\w+(?:\s+\w+){0,3}\s*$`,
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any);
+
+    // Backslashes are escaped so the regex survives byte-for-byte (was silently
+    // corrupted to `^s*w+...` when only single quotes were escaped).
+    expect(result).toContain(String.raw`regex: '^\\s*\\b\\w+(?:\\s+\\w+){0,3}\\s*$',`);
+    // The multiline description is escaped instead of breaking the parse.
+    expect(result).toContain(String.raw`description: 'The identifier can be found here:\nhttps://vimeo.com/<id>',`);
+    // No raw line break leaks into a string literal.
+    expect(result).not.toContain('found here:\n');
+  });
+
+  it('should escape single quotes in field names', () => {
+    const component = {
+      id: 1,
+      name: 'page',
+      created_at: '',
+      updated_at: '',
+      schema: {
+        'it\'s': { type: 'text', pos: 0 },
+      },
+    };
+
+    const result = generateComponentFile(component as any);
+
+    expect(result).toContain('defineField(\'it\\\'s\', {');
+  });
+
   it('should reverse-map wire reference keys to the DSL form', () => {
     const component = {
       id: 1,

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -4,6 +4,7 @@ import {
   DATASOURCE_STRIP_KEYS,
   formatValue,
   INDENT,
+  quoteString,
   stripKeys,
 } from '../utils';
 
@@ -80,7 +81,7 @@ function toDslField(field: Record<string, unknown>): Record<string, unknown> {
  */
 function generateFieldCode(fieldName: string, fieldData: Record<string, unknown>, depth: number): string {
   const clean = toDslField(stripKeys(fieldData, FIELD_STRIP_KEYS));
-  return `defineField('${fieldName.replace(/'/g, '\\\'')}', ${formatValue(clean, depth)})`;
+  return `defineField(${quoteString(fieldName)}, ${formatValue(clean, depth)})`;
 }
 
 /** Sorts schema fields by `pos` for stable ordering. */

--- a/packages/cli/src/commands/schema/utils.test.ts
+++ b/packages/cli/src/commands/schema/utils.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'pathe';
 import { describe, expect, it } from 'vitest';
 
-import { applyDefaults, displayPath, fileTimestamp, formatValue, stripKeys } from './utils';
+import { applyDefaults, displayPath, fileTimestamp, formatValue, quoteString, stripKeys } from './utils';
 
 describe('fileTimestamp', () => {
   it('should convert an ISO timestamp to compact YYYYMMDDHHmmss form', () => {
@@ -49,6 +49,27 @@ describe('formatValue', () => {
     expect(formatValue('it\'s', 0)).toBe('\'it\\\'s\'');
   });
 
+  it('should escape backslashes so regex values are not silently dropped', () => {
+    // Emitted as '\\d+' — a single-quoted literal that parses back to the exact
+    // input `\d+`. The old serializer emitted '\d+', which parses to `d+`.
+    expect(formatValue(String.raw`\d+`, 0)).toBe(String.raw`'\\d+'`);
+    expect(formatValue(String.raw`^\s*\b\w+(?:\s+\w+){0,3}\s*$`, 0))
+      .toBe(String.raw`'^\\s*\\b\\w+(?:\\s+\\w+){0,3}\\s*$'`);
+  });
+
+  it('should escape newlines instead of emitting raw line breaks', () => {
+    expect(formatValue('a\nb', 0)).toBe(String.raw`'a\nb'`);
+    expect(formatValue('a\nb', 0)).not.toContain('\n');
+  });
+
+  it('should escape a trailing backslash so it does not consume the closing quote', () => {
+    expect(formatValue('path\\', 0)).toBe(String.raw`'path\\'`);
+  });
+
+  it('should leave double quotes untouched inside single-quoted literals', () => {
+    expect(formatValue('he said "hi"', 0)).toBe(String.raw`'he said "hi"'`);
+  });
+
   it('should format numbers and booleans', () => {
     expect(formatValue(42, 0)).toBe('42');
     expect(formatValue(true, 0)).toBe('true');
@@ -81,6 +102,32 @@ describe('formatValue', () => {
   it('should handle nested objects with correct indentation', () => {
     const result = formatValue({ outer: { inner: 'value' } }, 0);
     expect(result).toContain('outer: {\n    inner:');
+  });
+});
+
+describe('quoteString', () => {
+  it('should wrap plain strings in single quotes', () => {
+    expect(quoteString('hello')).toBe(String.raw`'hello'`);
+  });
+
+  it('should escape single quotes', () => {
+    expect(quoteString('it\'s')).toBe('\'it\\\'s\'');
+  });
+
+  it('should escape backslashes', () => {
+    expect(quoteString(String.raw`\d+`)).toBe(String.raw`'\\d+'`);
+  });
+
+  it('should escape newlines', () => {
+    expect(quoteString('a\nb')).toBe(String.raw`'a\nb'`);
+  });
+
+  it('should escape a trailing backslash', () => {
+    expect(quoteString('path\\')).toBe(String.raw`'path\\'`);
+  });
+
+  it('should escape a backslash followed by a quote', () => {
+    expect(quoteString(String.raw`a\"b`)).toBe(String.raw`'a\\"b'`);
   });
 });
 

--- a/packages/cli/src/commands/schema/utils.ts
+++ b/packages/cli/src/commands/schema/utils.ts
@@ -79,6 +79,20 @@ export function applyDefaults<T extends Record<string, unknown>>(entity: T, defa
 export const INDENT = '  ';
 
 /**
+ * Serializes a string as a single-quoted TS literal with correct escaping.
+ * Uses JSON.stringify for backslash/control-char/newline handling, then converts
+ * the double-quoted result to single-quoted output. Without this, backslashes in
+ * values like regexes are silently dropped and raw newlines break the parse.
+ */
+export function quoteString(value: string): string {
+  const escaped = JSON.stringify(value)
+    .slice(1, -1) // strip the surrounding double quotes
+    .replace(/\\"/g, '"') // JSON-escaped `\"` → `"` (no need to escape " inside '...')
+    .replace(/'/g, '\\\''); // escape single quotes for the '...' delimiter
+  return `'${escaped}'`;
+}
+
+/**
  * Formats a JavaScript value as a multi-line code string.
  * All object properties are placed on separate lines.
  * Object keys are sorted alphabetically for stable output.
@@ -91,7 +105,7 @@ export function formatValue(value: unknown, depth: number): string {
     return String(value);
   }
   if (typeof value === 'string') {
-    return `'${value.replace(/'/g, '\\\'')}'`;
+    return quoteString(value);
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);


### PR DESCRIPTION
`storyblok schema init` (introduced in `storyblok@4.19.0-alpha.0`) serialized field option strings — and field names — into single-quoted TypeScript literals escaping **only** `'`. Backslashes and line terminators passed through raw, causing two real-world failures on the first bootstrap of an existing space:

1. **Multiline strings break the parse.** A `description` containing a newline emits a raw line break inside a single-quoted literal → `ParseError: Unterminated string constant`.
2. **Backslashes silently swallowed — data corruption on push.** A `regex` of `^\s*\b\w+(?:\s+\w+){0,3}\s*$` emits as `regex: '^\s*\b\w+...'`; that parses, but `\s`→`s` and `\b`→backspace, so the value silently becomes `^s*w+...`. A later `schema push` overwrites the correct remote regex with the corrupted one — nothing errors.

Root cause: the string branch of `formatValue()` in `packages/cli/src/commands/schema/utils.ts` (and the field-name escaping in `init/generate-code.ts`).

## Fix

Add a shared `quoteString()` helper that uses `JSON.stringify` for correct backslash/control-char/newline escaping while preserving the existing single-quote output style, and reuse it in both `formatValue` and the `defineField('name', …)` field name.

Because `serialize.ts` (push diffing) also uses `formatValue`, one fix makes `init` output and `push --dry-run` round-trip byte-for-byte — string values, including regexes, survive intact.

## Notes

- Users who already ran `init` and hand-fixed files are unaffected; only new bootstraps change.
- The separate `&`-in-group-name identifier bug (DX-478) is tracked independently and out of scope here.

Fixes #671