### PR TITLE
fix(js-client): correct return type of write methods to ISbResponse

### DIFF
--- a/packages/js-client/src/index.test-d.ts
+++ b/packages/js-client/src/index.test-d.ts
@@ -1,0 +1,17 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import StoryblokClient from '.';
+import type { ISbResponse } from './interfaces';
+
+// Regression guard for DX-472: the write methods resolve to the `ISbResponse`
+// envelope (`{ data, status, statusText, headers }`), not the body payload
+// `ISbResponseData`. The created resource lives at `response.data.*`.
+describe('write method return types', () => {
+  const client = new StoryblokClient({ oauthToken: 'token' });
+
+  it('post/put/patch/delete resolve to ISbResponse', () => {
+    expectTypeOf(client.post).returns.resolves.toEqualTypeOf<ISbResponse>();
+    expectTypeOf(client.put).returns.resolves.toEqualTypeOf<ISbResponse>();
+    expectTypeOf(client.patch).returns.resolves.toEqualTypeOf<ISbResponse>();
+    expectTypeOf(client.delete).returns.resolves.toEqualTypeOf<ISbResponse>();
+  });
+});

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -287,47 +287,47 @@ export class Storyblok {
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
-  ): Promise<ISbResponseData> {
+  ): Promise<ISbResponse> {
     const url = `/${slug}`;
 
     const rateLimit = determineRateLimit(undefined, undefined, this.rateLimitConfig, MANAGEMENT_API_DEFAULT_RATE_LIMIT);
-    return this.throttleManager.execute(rateLimit, 'post', url, params, fetchOptions) as Promise<ISbResponseData>;
+    return this.throttleManager.execute(rateLimit, 'post', url, params, fetchOptions) as Promise<ISbResponse>;
   }
 
   public put(
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
-  ): Promise<ISbResponseData> {
+  ): Promise<ISbResponse> {
     const url = `/${slug}`;
 
     const rateLimit = determineRateLimit(undefined, undefined, this.rateLimitConfig, MANAGEMENT_API_DEFAULT_RATE_LIMIT);
-    return this.throttleManager.execute(rateLimit, 'put', url, params, fetchOptions) as Promise<ISbResponseData>;
+    return this.throttleManager.execute(rateLimit, 'put', url, params, fetchOptions) as Promise<ISbResponse>;
   }
 
   public patch(
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
-  ): Promise<ISbResponseData> {
+  ): Promise<ISbResponse> {
     const url = `/${slug}`;
 
     const rateLimit = determineRateLimit(undefined, undefined, this.rateLimitConfig, MANAGEMENT_API_DEFAULT_RATE_LIMIT);
-    return this.throttleManager.execute(rateLimit, 'patch', url, params, fetchOptions) as Promise<ISbResponseData>;
+    return this.throttleManager.execute(rateLimit, 'patch', url, params, fetchOptions) as Promise<ISbResponse>;
   }
 
   public delete(
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
-  ): Promise<ISbResponseData> {
+  ): Promise<ISbResponse> {
     if (!params) {
       params = {} as ISbStoriesParams;
     }
     const url = `/${slug}`;
 
     const rateLimit = determineRateLimit(undefined, undefined, this.rateLimitConfig, MANAGEMENT_API_DEFAULT_RATE_LIMIT);
-    return this.throttleManager.execute(rateLimit, 'delete', url, params, fetchOptions) as Promise<ISbResponseData>;
+    return this.throttleManager.execute(rateLimit, 'delete', url, params, fetchOptions) as Promise<ISbResponse>;
   }
 
   public getStories(


### PR DESCRIPTION
`post`/`put`/`patch`/`delete` in `storyblok-js-client` declared `Promise<ISbResponseData>` but resolve at runtime to the `ISbResponse` envelope (`{ data, status, statusText, headers }`). The declared type described the **body payload** — what lives under `.data` — so TypeScript told users to read `response.story` when the created resource is actually at `response.data.story`. An `as` cast hid the mismatch from the compiler.

This changes the four write methods' return type (and cast) to `Promise<ISbResponse>`.

## Why this is correct

- `throttleManager.execute` resolves the value from `SbFetch._responseHandler`, which is `ISbResponse`.
- The package's existing unit tests already assert the result equals `{ data: {...}, headers: {}, status: 200 }` — i.e. `ISbResponse`.
- The `get` path already casts the same throttle result `as ISbResponse`; the write path skipped that and mislabeled it.

## Regression guard

Added `src/index.test-d.ts` with `expectTypeOf` assertions pinning each write method to `ISbResponse`. This is enforced by **both** `test:types` (tsc) and `vitest --typecheck`. Note: a plain assertion in `index.test.ts` would not work — that file is excluded from tsc and not matched by vitest typecheck, and because `throttleManager.execute` returns `Promise<unknown>`, an `as` cast to a wrong type compiles silently. The `.test-d.ts` file is the only thing that actually pins the annotation. Verified it fails when the type is reverted.

## Compatibility

Type-only change; runtime behavior is unchanged. TS consumers currently reading `response.story` on a write result will now get a compile error — that is the latent bug surfacing, not a regression. Consumers reading `response.data.*` (correct) are unaffected.

Fixes DX-472
Fixes #662