### PR TITLE
chore: rename ticket prefix WDX to DX

### DIFF
--- a/.agents/skills/investigate/SKILL.md
+++ b/.agents/skills/investigate/SKILL.md
@@ -16,11 +16,11 @@ Investigate the following GitHub issue: $ARGUMENTS
 ### Phase 1: Fetch Issue Details
 
 1. Parse the input:
-   - `WDX-123` or `linear.app` URL → **Linear ticket**
+   - `DX-123` or `linear.app` URL → **Linear ticket**
    - `#123`, bare number, or `github.com` URL → **GitHub issue**
 2. Fetch the ticket:
    - **GitHub:** `gh issue view <number> --json title,body,labels,comments,author,createdAt,state`
-   - **Linear:** `bash .agents/skills/triage/scripts/linear-fetch.sh issue WDX-123`
+   - **Linear:** `bash .agents/skills/triage/scripts/linear-fetch.sh issue DX-123`
 3. Extract: error messages, stack traces, reproduction steps, environment details
 
 ### Phase 2: Identify Affected Package(s)
@@ -47,7 +47,7 @@ For each root cause: the fix (file paths + line numbers), test coverage needed, 
 
 ## Output
 
-1. Extract identifier from arguments (issue `424` → `424`, ticket `WDX-296` → `WDX-296`, text → slugified)
+1. Extract identifier from arguments (issue `424` → `424`, ticket `DX-296` → `DX-296`, text → slugified)
 2. `mkdir -p claude-output`
 3. Write to `claude-output/investigate-<identifier>.md`
 4. Confirm to user: "Investigation written to `claude-output/investigate-<identifier>.md`"

--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -15,7 +15,7 @@ Generate a spec for: $ARGUMENTS
 **IMPORTANT:** Write the spec output to a markdown file, NOT to the terminal.
 
 1. Extract an identifier from the arguments:
-   - For ticket IDs like `WDX-237` -> use `wdx-237`
+   - For ticket IDs like `DX-237` -> use `dx-237`
    - For descriptions -> slugify the first few words (e.g., "CLI login flow" -> `cli-login-flow`)
 
 2. Create the output directory if it doesn't exist:

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -18,9 +18,9 @@ Read the ticket thoroughly, but do not dig into code. The goal is to classify, p
 
 ### Step 1: Parse ticket references
 
-- Anything matching `WDX-\d+` or a `linear.app` URL → **Linear**
+- Anything matching `DX-\d+` or a `linear.app` URL → **Linear**
 - Anything matching `#\d+`, a bare number, or a `github.com` URL → **GitHub**
-- `linear:triage` → fetch all Linear issues in Triage state (WDX team)
+- `linear:triage` → fetch all Linear issues in Triage state (DX team)
 
 ### Step 2: Fetch tickets
 
@@ -31,7 +31,7 @@ gh issue view <number> --repo storyblok/monoblok --json title,body,labels,state,
 
 **Linear:**
 ```bash
-bash .claude/skills/triage/scripts/linear-fetch.sh issue WDX-123 WDX-456
+bash .claude/skills/triage/scripts/linear-fetch.sh issue DX-123 DX-456
 bash .claude/skills/triage/scripts/linear-fetch.sh triage
 ```
 
@@ -113,7 +113,7 @@ If exact duplicate → mark as **duplicate** with link to original. If related b
 | Ticket | Title | Type | Priority | Verdict | Package |
 |--------|-------|------|----------|---------|---------|
 | #368 | ... | bug | P1 | actionable | cli |
-| WDX-123 | ... | improvement | P2 | actionable | vue |
+| DX-123 | ... | improvement | P2 | actionable | vue |
 ```
 
 #### Detailed assessment (one per ticket)

--- a/.agents/skills/triage/scripts/linear-fetch.sh
+++ b/.agents/skills/triage/scripts/linear-fetch.sh
@@ -2,9 +2,9 @@
 # Fetch Linear issues for triage.
 #
 # Usage:
-#   linear-fetch.sh issue WDX-123          # Single issue by identifier
-#   linear-fetch.sh issue WDX-123 WDX-456  # Multiple issues
-#   linear-fetch.sh triage                  # Triage issues for WDX team (default)
+#   linear-fetch.sh issue DX-123          # Single issue by identifier
+#   linear-fetch.sh issue DX-123 DX-456  # Multiple issues
+#   linear-fetch.sh triage                  # Triage issues for DX team (default)
 #   linear-fetch.sh triage --team OTHER    # Triage issues for a different team
 #
 # Requires LINEAR_API_KEY in the project .env file.
@@ -14,7 +14,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 LINEAR_API="https://api.linear.app/graphql"
-DEFAULT_TEAM="WDX"
+DEFAULT_TEAM="DX"
 
 # ---------------------------------------------------------------------------
 # load_env — loads LINEAR_API_KEY from .env
@@ -47,7 +47,7 @@ gql() {
 }
 
 # ---------------------------------------------------------------------------
-# fetch_issue — fetch a single issue by identifier (e.g. WDX-123)
+# fetch_issue — fetch a single issue by identifier (e.g. DX-123)
 # ---------------------------------------------------------------------------
 fetch_issue() {
   local identifier="$1"
@@ -77,7 +77,7 @@ fetch_issue() {
     }
   '
 
-  # Extract team key and number from identifier (e.g. WDX-123)
+  # Extract team key and number from identifier (e.g. DX-123)
   local team_key="${identifier%%-*}"
   local number="${identifier##*-}"
 
@@ -150,7 +150,7 @@ shift || true
 case "$command" in
   issue)
     if [ $# -eq 0 ]; then
-      echo "Usage: linear-fetch.sh issue WDX-123 [WDX-456 ...]" >&2
+      echo "Usage: linear-fetch.sh issue DX-123 [DX-456 ...]" >&2
       exit 1
     fi
     # Fetch each issue and collect results
@@ -166,8 +166,8 @@ case "$command" in
     echo "Usage: linear-fetch.sh <issue|triage> [args...]" >&2
     echo ""
     echo "Commands:"
-    echo "  issue WDX-123 [WDX-456 ...]   Fetch specific issues by identifier"
-    echo "  triage [--team WDX]            Fetch all issues in Triage state"
+    echo "  issue DX-123 [DX-456 ...]   Fetch specific issues by identifier"
+    echo "  triage [--team DX]            Fetch all issues in Triage state"
     exit 1
     ;;
 esac

--- a/.claude/rules/artifact-naming.md
+++ b/.claude/rules/artifact-naming.md
@@ -14,15 +14,15 @@ claude-output/<type>-<identifier>-<subtype>.md
 | Command | Pattern | Example |
 |---------|---------|---------|
 | `/review-and-qa` | `review-<id>.md` | `review-pr-435.md`, `review-login-flow.md` |
-| `/investigate` | `investigate-<id>.md` | `investigate-424.md`, `investigate-WDX-296.md` |
-| `/spec` (project) | `spec-<id>.md` | `spec-wdx-310.md`, `spec-asset-optimization.md` |
-| `/spec` (ticket) | `ticket-<id>.md` | `ticket-wdx-237.md`, `ticket-add-logout-button.md` |
-| PR description | `pr-<id>-summary.md` | `pr-435-summary.md`, `pr-WDX-308-summary.md` |
+| `/investigate` | `investigate-<id>.md` | `investigate-424.md`, `investigate-DX-296.md` |
+| `/spec` (project) | `spec-<id>.md` | `spec-dx-310.md`, `spec-asset-optimization.md` |
+| `/spec` (ticket) | `ticket-<id>.md` | `ticket-dx-237.md`, `ticket-add-logout-button.md` |
+| PR description | `pr-<id>-summary.md` | `pr-435-summary.md`, `pr-DX-308-summary.md` |
 
 ## Identifier extraction
 
 - PR URL `https://github.com/.../pull/435` or `#435` -> `435`
-- Ticket ID `WDX-308` -> `WDX-308`
+- Ticket ID `DX-308` -> `DX-308`
 - Free text "add logout button" -> `add-logout-button` (slugified)
 
 When the same PR/issue produces multiple artifacts (summary + review), the identifier stays the same and the type differentiates them: `pr-435-summary.md`, `review-pr-435.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ When a significant architectural decision is made, add a concise new ADR in `adr
 
 - **IMPORTANT:** Never stage or commit any code yourself unless explicitly told so!
 - **IMPORTANT:** Never use `git push --force`; if a force push is explicitly required, use `git push --force-with-lease` instead.
-- **Branch naming:** `[fix|feat|chore]/WDX-XXX-[title]` e.g. `feat/WDX-351-type-safe-schema-support`, `fix/WDX-391-push-stories-missing-story-identification`, or `chore/update-eslint-config`.
-- **Commits:** If information is available, add `Fixes WDX-*` and `Fixes #*` as footer lines at the end of commit messages for Linear and GitHub tracking.
+- **Branch naming:** `[fix|feat|chore]/DX-XXX-[title]` e.g. `feat/DX-351-type-safe-schema-support`, `fix/DX-391-push-stories-missing-story-identification`, or `chore/update-eslint-config`.
+- **Commits:** If information is available, add `Fixes DX-*` and `Fixes #*` as footer lines at the end of commit messages for Linear and GitHub tracking.
 
 **Worktrees:**
 

--- a/adr/0004-openapi-specs-pulled-on-demand.md
+++ b/adr/0004-openapi-specs-pulled-on-demand.md
@@ -10,7 +10,7 @@ Several packages generate their public types (and, for the API clients, SDK code
 Two pressures motivated a change:
 
 - The hand-written spec is a second source of truth that can drift from the backend, and the plan is to stop shipping any OpenAPI spec as a public artifact in the monorepo. The authoritative, overlay-applied specs live in a private repository (`storyblok/openapi-wdx`) that external contributors cannot access, yet the monorepo must stay buildable by them.
-- A single shared types package coupled unrelated consumers: any spec change bumped the shared package, cascading version bumps to every dependent regardless of whether its slice of the surface actually changed (WDX-430).
+- A single shared types package coupled unrelated consumers: any spec change bumped the shared package, cascading version bumps to every dependent regardless of whether its slice of the surface actually changed (DX-430).
 
 ## Decision
 
@@ -30,4 +30,4 @@ Key choices:
 - Version bumps are scoped per consumer, never driven by a shared types package or by the codegen tool.
 - Spec updates require a manual fetch, regeneration, and commit by someone with access. CI cannot do it.
 
-Links: WDX-406, WDX-430.
+Links: DX-406, DX-430.


### PR DESCRIPTION
Rename the previous Linear ticket prefix `WDX` to the new `DX` prefix across the repository.

## Changes

- Ticket references (`WDX-123` → `DX-123`) in agent skills (`investigate`, `spec`, `triage`), `.claude/rules/artifact-naming.md`, `AGENTS.md` (branch naming + commit footer conventions), and `adr/0004`.
- Linear team key in `linear-fetch.sh`: `DEFAULT_TEAM` and `--team` references (`WDX` → `DX`). The ticket prefix is the Linear team key, so leaving the default would break the `triage` command.

## Left untouched (intentional)

- `storyblok/openapi-wdx` repository name and the `openapi-wdx-` temp-dir prefix in `tools/openapi-codegen/` — a real GitHub repo name, not a ticket reference.