### PR TITLE
fix(cli): match uppercase X in asset dimension segment on push (MNT-1380)

### DIFF
--- a/packages/cli/src/commands/assets/utils.test.ts
+++ b/packages/cli/src/commands/assets/utils.test.ts
@@ -11,6 +11,10 @@ describe('extractAssetSizeFromFilename', () => {
     expect(extractAssetSizeFromFilename('https://a.storyblok.com/f/293255674717942/8ae82d3a12/image.jpg')).toBeUndefined();
   });
 
+  it('extracts the dimensions segment when it uses an uppercase X', () => {
+    expect(extractAssetSizeFromFilename('https://a.storyblok.com/f/329189/860X645/7aa24cb39f/image.jpg')).toBe('860X645');
+  });
+
   it('returns undefined for an empty or invalid filename', () => {
     expect(extractAssetSizeFromFilename(undefined)).toBeUndefined();
     expect(extractAssetSizeFromFilename('not-a-url')).toBeUndefined();

--- a/packages/cli/src/commands/assets/utils.ts
+++ b/packages/cli/src/commands/assets/utils.ts
@@ -94,7 +94,7 @@ export const extractAssetSizeFromFilename = (filename?: string): string | undefi
   }
   try {
     const segments = new URL(filename).pathname.split('/');
-    return segments.find(segment => /^\d+x\d+$/.test(segment));
+    return segments.find(segment => /^\d+x\d+$/i.test(segment));
   }
   catch {
     return undefined;


### PR DESCRIPTION
## Why

Porsche's migration (MNT-1370) hit inconsistent dimension-preservation after upgrading to
#672: some pushed assets kept their `<width>x<height>` URL segment, others silently
dropped it — even though the source assets looked identical.

## Root cause

Casing. `extractAssetSizeFromFilename`'s regex only matched lowercase `x`:

| Source segment | Result before fix |
|---|---|
| `2042x1331` (lowercase) | kept |
| `860X645` (uppercase) | **dropped** |

storyrails' own `S3_FILENAME_FORMAT` is case-insensitive and legitimately produces
uppercase-`X` segments, so the CLI's stricter regex was silently losing dimensions the
backend considers valid. Fix: add the `i` flag.

## Reproduce

1. Push an asset whose *source* CDN URL has an uppercase-X segment, e.g.
   `.../f/SPACE/860X645/hash/image.jpg`, with `storyblok assets push`.
2. Before this fix: target asset's URL drops the dimensions folder entirely.
3. A lowercase-x source keeps it either way — which is what made this easy to miss.

Fixes MNT-1380
