### PR TITLE
fix: change storyblokEditable to have narrow type

### DIFF
--- a/packages/js/src/editable.ts
+++ b/packages/js/src/editable.ts
@@ -1,6 +1,4 @@
-import type { SbBlokData } from './types';
-
-export default (blok: SbBlokData) => {
+export default (blok: { _editable?: string }) => {
   if (typeof blok !== 'object' || typeof blok._editable === 'undefined') {
     return {};
   }

--- a/packages/js/src/editable.ts
+++ b/packages/js/src/editable.ts
@@ -1,4 +1,4 @@
-export default <T extends Record<string, unknown>>(blok?: T) => {
+export default (blok?: { _editable?: string }) => {
   if (typeof blok !== 'object' || typeof blok._editable !== 'string') {
     return {};
   }

--- a/packages/js/src/editable.ts
+++ b/packages/js/src/editable.ts
@@ -1,5 +1,5 @@
-export default (blok: { _editable?: string }) => {
-  if (typeof blok !== 'object' || typeof blok._editable === 'undefined') {
+export default <T extends Record<string, unknown>>(blok?: T) => {
+  if (typeof blok !== 'object' || typeof blok._editable !== 'string') {
     return {};
   }
 


### PR DESCRIPTION
Closes #468.

Thanks to @intellix for the original contribution!

This picks up the fix from #468 and takes it a step further:
- Narrows the `storyblokEditable` parameter type to `{ _editable?: string }` — the function only needs this one property, so there's no reason to require callers to extend a broad type like `SbBlokData`
- Makes the `blok` parameter optional
- Tightens the internal guard to `!== 'string'` for correct type narrowing inside the function body