### PR TITLE
POC: OAuth Authorization Code Grant login in the CLI (DX-484)

### DIFF
--- a/DX-484-oauth-poc-findings.md
+++ b/DX-484-oauth-poc-findings.md
@@ -1,56 +1,87 @@
-# DX-484 OAuth POC — Findings
+# DX-484 OAuth POC Findings
 
-**Environment:** production EU (`app.storyblok.com` / `mapi.storyblok.com`), sandbox org.
-**Date:** <!-- fill in when the runbook runs -->
-**CLI branch:** `feat/DX-484-oauth-login-poc`
+**Environment:** production EU (`app.storyblok.com` / `mapi.storyblok.com`), sandbox org, space `monoblok-cli-qa` (290020686946333).
+**Date:** 2026-07-07 (setup) / 2026-07-08 (full runbook).
+**CLI branch:** `feat/DX-484-oauth-login-poc` (`storyblok oauth setup|login|call|refresh` POC commands).
 
 ## Must-answer questions
 
 ### 1. Does `offline_access` actually return a refresh token?
-- **Answer:**
-- **Evidence:** (raw `/oauth/token` response with secrets redacted)
-- Share with the MCP team — they are blocked on this question.
+
+- **Answer: YES.** Requesting `offline_access` in the authorize scope returns a `refresh_token` from `POST /oauth/token`, both on the initial code exchange and on every refresh.
+- **Evidence:** raw token response (redacted):
+
+  ```json
+  {
+    "access_token": "sb_o…(masked)",
+    "refresh_token": "sb_o…(masked)",
+    "token_type": "bearer",
+    "expires_in": 900,
+    "scope": "asset_folders:read … workflows:write offline_access"
+  }
+  ```
+
+  Notes: `expires_in` is 900 (15 min, matches `OauthGrant::ACCESS_TOKEN_LIFETIME`). Both token kinds use an `sb_o…` prefix (`sb_oat_` access / `sb_ort_` refresh). The response contains **no `space_ids` field**, although the grant is space-scoped by the consent selection; clients cannot learn the granted space(s) from the token response. Share this section with the MCP team.
 
 ### 2. Does refresh work as documented (new access token, refresh token unchanged)?
-- **Answer:**
-- **Note:** storyrails `token_endpoint.rb` revokes the old grant and issues a NEW refresh token on every
-  refresh (rotation) — the "refresh token unchanged" expectation appears wrong at the code level.
-  Record what actually happens.
-- **Evidence:** (`oauth refresh` output)
+
+- **Answer: NO. The refresh token ROTATES on every refresh.** Each `grant_type=refresh_token` call returns a new access token AND a new refresh token; the old refresh token is revoked and single-use.
+- **Evidence:**
+  - `oauth refresh` (twice in a row): `access token changed: true`, `Refresh token rotated: true` both times; response keys `access_token, refresh_token, token_type, expires_in, scope`.
+  - Reusing the pre-rotation refresh token: `400 Bad Request` `{"error": "invalid_grant", "error_description": "The provided access grant is invalid, expired, or revoked (…)"}`.
+- **Matches the backend code** (`token_endpoint.rb#exchange_refresh_token` revokes the old grant and mints a new one; refresh expiry is a rolling 1-month window, `REFRESH_TOKEN_LIFETIME`).
+- **Consequence for clients:** the stored refresh token MUST be atomically replaced after every refresh. A client that crashes between refresh and persist loses the session permanently (no recovery, re-login required). Concurrent refreshes from two processes sharing one credentials file will invalidate each other. The MAPI-client refresh interceptor needs a single-flight refresh + persist-before-use design.
 
 ### 3. Are expired-token vs missing-scope errors distinguishable (401 vs 403 shapes)?
-- **Expired token (after 15 min):**
-  - Status:
-  - WWW-Authenticate header:
-  - Body:
-- **Missing scope (narrowed-scope grant):**
-  - Status:
-  - Body: (expected per code: `{"error": "Insufficient scope: <scope> is required"}`)
-- **Verdict for the refresh-on-401 interceptor:**
+
+- **Answer: YES, cleanly distinguishable by status code and body.**
+- **Missing scope (grant narrowed to `stories:read offline_access`, calling `GET /v1/spaces/:id/components`):**
+  - Status: `403 Forbidden`
+  - WWW-Authenticate header: not set
+  - Body: `{"error": "Insufficient scope: components:read is required"}`
+  - In-scope control call (`GET /v1/spaces/:id/stories`) with the same token: `200 OK`.
+- **Expired token (after 16 min, no refresh):**
+  - Status: `401 Unauthorized`
+  - WWW-Authenticate header: not set (general MAPI endpoints do not send it; only the dedicated `/oauth/*` info endpoints do)
+  - Body: `{"error": "Unauthorized"}`
+- **Refresh after expiry works:** with the expired access token, `oauth refresh` succeeded (rotated as usual) and the follow-up MAPI call returned `200 OK`, the exact refresh-on-401 interceptor scenario.
+- **Verdict for the refresh-on-401 interceptor:** safe. 401 = token problem (refresh and retry), 403 = authorization problem (do NOT refresh; surface to the user). Discriminate on status code, not on the WWW-Authenticate header (absent on MAPI endpoints). The 403 body even names the missing scope, which is useful for error messages.
 
 ### 4. Does find-or-create behave sanely on re-runs?
-- **Answer:** (no duplicate apps? secret readable via show?)
-- **Evidence:**
+
+- **Answer: YES.** Re-running `oauth setup --token <PAT>` finds the existing "Storyblok CLI" app by name, reads `oauth_identifier` + `oauth_secret` via `GET /v1/oauth_clients/:id` (`include_secret`), and stores them. `GET /v1/oauth_clients` afterwards shows exactly one app (no duplicates).
+- **Gotchas found (create-time API contract):**
+  - `POST /v1/oauth_clients` returns **422 without a `slug`**: the App model validates slug format with no `allow_blank` plus global slug uniqueness, so a create must send a unique slug (POC sends `storyblok-cli-<base36 timestamp>`). The productized setup command must handle slug collisions across orgs.
+  - The scope catalog (`GET /v1/oauth_clients/metadata`) returns `available_scopes` as `[{"resource": "stories", "actions": ["read", "write", "publish"]}, …]` groups (15 resources) plus `additional_scopes: ["offline_access"]`; valid scope strings are `resource:action` (32 scopes total with `offline_access`).
 
 ### 5. Does `/oauth/authorize` accept `dev_oauth_redirect_uri` as well as `oauth_redirect_uri`?
-- **Answer:** (code says yes — `authorize_request.rb#redirect_urls_for`)
-- **Evidence:**
+
+- **Answer: YES.** With the app configured as `oauth_redirect_uri = http://localhost:4900/oauth/callback` and `dev_oauth_redirect_uri = http://localhost:4901/oauth/callback` (set via `PUT /v1/oauth_clients/:id`), a full authorize + code exchange against port 4901 succeeded. Both URIs are valid concurrently (matches `authorize_request.rb#redirect_urls_for`), so dev vs prod ports can coexist on one app.
 
 ### 6. Any surprises in consent UX with a CLI as the app?
-- App name/icon rendering:
-- Space selection step:
-- `/oauth/init` vs direct `/oauth/authorize` entry:
-- Other notes:
+
+- App name renders as "Storyblok CLI" with a placeholder icon (integration apps have no icon upload in this flow); acceptable for a CLI.
+- Space selection is part of the consent screen; the resulting grant is scoped to the selected space(s). The token response does not echo the selected `space_ids` back (see Q1), so the CLI cannot confirm programmatically which space was authorized without trying a call or using grant introspection (`GET /oauth/grant` with the access token).
+- Entry via `GET /oauth/init` on the MAPI host works as the documented client entry point (bounces through the app frontend to prime the session, then `/oauth/authorize`); no session problems observed when already logged in to the app in the browser.
+- Narrowed scope requests work: requesting a subset (`stories:read offline_access`) of the app's 32 allowed scopes shows only the read permission on the consent screen and issues a grant with exactly that scope (confirmed visually by the operator).
+- No other UX surprises: consent wording, space picker, and redirects all behaved as expected across both consent runs (operator confirmed).
 
 ## Additional observations
 
-- Scope catalog (`GET /v1/oauth_clients/metadata`) raw shape: **captured 2026-07-07.** `available_scopes` is an array of `{"resource": "...", "actions": ["read", "write", ...]}` groups (15 resources: asset_folders, assets, collaborators, comments, components, datasource_entries, datasources, releases, spaces, statistics, stories, tags, users, webhooks, workflows; releases and stories additionally have `publish`), plus `additional_scopes: ["offline_access"]`. Scope strings are built as `resource:action` (matches storyrails `token_scopeable.rb` VALID_SCOPES).
-- `POST /v1/oauth_clients` returned **422 when created without a `slug`**: the App model validates slug format with no `allow_blank` plus global slug uniqueness (storyrails `app.rb`), so API consumers must send a unique slug even though the issue's sketch only mentions name/redirect/scopes. The CLI now sends `storyblok-cli-<base36 timestamp>`. (First run also sent `allowed_scopes: ["offline_access"]` only, due to a CLI-side flatten bug, but the scope-content validator only runs on update, so the slug is the confirmed 422 trigger; exact 422 body to be captured on re-run if it recurs.)
-- Non-manager 403 shape from `/v1/oauth_clients`:
-- Org not enabled for OAuth grants (if hit):
-- Env-var client credentials path (`STORYBLOK_OAUTH_CLIENT_ID/SECRET`):
-- Anything else:
+- **Env-var client credentials path works:** with `oauth.eu.client` removed from `credentials.json` and `STORYBLOK_OAUTH_CLIENT_ID` / `STORYBLOK_OAUTH_CLIENT_SECRET` set, `oauth login` completes normally, so the zero-setup CI/scripting path is viable.
+- **Token endpoint is form-encoded:** `POST /oauth/token` expects `application/x-www-form-urlencoded` (Rack::OAuth2), not JSON.
+- **PKCE:** S256 verified working end-to-end (43-128 char verifier, `[A-Za-z0-9-._~]`); mandatory for scoped grants per backend code.
+- **Org prerequisites for `/v1/oauth_clients`:** requires `can_manage_org?` (else 403 "You can not access this endpoint with your role on Organization") and the org `allow_oauth_grants` flag (else 403 "Organization is not enabled for OAuth grants"). The sandbox org had both; the non-manager 403 was not exercised (no non-manager PAT available).
+- **Auth header formats:** PAT calls use `Authorization: <token>`; OAuth grant tokens use `Authorization: Bearer <token>`.
+- **`token_type` in the response is lowercase `"bearer"`.**
 
 ## Runbook log
 
-- 2026-07-07 step 1 (`oauth setup --token <PAT>`): PAT path reached the metadata + create endpoints (org manager role and `allow_oauth_grants` confirmed working). Create failed with 422; root causes: CLI flattened the grouped scope catalog to just `offline_access`, and no `slug` was sent. Both fixed in the CLI (scope mapping to `resource:action`, unique slug, 422 bodies now printed as evidence). Re-run pending.
+- 2026-07-07 step 1 (`oauth setup --token <PAT>`): first attempt returned 422; root causes were a CLI-side scope flatten bug and the missing `slug` (see Q4). Fixed in `69f2347a4`; re-run created the app with all 32 scopes + `offline_access`.
+- 2026-07-08 step 2 (re-run setup): find-or-create confirmed, one app, secret readable (Q4).
+- 2026-07-08 step 3 (`oauth login`, full scopes): browser consent OK, tokens persisted, refresh token present (Q1).
+- 2026-07-08 step 4 (`oauth call --space 290020686946333`): `200 OK` with `Bearer` access token.
+- 2026-07-08 step 5 (`oauth refresh` ×2 + old-token reuse): rotation confirmed, old refresh token `invalid_grant` (Q2).
+- 2026-07-08 step 6 (`PUT /v1/oauth_clients/:id` dev redirect + `oauth login --port 4901 --scope stories:read offline_access` with env-var client creds, stored client removed): success (Q5, env-var path, narrowed scope).
+- 2026-07-08 step 7 (probes with narrowed grant): stories `200` vs components `403 Insufficient scope` (Q3).
+- 2026-07-08 step 8 (16-min wait, `oauth call`): `401 {"error": "Unauthorized"}`, no WWW-Authenticate header (Q3); `oauth refresh` afterwards recovered the session (`200 OK`).

--- a/DX-484-oauth-poc-findings.md
+++ b/DX-484-oauth-poc-findings.md
@@ -66,6 +66,23 @@
 - Narrowed scope requests work: requesting a subset (`stories:read offline_access`) of the app's 32 allowed scopes shows only the read permission on the consent screen and issues a grant with exactly that scope (confirmed visually by the operator).
 - No other UX surprises: consent wording, space picker, and redirects all behaved as expected across both consent runs (operator confirmed).
 
+## MAPI client integration assessment
+
+How OAuth would work in `@storyblok/management-api-client`, based on the verified backend behavior:
+
+1. **Login stays outside the client.** The host (CLI browser flow, MCP server, app) performs the consent dance and hands the client an access token, refresh token, client id/secret, and a persist callback.
+2. **Requests** send `Authorization: Bearer <access_token>` (PAT uses the bare token, so the client must switch header formats by auth type).
+3. **Refresh proactively or on 401 only.** Access tokens live 15 minutes, so any session longer than that refreshes. Either check `expires_at` before requests or intercept 401. Never refresh on 403: that is a scope problem, cleanly distinguishable by status code (no `WWW-Authenticate` header to parse).
+4. **Refresh must be single-flight with persist-before-use.** Because the refresh token rotates and the old one is single-use, the client must serialize concurrent refreshes, call the persist callback with the new refresh token before using the new access token, then retry the original request once.
+
+**Verdict: practical for interactive, single-process use; risky beyond that.** The mechanics are all fine (clean 401/403 split, refresh-after-expiry works, scope errors name the missing scope). The one backend design choice that hurts is strict rotation with no grace window:
+
+- Two processes sharing one credentials file (two CLI invocations, or CLI plus MCP server) invalidate each other's session on refresh. In-process single-flight does not fix cross-process races; that needs file locking or per-process grants.
+- A crash between refresh and persist permanently kills the session (re-login required, no recovery).
+- 15-minute access tokens make refresh a constant occurrence, not a rare edge case.
+
+Recommendation: ship OAuth for the CLI (one process, one credentials file, easy to lock), but for long-running or multi-process consumers ask the backend team for either a short reuse grace period on rotated refresh tokens or a machine-to-machine grant for CI. Also note the token response omits the consented `space_ids`, so the client cannot tell which space it is authorized for without a probe call or `GET /oauth/grant`.
+
 ## Additional observations
 
 - **Env-var client credentials path works:** with `oauth.eu.client` removed from `credentials.json` and `STORYBLOK_OAUTH_CLIENT_ID` / `STORYBLOK_OAUTH_CLIENT_SECRET` set, `oauth login` completes normally, so the zero-setup CI/scripting path is viable.

--- a/DX-484-oauth-poc-findings.md
+++ b/DX-484-oauth-poc-findings.md
@@ -44,7 +44,8 @@
 
 ## Additional observations
 
-- Scope catalog (`GET /v1/oauth_clients/metadata`) raw shape:
+- Scope catalog (`GET /v1/oauth_clients/metadata`) raw shape: **captured 2026-07-07.** `available_scopes` is an array of `{"resource": "...", "actions": ["read", "write", ...]}` groups (15 resources: asset_folders, assets, collaborators, comments, components, datasource_entries, datasources, releases, spaces, statistics, stories, tags, users, webhooks, workflows; releases and stories additionally have `publish`), plus `additional_scopes: ["offline_access"]`. Scope strings are built as `resource:action` (matches storyrails `token_scopeable.rb` VALID_SCOPES).
+- `POST /v1/oauth_clients` returned **422 when created without a `slug`**: the App model validates slug format with no `allow_blank` plus global slug uniqueness (storyrails `app.rb`), so API consumers must send a unique slug even though the issue's sketch only mentions name/redirect/scopes. The CLI now sends `storyblok-cli-<base36 timestamp>`. (First run also sent `allowed_scopes: ["offline_access"]` only, due to a CLI-side flatten bug, but the scope-content validator only runs on update, so the slug is the confirmed 422 trigger; exact 422 body to be captured on re-run if it recurs.)
 - Non-manager 403 shape from `/v1/oauth_clients`:
 - Org not enabled for OAuth grants (if hit):
 - Env-var client credentials path (`STORYBLOK_OAUTH_CLIENT_ID/SECRET`):
@@ -52,4 +53,4 @@
 
 ## Runbook log
 
-(Chronological notes per runbook step from the design doc, section "Manual runbook".)
+- 2026-07-07 step 1 (`oauth setup --token <PAT>`): PAT path reached the metadata + create endpoints (org manager role and `allow_oauth_grants` confirmed working). Create failed with 422; root causes: CLI flattened the grouped scope catalog to just `offline_access`, and no `slug` was sent. Both fixed in the CLI (scope mapping to `resource:action`, unique slug, 422 bodies now printed as evidence). Re-run pending.

--- a/DX-484-oauth-poc-findings.md
+++ b/DX-484-oauth-poc-findings.md
@@ -1,0 +1,55 @@
+# DX-484 OAuth POC — Findings
+
+**Environment:** production EU (`app.storyblok.com` / `mapi.storyblok.com`), sandbox org.
+**Date:** <!-- fill in when the runbook runs -->
+**CLI branch:** `feat/DX-484-oauth-login-poc`
+
+## Must-answer questions
+
+### 1. Does `offline_access` actually return a refresh token?
+- **Answer:**
+- **Evidence:** (raw `/oauth/token` response with secrets redacted)
+- Share with the MCP team — they are blocked on this question.
+
+### 2. Does refresh work as documented (new access token, refresh token unchanged)?
+- **Answer:**
+- **Note:** storyrails `token_endpoint.rb` revokes the old grant and issues a NEW refresh token on every
+  refresh (rotation) — the "refresh token unchanged" expectation appears wrong at the code level.
+  Record what actually happens.
+- **Evidence:** (`oauth refresh` output)
+
+### 3. Are expired-token vs missing-scope errors distinguishable (401 vs 403 shapes)?
+- **Expired token (after 15 min):**
+  - Status:
+  - WWW-Authenticate header:
+  - Body:
+- **Missing scope (narrowed-scope grant):**
+  - Status:
+  - Body: (expected per code: `{"error": "Insufficient scope: <scope> is required"}`)
+- **Verdict for the refresh-on-401 interceptor:**
+
+### 4. Does find-or-create behave sanely on re-runs?
+- **Answer:** (no duplicate apps? secret readable via show?)
+- **Evidence:**
+
+### 5. Does `/oauth/authorize` accept `dev_oauth_redirect_uri` as well as `oauth_redirect_uri`?
+- **Answer:** (code says yes — `authorize_request.rb#redirect_urls_for`)
+- **Evidence:**
+
+### 6. Any surprises in consent UX with a CLI as the app?
+- App name/icon rendering:
+- Space selection step:
+- `/oauth/init` vs direct `/oauth/authorize` entry:
+- Other notes:
+
+## Additional observations
+
+- Scope catalog (`GET /v1/oauth_clients/metadata`) raw shape:
+- Non-manager 403 shape from `/v1/oauth_clients`:
+- Org not enabled for OAuth grants (if hit):
+- Env-var client credentials path (`STORYBLOK_OAUTH_CLIENT_ID/SECRET`):
+- Anything else:
+
+## Runbook log
+
+(Chronological notes per runbook step from the design doc, section "Manual runbook".)

--- a/docs/superpowers/plans/2026-07-07-dx-484-oauth-cli-poc.md
+++ b/docs/superpowers/plans/2026-07-07-dx-484-oauth-cli-poc.md
@@ -1,0 +1,956 @@
+# DX-484 OAuth CLI POC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the OAuth Authorization Code Grant flow end-to-end against production EU with the sandbox org, via throwaway `storyblok oauth` CLI commands, producing verified answers in a findings doc.
+
+**Architecture:** A new `storyblok oauth` parent command with four subcommands (`setup`, `login`, `call`, `refresh`) under `packages/cli/src/commands/oauth/`, following the CLI's parent/subcommand pattern. Client credentials and tokens persist in a new `oauth` section of `~/.storyblok/credentials.json`. Raw `fetch` is used for the OAuth token endpoint (form-encoded) and probes (need raw status/headers/body); `customFetch` for the JSON `/v1/oauth_clients` MAPI calls.
+
+**Tech Stack:** TypeScript, Commander (via `getProgram()`), `@inquirer/prompts`, `open`, `node:http`, `node:crypto`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-dx-484-oauth-cli-poc-design.md` (read it first — it contains the backend facts and the manual runbook).
+
+## Global Constraints
+
+- Work happens in the worktree `.worktrees/feat-DX-484-oauth-login-poc` (branch `feat/DX-484-oauth-login-poc`). All commands below run from that directory.
+- **POC / throwaway code: no unit tests.** Verification per task = `pnpm nx lint:fix storyblok` + `pnpm nx test:types storyblok` + build/smoke. The real verification is the manual runbook (Task 7), driven by the user.
+- Repo rule: never `git push --force`; commits only because the user approved executing this plan. Commit messages end with the footer line `Fixes DX-484`.
+- Fixed callback: `http://localhost:4900/oauth/callback` (constant, one place).
+- Existing `login` command must remain untouched.
+- Secrets (PAT, client secret, tokens) must never be printed in full — mask with the existing `maskToken` util where displayed.
+- Environment: production EU. Base URLs come from existing constants (`managementApiRegions.eu` = `mapi.storyblok.com`, `getStoryblokUrl(region)` = `https://mapi.storyblok.com/v1`).
+
+---
+
+### Task 1: Scaffold the `oauth` parent command
+
+**Files:**
+- Modify: `packages/cli/src/constants.ts` (add `OAUTH` to `commands` and `colorPalette`)
+- Modify: `packages/cli/src/index.ts` (register command import)
+- Create: `packages/cli/src/commands/oauth/command.ts`
+- Create: `packages/cli/src/commands/oauth/constants.ts`
+- Create: `packages/cli/src/commands/oauth/index.ts`
+
+**Interfaces:**
+- Produces: `oauthCommand` (Commander command, exported from `command.ts`) — Tasks 3/5/6 attach subcommands to it. Constants `OAUTH_CALLBACK_PORT: number`, `OAUTH_CALLBACK_PATH: string`, `OAUTH_REDIRECT_URI: string`, `OAUTH_APP_NAME: string`, `DEFAULT_LOGIN_SCOPES: string[]` from `constants.ts`.
+
+- [ ] **Step 1: Add the command constant and color**
+
+In `packages/cli/src/constants.ts`, add to the `commands` object (after `STORIES: 'stories',`):
+
+```ts
+  OAUTH: 'oauth',
+```
+
+and to the `colorPalette` object (same file, after the `LOGIN` entry):
+
+```ts
+  OAUTH: '#dad4ff',
+```
+
+- [ ] **Step 2: Create the POC constants**
+
+Create `packages/cli/src/commands/oauth/constants.ts`:
+
+```ts
+export const OAUTH_CALLBACK_PORT = 4900;
+export const OAUTH_CALLBACK_PATH = '/oauth/callback';
+export const OAUTH_REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
+export const OAUTH_APP_NAME = 'Storyblok CLI';
+// Fallback when no scope list was stored at setup time (manual path).
+export const DEFAULT_LOGIN_SCOPES = ['read_content', 'write_content', 'offline_access'];
+```
+
+- [ ] **Step 3: Create the parent command**
+
+Create `packages/cli/src/commands/oauth/command.ts`:
+
+```ts
+import { commands } from '../../constants';
+import { getProgram } from '../../program';
+
+const program = getProgram();
+
+export const oauthCommand = program
+  .command(commands.OAUTH)
+  .description('POC: OAuth Authorization Code Grant flow (DX-484)');
+```
+
+Create `packages/cli/src/commands/oauth/index.ts` (subcommand imports get added in later tasks):
+
+```ts
+import './command';
+
+export { oauthCommand } from './command';
+```
+
+- [ ] **Step 4: Register the command**
+
+In `packages/cli/src/index.ts`, add after `import './commands/stories';`:
+
+```ts
+import './commands/oauth';
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+pnpm nx lint:fix storyblok && pnpm nx test:types storyblok
+pnpm nx build storyblok && node packages/cli/dist/index.mjs oauth --help
+```
+
+Expected: lint/types pass; help output shows `oauth` with the POC description.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/constants.ts packages/cli/src/index.ts packages/cli/src/commands/oauth
+git commit -m "feat(cli): scaffold oauth POC command
+
+Fixes DX-484"
+```
+
+---
+
+### Task 2: OAuth credentials store
+
+**Files:**
+- Create: `packages/cli/src/commands/oauth/store.ts`
+
+**Interfaces:**
+- Consumes: `getCredentials` from `src/creds.ts`, `saveToFile`/`getStoryblokGlobalPath` from `src/utils/filesystem.ts`.
+- Produces:
+  - `type OauthClientCredentials = { client_id: string; client_secret: string; scopes?: string[] }`
+  - `type OauthTokens = { auth_type: 'oauth'; access_token: string; refresh_token?: string; expires_at: string }`
+  - `getOauthEntry(region: RegionCode): Promise<{ client?: OauthClientCredentials; tokens?: OauthTokens }>`
+  - `resolveOauthClient(region: RegionCode): Promise<OauthClientCredentials | null>` (env vars win)
+  - `updateOauthEntry(region: RegionCode, patch: { client?: OauthClientCredentials; tokens?: OauthTokens }): Promise<void>`
+
+- [ ] **Step 1: Implement the store**
+
+Create `packages/cli/src/commands/oauth/store.ts`:
+
+```ts
+import { join } from 'pathe';
+import type { RegionCode } from '../../constants';
+import { getCredentials } from '../../creds';
+import { getStoryblokGlobalPath, saveToFile } from '../../utils/filesystem';
+
+export interface OauthClientCredentials {
+  client_id: string;
+  client_secret: string;
+  // Allowed scopes captured at setup time (PAT path); used as the default login scope set.
+  scopes?: string[];
+}
+
+export interface OauthTokens {
+  auth_type: 'oauth';
+  access_token: string;
+  refresh_token?: string;
+  expires_at: string;
+}
+
+export interface OauthRegionEntry {
+  client?: OauthClientCredentials;
+  tokens?: OauthTokens;
+}
+
+const credentialsPath = () => join(getStoryblokGlobalPath(), 'credentials.json');
+
+const readAll = async (): Promise<Record<string, unknown>> => {
+  return (await getCredentials(credentialsPath()) as Record<string, unknown> | null) ?? {};
+};
+
+export const getOauthEntry = async (region: RegionCode): Promise<OauthRegionEntry> => {
+  const all = await readAll();
+  const oauth = (all.oauth ?? {}) as Record<string, OauthRegionEntry>;
+  return oauth[region] ?? {};
+};
+
+export const getOauthClientFromEnv = (): OauthClientCredentials | null => {
+  const clientId = process.env.STORYBLOK_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.STORYBLOK_OAUTH_CLIENT_SECRET;
+  if (clientId && clientSecret) {
+    return { client_id: clientId, client_secret: clientSecret };
+  }
+  return null;
+};
+
+export const resolveOauthClient = async (region: RegionCode): Promise<OauthClientCredentials | null> => {
+  return getOauthClientFromEnv() ?? (await getOauthEntry(region)).client ?? null;
+};
+
+export const updateOauthEntry = async (region: RegionCode, patch: OauthRegionEntry): Promise<void> => {
+  const all = await readAll();
+  const oauth = (all.oauth ?? {}) as Record<string, OauthRegionEntry>;
+  oauth[region] = { ...oauth[region], ...patch };
+  await saveToFile(credentialsPath(), JSON.stringify({ ...all, oauth }, null, 2), { mode: 0o600 });
+};
+```
+
+Note: `getCredentials` returns the parsed `credentials.json` object keyed by machine name (its `StoryblokCredentials` type annotation is looser than reality — hence the local cast). The `oauth` key sits next to those machine entries, matching the spec's storage shape.
+
+- [ ] **Step 2: Verify**
+
+```bash
+pnpm nx lint:fix storyblok && pnpm nx test:types storyblok
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/commands/oauth/store.ts
+git commit -m "feat(cli): oauth POC credentials store
+
+Fixes DX-484"
+```
+
+---
+
+### Task 3: `storyblok oauth setup`
+
+**Files:**
+- Create: `packages/cli/src/commands/oauth/actions.ts`
+- Create: `packages/cli/src/commands/oauth/setup.ts`
+- Modify: `packages/cli/src/commands/oauth/index.ts`
+
+**Interfaces:**
+- Consumes: `oauthCommand` (Task 1), `updateOauthEntry`/`OauthClientCredentials` (Task 2), `customFetch`/`FetchError` from `src/utils/fetch.ts`, `getStoryblokUrl` from `src/utils/api-routes.ts`, `maskToken`/`CommandError`/`handleError`/`isRegion` from `src/utils`.
+- Produces: `findOrCreateCliClient(pat: string, region: RegionCode): Promise<OauthClientCredentials>` and `fetchScopeCatalog(pat: string, region: RegionCode): Promise<string[]>` in `actions.ts` (also used by the runbook and debugging).
+
+- [ ] **Step 1: Implement the MAPI actions**
+
+Create `packages/cli/src/commands/oauth/actions.ts`:
+
+```ts
+import type { RegionCode } from '../../constants';
+import { getStoryblokUrl } from '../../utils/api-routes';
+import { customFetch, FetchError } from '../../utils/fetch';
+import { CommandError } from '../../utils';
+import { OAUTH_APP_NAME, OAUTH_REDIRECT_URI } from './constants';
+import type { OauthClientCredentials } from './store';
+
+interface OauthClientSummary {
+  id: number;
+  name: string;
+}
+
+interface OauthClientDetail extends OauthClientSummary {
+  oauth_identifier: string;
+  oauth_secret?: string;
+}
+
+interface OauthClientsListResponse {
+  oauth_clients: OauthClientSummary[];
+}
+
+interface OauthClientResponse {
+  oauth_client: OauthClientDetail;
+}
+
+interface ScopeMetadataResponse {
+  available_scopes: unknown;
+  additional_scopes: string[];
+}
+
+const patHeaders = (pat: string) => ({ Authorization: pat });
+
+// The grouped-scopes shape is a UI-oriented structure; flatten defensively and
+// keep only plain scope strings. Log the raw payload once during the runbook to confirm.
+export const fetchScopeCatalog = async (pat: string, region: RegionCode): Promise<string[]> => {
+  const url = getStoryblokUrl(region);
+  const { available_scopes, additional_scopes } = await customFetch<ScopeMetadataResponse>(
+    `${url}/oauth_clients/metadata`,
+    { headers: patHeaders(pat) },
+  );
+  const grouped = Array.isArray(available_scopes)
+    ? available_scopes
+    : Object.values(available_scopes as Record<string, unknown>);
+  const flat = (grouped as unknown[]).flat(Infinity).filter(scope => typeof scope === 'string') as string[];
+  return [...new Set([...flat, ...additional_scopes])];
+};
+
+export const findOrCreateCliClient = async (pat: string, region: RegionCode): Promise<OauthClientCredentials> => {
+  const url = getStoryblokUrl(region);
+  const headers = patHeaders(pat);
+
+  try {
+    const { oauth_clients } = await customFetch<OauthClientsListResponse>(`${url}/oauth_clients`, { headers });
+    const existing = oauth_clients.find(client => client.name === OAUTH_APP_NAME);
+    const scopes = await fetchScopeCatalog(pat, region);
+
+    if (existing) {
+      const { oauth_client } = await customFetch<OauthClientResponse>(`${url}/oauth_clients/${existing.id}`, { headers });
+      if (!oauth_client.oauth_secret) {
+        throw new CommandError(`Found existing "${OAUTH_APP_NAME}" app (id ${existing.id}) but the response did not include a secret. Record this in the findings doc.`);
+      }
+      return { client_id: oauth_client.oauth_identifier, client_secret: oauth_client.oauth_secret, scopes };
+    }
+
+    const { oauth_client } = await customFetch<OauthClientResponse>(`${url}/oauth_clients`, {
+      method: 'POST',
+      headers,
+      body: {
+        oauth_client: {
+          name: OAUTH_APP_NAME,
+          oauth_redirect_uri: OAUTH_REDIRECT_URI,
+          allowed_scopes: scopes,
+        },
+      },
+    });
+    if (!oauth_client.oauth_secret) {
+      throw new CommandError('Created app but the response did not include a secret. Record this in the findings doc.');
+    }
+    return { client_id: oauth_client.oauth_identifier, client_secret: oauth_client.oauth_secret, scopes };
+  }
+  catch (error) {
+    if (error instanceof FetchError && error.response.status === 403) {
+      const backendMessage = JSON.stringify(error.response.data);
+      throw new CommandError(
+        `Access to /v1/oauth_clients was denied (403): ${backendMessage}\n`
+        + `Managing OAuth clients requires an org manager role and the org must be enabled for OAuth grants.\n`
+        + `If you are not an org manager, ask your org admin for a client id + secret and run:\n`
+        + `  storyblok oauth setup --client-id <id> --client-secret <secret>`,
+      );
+    }
+    throw error;
+  }
+};
+```
+
+- [ ] **Step 2: Implement the setup subcommand**
+
+Create `packages/cli/src/commands/oauth/setup.ts`:
+
+```ts
+import { input, password, select } from '@inquirer/prompts';
+import type { RegionCode } from '../../constants';
+import { colorPalette, commands, regions } from '../../constants';
+import { getProgram } from '../../program';
+import { CommandError, handleError, isRegion, konsola, maskToken } from '../../utils';
+import { findOrCreateCliClient } from './actions';
+import { updateOauthEntry } from './store';
+import { oauthCommand } from './command';
+
+const program = getProgram();
+
+const setupCommand = oauthCommand
+  .command('setup')
+  .description('One-time OAuth client provisioning for your org (POC)')
+  .option('-t, --token <token>', 'Personal access token of an org manager (find-or-create the "Storyblok CLI" app)')
+  .option('--client-id <clientId>', 'OAuth client id shared by your org admin')
+  .option('--client-secret <clientSecret>', 'OAuth client secret shared by your org admin')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .action(async (options: { token?: string; clientId?: string; clientSecret?: string; region: RegionCode }) => {
+    konsola.title(`${commands.OAUTH} setup`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`The provided region: ${options.region} is not valid. Please use one of: ${Object.values(regions).join(' | ')}`);
+      }
+      const region = options.region;
+
+      let pat = options.token;
+      let manualClientId = options.clientId;
+      let manualClientSecret = options.clientSecret;
+
+      if ((manualClientId && !manualClientSecret) || (!manualClientId && manualClientSecret)) {
+        throw new CommandError('--client-id and --client-secret must be provided together.');
+      }
+
+      if (!pat && !manualClientId) {
+        const path = await select({
+          message: 'How do you want to provision the OAuth client?',
+          choices: [
+            { name: 'I manage this org — use my personal access token (creates a "Storyblok CLI" app)', value: 'pat' },
+            { name: 'My org admin shared a client id + secret with me', value: 'manual' },
+          ],
+        });
+        if (path === 'pat') {
+          pat = await password({ message: 'Personal access token (used once, not stored):' });
+        }
+        else {
+          manualClientId = await input({ message: 'OAuth client id:' });
+          manualClientSecret = await password({ message: 'OAuth client secret:' });
+        }
+      }
+
+      if (pat) {
+        const client = await findOrCreateCliClient(pat, region);
+        await updateOauthEntry(region, { client });
+        konsola.ok(`OAuth client ${maskToken(client.client_id)} stored for region ${region}. The token was not persisted.`, true);
+        return;
+      }
+
+      if (!manualClientId?.trim() || !manualClientSecret?.trim()) {
+        throw new CommandError('Client id and client secret must not be empty.');
+      }
+      await updateOauthEntry(region, {
+        client: { client_id: manualClientId.trim(), client_secret: manualClientSecret.trim() },
+      });
+      konsola.ok(`OAuth client ${maskToken(manualClientId.trim())} stored for region ${region}.`, true);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });
+
+export { setupCommand };
+```
+
+Note: this POC uses `konsola` like the existing `login` command does (the `getUI()` singleton is only enabled for migrated commands via program hooks; matching `login` keeps the POC self-consistent). If lint complains about `konsola` usage, switch the calls to `const ui = getUI({ enabled: true })` + `ui.ok(...)`/`ui.title(...)` — same signatures.
+
+- [ ] **Step 3: Register the subcommand**
+
+In `packages/cli/src/commands/oauth/index.ts`, replace the content with:
+
+```ts
+import './command';
+import './setup';
+
+export { oauthCommand } from './command';
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+pnpm nx lint:fix storyblok && pnpm nx test:types storyblok
+pnpm nx build storyblok && node packages/cli/dist/index.mjs oauth setup --help
+```
+
+Expected: pass; help shows `--token`, `--client-id`, `--client-secret`, `--region`.
+
+Manual smoke (no real PAT needed): `node packages/cli/dist/index.mjs oauth setup --client-id foo --client-secret bar` then `cat ~/.storyblok/credentials.json` — expect an `oauth.eu.client` entry; file mode stays 0600 (`ls -l ~/.storyblok/credentials.json`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/commands/oauth
+git commit -m "feat(cli): oauth setup POC command (PAT and manual paths)
+
+Fixes DX-484"
+```
+
+---
+
+### Task 4: PKCE and callback-server helpers
+
+**Files:**
+- Create: `packages/cli/src/commands/oauth/pkce.ts`
+- Create: `packages/cli/src/commands/oauth/server.ts`
+
+**Interfaces:**
+- Produces:
+  - `generatePkce(): { verifier: string; challenge: string }` — S256; verifier is 64 base64url chars (backend requires 43–128 chars of `[A-Za-z0-9-._~]`; base64url's `A-Za-z0-9-_` is a subset).
+  - `generateState(): string`
+  - `waitForCallback(port: number, path: string): Promise<{ code: string; state: string }>` — one-shot `node:http` server; resolves on the first matching request, rejects on `error`/`error_description` params, missing code/state, or port-in-use.
+
+- [ ] **Step 1: Implement PKCE**
+
+Create `packages/cli/src/commands/oauth/pkce.ts`:
+
+```ts
+import { createHash, randomBytes } from 'node:crypto';
+
+export const generatePkce = (): { verifier: string; challenge: string } => {
+  const verifier = randomBytes(48).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+};
+
+export const generateState = (): string => randomBytes(16).toString('base64url');
+```
+
+- [ ] **Step 2: Implement the callback server**
+
+Create `packages/cli/src/commands/oauth/server.ts`:
+
+```ts
+import { createServer } from 'node:http';
+
+const SUCCESS_PAGE = `<!doctype html><html><body style="font-family: sans-serif; text-align: center; padding-top: 4rem;">
+<h1>Storyblok CLI</h1><p>Authorization received. You can close this tab and return to the terminal.</p>
+</body></html>`;
+
+export const waitForCallback = (port: number, path: string): Promise<{ code: string; state: string }> => {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      if (url.pathname !== path) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(SUCCESS_PAGE);
+      server.close();
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        reject(new Error(`Authorization failed: ${error} — ${url.searchParams.get('error_description') ?? 'no description'}`));
+        return;
+      }
+      const code = url.searchParams.get('code');
+      const state = url.searchParams.get('state');
+      if (!code || !state) {
+        reject(new Error('Callback did not include code and state query params.'));
+        return;
+      }
+      resolve({ code, state });
+    });
+
+    server.on('error', reject);
+    server.listen(port);
+  });
+};
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+pnpm nx lint:fix storyblok && pnpm nx test:types storyblok
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/src/commands/oauth/pkce.ts packages/cli/src/commands/oauth/server.ts
+git commit -m "feat(cli): PKCE and callback server helpers for oauth POC
+
+Fixes DX-484"
+```
+
+---
+
+### Task 5: `storyblok oauth login`
+
+**Files:**
+- Create: `packages/cli/src/commands/oauth/token-endpoint.ts`
+- Create: `packages/cli/src/commands/oauth/login.ts`
+- Modify: `packages/cli/src/commands/oauth/index.ts`
+
+**Interfaces:**
+- Consumes: Tasks 1–4 exports; `managementApiRegions` from `src/constants.ts`; `open` package.
+- Produces: `exchangeToken(region: RegionCode, params: Record<string, string>): Promise<TokenResponse>` in `token-endpoint.ts` where `TokenResponse = { access_token: string; refresh_token?: string; expires_in: number; scope?: string; raw: Record<string, unknown> }` — Task 6's `refresh` reuses it.
+
+- [ ] **Step 1: Implement the token endpoint client**
+
+The token endpoint is Rack::OAuth2 — it expects `application/x-www-form-urlencoded`, so raw `fetch` (not `customFetch`, which JSON-encodes) is used. Create `packages/cli/src/commands/oauth/token-endpoint.ts`:
+
+```ts
+import type { RegionCode } from '../../constants';
+import { managementApiRegions } from '../../constants';
+import { CommandError } from '../../utils';
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+  raw: Record<string, unknown>;
+}
+
+export const exchangeToken = async (region: RegionCode, params: Record<string, string>): Promise<TokenResponse> => {
+  const response = await fetch(`https://${managementApiRegions[region]}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params).toString(),
+  });
+
+  const text = await response.text();
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(text);
+  }
+  catch {
+    throw new CommandError(`Token endpoint returned non-JSON (${response.status} ${response.statusText}): ${text.slice(0, 500)}`);
+  }
+
+  if (!response.ok) {
+    throw new CommandError(`Token endpoint error ${response.status}: ${JSON.stringify(raw)}`);
+  }
+
+  return {
+    access_token: raw.access_token as string,
+    refresh_token: raw.refresh_token as string | undefined,
+    expires_in: raw.expires_in as number,
+    scope: raw.scope as string | undefined,
+    raw,
+  };
+};
+```
+
+- [ ] **Step 2: Implement the login subcommand**
+
+Create `packages/cli/src/commands/oauth/login.ts`:
+
+```ts
+import open from 'open';
+import type { RegionCode } from '../../constants';
+import { colorPalette, commands, managementApiRegions, regions } from '../../constants';
+import { getProgram } from '../../program';
+import { CommandError, handleError, isRegion, konsola, maskToken } from '../../utils';
+import { DEFAULT_LOGIN_SCOPES, OAUTH_CALLBACK_PATH, OAUTH_CALLBACK_PORT } from './constants';
+import { generatePkce, generateState } from './pkce';
+import { waitForCallback } from './server';
+import { getOauthEntry, resolveOauthClient, updateOauthEntry } from './store';
+import { exchangeToken } from './token-endpoint';
+import { oauthCommand } from './command';
+
+const program = getProgram();
+
+const loginSubcommand = oauthCommand
+  .command('login')
+  .description('Login via OAuth Authorization Code Grant with PKCE (POC)')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .option('--scope <scopes...>', 'Override the requested scopes (POC: used to force insufficient-scope errors)')
+  .option('--port <port>', 'Override the callback port (POC: dev_oauth_redirect_uri experiment)', `${OAUTH_CALLBACK_PORT}`)
+  .action(async (options: { region: RegionCode; scope?: string[]; port: string }) => {
+    konsola.title(`${commands.OAUTH} login`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`The provided region: ${options.region} is not valid. Please use one of: ${Object.values(regions).join(' | ')}`);
+      }
+      const region = options.region;
+
+      const client = await resolveOauthClient(region);
+      if (!client) {
+        throw new CommandError(
+          'No OAuth client credentials found. Set STORYBLOK_OAUTH_CLIENT_ID / STORYBLOK_OAUTH_CLIENT_SECRET '
+          + 'or run: storyblok oauth setup',
+        );
+      }
+
+      const port = Number(options.port);
+      const redirectUri = `http://localhost:${port}${OAUTH_CALLBACK_PATH}`;
+      const scopes = options.scope ?? (await getOauthEntry(region)).client?.scopes ?? DEFAULT_LOGIN_SCOPES;
+      const { verifier, challenge } = generatePkce();
+      const state = generateState();
+
+      const authorizeUrl = `https://${managementApiRegions[region]}/oauth/init?${new URLSearchParams({
+        client_id: client.client_id,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: scopes.join(' '),
+        state,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+      })}`;
+
+      const callback = waitForCallback(port, OAUTH_CALLBACK_PATH);
+      konsola.info(`Opening browser for authorization (listening on ${redirectUri})...`);
+      konsola.info(`If the browser does not open, visit:\n${authorizeUrl}`);
+      await open(authorizeUrl);
+
+      const { code, state: returnedState } = await callback;
+      if (returnedState !== state) {
+        throw new CommandError('State mismatch — possible CSRF; aborting without exchanging the code.');
+      }
+
+      const tokens = await exchangeToken(region, {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+        code_verifier: verifier,
+      });
+
+      await updateOauthEntry(region, {
+        tokens: {
+          auth_type: 'oauth',
+          access_token: tokens.access_token,
+          refresh_token: tokens.refresh_token,
+          expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
+        },
+      });
+
+      konsola.ok(`Logged in. Access token ${maskToken(tokens.access_token)} (expires in ${tokens.expires_in}s).`, true);
+      konsola.info(`Granted scope: ${tokens.scope ?? '(none reported)'}`);
+      konsola.info(`Refresh token returned: ${tokens.refresh_token ? `yes (${maskToken(tokens.refresh_token)})` : 'NO'}`);
+      konsola.info(`Raw token response keys: ${Object.keys(tokens.raw).join(', ')}`);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });
+
+export { loginSubcommand };
+```
+
+- [ ] **Step 3: Register the subcommand**
+
+In `packages/cli/src/commands/oauth/index.ts`, add after `import './setup';`:
+
+```ts
+import './login';
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+pnpm nx lint:fix storyblok && pnpm nx test:types storyblok
+pnpm nx build storyblok && node packages/cli/dist/index.mjs oauth login --help
+```
+
+Expected: pass; help shows `--region`, `--scope`, `--port`.
+
+Manual smoke without a real client: unset the env vars, remove any `oauth` section from `~/.storyblok/credentials.json`, run `node packages/cli/dist/index.mjs oauth login` — expect the "No OAuth client credentials found" error mentioning `oauth setup`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/commands/oauth
+git commit -m "feat(cli): oauth login POC command (PKCE + local callback)
+
+Fixes DX-484"
+```
+
+---
+
+### Task 6: `oauth call` and `oauth refresh` probes
+
+**Files:**
+- Create: `packages/cli/src/commands/oauth/probes.ts`
+- Modify: `packages/cli/src/commands/oauth/index.ts`
+
+**Interfaces:**
+- Consumes: `exchangeToken` (Task 5), store (Task 2), `managementApiRegions`.
+- Produces: nothing consumed later — these print raw evidence for the findings doc.
+
+- [ ] **Step 1: Implement the probes**
+
+Create `packages/cli/src/commands/oauth/probes.ts`:
+
+```ts
+import type { RegionCode } from '../../constants';
+import { colorPalette, commands, managementApiRegions, regions } from '../../constants';
+import { getProgram } from '../../program';
+import { CommandError, handleError, isRegion, konsola, maskToken } from '../../utils';
+import { getOauthEntry, resolveOauthClient, updateOauthEntry } from './store';
+import { exchangeToken } from './token-endpoint';
+import { oauthCommand } from './command';
+
+const program = getProgram();
+
+const requireTokens = async (region: RegionCode) => {
+  const { tokens } = await getOauthEntry(region);
+  if (!tokens) {
+    throw new CommandError('No OAuth tokens stored. Run: storyblok oauth login');
+  }
+  return tokens;
+};
+
+oauthCommand
+  .command('call [path]')
+  .description('POC probe: call a MAPI path with the stored OAuth access token and print the raw response')
+  .option('-s, --space <space>', 'Space id (used by the default path)')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .action(async (path: string | undefined, options: { space?: string; region: RegionCode }) => {
+    konsola.title(`${commands.OAUTH} call`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`Invalid region: ${options.region}`);
+      }
+      const region = options.region;
+      const tokens = await requireTokens(region);
+
+      const requestPath = path ?? (options.space ? `/v1/spaces/${options.space}` : undefined);
+      if (!requestPath) {
+        throw new CommandError('Provide a path argument or --space for the default GET /v1/spaces/:id probe.');
+      }
+
+      const url = `https://${managementApiRegions[region]}${requestPath}`;
+      konsola.info(`GET ${url}`);
+      konsola.info(`Authorization: Bearer ${maskToken(tokens.access_token)} (stored expiry: ${tokens.expires_at})`);
+
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${tokens.access_token}` },
+      });
+      const body = await response.text();
+
+      konsola.info(`Status: ${response.status} ${response.statusText}`);
+      konsola.info(`WWW-Authenticate: ${response.headers.get('www-authenticate') ?? '(not set)'}`);
+      konsola.info(`Body: ${body.slice(0, 2000)}`);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });
+
+oauthCommand
+  .command('refresh')
+  .description('POC probe: force a refresh_token grant and report whether the refresh token rotated')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .action(async (options: { region: RegionCode }) => {
+    konsola.title(`${commands.OAUTH} refresh`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`Invalid region: ${options.region}`);
+      }
+      const region = options.region;
+      const tokens = await requireTokens(region);
+      if (!tokens.refresh_token) {
+        throw new CommandError('No refresh token stored — was offline_access granted? Record this in the findings doc.');
+      }
+      const client = await resolveOauthClient(region);
+      if (!client) {
+        throw new CommandError('No OAuth client credentials found. Run: storyblok oauth setup');
+      }
+
+      const refreshed = await exchangeToken(region, {
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      });
+
+      const accessChanged = refreshed.access_token !== tokens.access_token;
+      const refreshChanged = !!refreshed.refresh_token && refreshed.refresh_token !== tokens.refresh_token;
+
+      await updateOauthEntry(region, {
+        tokens: {
+          auth_type: 'oauth',
+          access_token: refreshed.access_token,
+          refresh_token: refreshed.refresh_token ?? tokens.refresh_token,
+          expires_at: new Date(Date.now() + refreshed.expires_in * 1000).toISOString(),
+        },
+      });
+
+      konsola.ok(`Refreshed. New access token: ${maskToken(refreshed.access_token)} (changed: ${accessChanged})`, true);
+      konsola.info(`Refresh token in response: ${refreshed.refresh_token ? maskToken(refreshed.refresh_token) : 'NOT RETURNED'}`);
+      konsola.info(`Refresh token rotated: ${refreshChanged}`);
+      konsola.info(`Raw response keys: ${Object.keys(refreshed.raw).join(', ')}`);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });
+```
+
+- [ ] **Step 2: Register the probes**
+
+In `packages/cli/src/commands/oauth/index.ts`, add after `import './login';`:
+
+```ts
+import './probes';
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+pnpm nx lint:fix storyblok && pnpm nx test:types storyblok
+pnpm nx build storyblok && node packages/cli/dist/index.mjs oauth --help
+```
+
+Expected: pass; `oauth --help` lists `setup`, `login`, `call`, `refresh`.
+
+Manual smoke: with no tokens stored, `node packages/cli/dist/index.mjs oauth call --space 1` → "No OAuth tokens stored. Run: storyblok oauth login".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/src/commands/oauth
+git commit -m "feat(cli): oauth call/refresh POC probes
+
+Fixes DX-484"
+```
+
+---
+
+### Task 7: Findings doc skeleton + manual runbook
+
+The runbook itself is user-driven (real PAT, browser consent, 15-minute waits). This task prepares the evidence-capture document so every runbook step has a place to land.
+
+**Files:**
+- Create: `DX-484-oauth-poc-findings.md` (worktree root)
+
+- [ ] **Step 1: Create the findings skeleton**
+
+Create `DX-484-oauth-poc-findings.md`:
+
+```markdown
+# DX-484 OAuth POC — Findings
+
+**Environment:** production EU (`app.storyblok.com` / `mapi.storyblok.com`), sandbox org.
+**Date:** <!-- fill in when the runbook runs -->
+**CLI branch:** `feat/DX-484-oauth-login-poc`
+
+## Must-answer questions
+
+### 1. Does `offline_access` actually return a refresh token?
+- **Answer:**
+- **Evidence:** (raw `/oauth/token` response with secrets redacted)
+- Share with the MCP team — they are blocked on this question.
+
+### 2. Does refresh work as documented (new access token, refresh token unchanged)?
+- **Answer:**
+- **Note:** storyrails `token_endpoint.rb` revokes the old grant and issues a NEW refresh token on every
+  refresh (rotation) — the "refresh token unchanged" expectation appears wrong at the code level.
+  Record what actually happens.
+- **Evidence:** (`oauth refresh` output)
+
+### 3. Are expired-token vs missing-scope errors distinguishable (401 vs 403 shapes)?
+- **Expired token (after 15 min):**
+  - Status:
+  - WWW-Authenticate header:
+  - Body:
+- **Missing scope (narrowed-scope grant):**
+  - Status:
+  - Body: (expected per code: `{"error": "Insufficient scope: <scope> is required"}`)
+- **Verdict for the refresh-on-401 interceptor:**
+
+### 4. Does find-or-create behave sanely on re-runs?
+- **Answer:** (no duplicate apps? secret readable via show?)
+- **Evidence:**
+
+### 5. Does `/oauth/authorize` accept `dev_oauth_redirect_uri` as well as `oauth_redirect_uri`?
+- **Answer:** (code says yes — `authorize_request.rb#redirect_urls_for`)
+- **Evidence:**
+
+### 6. Any surprises in consent UX with a CLI as the app?
+- App name/icon rendering:
+- Space selection step:
+- `/oauth/init` vs direct `/oauth/authorize` entry:
+- Other notes:
+
+## Additional observations
+
+- Scope catalog (`GET /v1/oauth_clients/metadata`) raw shape:
+- Non-manager 403 shape from `/v1/oauth_clients`:
+- Org not enabled for OAuth grants (if hit):
+- Env-var client credentials path (`STORYBLOK_OAUTH_CLIENT_ID/SECRET`):
+- Anything else:
+
+## Runbook log
+
+(Chronological notes per runbook step from the design doc, section "Manual runbook".)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add DX-484-oauth-poc-findings.md
+git commit -m "docs: findings skeleton for DX-484 oauth POC
+
+Fixes DX-484"
+```
+
+- [ ] **Step 3: Hand off to the user for the manual runbook**
+
+Tell the user the build command (`pnpm nx build storyblok`, then `node packages/cli/dist/index.mjs oauth …` from the worktree) and walk them through the runbook in the design doc (`docs/superpowers/specs/2026-07-07-dx-484-oauth-cli-poc-design.md`, "Manual runbook" section), filling `DX-484-oauth-poc-findings.md` as evidence comes in. Preconditions to confirm first:
+1. The sandbox org has `allow_oauth_grants` enabled (otherwise `oauth setup --token <PAT>` returns the 403 "Organization is not enabled for OAuth grants" — itself a finding).
+2. The user has an org-manager PAT for the sandbox org; the spaces from `.env.qa-engineer-manual` are used for `oauth call --space <id>` probes.
+```

--- a/docs/superpowers/specs/2026-07-07-dx-484-oauth-cli-poc-design.md
+++ b/docs/superpowers/specs/2026-07-07-dx-484-oauth-cli-poc-design.md
@@ -1,0 +1,114 @@
+# DX-484 — POC: OAuth Authorization Code Grant login in the CLI
+
+**Status:** Approved design (POC — throwaway code, the deliverable is verified answers)
+**Issue:** [DX-484](https://linear.app/storyblok/issue/DX-484)
+**Branch/worktree:** `feat/DX-484-oauth-login-poc` → `.worktrees/feat-DX-484-oauth-login-poc`
+**Environment:** Production EU (`app.storyblok.com` / `mapi.storyblok.com`) with the sandbox org. The two spaces with PATs in `.env.qa-engineer-manual` are available for manual tests.
+
+## Goal
+
+Prove the full OAuth Authorization Code Grant flow end-to-end against the real backend, covering both client-provisioning paths, and produce verified answers to the issue's "must answer" list in a findings doc.
+
+## Backend facts (from storyrails code — POC verifies empirically)
+
+Source: `../storyrails` (`app/controllers/v1/oauth_controller.rb`, `app/controllers/v1/oauth_clients_controller.rb`, `app/services/authn/token_auth/token_endpoint.rb`, `app/services/authn/token_auth/authorize_request.rb`, `app/models/oauth_grant.rb`, `app/controllers/concerns/scope_enforceable.rb`).
+
+- Endpoints live on the region API host (EU: `mapi.storyblok.com`):
+  - `GET /oauth/init` — documented client entry point; bounces to `app.storyblok.com/#/oauth/init` to prime the session, then to `/oauth/authorize`.
+  - `GET /oauth/authorize` / `POST /oauth/authorize` (consent approval).
+  - `POST /oauth/token` — grant types: `authorization_code`, `refresh_token`, `client_credentials`. Requires `client_id` + `client_secret` (confidential client), exact `redirect_uri` match with the authorize request.
+  - `GET/POST /v1/oauth_clients`, `GET /v1/oauth_clients/:id` (returns `oauth_secret` via `include_secret`), `GET /v1/oauth_clients/metadata` (scope catalog: `available_scopes` grouped + `additional_scopes` incl. `offline_access`).
+- PKCE S256 is **mandatory** for scoped grants. Verifier: 43–128 chars of `[A-Za-z0-9-._~]`.
+- `offline_access` scope → refresh token issued. Access token lifetime **15 minutes**, refresh token lifetime **1 month**.
+- On `refresh_token` grant the old grant is **revoked and a new refresh token is issued** (rotation) — this contradicts the "refresh token unchanged" wording in the issue; capture the observed behavior as a headline finding.
+- Missing scope → `403 {"error": "Insufficient scope: <scope> is required"}`. Expired/invalid token → 401. Shapes look distinguishable; capture raw bodies of both.
+- `dev_oauth_redirect_uri` is accepted at authorize alongside `oauth_redirect_uri` (`authorize_request.rb#redirect_urls_for`).
+- `/v1/oauth_clients` requires `can_manage_org?` (else `403 {"error": "You can not access this endpoint with your role on Organization"}`) **and** the org's `allow_oauth_grants` flag (else `403 {"error": "Organization is not enabled for OAuth grants"}`). Sandbox-org precondition to verify first.
+- Consent includes **space selection**; grants are space-scoped (`space_ids`). MAPI probes must target a space selected at consent.
+
+## Command surface
+
+All new code under `packages/cli/src/commands/oauth/` following the CLI command patterns (`index.ts` command definitions, `actions.ts` for API/filesystem work, `getUI()`/`getLogger()`, typed `APIError`/`CommandError`). The existing `login` command is untouched.
+
+Fixed callback: `http://localhost:4900/oauth/callback` (port is an arbitrary one-line constant).
+
+### `storyblok oauth setup`
+
+One-time client provisioning per org/region. Interactive by default (select path); non-interactive via flags.
+
+- **PAT path** (`--token <PAT>` or interactive prompt): find-or-create an Integration app named "Storyblok CLI" via `GET /v1/oauth_clients` → match by name → `GET /v1/oauth_clients/:id` for the secret, else `POST /v1/oauth_clients` with `name`, `oauth_redirect_uri: http://localhost:4900/oauth/callback`, `allowed_scopes`: full catalog from `metadata` + `offline_access`. Read `oauth_identifier`/`oauth_secret`, store, discard the PAT (never persisted).
+  - 403 (non-manager) → clear error pointing at the manual path ("ask your org admin for a client id/secret").
+  - 403 (org not enabled for OAuth grants) → surfaced verbatim.
+- **Manual path** (`--client-id <id> --client-secret <secret>` or interactive prompts): validate non-empty, store.
+- `--region <region>` supported; defaults to `eu`.
+
+### `storyblok oauth login`
+
+1. Resolve client credentials: `STORYBLOK_OAUTH_CLIENT_ID`/`STORYBLOK_OAUTH_CLIENT_SECRET` env vars → `credentials.json` → error pointing at `oauth setup`.
+2. Start `node:http` callback server on port 4900; generate PKCE verifier/challenge (S256) + random `state`.
+3. Open browser (existing `open` dependency) to `https://mapi.storyblok.com/oauth/init?client_id=…&redirect_uri=…&response_type=code&scope=…&state=…&code_challenge=…&code_challenge_method=S256`.
+4. On callback: validate `state`, exchange `code` + `code_verifier` + client secret at `POST /oauth/token`, respond with a minimal "you can close this tab" page, shut the server down.
+5. Persist tokens (see storage). Print granted scopes + space ids.
+
+POC-only flags: `--scope <scopes>` overrides the requested scope list (defaults to the full allowed catalog + `offline_access`; used to force the insufficient-scope 403), and `--port <port>` overrides the callback port/redirect URI (used for the `dev_oauth_redirect_uri` experiment — the app's dev redirect is set beforehand via `PUT /v1/oauth_clients/:id` or the UI).
+
+### `storyblok oauth call [path] [--space <id>]` (probe, throwaway)
+
+Calls a MAPI endpoint (default `GET /v1/spaces/:space_id`) with the stored access token; prints HTTP status and raw body. Evidence collector for the 401-vs-403 question and for post-login/post-refresh verification.
+
+### `storyblok oauth refresh` (probe, throwaway)
+
+Forces a `refresh_token` grant at `POST /oauth/token`, persists the new tokens, and prints whether the refresh token changed (rotation check).
+
+## Credentials storage
+
+Same `~/.storyblok/credentials.json` (mode 0600, existing `saveToFile` util). New `oauth` section next to the existing PAT entries, keyed per region:
+
+```json
+{
+  "api.storyblok.com": { "login": "…", "password": "…", "region": "eu" },
+  "oauth": {
+    "eu": {
+      "client": { "client_id": "…", "client_secret": "…" },
+      "tokens": {
+        "auth_type": "oauth",
+        "access_token": "…",
+        "refresh_token": "…",
+        "expires_at": "2026-07-07T12:34:56.000Z"
+      }
+    }
+  }
+}
+```
+
+Env vars `STORYBLOK_OAUTH_CLIENT_ID`/`STORYBLOK_OAUTH_CLIENT_SECRET` override the stored `client` block everywhere (the CI/scripting path — works with zero setup).
+
+## Deliverable
+
+`DX-484-oauth-poc-findings.md` at the worktree root:
+
+- Each "must answer" question → observed behavior + raw request/response evidence (redacted secrets).
+- Headline: refresh-token rotation observed vs. the "refresh token unchanged" expectation.
+- Consent UX notes (app name/icon rendering, space-selection step) with the CLI as the app.
+- Shared verbatim with the MCP team (they're blocked on the `offline_access` question).
+
+### Manual runbook (user drives browser/consent)
+
+1. `oauth setup --token <PAT>` against the sandbox org → app created; note response.
+2. Re-run `oauth setup` → find-or-create: no duplicate app; secret readable via show.
+3. `oauth setup` with a non-manager PAT (if available) → capture the 403 and the manual-path hint.
+4. `oauth login` → full browser flow; note consent UX; tokens persisted.
+5. `oauth call` → 200 with fresh token.
+6. Narrowed-scope authorize (`oauth login --scope read_content offline_access`) → `oauth call` against an endpoint outside the granted scopes → capture the 403 shape.
+7. Wait ≥15 min → `oauth call` → capture the 401 shape.
+8. `oauth refresh` → new access token works; record whether the refresh token rotated.
+9. Set `dev_oauth_redirect_uri` on the app (different port, via `PUT /v1/oauth_clients/:id`) → `oauth login --port <devport>` → does authorize accept it?
+10. `STORYBLOK_OAUTH_CLIENT_ID`/`SECRET` env-var path → `oauth login` with no stored client creds.
+
+## Testing / verification
+
+Throwaway POC: no unit tests. `pnpm nx lint:fix storyblok` and typecheck must pass. Verification is the manual runbook + findings doc.
+
+## Out of scope (per issue)
+
+Logout/revocation, MAPI-client refresh interceptor, multi-region credentials handling, packaging/UX polish, default-scope policy for the auto-created app.

--- a/packages/cli/src/commands/oauth/actions.ts
+++ b/packages/cli/src/commands/oauth/actions.ts
@@ -1,0 +1,93 @@
+import type { RegionCode } from '../../constants';
+import { getStoryblokUrl } from '../../utils/api-routes';
+import { customFetch, FetchError } from '../../utils/fetch';
+import { CommandError } from '../../utils';
+import { OAUTH_APP_NAME, OAUTH_REDIRECT_URI } from './constants';
+import type { OauthClientCredentials } from './store';
+
+interface OauthClientSummary {
+  id: number;
+  name: string;
+}
+
+interface OauthClientDetail extends OauthClientSummary {
+  oauth_identifier: string;
+  oauth_secret?: string;
+}
+
+interface OauthClientsListResponse {
+  oauth_clients: OauthClientSummary[];
+}
+
+interface OauthClientResponse {
+  oauth_client: OauthClientDetail;
+}
+
+interface ScopeMetadataResponse {
+  available_scopes: unknown;
+  additional_scopes: string[];
+}
+
+const patHeaders = (pat: string) => ({ Authorization: pat });
+
+// The grouped-scopes shape is a UI-oriented structure; flatten defensively and
+// keep only plain scope strings. Log the raw payload once during the runbook to confirm.
+export const fetchScopeCatalog = async (pat: string, region: RegionCode): Promise<string[]> => {
+  const url = getStoryblokUrl(region);
+  const { available_scopes, additional_scopes } = await customFetch<ScopeMetadataResponse>(
+    `${url}/oauth_clients/metadata`,
+    { headers: patHeaders(pat) },
+  );
+  const grouped = Array.isArray(available_scopes)
+    ? available_scopes
+    : Object.values(available_scopes as Record<string, unknown>);
+  const flat = (grouped as unknown[]).flat(Infinity).filter(scope => typeof scope === 'string') as string[];
+  return [...new Set([...flat, ...additional_scopes])];
+};
+
+export const findOrCreateCliClient = async (pat: string, region: RegionCode): Promise<OauthClientCredentials> => {
+  const url = getStoryblokUrl(region);
+  const headers = patHeaders(pat);
+
+  try {
+    const { oauth_clients } = await customFetch<OauthClientsListResponse>(`${url}/oauth_clients`, { headers });
+    const existing = oauth_clients.find(client => client.name === OAUTH_APP_NAME);
+    const scopes = await fetchScopeCatalog(pat, region);
+
+    if (existing) {
+      const { oauth_client } = await customFetch<OauthClientResponse>(`${url}/oauth_clients/${existing.id}`, { headers });
+      if (!oauth_client.oauth_secret) {
+        throw new CommandError(`Found existing "${OAUTH_APP_NAME}" app (id ${existing.id}) but the response did not include a secret. Record this in the findings doc.`);
+      }
+      return { client_id: oauth_client.oauth_identifier, client_secret: oauth_client.oauth_secret, scopes };
+    }
+
+    const { oauth_client } = await customFetch<OauthClientResponse>(`${url}/oauth_clients`, {
+      method: 'POST',
+      headers,
+      body: {
+        oauth_client: {
+          name: OAUTH_APP_NAME,
+          oauth_redirect_uri: OAUTH_REDIRECT_URI,
+          allowed_scopes: scopes,
+        },
+      },
+    });
+    if (!oauth_client.oauth_secret) {
+      throw new CommandError('Created app but the response did not include a secret. Record this in the findings doc.');
+    }
+    return { client_id: oauth_client.oauth_identifier, client_secret: oauth_client.oauth_secret, scopes };
+  }
+  catch (error) {
+    if (error instanceof FetchError && error.response.status === 403) {
+      const backendMessage = JSON.stringify(error.response.data);
+      throw new CommandError(
+        `Access to /v1/oauth_clients was denied (403): ${backendMessage}\n`
+        + `Managing OAuth clients requires an org manager role and the org must be enabled for OAuth grants.\n`
+        + `If you are not an org manager, ask your org admin for a client id + secret and run:\n`
+        + `  storyblok oauth setup --client-id <id> --client-secret <secret>`,
+      );
+    }
+    throw error;
+  }
+};

--- a/packages/cli/src/commands/oauth/actions.ts
+++ b/packages/cli/src/commands/oauth/actions.ts
@@ -23,15 +23,20 @@ interface OauthClientResponse {
   oauth_client: OauthClientDetail;
 }
 
+interface ScopeGroup {
+  resource: string;
+  actions: string[];
+}
+
 interface ScopeMetadataResponse {
-  available_scopes: unknown;
+  available_scopes: ScopeGroup[];
   additional_scopes: string[];
 }
 
 const patHeaders = (pat: string) => ({ Authorization: pat });
 
-// The grouped-scopes shape is a UI-oriented structure; flatten defensively and
-// keep only plain scope strings. Log the raw payload once during the runbook to confirm.
+// Scope strings are built as `resource:action` from the grouped catalog
+// (storyrails token_scopeable.rb VALID_SCOPES).
 export const fetchScopeCatalog = async (pat: string, region: RegionCode): Promise<string[]> => {
   const url = getStoryblokUrl(region);
   const { available_scopes, additional_scopes } = await customFetch<ScopeMetadataResponse>(
@@ -39,10 +44,7 @@ export const fetchScopeCatalog = async (pat: string, region: RegionCode): Promis
     { headers: patHeaders(pat) },
   );
   konsola.info(`Raw scope metadata: ${JSON.stringify({ available_scopes, additional_scopes })}`);
-  const grouped = Array.isArray(available_scopes)
-    ? available_scopes
-    : Object.values(available_scopes as Record<string, unknown>);
-  const flat = (grouped as unknown[]).flat(Infinity).filter(scope => typeof scope === 'string') as string[];
+  const flat = available_scopes.flatMap(group => group.actions.map(action => `${group.resource}:${action}`));
   const scopes = [...new Set([...flat, ...additional_scopes])];
   konsola.info(`Resolved allowed_scopes (${scopes.length}): ${scopes.join(' ')}`);
   return scopes;
@@ -71,6 +73,9 @@ export const findOrCreateCliClient = async (pat: string, region: RegionCode): Pr
       body: {
         oauth_client: {
           name: OAUTH_APP_NAME,
+          // App validates slug format with no allow_blank and global uniqueness,
+          // so creates need a unique slug (storyrails app.rb).
+          slug: `storyblok-cli-${Date.now().toString(36)}`,
           oauth_redirect_uri: OAUTH_REDIRECT_URI,
           allowed_scopes: scopes,
         },
@@ -89,6 +94,12 @@ export const findOrCreateCliClient = async (pat: string, region: RegionCode): Pr
         + `Managing OAuth clients requires an org manager role and the org must be enabled for OAuth grants.\n`
         + `If you are not an org manager, ask your org admin for a client id + secret and run:\n`
         + `  storyblok oauth setup --client-id <id> --client-secret <secret>`,
+      );
+    }
+    if (error instanceof FetchError) {
+      // Surface the raw error body — it's runbook evidence (e.g. 422 validation shapes).
+      throw new CommandError(
+        `/v1/oauth_clients request failed (${error.response.status} ${error.response.statusText}): ${JSON.stringify(error.response.data)}`,
       );
     }
     throw error;

--- a/packages/cli/src/commands/oauth/actions.ts
+++ b/packages/cli/src/commands/oauth/actions.ts
@@ -1,7 +1,7 @@
 import type { RegionCode } from '../../constants';
 import { getStoryblokUrl } from '../../utils/api-routes';
 import { customFetch, FetchError } from '../../utils/fetch';
-import { CommandError } from '../../utils';
+import { CommandError, konsola } from '../../utils';
 import { OAUTH_APP_NAME, OAUTH_REDIRECT_URI } from './constants';
 import type { OauthClientCredentials } from './store';
 
@@ -38,11 +38,14 @@ export const fetchScopeCatalog = async (pat: string, region: RegionCode): Promis
     `${url}/oauth_clients/metadata`,
     { headers: patHeaders(pat) },
   );
+  konsola.info(`Raw scope metadata: ${JSON.stringify({ available_scopes, additional_scopes })}`);
   const grouped = Array.isArray(available_scopes)
     ? available_scopes
     : Object.values(available_scopes as Record<string, unknown>);
   const flat = (grouped as unknown[]).flat(Infinity).filter(scope => typeof scope === 'string') as string[];
-  return [...new Set([...flat, ...additional_scopes])];
+  const scopes = [...new Set([...flat, ...additional_scopes])];
+  konsola.info(`Resolved allowed_scopes (${scopes.length}): ${scopes.join(' ')}`);
+  return scopes;
 };
 
 export const findOrCreateCliClient = async (pat: string, region: RegionCode): Promise<OauthClientCredentials> => {

--- a/packages/cli/src/commands/oauth/command.ts
+++ b/packages/cli/src/commands/oauth/command.ts
@@ -1,0 +1,8 @@
+import { commands } from '../../constants';
+import { getProgram } from '../../program';
+
+const program = getProgram();
+
+export const oauthCommand = program
+  .command(commands.OAUTH)
+  .description('POC: OAuth Authorization Code Grant flow (DX-484)');

--- a/packages/cli/src/commands/oauth/constants.ts
+++ b/packages/cli/src/commands/oauth/constants.ts
@@ -3,4 +3,5 @@ export const OAUTH_CALLBACK_PATH = '/oauth/callback';
 export const OAUTH_REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
 export const OAUTH_APP_NAME = 'Storyblok CLI';
 // Fallback when no scope list was stored at setup time (manual path).
-export const DEFAULT_LOGIN_SCOPES = ['read_content', 'write_content', 'offline_access'];
+// Grant scopes use the `resource:action` format (storyrails token_scopeable.rb).
+export const DEFAULT_LOGIN_SCOPES = ['stories:read', 'stories:write', 'offline_access'];

--- a/packages/cli/src/commands/oauth/constants.ts
+++ b/packages/cli/src/commands/oauth/constants.ts
@@ -1,0 +1,6 @@
+export const OAUTH_CALLBACK_PORT = 4900;
+export const OAUTH_CALLBACK_PATH = '/oauth/callback';
+export const OAUTH_REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
+export const OAUTH_APP_NAME = 'Storyblok CLI';
+// Fallback when no scope list was stored at setup time (manual path).
+export const DEFAULT_LOGIN_SCOPES = ['read_content', 'write_content', 'offline_access'];

--- a/packages/cli/src/commands/oauth/index.ts
+++ b/packages/cli/src/commands/oauth/index.ts
@@ -1,0 +1,3 @@
+import './command';
+
+export { oauthCommand } from './command';

--- a/packages/cli/src/commands/oauth/index.ts
+++ b/packages/cli/src/commands/oauth/index.ts
@@ -1,5 +1,6 @@
 import './command';
 import './setup';
 import './login';
+import './probes';
 
 export { oauthCommand } from './command';

--- a/packages/cli/src/commands/oauth/index.ts
+++ b/packages/cli/src/commands/oauth/index.ts
@@ -1,4 +1,5 @@
 import './command';
 import './setup';
+import './login';
 
 export { oauthCommand } from './command';

--- a/packages/cli/src/commands/oauth/index.ts
+++ b/packages/cli/src/commands/oauth/index.ts
@@ -1,3 +1,4 @@
 import './command';
+import './setup';
 
 export { oauthCommand } from './command';

--- a/packages/cli/src/commands/oauth/login.ts
+++ b/packages/cli/src/commands/oauth/login.ts
@@ -1,0 +1,93 @@
+import open from 'open';
+import type { RegionCode } from '../../constants';
+import { colorPalette, commands, managementApiRegions, regions } from '../../constants';
+import { getProgram } from '../../program';
+import { CommandError, handleError, isRegion, konsola, maskToken } from '../../utils';
+import { DEFAULT_LOGIN_SCOPES, OAUTH_CALLBACK_PATH, OAUTH_CALLBACK_PORT } from './constants';
+import { generatePkce, generateState } from './pkce';
+import { waitForCallback } from './server';
+import { getOauthEntry, resolveOauthClient, updateOauthEntry } from './store';
+import { exchangeToken } from './token-endpoint';
+import { oauthCommand } from './command';
+
+const program = getProgram();
+
+const loginSubcommand = oauthCommand
+  .command('login')
+  .description('Login via OAuth Authorization Code Grant with PKCE (POC)')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .option('--scope <scopes...>', 'Override the requested scopes (POC: used to force insufficient-scope errors)')
+  .option('--port <port>', 'Override the callback port (POC: dev_oauth_redirect_uri experiment)', `${OAUTH_CALLBACK_PORT}`)
+  .action(async (options: { region: RegionCode; scope?: string[]; port: string }) => {
+    konsola.title(`${commands.OAUTH} login`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`The provided region: ${options.region} is not valid. Please use one of: ${Object.values(regions).join(' | ')}`);
+      }
+      const region = options.region;
+
+      const client = await resolveOauthClient(region);
+      if (!client) {
+        throw new CommandError(
+          'No OAuth client credentials found. Set STORYBLOK_OAUTH_CLIENT_ID / STORYBLOK_OAUTH_CLIENT_SECRET '
+          + 'or run: storyblok oauth setup',
+        );
+      }
+
+      const port = Number(options.port);
+      const redirectUri = `http://localhost:${port}${OAUTH_CALLBACK_PATH}`;
+      const scopes = options.scope ?? (await getOauthEntry(region)).client?.scopes ?? DEFAULT_LOGIN_SCOPES;
+      const { verifier, challenge } = generatePkce();
+      const state = generateState();
+
+      const authorizeUrl = `https://${managementApiRegions[region]}/oauth/init?${new URLSearchParams({
+        client_id: client.client_id,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: scopes.join(' '),
+        state,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+      })}`;
+
+      const callback = waitForCallback(port, OAUTH_CALLBACK_PATH);
+      konsola.info(`Opening browser for authorization (listening on ${redirectUri})...`);
+      konsola.info(`If the browser does not open, visit:\n${authorizeUrl}`);
+      await open(authorizeUrl);
+
+      const { code, state: returnedState } = await callback;
+      if (returnedState !== state) {
+        throw new CommandError('State mismatch — possible CSRF; aborting without exchanging the code.');
+      }
+
+      const tokens = await exchangeToken(region, {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+        code_verifier: verifier,
+      });
+
+      await updateOauthEntry(region, {
+        tokens: {
+          auth_type: 'oauth',
+          access_token: tokens.access_token,
+          refresh_token: tokens.refresh_token,
+          expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
+        },
+      });
+
+      konsola.ok(`Logged in. Access token ${maskToken(tokens.access_token)} (expires in ${tokens.expires_in}s).`, true);
+      konsola.info(`Granted scope: ${tokens.scope ?? '(none reported)'}`);
+      konsola.info(`Refresh token returned: ${tokens.refresh_token ? `yes (${maskToken(tokens.refresh_token)})` : 'NO'}`);
+      konsola.info(`Raw token response keys: ${Object.keys(tokens.raw).join(', ')}`);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });
+
+export { loginSubcommand };

--- a/packages/cli/src/commands/oauth/login.ts
+++ b/packages/cli/src/commands/oauth/login.ts
@@ -83,7 +83,12 @@ const loginSubcommand = oauthCommand
       konsola.ok(`Logged in. Access token ${maskToken(tokens.access_token)} (expires in ${tokens.expires_in}s).`, true);
       konsola.info(`Granted scope: ${tokens.scope ?? '(none reported)'}`);
       konsola.info(`Refresh token returned: ${tokens.refresh_token ? `yes (${maskToken(tokens.refresh_token)})` : 'NO'}`);
-      konsola.info(`Raw token response keys: ${Object.keys(tokens.raw).join(', ')}`);
+      const redactedResponse = {
+        ...tokens.raw,
+        access_token: maskToken(tokens.access_token),
+        ...(tokens.refresh_token ? { refresh_token: maskToken(tokens.refresh_token) } : {}),
+      };
+      konsola.info(`Raw token response (redacted): ${JSON.stringify(redactedResponse, null, 2)}`);
     }
     catch (error) {
       handleError(error as Error, verbose);

--- a/packages/cli/src/commands/oauth/login.ts
+++ b/packages/cli/src/commands/oauth/login.ts
@@ -83,11 +83,11 @@ const loginSubcommand = oauthCommand
       konsola.ok(`Logged in. Access token ${maskToken(tokens.access_token)} (expires in ${tokens.expires_in}s).`, true);
       konsola.info(`Granted scope: ${tokens.scope ?? '(none reported)'}`);
       konsola.info(`Refresh token returned: ${tokens.refresh_token ? `yes (${maskToken(tokens.refresh_token)})` : 'NO'}`);
-      const redactedResponse = {
-        ...tokens.raw,
-        access_token: maskToken(tokens.access_token),
-        ...(tokens.refresh_token ? { refresh_token: maskToken(tokens.refresh_token) } : {}),
-      };
+      const redactedResponse = Object.fromEntries(
+        Object.entries(tokens.raw).map(([key, value]) =>
+          /token|secret/i.test(key) && typeof value === 'string' ? [key, maskToken(value)] : [key, value],
+        ),
+      );
       konsola.info(`Raw token response (redacted): ${JSON.stringify(redactedResponse, null, 2)}`);
     }
     catch (error) {

--- a/packages/cli/src/commands/oauth/pkce.ts
+++ b/packages/cli/src/commands/oauth/pkce.ts
@@ -1,0 +1,9 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+export const generatePkce = (): { verifier: string; challenge: string } => {
+  const verifier = randomBytes(48).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+};
+
+export const generateState = (): string => randomBytes(16).toString('base64url');

--- a/packages/cli/src/commands/oauth/probes.ts
+++ b/packages/cli/src/commands/oauth/probes.ts
@@ -1,0 +1,107 @@
+import type { RegionCode } from '../../constants';
+import { colorPalette, commands, managementApiRegions, regions } from '../../constants';
+import { getProgram } from '../../program';
+import { CommandError, handleError, isRegion, konsola, maskToken } from '../../utils';
+import { getOauthEntry, resolveOauthClient, updateOauthEntry } from './store';
+import { exchangeToken } from './token-endpoint';
+import { oauthCommand } from './command';
+
+const program = getProgram();
+
+const requireTokens = async (region: RegionCode) => {
+  const { tokens } = await getOauthEntry(region);
+  if (!tokens) {
+    throw new CommandError('No OAuth tokens stored. Run: storyblok oauth login');
+  }
+  return tokens;
+};
+
+oauthCommand
+  .command('call [path]')
+  .description('POC probe: call a MAPI path with the stored OAuth access token and print the raw response')
+  .option('-s, --space <space>', 'Space id (used by the default path)')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .action(async (path: string | undefined, options: { space?: string; region: RegionCode }) => {
+    konsola.title(`${commands.OAUTH} call`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`Invalid region: ${options.region}`);
+      }
+      const region = options.region;
+      const tokens = await requireTokens(region);
+
+      const requestPath = path ?? (options.space ? `/v1/spaces/${options.space}` : undefined);
+      if (!requestPath) {
+        throw new CommandError('Provide a path argument or --space for the default GET /v1/spaces/:id probe.');
+      }
+
+      const url = `https://${managementApiRegions[region]}${requestPath}`;
+      konsola.info(`GET ${url}`);
+      konsola.info(`Authorization: Bearer ${maskToken(tokens.access_token)} (stored expiry: ${tokens.expires_at})`);
+
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${tokens.access_token}` },
+      });
+      const body = await response.text();
+
+      konsola.info(`Status: ${response.status} ${response.statusText}`);
+      konsola.info(`WWW-Authenticate: ${response.headers.get('www-authenticate') ?? '(not set)'}`);
+      konsola.info(`Body: ${body.slice(0, 2000)}`);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });
+
+oauthCommand
+  .command('refresh')
+  .description('POC probe: force a refresh_token grant and report whether the refresh token rotated')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .action(async (options: { region: RegionCode }) => {
+    konsola.title(`${commands.OAUTH} refresh`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`Invalid region: ${options.region}`);
+      }
+      const region = options.region;
+      const tokens = await requireTokens(region);
+      if (!tokens.refresh_token) {
+        throw new CommandError('No refresh token stored — was offline_access granted? Record this in the findings doc.');
+      }
+      const client = await resolveOauthClient(region);
+      if (!client) {
+        throw new CommandError('No OAuth client credentials found. Run: storyblok oauth setup');
+      }
+
+      const refreshed = await exchangeToken(region, {
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      });
+
+      const accessChanged = refreshed.access_token !== tokens.access_token;
+      const refreshChanged = !!refreshed.refresh_token && refreshed.refresh_token !== tokens.refresh_token;
+
+      await updateOauthEntry(region, {
+        tokens: {
+          auth_type: 'oauth',
+          access_token: refreshed.access_token,
+          refresh_token: refreshed.refresh_token ?? tokens.refresh_token,
+          expires_at: new Date(Date.now() + refreshed.expires_in * 1000).toISOString(),
+        },
+      });
+
+      konsola.ok(`Refreshed. New access token: ${maskToken(refreshed.access_token)} (changed: ${accessChanged})`, true);
+      konsola.info(`Refresh token in response: ${refreshed.refresh_token ? maskToken(refreshed.refresh_token) : 'NOT RETURNED'}`);
+      konsola.info(`Refresh token rotated: ${refreshChanged}`);
+      konsola.info(`Raw response keys: ${Object.keys(refreshed.raw).join(', ')}`);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });

--- a/packages/cli/src/commands/oauth/server.ts
+++ b/packages/cli/src/commands/oauth/server.ts
@@ -1,0 +1,38 @@
+import { createServer } from 'node:http';
+
+const SUCCESS_PAGE = `<!doctype html><html><body style="font-family: sans-serif; text-align: center; padding-top: 4rem;">
+<h1>Storyblok CLI</h1><p>Authorization received. You can close this tab and return to the terminal.</p>
+</body></html>`;
+
+export const waitForCallback = (port: number, path: string): Promise<{ code: string; state: string }> => {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      if (url.pathname !== path) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(SUCCESS_PAGE);
+      server.close();
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        reject(new Error(`Authorization failed: ${error} — ${url.searchParams.get('error_description') ?? 'no description'}`));
+        return;
+      }
+      const code = url.searchParams.get('code');
+      const state = url.searchParams.get('state');
+      if (!code || !state) {
+        reject(new Error('Callback did not include code and state query params.'));
+        return;
+      }
+      resolve({ code, state });
+    });
+
+    server.on('error', reject);
+    server.listen(port);
+  });
+};

--- a/packages/cli/src/commands/oauth/setup.ts
+++ b/packages/cli/src/commands/oauth/setup.ts
@@ -1,0 +1,74 @@
+import { input, password, select } from '@inquirer/prompts';
+import type { RegionCode } from '../../constants';
+import { colorPalette, commands, regions } from '../../constants';
+import { getProgram } from '../../program';
+import { CommandError, handleError, isRegion, konsola, maskToken } from '../../utils';
+import { findOrCreateCliClient } from './actions';
+import { updateOauthEntry } from './store';
+import { oauthCommand } from './command';
+
+const program = getProgram();
+
+const setupCommand = oauthCommand
+  .command('setup')
+  .description('One-time OAuth client provisioning for your org (POC)')
+  .option('-t, --token <token>', 'Personal access token of an org manager (find-or-create the "Storyblok CLI" app)')
+  .option('--client-id <clientId>', 'OAuth client id shared by your org admin')
+  .option('--client-secret <clientSecret>', 'OAuth client secret shared by your org admin')
+  .option('-r, --region <region>', 'Region (eu, us, cn, ca, ap)', regions.EU)
+  .action(async (options: { token?: string; clientId?: string; clientSecret?: string; region: RegionCode }) => {
+    konsola.title(`${commands.OAUTH} setup`, colorPalette.OAUTH);
+    const verbose = program.opts().verbose;
+
+    try {
+      if (!isRegion(options.region)) {
+        throw new CommandError(`The provided region: ${options.region} is not valid. Please use one of: ${Object.values(regions).join(' | ')}`);
+      }
+      const region = options.region;
+
+      let pat = options.token;
+      let manualClientId = options.clientId;
+      let manualClientSecret = options.clientSecret;
+
+      if ((manualClientId && !manualClientSecret) || (!manualClientId && manualClientSecret)) {
+        throw new CommandError('--client-id and --client-secret must be provided together.');
+      }
+
+      if (!pat && !manualClientId) {
+        const path = await select({
+          message: 'How do you want to provision the OAuth client?',
+          choices: [
+            { name: 'I manage this org — use my personal access token (creates a "Storyblok CLI" app)', value: 'pat' },
+            { name: 'My org admin shared a client id + secret with me', value: 'manual' },
+          ],
+        });
+        if (path === 'pat') {
+          pat = await password({ message: 'Personal access token (used once, not stored):' });
+        }
+        else {
+          manualClientId = await input({ message: 'OAuth client id:' });
+          manualClientSecret = await password({ message: 'OAuth client secret:' });
+        }
+      }
+
+      if (pat) {
+        const client = await findOrCreateCliClient(pat, region);
+        await updateOauthEntry(region, { client });
+        konsola.ok(`OAuth client ${maskToken(client.client_id)} stored for region ${region}. The token was not persisted.`, true);
+        return;
+      }
+
+      if (!manualClientId?.trim() || !manualClientSecret?.trim()) {
+        throw new CommandError('Client id and client secret must not be empty.');
+      }
+      await updateOauthEntry(region, {
+        client: { client_id: manualClientId.trim(), client_secret: manualClientSecret.trim() },
+      });
+      konsola.ok(`OAuth client ${maskToken(manualClientId.trim())} stored for region ${region}.`, true);
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });
+
+export { setupCommand };

--- a/packages/cli/src/commands/oauth/store.ts
+++ b/packages/cli/src/commands/oauth/store.ts
@@ -1,0 +1,55 @@
+import { join } from 'pathe';
+import type { RegionCode } from '../../constants';
+import { getCredentials } from '../../creds';
+import { getStoryblokGlobalPath, saveToFile } from '../../utils/filesystem';
+
+export interface OauthClientCredentials {
+  client_id: string;
+  client_secret: string;
+  // Allowed scopes captured at setup time (PAT path); used as the default login scope set.
+  scopes?: string[];
+}
+
+export interface OauthTokens {
+  auth_type: 'oauth';
+  access_token: string;
+  refresh_token?: string;
+  expires_at: string;
+}
+
+export interface OauthRegionEntry {
+  client?: OauthClientCredentials;
+  tokens?: OauthTokens;
+}
+
+const credentialsPath = () => join(getStoryblokGlobalPath(), 'credentials.json');
+
+const readAll = async (): Promise<Record<string, unknown>> => {
+  return (await getCredentials(credentialsPath()) as Record<string, unknown> | null) ?? {};
+};
+
+export const getOauthEntry = async (region: RegionCode): Promise<OauthRegionEntry> => {
+  const all = await readAll();
+  const oauth = (all.oauth ?? {}) as Record<string, OauthRegionEntry>;
+  return oauth[region] ?? {};
+};
+
+export const getOauthClientFromEnv = (): OauthClientCredentials | null => {
+  const clientId = process.env.STORYBLOK_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.STORYBLOK_OAUTH_CLIENT_SECRET;
+  if (clientId && clientSecret) {
+    return { client_id: clientId, client_secret: clientSecret };
+  }
+  return null;
+};
+
+export const resolveOauthClient = async (region: RegionCode): Promise<OauthClientCredentials | null> => {
+  return getOauthClientFromEnv() ?? (await getOauthEntry(region)).client ?? null;
+};
+
+export const updateOauthEntry = async (region: RegionCode, patch: OauthRegionEntry): Promise<void> => {
+  const all = await readAll();
+  const oauth = (all.oauth ?? {}) as Record<string, OauthRegionEntry>;
+  oauth[region] = { ...oauth[region], ...patch };
+  await saveToFile(credentialsPath(), JSON.stringify({ ...all, oauth }, null, 2), { mode: 0o600 });
+};

--- a/packages/cli/src/commands/oauth/token-endpoint.ts
+++ b/packages/cli/src/commands/oauth/token-endpoint.ts
@@ -1,0 +1,40 @@
+import type { RegionCode } from '../../constants';
+import { managementApiRegions } from '../../constants';
+import { CommandError } from '../../utils';
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+  raw: Record<string, unknown>;
+}
+
+export const exchangeToken = async (region: RegionCode, params: Record<string, string>): Promise<TokenResponse> => {
+  const response = await fetch(`https://${managementApiRegions[region]}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params).toString(),
+  });
+
+  const text = await response.text();
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(text);
+  }
+  catch {
+    throw new CommandError(`Token endpoint returned non-JSON (${response.status} ${response.statusText}): ${text.slice(0, 500)}`);
+  }
+
+  if (!response.ok) {
+    throw new CommandError(`Token endpoint error ${response.status}: ${JSON.stringify(raw)}`);
+  }
+
+  return {
+    access_token: raw.access_token as string,
+    refresh_token: raw.refresh_token as string | undefined,
+    expires_in: raw.expires_in as number,
+    scope: raw.scope as string | undefined,
+    raw,
+  };
+};

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -14,11 +14,13 @@ export const commands = {
   REPORTS: 'reports',
   ASSETS: 'assets',
   STORIES: 'stories',
+  OAUTH: 'oauth',
 } as const;
 
 export const colorPalette = {
   PRIMARY: '#8d60ff',
   LOGIN: '#dad4ff',
+  OAUTH: '#dad4ff',
   LOGOUT: '#6d6d6d',
   SIGNUP: '#b6ff6d',
   USER: '#71d300',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import './commands/logs';
 import './commands/reports';
 import './commands/assets';
 import './commands/stories';
+import './commands/oauth';
 
 import { colorPalette } from './constants';
 


### PR DESCRIPTION
> [!WARNING]
> **POC, do not merge.** This branch exists to answer the DX-484 questions against the real backend. The code is throwaway by design (no unit tests, `konsola` output, full-catalog scopes). Productization happens in follow-up tickets.

Proof of concept for OAuth Authorization Code Grant login in the CLI (Linear [DX-484](https://linear.app/storyblok/issue/DX-484)). Adds `storyblok oauth setup|login|call|refresh` POC commands and runs the full flow end to end against production EU with the sandbox org. Full evidence lives in [`DX-484-oauth-poc-findings.md`](https://github.com/storyblok/monoblok/blob/feat/DX-484-oauth-login-poc/DX-484-oauth-poc-findings.md); spec and plan are under `docs/superpowers/`.

## Answers to the must-answer questions

### 1. Does `offline_access` return a refresh token?

**Yes.** `POST /oauth/token` returns `refresh_token` on the initial code exchange and on every refresh. Access tokens live 15 minutes (`expires_in: 900`), refresh tokens 1 month (rolling).

### 2. Does refresh work as documented (new access token, refresh token unchanged)?

**No: the refresh token ROTATES on every refresh.** Each refresh revokes the old grant and returns a new access token AND a new refresh token; reusing the pre-rotation refresh token yields `400 {"error": "invalid_grant", …}`. Consequence: clients must atomically persist the new refresh token after every refresh. A crash between refresh and persist permanently kills the session, and two processes sharing one credentials file will invalidate each other. The MAPI-client interceptor needs single-flight refresh with persist-before-use. The backend docs saying "refresh token unchanged" are wrong; the backend team should be told.

### 3. Are expired-token vs missing-scope errors distinguishable (401 vs 403)?

**Yes, cleanly, by status code.**

| Case | Status | Body |
| --- | --- | --- |
| Expired access token (16 min) | `401` | `{"error": "Unauthorized"}` |
| Missing scope (`stories:read`-only grant calling components) | `403` | `{"error": "Insufficient scope: components:read is required"}` |

Neither sends a `WWW-Authenticate` header on MAPI endpoints, so discriminate on status code only. Refresh after expiry recovers the session (verified: 401 → refresh → 200), so a refresh-on-401 interceptor is safe; never refresh on 403.

### 4. Does find-or-create behave sanely on re-runs?

**Yes.** Re-running `oauth setup` finds the existing "Storyblok CLI" app by name and reads the secret via `GET /v1/oauth_clients/:id`; no duplicate apps. Two create-time API facts the issue's sketch missed: `POST /v1/oauth_clients` **422s without a unique `slug`** (format validation without `allow_blank` plus global uniqueness), and the scope catalog returns `{resource, actions}` groups where valid scope strings are `resource:action` (32 scopes + `offline_access`).

### 5. Does `/oauth/authorize` accept `dev_oauth_redirect_uri`?

**Yes.** With `oauth_redirect_uri` on port 4900 and `dev_oauth_redirect_uri` on port 4901, a full authorize + exchange against 4901 succeeded. Both URIs are valid concurrently, so dev and prod ports can coexist on one app.

### 6. Consent UX surprises with a CLI as the app?

None blocking. App shows as "Storyblok CLI" with a placeholder icon. The consent screen includes a space picker and correctly shows only the requested scope subset when the CLI narrows the request. Entry via `GET /oauth/init` on the MAPI host works as documented.

## MAPI client integration assessment

OAuth in `@storyblok/management-api-client` would work like this: login stays outside the client (host does the consent dance and hands over tokens plus a persist callback); requests send `Authorization: Bearer <access_token>`; refresh proactively or on 401 only (never 403, which is a scope problem); refresh must be single-flight with persist-before-use because the refresh token rotates and the old one is single-use, then retry once.

**Verdict: practical for interactive, single-process use; risky beyond that.** The mechanics are fine, but strict rotation with no grace window means: two processes sharing one credentials file invalidate each other on refresh (in-process single-flight does not fix cross-process races; needs file locking or per-process grants), a crash between refresh and persist permanently kills the session, and 15-minute access tokens make refresh constant. Recommendation: ship OAuth for the CLI, and ask the backend team for a reuse grace period on rotated refresh tokens or a machine-to-machine grant before targeting long-running or multi-process consumers (MCP server, CI).

## Additional findings

- Env-var client credentials (`STORYBLOK_OAUTH_CLIENT_ID`/`SECRET`) work with zero setup, so the CI path is viable.
- `POST /oauth/token` is form-encoded (`application/x-www-form-urlencoded`), not JSON.
- PKCE S256 is mandatory for scoped grants and verified end to end.
- `/v1/oauth_clients` requires `can_manage_org?` plus the org `allow_oauth_grants` flag (distinct 403s for each).
- Auth header formats: PAT is `Authorization: <token>`, OAuth is `Authorization: Bearer <token>`; `token_type` comes back lowercase (`"bearer"`).

## Try it yourself

Prerequisites: a PAT with an org manager role on an org that has OAuth grants enabled (`allow_oauth_grants`), and a space in that org. Everything runs against production EU.

```bash
pnpm install && pnpm nx build storyblok

# Provision the "Storyblok CLI" app and store client credentials (PAT is used once, never stored)
node packages/cli/dist/index.mjs oauth setup --token <PAT>

# Full authorization code + PKCE flow: opens the browser for consent, callback on localhost:4900
node packages/cli/dist/index.mjs oauth login

# Probe MAPI with the access token (defaults to GET /v1/spaces/:id/stories)
node packages/cli/dist/index.mjs oauth call --space <SPACE_ID>

# Refresh: prints whether access and refresh tokens rotated
node packages/cli/dist/index.mjs oauth refresh
```

Tokens land in `~/.storyblok/credentials.json` under `oauth.eu`. To reproduce the 401 vs 403 findings: wait 16 minutes and run `oauth call` again for the 401, or log in with `oauth login --scope stories:read offline_access` and call `oauth call /v1/spaces/<SPACE_ID>/components --space <SPACE_ID>` for the 403.

### Manual path (without the PAT setup)

If you already have a client id and secret for an existing OAuth app (for example from the UI, or handed over by an org admin), skip the PAT path entirely. The app's redirect URI must be `http://localhost:4900/oauth/callback`. Either store the credentials:

```bash
node packages/cli/dist/index.mjs oauth setup --client-id <id> --client-secret <secret>
```

or skip storage entirely and pass them via env vars (the zero-setup CI path):

```bash
STORYBLOK_OAUTH_CLIENT_ID=<id> STORYBLOK_OAUTH_CLIENT_SECRET=<secret> \
  node packages/cli/dist/index.mjs oauth login --scope stories:read stories:write offline_access
```

Note for the manual path: no scope catalog is stored, so `oauth login` without `--scope` falls back to `stories:read stories:write offline_access`. Whatever you request must be a subset of the app's allowed scopes.
