### PR TITLE
chore(repo): require scoped commits to prevent version fan-out

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,30 @@
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Commit scopes derived from the folders under `packages/`, so the list stays
+// in sync automatically as packages are added or removed.
+const packagesDir = join(dirname(fileURLToPath(import.meta.url)), 'packages');
+const packageScopes = readdirSync(packagesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+// Scopes for changes that don't belong to a single package (root config,
+// tooling, CI, docs, agent skills, automated releases). These are intentionally
+// NOT packages, so such commits bump no package version.
+const metaScopes = ['release', 'repo', 'deps', 'ci', 'docs', 'tools', 'agents'];
+
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'body-max-line-length': [2, 'always', 200],
+    // A scope is mandatory. Nx attributes an *unscoped* commit that touches
+    // non-project files (e.g. `.agents/`, root config) to EVERY package, which
+    // bumps the version of packages that had no actual change. Requiring a
+    // scope prevents that accidental workspace-wide fan-out.
+    'scope-empty': [2, 'never'],
+    // Comma-separated scopes are allowed, e.g. `feat(cli,mapi-client): ...`.
+    'scope-enum': [2, 'always', [...packageScopes, ...metaScopes]],
   },
 };


### PR DESCRIPTION
The last `pnpm release --dry-run` bumped **every** package a `minor` — including `@storyblok/eslint-config`, `@storyblok/region-helper`, and `@storyblok/openapi`, whose changelogs read *"version bump only … there were no code changes."*

Root cause is an Nx release rule (`node_modules/nx/src/command-line/release/utils/shared.js`, `getCommitsRelevantToProjects`):

```js
// The relevant commits are those that either:
// - touch project files which are contained within the list of projects directly
// - touch non-project files and the commit is not scoped
return commits.filter((c) => c.affectedFiles.some((f) =>
    filesInReleaseGroup.has(f) ||
    (!c.scope && fileMap.nonProjectFiles.some((npf) => npf.file === f))
));
```

An **unscoped** conventional commit that touches **non-project files** (anything outside a package root) is attributed to **every** package. The trigger this time was `a3d9612e6 feat: support global assets library` (#630), which was scopeless *and* touched `.agents/skills/**` (non-project files) → workspace-wide `minor` fan-out.

Nx is already diff/file-based for the common case; scope only matters as the negative filter for that non-project-file fallback. So requiring a scope on every commit closes the hole: `!c.scope` is never true, and a scoped commit touching only non-project files bumps nothing.

## Change

`commitlint.config.js`:

- **`scope-empty: [2, 'never']`** — scope is mandatory.
- **`scope-enum`** — allowed scopes are the `packages/*` folder names, **auto-derived** from the filesystem so the list stays in sync as packages are added/removed, plus meta scopes for non-package changes (`release`, `repo`, `deps`, `ci`, `docs`, `tools`, `agents`).
- Comma-separated scopes remain valid (`feat(cli,mapi-client): …`) — commitlint's `scope-enum` splits on `,`/`/`/`\` and validates each segment.