### PR TITLE
fix(cli): drive single-option empty type by required, not UI setting

### DIFF
--- a/packages/cli/src/commands/types/generate/actions.test.ts
+++ b/packages/cli/src/commands/types/generate/actions.test.ts
@@ -1046,6 +1046,84 @@ describe('component property type annotations', () => {
   });
 });
 
+describe('single-option empty value', () => {
+  const opt = (values: string[], required: boolean, excludeEmpty: boolean) => ({
+    type: 'option' as const,
+    pos: 0,
+    required,
+    exclude_empty_option: excludeEmpty,
+    options: values.map(value => ({ name: value, value })),
+  });
+
+  const generate = async (schema: Record<string, unknown>) => {
+    const component: Component = {
+      name: 'test_component',
+      display_name: 'Test Component',
+      created_at: '2023-01-01T00:00:00Z',
+      updated_at: '2023-01-01T00:00:00Z',
+      id: 1,
+      schema,
+      internal_tags_list: [],
+      internal_tag_ids: [],
+    } as unknown as Component;
+    const spaceData: SpaceComponentsData = {
+      components: [component],
+      datasources: [],
+    } as unknown as SpaceComponentsData;
+    return (await generateTypes(spaceData, { strict: false })) as string;
+  };
+
+  // "" inclusion must be driven by `required`, never by `exclude_empty_option`
+  // (UI-only "Hide empty option"). Assert on the field's own union, not the
+  // `[k: string]: unknown` index signature (unrelated non-strict-mode behavior).
+
+  it('required field excludes "" regardless of exclude_empty_option', async () => {
+    const result = await generate({
+      first: opt(['one', 'two'], true, false),
+      second: opt(['one', 'two'], true, true),
+    });
+    expect(result).toContain('first: "one" | "two";');
+    expect(result).toContain('second: "one" | "two";');
+    expect(result).not.toContain('first: "" | "one" | "two"');
+  });
+
+  it('non-required field includes "" regardless of exclude_empty_option', async () => {
+    const result = await generate({
+      third: opt(['one', 'two'], false, false),
+      fourth: opt(['one', 'two'], false, true),
+    });
+    expect(result).toContain('third?: "" | "one" | "two";');
+    expect(result).toContain('fourth?: "" | "one" | "two";');
+  });
+
+  it('required field with a manual empty option still excludes ""', async () => {
+    const result = await generate({
+      fifth: opt(['one', 'two', ''], true, false),
+      sixth: opt(['one', 'two', ''], true, true),
+    });
+    expect(result).toContain('fifth: "one" | "two";');
+    expect(result).toContain('sixth: "one" | "two";');
+  });
+
+  it('non-required field with a manual empty option includes "" once', async () => {
+    const result = await generate({
+      seventh: opt(['one', 'two', ''], false, false),
+      eighth: opt(['one', 'two', ''], false, true),
+    });
+    expect(result).toContain('seventh?: "" | "one" | "two";');
+    expect(result).toContain('eighth?: "" | "one" | "two";');
+  });
+
+  it('multi-options mirrors the same required-driven "" behavior on items', async () => {
+    const result = await generate({
+      tags: { type: 'options', pos: 0, required: false, options: [{ name: 'one', value: 'one' }, { name: 'two', value: 'two' }] },
+      musts: { type: 'options', pos: 1, required: true, options: [{ name: 'one', value: 'one' }, { name: 'two', value: 'two' }] },
+    });
+    expect(result).toContain('tags?: ("" | "one" | "two")[];');
+    expect(result).toContain('musts: ("one" | "two")[];');
+  });
+});
+
 describe('generateStoryblokTypes', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -40,12 +40,17 @@ const getPropertyTypeAnnotation = (property: ComponentPropertySchema, prefix?: s
 
   let type: string | string[] = 'unknown';
 
-  const options = property.options && property.options.length > 0 ? property.options.map((item: { value: string }) => item.value) : [];
+  // Manual empty options behave like clearing the field, so normalize them out first,
+  // then decide whether "" is a reachable stored value based solely on `required`.
+  // `exclude_empty_option` ("Hide empty option") is a UI-only setting and must not
+  // affect the generated types.
+  const optionValues = property.options && property.options.length > 0
+    ? property.options.map((item: { value: string }) => item.value).filter(value => value !== '')
+    : [];
 
-  // Add empty option to options array
-  if (options.length > 0 && property.exclude_empty_option !== true) {
-    options.unshift('');
-  }
+  const options = optionValues.length > 0 && !property.required
+    ? ['', ...optionValues]
+    : optionValues;
 
   if (property.source === 'internal_stories') {
     // Only if there is a filter_content_type, we can return a proper type


### PR DESCRIPTION
Single/multi-option field type generation added the `""` union member based on `exclude_empty_option` ("Hide empty option") — a UI-only setting that never affects the stored payload. Whether `""` is a reachable value is actually determined by `required`.

This drives the empty-string member by `required` instead:

- `required: true` → `"one" | "two"` (never `""`)
- `required: false` → `"one" | "two" | ""` (clearable to `""`)

Any manually-added empty option is normalized out first, then `""` is re-added only when the field is not required. `exclude_empty_option` no longer influences the generated types.

## Reproduction (from the issue)

The 8-field matrix in DX-475 now matches the reporter's expected output for the value union in every case.

| field | config | before | after |
|---|---|---|---|
| `first` | req | `"" \| "one" \| "two"` | `"one" \| "two"` |
| `second` | req, hide | `"one" \| "two"` | `"one" \| "two"` |
| `fourth` | opt, hide | `"one" \| "two"` | `"" \| "one" \| "two"` |
| `fifth` | req, +manual "" | `"" \| "one" \| "two"` | `"one" \| "two"` |

## Out of scope (follow-up)

The reporter also flagged that `required: false` emits an **optional** property (`third?:`), but option fields are never omitted from the payload. That `required → optional (?)` mapping is a *global* mechanism affecting every field type, with its own design questions (conditional fields). Left untouched here; needs a separate ticket. After this fix `third` is `third?: "" | "one" | "two"` — the `""` is now correct, the `?` is the follow-up.

Fixes DX-475
Fixes #668