### PR TITLE
docs(cli): fix types.generate config example using invalid `output` property

### DIFF
--- a/packages/cli/src/lib/config/README.md
+++ b/packages/cli/src/lib/config/README.md
@@ -186,7 +186,7 @@ export default defineConfig({
     },
     types: {
       generate: {
-        output: 'storyblok-component-types.d.ts',
+        filename: 'storyblok-component-types.d.ts',
       },
     },
   },


### PR DESCRIPTION
## What

The complete `storyblok.config.ts` example in the CLI config docs used an invalid property `output` under `types.generate`, which does not exist on `GenerateTypesOptions`.

## Why

`GenerateTypesOptions` (defined in `src/commands/types/generate/constants.ts`) has no `output` field. The correct property for specifying the output filename is `filename`. The invalid key was silently ignored at runtime since the config shape uses `Partial<GenerateTypesOptions>`.

## Change

```diff
 types: {
   generate: {
-    output: 'storyblok-component-types.d.ts',
+    filename: 'storyblok-component-types.d.ts',
   },
 },
```

Fixes DX-485