### PR TITLE
fix(cli): sanitize schema init generated identifiers and file names

### DIFF
--- a/packages/cli/src/commands/schema/init/actions.ts
+++ b/packages/cli/src/commands/schema/init/actions.ts
@@ -5,15 +5,11 @@ import { dirname, join } from 'pathe';
 import type { Component, ComponentFolder, Datasource } from '../../../types';
 import { buildGroupPathByUuid } from '../folders';
 import {
-  componentFileName,
-  componentVarName,
-  datasourceFileName,
-  datasourceVarName,
   generateComponentFile,
   generateDatasourceFile,
   generateSchemaFile,
-  resolveFileNames,
-  resolveVarNames,
+  resolveComponents,
+  resolveDatasources,
 } from './generate-code';
 
 /** Writes a file, creating parent directories as needed. */
@@ -38,53 +34,36 @@ export async function writeSchemaFiles(
 ): Promise<string[]> {
   const writtenFiles: string[] = [];
   const groupPathByUuid = buildGroupPathByUuid(componentFolders);
-  const groupPathByComponentName = new Map<string, string[]>();
-  const componentVarNames = resolveVarNames(components.map(c => c.name), componentVarName);
-  const datasourceVarNames = resolveVarNames(datasources.map(d => d.name), datasourceVarName);
 
-  // Precompute each block's group directory segments (mirrors remote groups).
-  const componentSegments = components.map((comp) => {
-    const segments = comp.component_group_uuid ? groupPathByUuid.get(comp.component_group_uuid) ?? [] : [];
-    if (segments.length > 0) { groupPathByComponentName.set(comp.name, segments); }
-    return segments;
-  });
-  // Dedup file names so two names that kebab-collapse to the same file don't
-  // overwrite each other (and schema.ts doesn't import two symbols from one
-  // path). Scoped per group directory for blocks; datasources are flat.
-  const componentFileNames = resolveFileNames(
-    components.map(c => componentFileName(c.name)),
-    componentSegments.map(s => s.join('/')),
+  // Each block's group directory segments (mirrors remote groups); ungrouped
+  // blocks resolve to `[]` and are written at the blocks root.
+  const componentSegments = components.map(comp =>
+    comp.component_group_uuid ? groupPathByUuid.get(comp.component_group_uuid) ?? [] : [],
   );
-  const datasourceFileNames = resolveFileNames(datasources.map(d => datasourceFileName(d)));
+
+  // Resolve unique variable and file names once so the written file path and
+  // the schema.ts import path are the same value. File names are deduped per
+  // group directory for blocks (kebab-casing is lossy); datasources are flat.
+  const resolvedComponents = resolveComponents(components, componentSegments);
+  const resolvedDatasources = resolveDatasources(datasources);
 
   // Write component files into their group directory
-  for (const [i, comp] of components.entries()) {
-    const filePath = join(targetPath, 'blocks', ...componentSegments[i], `${componentFileNames[i]}.ts`);
-    await writeFileWithDirs(filePath, generateComponentFile(comp, componentVarNames[i]));
+  for (const { component, varName, fileName, segments } of resolvedComponents) {
+    const filePath = join(targetPath, 'blocks', ...segments, `${fileName}.ts`);
+    await writeFileWithDirs(filePath, generateComponentFile(component, varName));
     writtenFiles.push(filePath);
   }
 
   // Write datasource files
-  for (const [i, ds] of datasources.entries()) {
-    const filePath = join(targetPath, 'datasources', `${datasourceFileNames[i]}.ts`);
-    await writeFileWithDirs(filePath, generateDatasourceFile(ds, datasourceVarNames[i]));
+  for (const { datasource, varName, fileName } of resolvedDatasources) {
+    const filePath = join(targetPath, 'datasources', `${fileName}.ts`);
+    await writeFileWithDirs(filePath, generateDatasourceFile(datasource, varName));
     writtenFiles.push(filePath);
   }
 
   // Write schema.ts (entry point with schema object, types, and Story alias)
   const schemaPath = join(targetPath, 'schema.ts');
-  await writeFileWithDirs(
-    schemaPath,
-    generateSchemaFile(
-      components,
-      datasources,
-      groupPathByComponentName,
-      componentVarNames,
-      datasourceVarNames,
-      componentFileNames,
-      datasourceFileNames,
-    ),
-  );
+  await writeFileWithDirs(schemaPath, generateSchemaFile(resolvedComponents, resolvedDatasources));
   writtenFiles.push(schemaPath);
 
   return writtenFiles;

--- a/packages/cli/src/commands/schema/init/actions.ts
+++ b/packages/cli/src/commands/schema/init/actions.ts
@@ -6,10 +6,13 @@ import type { Component, ComponentFolder, Datasource } from '../../../types';
 import { buildGroupPathByUuid } from '../folders';
 import {
   componentFileName,
+  componentVarName,
   datasourceFileName,
+  datasourceVarName,
   generateComponentFile,
   generateDatasourceFile,
   generateSchemaFile,
+  resolveVarNames,
 } from './generate-code';
 
 /** Writes a file, creating parent directories as needed. */
@@ -35,29 +38,34 @@ export async function writeSchemaFiles(
   const writtenFiles: string[] = [];
   const groupPathByUuid = buildGroupPathByUuid(componentFolders);
   const groupPathByComponentName = new Map<string, string[]>();
+  const componentVarNames = resolveVarNames(components.map(c => c.name), componentVarName);
+  const datasourceVarNames = resolveVarNames(datasources.map(d => d.name), datasourceVarName);
 
   // Write component files into their group directory
-  for (const comp of components) {
+  for (const [i, comp] of components.entries()) {
     const segments = comp.component_group_uuid ? groupPathByUuid.get(comp.component_group_uuid) ?? [] : [];
     if (segments.length > 0) { groupPathByComponentName.set(comp.name, segments); }
 
     const fileName = componentFileName(comp.name);
     const filePath = join(targetPath, 'blocks', ...segments, `${fileName}.ts`);
-    await writeFileWithDirs(filePath, generateComponentFile(comp));
+    await writeFileWithDirs(filePath, generateComponentFile(comp, componentVarNames[i]));
     writtenFiles.push(filePath);
   }
 
   // Write datasource files
-  for (const ds of datasources) {
+  for (const [i, ds] of datasources.entries()) {
     const fileName = datasourceFileName(ds);
     const filePath = join(targetPath, 'datasources', `${fileName}.ts`);
-    await writeFileWithDirs(filePath, generateDatasourceFile(ds));
+    await writeFileWithDirs(filePath, generateDatasourceFile(ds, datasourceVarNames[i]));
     writtenFiles.push(filePath);
   }
 
   // Write schema.ts (entry point with schema object, types, and Story alias)
   const schemaPath = join(targetPath, 'schema.ts');
-  await writeFileWithDirs(schemaPath, generateSchemaFile(components, datasources, groupPathByComponentName));
+  await writeFileWithDirs(
+    schemaPath,
+    generateSchemaFile(components, datasources, groupPathByComponentName, componentVarNames, datasourceVarNames),
+  );
   writtenFiles.push(schemaPath);
 
   return writtenFiles;

--- a/packages/cli/src/commands/schema/init/actions.ts
+++ b/packages/cli/src/commands/schema/init/actions.ts
@@ -12,6 +12,7 @@ import {
   generateComponentFile,
   generateDatasourceFile,
   generateSchemaFile,
+  resolveFileNames,
   resolveVarNames,
 } from './generate-code';
 
@@ -41,21 +42,31 @@ export async function writeSchemaFiles(
   const componentVarNames = resolveVarNames(components.map(c => c.name), componentVarName);
   const datasourceVarNames = resolveVarNames(datasources.map(d => d.name), datasourceVarName);
 
-  // Write component files into their group directory
-  for (const [i, comp] of components.entries()) {
+  // Precompute each block's group directory segments (mirrors remote groups).
+  const componentSegments = components.map((comp) => {
     const segments = comp.component_group_uuid ? groupPathByUuid.get(comp.component_group_uuid) ?? [] : [];
     if (segments.length > 0) { groupPathByComponentName.set(comp.name, segments); }
+    return segments;
+  });
+  // Dedup file names so two names that kebab-collapse to the same file don't
+  // overwrite each other (and schema.ts doesn't import two symbols from one
+  // path). Scoped per group directory for blocks; datasources are flat.
+  const componentFileNames = resolveFileNames(
+    components.map(c => componentFileName(c.name)),
+    componentSegments.map(s => s.join('/')),
+  );
+  const datasourceFileNames = resolveFileNames(datasources.map(d => datasourceFileName(d)));
 
-    const fileName = componentFileName(comp.name);
-    const filePath = join(targetPath, 'blocks', ...segments, `${fileName}.ts`);
+  // Write component files into their group directory
+  for (const [i, comp] of components.entries()) {
+    const filePath = join(targetPath, 'blocks', ...componentSegments[i], `${componentFileNames[i]}.ts`);
     await writeFileWithDirs(filePath, generateComponentFile(comp, componentVarNames[i]));
     writtenFiles.push(filePath);
   }
 
   // Write datasource files
   for (const [i, ds] of datasources.entries()) {
-    const fileName = datasourceFileName(ds);
-    const filePath = join(targetPath, 'datasources', `${fileName}.ts`);
+    const filePath = join(targetPath, 'datasources', `${datasourceFileNames[i]}.ts`);
     await writeFileWithDirs(filePath, generateDatasourceFile(ds, datasourceVarNames[i]));
     writtenFiles.push(filePath);
   }
@@ -64,7 +75,15 @@ export async function writeSchemaFiles(
   const schemaPath = join(targetPath, 'schema.ts');
   await writeFileWithDirs(
     schemaPath,
-    generateSchemaFile(components, datasources, groupPathByComponentName, componentVarNames, datasourceVarNames),
+    generateSchemaFile(
+      components,
+      datasources,
+      groupPathByComponentName,
+      componentVarNames,
+      datasourceVarNames,
+      componentFileNames,
+      datasourceFileNames,
+    ),
   );
   writtenFiles.push(schemaPath);
 

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  componentFileName,
   componentVarName,
   datasourceVarName,
   generateComponentFile,
@@ -199,6 +200,18 @@ describe('generateSchemaFile', () => {
 
     expect(result).toContain('  blocks: {');
     expect(result).not.toContain('  datasources: {');
+  });
+});
+
+describe('componentFileName', () => {
+  it('keeps well-formed names unchanged', () => {
+    expect(componentFileName('teaser_list')).toBe('teaser-list');
+    expect(componentFileName('page')).toBe('page');
+  });
+
+  it('strips characters that are not filesystem/shell-safe', () => {
+    expect(componentFileName('Interaktion & CTAs')).toBe('interaktion-ctas');
+    expect(componentFileName('A+B (C)')).toBe('a-b-c');
   });
 });
 

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -7,6 +7,7 @@ import {
   generateComponentFile,
   generateDatasourceFile,
   generateSchemaFile,
+  resolveFileNames,
   resolveVarNames,
 } from './generate-code';
 
@@ -251,6 +252,40 @@ describe('resolveVarNames', () => {
   });
 });
 
+describe('resolveFileNames', () => {
+  it('leaves distinct file names untouched', () => {
+    expect(resolveFileNames(['page', 'hero'])).toEqual(['page', 'hero']);
+  });
+
+  it('appends a -N suffix when kebab-collapsed names collide', () => {
+    // `hero_cta` and `hero-cta` both kebab to `hero-cta`.
+    expect(resolveFileNames(['hero-cta', 'hero-cta', 'hero-cta']))
+      .toEqual(['hero-cta', 'hero-cta-2', 'hero-cta-3']);
+  });
+
+  it('scopes uniqueness per directory so different dirs may share a name', () => {
+    // Same file name in different group directories does not collide on disk.
+    expect(resolveFileNames(['hero', 'hero', 'hero'], ['group-a', 'group-b', 'group-a']))
+      .toEqual(['hero', 'hero', 'hero-2']);
+  });
+});
+
+describe('generateSchemaFile with colliding block file names', () => {
+  it('imports each block from a unique path scoped per group directory', () => {
+    // `hero_cta` and `hero-cta` are distinct component names that both kebab to
+    // `hero-cta`; ungrouped, so they share the blocks root and must not collide.
+    const components = [
+      { id: 1, name: 'hero_cta', created_at: '', updated_at: '', schema: {} },
+      { id: 2, name: 'hero-cta', created_at: '', updated_at: '', schema: {} },
+    ] as any[];
+
+    const result = generateSchemaFile(components, []);
+
+    expect(result).toContain('from \'./blocks/hero-cta\';');
+    expect(result).toContain('from \'./blocks/hero-cta-2\';');
+  });
+});
+
 describe('generateComponentFile with explicit var name', () => {
   it('uses the provided var name for the export', () => {
     const result = generateComponentFile(
@@ -274,5 +309,18 @@ describe('generateSchemaFile with colliding datasources', () => {
     expect(result).toContain('import { colorsSizesDatasource2 } from \'./datasources/colors-slash-sizes\';');
     expect(result).toContain('    colorsSizesDatasource,');
     expect(result).toContain('    colorsSizesDatasource2,');
+  });
+
+  it('imports each datasource from a unique path when slugs kebab-collapse to the same file name', () => {
+    // Distinct slugs `colors-sizes` and `colors_sizes` both kebab to `colors-sizes`.
+    const datasources = [
+      { name: 'Colors A', slug: 'colors-sizes' },
+      { name: 'Colors B', slug: 'colors_sizes' },
+    ] as any[];
+
+    const result = generateSchemaFile([], datasources);
+
+    expect(result).toContain('from \'./datasources/colors-sizes\';');
+    expect(result).toContain('from \'./datasources/colors-sizes-2\';');
   });
 });

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -7,6 +7,7 @@ import {
   generateComponentFile,
   generateDatasourceFile,
   generateSchemaFile,
+  resolveVarNames,
 } from './generate-code';
 
 describe('generateComponentFile', () => {
@@ -235,5 +236,43 @@ describe('componentVarName / datasourceVarName', () => {
 
   it('falls back to `_` when the name has no identifier-safe characters', () => {
     expect(datasourceVarName('&&&')).toBe('_Datasource');
+  });
+});
+
+describe('resolveVarNames', () => {
+  it('leaves distinct names untouched', () => {
+    expect(resolveVarNames(['page', 'hero'], componentVarName))
+      .toEqual(['pageBlock', 'heroBlock']);
+  });
+
+  it('appends a numeric suffix when sanitized names collide', () => {
+    expect(resolveVarNames(['Colors & Sizes', 'Colors / Sizes'], datasourceVarName))
+      .toEqual(['colorsSizesDatasource', 'colorsSizesDatasource2']);
+  });
+});
+
+describe('generateComponentFile with explicit var name', () => {
+  it('uses the provided var name for the export', () => {
+    const result = generateComponentFile(
+      { id: 1, name: 'hero', created_at: '', updated_at: '', schema: {} } as any,
+      'heroBlock2',
+    );
+    expect(result).toContain('export const heroBlock2 = defineBlock({');
+  });
+});
+
+describe('generateSchemaFile with colliding datasources', () => {
+  it('imports and keys each datasource under a unique identifier', () => {
+    const datasources = [
+      { name: 'Colors & Sizes', slug: 'colors-sizes' },
+      { name: 'Colors / Sizes', slug: 'colors-slash-sizes' },
+    ] as any[];
+
+    const result = generateSchemaFile([], datasources);
+
+    expect(result).toContain('import { colorsSizesDatasource } from \'./datasources/colors-sizes\';');
+    expect(result).toContain('import { colorsSizesDatasource2 } from \'./datasources/colors-slash-sizes\';');
+    expect(result).toContain('    colorsSizesDatasource,');
+    expect(result).toContain('    colorsSizesDatasource2,');
   });
 });

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  componentVarName,
+  datasourceVarName,
   generateComponentFile,
   generateDatasourceFile,
   generateSchemaFile,
@@ -197,5 +199,28 @@ describe('generateSchemaFile', () => {
 
     expect(result).toContain('  blocks: {');
     expect(result).not.toContain('  datasources: {');
+  });
+});
+
+describe('componentVarName / datasourceVarName', () => {
+  it('keeps well-formed names unchanged', () => {
+    expect(componentVarName('teaser_list')).toBe('teaserListBlock');
+    expect(datasourceVarName('Categories')).toBe('categoriesDatasource');
+  });
+
+  it('strips characters that are invalid in JS identifiers', () => {
+    expect(datasourceVarName('Colors & Sizes')).toBe('colorsSizesDatasource');
+    expect(datasourceVarName('Colors / Sizes')).toBe('colorsSizesDatasource');
+    // Symbols with no surrounding space are stripped (not treated as word
+    // boundaries), so `A` and `B` merge — still a valid identifier.
+    expect(datasourceVarName('A+B (C)')).toBe('abCDatasource');
+  });
+
+  it('prefixes a leading digit so the identifier is valid', () => {
+    expect(datasourceVarName('123 items')).toBe('_123ItemsDatasource');
+  });
+
+  it('falls back to `_` when the name has no identifier-safe characters', () => {
+    expect(datasourceVarName('&&&')).toBe('_Datasource');
   });
 });

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -7,6 +7,8 @@ import {
   generateComponentFile,
   generateDatasourceFile,
   generateSchemaFile,
+  resolveComponents,
+  resolveDatasources,
   resolveFileNames,
   resolveVarNames,
 } from './generate-code';
@@ -173,9 +175,11 @@ describe('generateSchemaFile', () => {
   it('should generate schema.ts exporting { blocks, datasources }', () => {
     const components = [{ name: 'page' }, { name: 'hero' }, { name: 'teaser_list' }] as any[];
     const datasources = [{ name: 'Categories', slug: 'categories' }] as any[];
-    const groupPaths = new Map([['hero', ['Layout']]]);
 
-    const result = generateSchemaFile(components, datasources, groupPaths);
+    const result = generateSchemaFile(
+      resolveComponents(components, [[], ['Layout'], []]),
+      resolveDatasources(datasources),
+    );
 
     expect(result).toContain('import { defineSchema } from \'@storyblok/schema\';');
     expect(result).toContain('import type { Schema as InferSchema, Story as InferStory } from \'@storyblok/schema\';');
@@ -198,7 +202,10 @@ describe('generateSchemaFile', () => {
   });
 
   it('should omit empty sections from the schema object', () => {
-    const result = generateSchemaFile([{ name: 'page' }] as any[], []);
+    const result = generateSchemaFile(
+      resolveComponents([{ name: 'page' }] as any[], [[]]),
+      resolveDatasources([]),
+    );
 
     expect(result).toContain('  blocks: {');
     expect(result).not.toContain('  datasources: {');
@@ -279,7 +286,7 @@ describe('generateSchemaFile with colliding block file names', () => {
       { id: 2, name: 'hero-cta', created_at: '', updated_at: '', schema: {} },
     ] as any[];
 
-    const result = generateSchemaFile(components, []);
+    const result = generateSchemaFile(resolveComponents(components, [[], []]), resolveDatasources([]));
 
     expect(result).toContain('from \'./blocks/hero-cta\';');
     expect(result).toContain('from \'./blocks/hero-cta-2\';');
@@ -303,7 +310,7 @@ describe('generateSchemaFile with colliding datasources', () => {
       { name: 'Colors / Sizes', slug: 'colors-slash-sizes' },
     ] as any[];
 
-    const result = generateSchemaFile([], datasources);
+    const result = generateSchemaFile(resolveComponents([], []), resolveDatasources(datasources));
 
     expect(result).toContain('import { colorsSizesDatasource } from \'./datasources/colors-sizes\';');
     expect(result).toContain('import { colorsSizesDatasource2 } from \'./datasources/colors-slash-sizes\';');
@@ -318,7 +325,7 @@ describe('generateSchemaFile with colliding datasources', () => {
       { name: 'Colors B', slug: 'colors_sizes' },
     ] as any[];
 
-    const result = generateSchemaFile([], datasources);
+    const result = generateSchemaFile(resolveComponents([], []), resolveDatasources(datasources));
 
     expect(result).toContain('from \'./datasources/colors-sizes\';');
     expect(result).toContain('from \'./datasources/colors-sizes-2\';');

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -26,14 +26,18 @@ function toCamelCaseIdentifier(str: string): string {
 }
 
 /**
- * Converts a string to kebab-case.
- * Handles snake_case, camelCase, PascalCase, and space-separated words.
+ * Converts a string to kebab-case, keeping only filesystem/shell-safe
+ * characters. Handles snake_case, camelCase, PascalCase, and space-separated
+ * words; any remaining non-`[a-z0-9-]` characters collapse to a single `-`.
  */
 function toKebabCase(str: string): string {
   return str
     .replace(/[\s_]+/g, '-')
     .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .toLowerCase();
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /** Returns the variable name for a component. e.g. `'teaser_list'` -> `'teaserListBlock'` */

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -50,6 +50,24 @@ export function datasourceVarName(name: string): string {
   return `${toCamelCaseIdentifier(name)}Datasource`;
 }
 
+/**
+ * Resolves an ordered list of raw names to unique variable names. Names that
+ * sanitize to the same identifier get a numeric suffix (`…2`, `…3`), so the
+ * generated `export const`s and schema-object keys never collide. Index-aligned
+ * to `rawNames`.
+ */
+export function resolveVarNames(rawNames: string[], baseVarName: (name: string) => string): string[] {
+  const used = new Set<string>();
+  return rawNames.map((raw) => {
+    const base = baseVarName(raw);
+    let candidate = base;
+    let n = 2;
+    while (used.has(candidate)) { candidate = `${base}${n++}`; }
+    used.add(candidate);
+    return candidate;
+  });
+}
+
 /** Returns the file name (without extension) for a component. e.g. `'teaser_list'` -> `'teaser-list'` */
 export function componentFileName(name: string): string {
   return toKebabCase(name);
@@ -110,7 +128,7 @@ function sortSchemaByPos(schema: Record<string, Record<string, unknown>>): [stri
  * `defineField()` calls (sorted by `pos`). `component_group_uuid` is dropped —
  * groups are a UI concern and aren't part of a content-shape definition.
  */
-export function generateComponentFile(component: Component): string {
+export function generateComponentFile(component: Component, varName?: string): string {
   const lines: string[] = [];
 
   lines.push('import {');
@@ -119,8 +137,8 @@ export function generateComponentFile(component: Component): string {
   lines.push('} from \'@storyblok/schema\';');
   lines.push('');
 
-  const varName = componentVarName(component.name);
-  lines.push(`export const ${varName} = defineBlock({`);
+  const resolvedVarName = varName ?? componentVarName(component.name);
+  lines.push(`export const ${resolvedVarName} = defineBlock({`);
 
   const clean = stripKeys(component as unknown as Record<string, unknown>, COMPONENT_STRIP_KEYS);
 
@@ -173,14 +191,14 @@ export function generateComponentFile(component: Component): string {
  * Generates a full TypeScript file for a datasource with `defineDatasource()`.
  * Strips API-assigned fields (id, created_at, updated_at).
  */
-export function generateDatasourceFile(datasource: Datasource): string {
+export function generateDatasourceFile(datasource: Datasource, varName?: string): string {
   const lines: string[] = [];
 
   lines.push('import { defineDatasource } from \'@storyblok/schema\';');
   lines.push('');
 
-  const varName = datasourceVarName(datasource.name);
-  lines.push(`export const ${varName} = defineDatasource({`);
+  const resolvedVarName = varName ?? datasourceVarName(datasource.name);
+  lines.push(`export const ${resolvedVarName} = defineDatasource({`);
 
   const clean = stripKeys(datasource as unknown as Record<string, unknown>, DATASOURCE_STRIP_KEYS);
 
@@ -214,8 +232,13 @@ export function generateSchemaFile(
   components: Component[],
   datasources: Datasource[],
   groupPathByComponentName: Map<string, string[]> = new Map(),
+  componentVarNames?: string[],
+  datasourceVarNames?: string[],
 ): string {
   const lines: string[] = [];
+
+  const compVars = componentVarNames ?? resolveVarNames(components.map(c => c.name), componentVarName);
+  const dsVars = datasourceVarNames ?? resolveVarNames(datasources.map(d => d.name), datasourceVarName);
 
   // Import the defineSchema helper and the Schema/Story type helpers
   lines.push('import { defineSchema } from \'@storyblok/schema\';');
@@ -224,22 +247,22 @@ export function generateSchemaFile(
   lines.push('');
 
   // Import blocks from their group subdirectory
-  for (const component of components) {
-    const varName = componentVarName(component.name);
+  components.forEach((component, i) => {
+    const varName = compVars[i];
     const fileName = componentFileName(component.name);
     // Blocks are imported from their (slugified) group subdirectory — local
     // organization that mirrors the remote groups; `schema push` ignores it.
     const segments = groupPathByComponentName.get(component.name) ?? [];
     const subPath = segments.length > 0 ? `${segments.join('/')}/` : '';
     lines.push(`import { ${varName} } from './blocks/${subPath}${fileName}';`);
-  }
+  });
 
   // Import datasources
-  for (const datasource of datasources) {
-    const varName = datasourceVarName(datasource.name);
+  datasources.forEach((datasource, i) => {
+    const varName = dsVars[i];
     const fileName = datasourceFileName(datasource);
     lines.push(`import { ${varName} } from './datasources/${fileName}';`);
-  }
+  });
 
   lines.push('');
 
@@ -248,19 +271,17 @@ export function generateSchemaFile(
 
   if (components.length > 0) {
     lines.push('  blocks: {');
-    for (const component of components) {
-      const varName = componentVarName(component.name);
+    compVars.forEach((varName) => {
       lines.push(`    ${varName},`);
-    }
+    });
     lines.push('  },');
   }
 
   if (datasources.length > 0) {
     lines.push('  datasources: {');
-    for (const datasource of datasources) {
-      const varName = datasourceVarName(datasource.name);
+    dsVars.forEach((varName) => {
       lines.push(`    ${varName},`);
-    }
+    });
     lines.push('  },');
   }
 

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -68,6 +68,14 @@ export function resolveVarNames(rawNames: string[], baseVarName: (name: string) 
   });
 }
 
+/**
+ * File names are sanitized but not deduplicated (unlike variable names): the
+ * scheme relies on the source identifiers already being unique — component
+ * `name` is unique per space, and datasource `slug` is a required, unique,
+ * URL-friendly string. If two entries ever produced the same file name, the
+ * second would overwrite the first and its `schema.ts` import would break.
+ */
+
 /** Returns the file name (without extension) for a component. e.g. `'teaser_list'` -> `'teaser-list'` */
 export function componentFileName(name: string): string {
   return toKebabCase(name);

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -1,4 +1,5 @@
 import type { Component, Datasource } from '../../../types';
+import { slugify } from '../../../utils/format';
 import {
   COMPONENT_STRIP_KEYS,
   DATASOURCE_STRIP_KEYS,
@@ -11,13 +12,17 @@ import {
 const FIELD_STRIP_KEYS = new Set(['id', 'pos']);
 
 /**
- * Converts a string to camelCase.
- * Handles snake_case, kebab-case, and space-separated words.
+ * Converts an arbitrary name into a valid camelCase JS identifier.
+ * `slugify` reduces the input to `[a-z0-9_-]` (symbols stripped, spaces → `-`);
+ * we then camelCase across `_`/`-` runs and guard against an empty or
+ * leading-digit result so the output is always usable as an identifier.
  */
-function toCamelCase(str: string): string {
-  return str
-    .toLowerCase()
-    .replace(/[\s_-]+(.)/g, (_, char: string) => char.toUpperCase());
+function toCamelCaseIdentifier(str: string): string {
+  const camel = slugify(str)
+    .replace(/^[_-]+/, '')
+    .replace(/[_-]+(.)/g, (_, char: string) => char.toUpperCase());
+  if (!camel) { return '_'; }
+  return /^\d/.test(camel) ? `_${camel}` : camel;
 }
 
 /**
@@ -33,12 +38,12 @@ function toKebabCase(str: string): string {
 
 /** Returns the variable name for a component. e.g. `'teaser_list'` -> `'teaserListBlock'` */
 export function componentVarName(name: string): string {
-  return `${toCamelCase(name)}Block`;
+  return `${toCamelCaseIdentifier(name)}Block`;
 }
 
 /** Returns the variable name for a datasource. e.g. `'Categories'` -> `'categoriesDatasource'` */
 export function datasourceVarName(name: string): string {
-  return `${toCamelCase(name)}Datasource`;
+  return `${toCamelCaseIdentifier(name)}Datasource`;
 }
 
 /** Returns the file name (without extension) for a component. e.g. `'teaser_list'` -> `'teaser-list'` */

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -69,12 +69,31 @@ export function resolveVarNames(rawNames: string[], baseVarName: (name: string) 
 }
 
 /**
- * File names are sanitized but not deduplicated (unlike variable names): the
- * scheme relies on the source identifiers already being unique — component
- * `name` is unique per space, and datasource `slug` is a required, unique,
- * URL-friendly string. If two entries ever produced the same file name, the
- * second would overwrite the first and its `schema.ts` import would break.
+ * Resolves an ordered list of already-sanitized base file names to unique ones.
+ * `toKebabCase` is lossy (it collapses `_`/`-` runs and strips symbols), so two
+ * distinct source names can produce the same file name even though the raw names
+ * are unique. Collisions get a `-2`, `-3`, … suffix so generated files never
+ * overwrite each other and each `schema.ts` import resolves unambiguously.
+ *
+ * `dirKeys` scopes uniqueness per directory: blocks live in their group
+ * subdirectory, so two blocks with the same file name in *different* group
+ * directories don't collide on disk and must keep their shared name. Pass the
+ * containing directory (e.g. the joined group path) per index; omit for a flat
+ * layout (datasources). Index-aligned to `baseNames`.
  */
+export function resolveFileNames(baseNames: string[], dirKeys?: string[]): string[] {
+  const usedByDir = new Map<string, Set<string>>();
+  return baseNames.map((base, i) => {
+    const dir = dirKeys?.[i] ?? '';
+    let used = usedByDir.get(dir);
+    if (!used) { used = new Set<string>(); usedByDir.set(dir, used); }
+    let candidate = base;
+    let n = 2;
+    while (used.has(candidate)) { candidate = `${base}-${n++}`; }
+    used.add(candidate);
+    return candidate;
+  });
+}
 
 /** Returns the file name (without extension) for a component. e.g. `'teaser_list'` -> `'teaser-list'` */
 export function componentFileName(name: string): string {
@@ -242,11 +261,18 @@ export function generateSchemaFile(
   groupPathByComponentName: Map<string, string[]> = new Map(),
   componentVarNames?: string[],
   datasourceVarNames?: string[],
+  componentFileNames?: string[],
+  datasourceFileNames?: string[],
 ): string {
   const lines: string[] = [];
 
   const compVars = componentVarNames ?? resolveVarNames(components.map(c => c.name), componentVarName);
   const dsVars = datasourceVarNames ?? resolveVarNames(datasources.map(d => d.name), datasourceVarName);
+  const compFiles = componentFileNames ?? resolveFileNames(
+    components.map(c => componentFileName(c.name)),
+    components.map(c => (groupPathByComponentName.get(c.name) ?? []).join('/')),
+  );
+  const dsFiles = datasourceFileNames ?? resolveFileNames(datasources.map(d => datasourceFileName(d)));
 
   // Import the defineSchema helper and the Schema/Story type helpers
   lines.push('import { defineSchema } from \'@storyblok/schema\';');
@@ -257,7 +283,7 @@ export function generateSchemaFile(
   // Import blocks from their group subdirectory
   components.forEach((component, i) => {
     const varName = compVars[i];
-    const fileName = componentFileName(component.name);
+    const fileName = compFiles[i];
     // Blocks are imported from their (slugified) group subdirectory — local
     // organization that mirrors the remote groups; `schema push` ignores it.
     const segments = groupPathByComponentName.get(component.name) ?? [];
@@ -266,9 +292,9 @@ export function generateSchemaFile(
   });
 
   // Import datasources
-  datasources.forEach((datasource, i) => {
+  datasources.forEach((_datasource, i) => {
     const varName = dsVars[i];
-    const fileName = datasourceFileName(datasource);
+    const fileName = dsFiles[i];
     lines.push(`import { ${varName} } from './datasources/${fileName}';`);
   });
 

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -106,6 +106,57 @@ export function datasourceFileName(datasource: Pick<Datasource, 'name'> & { slug
 }
 
 /**
+ * A component paired with the identifiers derived for it: a unique `export`
+ * variable name, a unique file name (deduped within its group directory), and
+ * the group-path `segments` that place its file. Resolved once so the written
+ * file path and the `schema.ts` import path are the same value by construction.
+ */
+export interface ResolvedComponent {
+  component: Component;
+  varName: string;
+  fileName: string;
+  segments: string[];
+}
+
+/** A datasource paired with its unique variable name and (flat) file name. */
+export interface ResolvedDatasource {
+  datasource: Datasource;
+  varName: string;
+  fileName: string;
+}
+
+/**
+ * Resolves each component to its unique variable and file names.
+ * `segmentsByIndex` gives the group-path directory segments per component
+ * (index-aligned to `components`); file-name uniqueness is scoped to that
+ * directory, so identically-named blocks in different groups keep their name.
+ */
+export function resolveComponents(components: Component[], segmentsByIndex: string[][]): ResolvedComponent[] {
+  const varNames = resolveVarNames(components.map(c => c.name), componentVarName);
+  const fileNames = resolveFileNames(
+    components.map(c => componentFileName(c.name)),
+    segmentsByIndex.map(segments => segments.join('/')),
+  );
+  return components.map((component, i) => ({
+    component,
+    varName: varNames[i],
+    fileName: fileNames[i],
+    segments: segmentsByIndex[i],
+  }));
+}
+
+/** Resolves each datasource to its unique variable and file names (flat layout). */
+export function resolveDatasources(datasources: Datasource[]): ResolvedDatasource[] {
+  const varNames = resolveVarNames(datasources.map(d => d.name), datasourceVarName);
+  const fileNames = resolveFileNames(datasources.map(d => datasourceFileName(d)));
+  return datasources.map((datasource, i) => ({
+    datasource,
+    varName: varNames[i],
+    fileName: fileNames[i],
+  }));
+}
+
+/**
  * Reverse of the push-time DSL→wire field mapping: renames the wire reference
  * keys back to their DSL form (`component_whitelist`→`allow`,
  * `datasource_slug`→`datasource`). The `source` selector is left untouched.
@@ -252,27 +303,14 @@ export function generateDatasourceFile(datasource: Datasource, varName?: string)
 
 /**
  * Generates a `schema.ts` file that combines the schema object, types, and Story
- * alias. Blocks are imported from their group subdirectory (encoded by
- * `groupPathByComponentName`); the schema object exports `{ blocks, datasources }`.
+ * alias. Blocks are imported from their group subdirectory (via each resolved
+ * component's `segments`); the schema object exports `{ blocks, datasources }`.
  */
 export function generateSchemaFile(
-  components: Component[],
-  datasources: Datasource[],
-  groupPathByComponentName: Map<string, string[]> = new Map(),
-  componentVarNames?: string[],
-  datasourceVarNames?: string[],
-  componentFileNames?: string[],
-  datasourceFileNames?: string[],
+  components: ResolvedComponent[],
+  datasources: ResolvedDatasource[],
 ): string {
   const lines: string[] = [];
-
-  const compVars = componentVarNames ?? resolveVarNames(components.map(c => c.name), componentVarName);
-  const dsVars = datasourceVarNames ?? resolveVarNames(datasources.map(d => d.name), datasourceVarName);
-  const compFiles = componentFileNames ?? resolveFileNames(
-    components.map(c => componentFileName(c.name)),
-    components.map(c => (groupPathByComponentName.get(c.name) ?? []).join('/')),
-  );
-  const dsFiles = datasourceFileNames ?? resolveFileNames(datasources.map(d => datasourceFileName(d)));
 
   // Import the defineSchema helper and the Schema/Story type helpers
   lines.push('import { defineSchema } from \'@storyblok/schema\';');
@@ -280,23 +318,17 @@ export function generateSchemaFile(
   lines.push('import type { MapiStory as InferStoryMapi } from \'@storyblok/schema\';');
   lines.push('');
 
-  // Import blocks from their group subdirectory
-  components.forEach((component, i) => {
-    const varName = compVars[i];
-    const fileName = compFiles[i];
-    // Blocks are imported from their (slugified) group subdirectory — local
-    // organization that mirrors the remote groups; `schema push` ignores it.
-    const segments = groupPathByComponentName.get(component.name) ?? [];
+  // Import blocks from their (slugified) group subdirectory — local
+  // organization that mirrors the remote groups; `schema push` ignores it.
+  for (const { varName, fileName, segments } of components) {
     const subPath = segments.length > 0 ? `${segments.join('/')}/` : '';
     lines.push(`import { ${varName} } from './blocks/${subPath}${fileName}';`);
-  });
+  }
 
   // Import datasources
-  datasources.forEach((_datasource, i) => {
-    const varName = dsVars[i];
-    const fileName = dsFiles[i];
+  for (const { varName, fileName } of datasources) {
     lines.push(`import { ${varName} } from './datasources/${fileName}';`);
-  });
+  }
 
   lines.push('');
 
@@ -305,17 +337,17 @@ export function generateSchemaFile(
 
   if (components.length > 0) {
     lines.push('  blocks: {');
-    compVars.forEach((varName) => {
+    for (const { varName } of components) {
       lines.push(`    ${varName},`);
-    });
+    }
     lines.push('  },');
   }
 
   if (datasources.length > 0) {
     lines.push('  datasources: {');
-    dsVars.forEach((varName) => {
+    for (const { varName } of datasources) {
       lines.push(`    ${varName},`);
-    });
+    }
     lines.push('  },');
   }
 

--- a/packages/cli/src/commands/schema/init/index.test.ts
+++ b/packages/cli/src/commands/schema/init/index.test.ts
@@ -175,6 +175,29 @@ describe('schema init command', () => {
     expect(content).toContain('slug: \'categories\'');
   });
 
+  it('generates valid identifiers for datasource names containing special characters', async () => {
+    const ds = makeMockDatasource({ name: 'Colors & Sizes', slug: 'colors-sizes' });
+    preconditions.hasRemoteSchema({ datasources: [ds] });
+
+    await schemaCommand.parseAsync(['node', 'test', 'init', '--space', DEFAULT_SPACE]);
+
+    const files = Object.keys(vol.toJSON());
+
+    // Datasource file name is shell-safe.
+    const dsFile = files.find(f => f.includes('/datasources/colors-sizes.ts'));
+    expect(dsFile).toBeDefined();
+    const dsContent = vol.readFileSync(dsFile!, 'utf-8') as string;
+    expect(dsContent).toContain('export const colorsSizesDatasource = defineDatasource({');
+
+    // schema.ts import, export reference, and key all agree and contain no `&`.
+    const schemaFile = files.find(f => f.endsWith('/schema.ts'));
+    expect(schemaFile).toBeDefined();
+    const schemaContent = vol.readFileSync(schemaFile!, 'utf-8') as string;
+    expect(schemaContent).toContain('import { colorsSizesDatasource } from \'./datasources/colors-sizes\';');
+    expect(schemaContent).toContain('    colorsSizesDatasource,');
+    expect(schemaContent).not.toContain('&');
+  });
+
   it('should generate schema.ts with schema object and types', async () => {
     const comp = makeMockComponent({ name: 'page', is_root: true });
     preconditions.hasRemoteSchema({ components: [comp] });

--- a/packages/cli/src/commands/schema/init/index.test.ts
+++ b/packages/cli/src/commands/schema/init/index.test.ts
@@ -198,6 +198,52 @@ describe('schema init command', () => {
     expect(schemaContent).not.toContain('&');
   });
 
+  it('writes distinct files when component names collapse to the same kebab-case file name', async () => {
+    // `hero_cta` and `hero-cta` are distinct component names that both kebab to
+    // `hero-cta`. Without dedup the second file would overwrite the first while
+    // schema.ts still imports two symbols from the one path (uncompilable TS).
+    const comps = [
+      makeMockComponent({ name: 'hero_cta' }),
+      makeMockComponent({ name: 'hero-cta' }),
+    ];
+    preconditions.hasRemoteSchema({ components: comps });
+
+    await schemaCommand.parseAsync(['node', 'test', 'init', '--space', DEFAULT_SPACE]);
+
+    const files = Object.keys(vol.toJSON());
+    // Both blocks land in their own file — no overwrite.
+    expect(files.some(f => f.endsWith('/blocks/hero-cta.ts'))).toBe(true);
+    expect(files.some(f => f.endsWith('/blocks/hero-cta-2.ts'))).toBe(true);
+
+    // schema.ts imports each block from a distinct existing path.
+    const schemaContent = vol.readFileSync(files.find(f => f.endsWith('/schema.ts'))!, 'utf-8') as string;
+    expect(schemaContent).toContain('from \'./blocks/hero-cta\';');
+    expect(schemaContent).toContain('from \'./blocks/hero-cta-2\';');
+  });
+
+  it('keeps a shared file name for colliding blocks in different group directories', async () => {
+    // `hero_cta` and `hero-cta` both kebab to `hero-cta`, but they live in
+    // different group directories — they don't collide on disk, so each keeps
+    // the shared file name and its import carries the distinguishing subpath.
+    const folderA = makeMockFolder({ name: 'Group A', uuid: 'group-a-uuid' });
+    const folderB = makeMockFolder({ name: 'Group B', uuid: 'group-b-uuid' });
+    const comps = [
+      makeMockComponent({ name: 'hero_cta', component_group_uuid: 'group-a-uuid' } as any),
+      makeMockComponent({ name: 'hero-cta', component_group_uuid: 'group-b-uuid' } as any),
+    ];
+    preconditions.hasRemoteSchema({ components: comps, folders: [folderA, folderB] });
+
+    await schemaCommand.parseAsync(['node', 'test', 'init', '--space', DEFAULT_SPACE]);
+
+    const files = Object.keys(vol.toJSON());
+    expect(files.some(f => f.endsWith('/blocks/group-a/hero-cta.ts'))).toBe(true);
+    expect(files.some(f => f.endsWith('/blocks/group-b/hero-cta.ts'))).toBe(true);
+
+    const schemaContent = vol.readFileSync(files.find(f => f.endsWith('/schema.ts'))!, 'utf-8') as string;
+    expect(schemaContent).toContain('from \'./blocks/group-a/hero-cta\';');
+    expect(schemaContent).toContain('from \'./blocks/group-b/hero-cta\';');
+  });
+
   it('should generate schema.ts with schema object and types', async () => {
     const comp = makeMockComponent({ name: 'page', is_root: true });
     preconditions.hasRemoteSchema({ components: [comp] });

--- a/packages/cli/src/commands/schema/push/serialize.test.ts
+++ b/packages/cli/src/commands/schema/push/serialize.test.ts
@@ -95,6 +95,33 @@ describe('serializeComponent', () => {
     expect(result).toContain('type: \'bloks\',');
   });
 
+  it('should treat an empty restrict_type as equivalent to an absent one', () => {
+    // MAPI never stores `restrict_type: ''` (the "restrict by component whitelist"
+    // mode) and omits the key on read, while a whitelist re-derived from the DSL
+    // `allow` re-adds it on push. The two must serialize identically so no false
+    // diff is produced.
+    const withEmpty = {
+      name: 'page',
+      schema: { body: { type: 'bloks', pos: 0, restrict_components: true, component_whitelist: ['hero'], restrict_type: '' } },
+    };
+    const withoutKey = {
+      name: 'page',
+      schema: { body: { type: 'bloks', pos: 0, restrict_components: true, component_whitelist: ['hero'] } },
+    };
+
+    expect(serializeComponent(withEmpty)).toBe(serializeComponent(withoutKey));
+    expect(serializeComponent(withEmpty)).not.toContain('restrict_type');
+  });
+
+  it('should keep a non-empty restrict_type (e.g. group restriction)', () => {
+    const component = {
+      name: 'page',
+      schema: { body: { type: 'bloks', pos: 0, restrict_type: 'groups', component_group_whitelist: ['group-uuid'] } },
+    };
+
+    expect(serializeComponent(component)).toContain('restrict_type: \'groups\',');
+  });
+
   it('should strip component_group_uuid by default', () => {
     const component = {
       name: 'hero',

--- a/packages/cli/src/commands/schema/serialize.ts
+++ b/packages/cli/src/commands/schema/serialize.ts
@@ -18,6 +18,13 @@ function sortSchemaByPos(schema: Record<string, Record<string, unknown>>): Recor
   return Object.fromEntries(
     entries.map(([key, field]) => {
       const { id, ...rest } = field;
+      // `restrict_type: ''` is the wire byproduct of a component whitelist (the
+      // "restrict by component" mode). MAPI never reads it and omits it on read,
+      // and the Visual Editor treats `''` and absent identically — so a value
+      // re-derived from the DSL `allow` must not diff against a remote that
+      // lacks the key. A non-empty `restrict_type` (`'groups'`/`'tags'`) is real
+      // state and is kept.
+      if (rest.restrict_type === '') { delete rest.restrict_type; }
       return [key, rest];
     }),
   );


### PR DESCRIPTION
`storyblok schema init` generated syntactically invalid TypeScript when a component-group or datasource name contained characters that aren't valid in JS identifiers (e.g. `&`). The generated `export const … = defineDatasource(...)`, its `import`, and its schema-object key all derived from a camelCaser that only treated `[\s_-]+` as word boundaries, so a datasource named `Colors & Sizes` produced `export const colors&SizesDatasource = …` — the whole `schema.ts` then failed to parse in `tsc` and in a subsequent `schema push`.

The originally reported trigger (component **group** names) was already resolved by the directory/`slugify` layout; this PR fixes the underlying weakness, which is still live via **datasource** variable names (derived from the arbitrary `datasource.name`).

## How

- **`toCamelCaseIdentifier`** — built on the existing `slugify`, always yields a valid identifier: symbols stripped, leading digit `_`-prefixed, empty result → `_`. Well-formed names are unchanged (`teaser_list → teaserListBlock`, `Categories → categoriesDatasource`).
- **Hardened `toKebabCase`** so generated file names contain only shell-safe `[a-z0-9-]`.
- **`resolveVarNames`** collision dedup (append `2`, `3`, …), threaded index-aligned through `generateComponentFile` / `generateDatasourceFile` / `generateSchemaFile` and `init/actions.ts` so each `export const`, its `import`, and its schema-object key always agree.
- Documented that file names rely on source uniqueness (datasource `slug` / component `name` are unique), so file names are sanitized but not deduped.

Fixes DX-478
Fixes #670
