### PR TITLE
feat(cli): add --all flag for assets transfer command

### DIFF
--- a/.agents/skills/qa-engineer-manual/SKILL.md
+++ b/.agents/skills/qa-engineer-manual/SKILL.md
@@ -118,6 +118,10 @@ bash .claude/skills/qa-engineer-manual/scripts/cleanup-remote.sh --shared --libr
 
 Inspect a library first with `list.sh --resource shared-assets|shared-folders|shared-tags`. Package guides (for example `packages/cli/test/GUIDE.md`) describe the CLI push/pull workflow against libraries.
 
+`list.sh --resource shared-folders` only shows libraries the given `--space` already has access to; an empty result doesn't mean none exists. Check the org endpoint instead: `curl https://mapi.storyblok.com/v1/orgs/<orgId>/shared_asset_folders -H "Authorization: $STORYBLOK_TOKEN"`. To grant your QA space access, `PUT` to that same endpoint with `asset_folder_access` — it replaces the whole list, so include existing entries too or you'll revoke them.
+
+Before reusing a library, list its contents (`list.sh --resource shared-assets --library <libraryId>`). If it looks like production data, stop and tell the user instead of writing to or cleaning it. If it looks like test fixtures, it's fine to use.
+
 ### Scenario structure
 
 A scenario is a directory with optional subdirectories for each resource type:

--- a/packages/cli/src/commands/assets/actions.test.ts
+++ b/packages/cli/src/commands/assets/actions.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { getMapiClient } from '../../api';
-import { fetchAllSpaceAssetIds, transferAsset } from './actions';
+import { fetchAllSpaceAssetIds, transferAsset, transferAssets } from './actions';
 import { APIError } from '../../utils/error/api-error';
 
 const server = setupServer();
@@ -93,5 +93,38 @@ describe('fetchAllSpaceAssetIds', () => {
     await fetchAllSpaceAssetIds('123', { search: 'logo' } as never);
 
     expect(seen?.searchParams.get('search')).toBe('logo');
+  });
+});
+
+describe('transferAssets', () => {
+  it('should report progress once per asset and preserve input order', async () => {
+    server.use(
+      http.post('https://mapi.storyblok.com/v1/spaces/123/assets/:assetId/convert', ({ params }) =>
+        HttpResponse.json({ id: Number(params.assetId), filename: `f-${params.assetId}.png`, space_id: null })),
+    );
+    const progress: number[] = [];
+
+    const results = await transferAssets('123', [3, 1, 2], 7, {
+      onProgress: completed => progress.push(completed),
+    });
+
+    expect(results.map(r => r.assetId)).toEqual([3, 1, 2]); // order preserved
+    expect(results.every(r => r.status === 'transferred')).toBe(true);
+    expect(progress).toHaveLength(3);
+    expect(progress[progress.length - 1]).toBe(3);
+  });
+
+  it('should capture per-asset failures without aborting the batch', async () => {
+    server.use(
+      http.post('https://mapi.storyblok.com/v1/spaces/123/assets/:assetId/convert', ({ params }) =>
+        Number(params.assetId) === 2
+          ? HttpResponse.json({ error: 'Forbidden' }, { status: 403 })
+          : HttpResponse.json({ id: Number(params.assetId), filename: `f-${params.assetId}.png`, space_id: null })),
+    );
+
+    const results = await transferAssets('123', [1, 2, 3], 7);
+
+    expect(results.find(r => r.assetId === 2)?.status).toBe('failed');
+    expect(results.filter(r => r.status === 'transferred')).toHaveLength(2);
   });
 });

--- a/packages/cli/src/commands/assets/actions.test.ts
+++ b/packages/cli/src/commands/assets/actions.test.ts
@@ -77,4 +77,21 @@ describe('fetchAllSpaceAssetIds', () => {
 
     expect(ids).toEqual([10]);
   });
+
+  it('should forward filter params to the asset list query', async () => {
+    let seen: URL | undefined;
+    server.use(
+      http.get('https://mapi.storyblok.com/v1/spaces/123/assets', ({ request }) => {
+        seen = new URL(request.url);
+        return HttpResponse.json(
+          { assets: [{ id: 1 }] },
+          { headers: { 'Total': '1', 'Per-Page': '100' } },
+        );
+      }),
+    );
+
+    await fetchAllSpaceAssetIds('123', { search: 'logo' } as never);
+
+    expect(seen?.searchParams.get('search')).toBe('logo');
+  });
 });

--- a/packages/cli/src/commands/assets/actions.test.ts
+++ b/packages/cli/src/commands/assets/actions.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { getMapiClient } from '../../api';
-import { transferAsset } from './actions';
+import { fetchAllSpaceAssetIds, transferAsset } from './actions';
 import { APIError } from '../../utils/error/api-error';
 
 const server = setupServer();
@@ -40,5 +40,41 @@ describe('transferAsset', () => {
     expect(error).toBeInstanceOf(APIError);
     expect(error.message).toContain('write access');
     expect(error.code).toBe(403);
+  });
+});
+
+describe('fetchAllSpaceAssetIds', () => {
+  it('should paginate and return every numeric asset id', async () => {
+    server.use(
+      http.get('https://mapi.storyblok.com/v1/spaces/123/assets', ({ request }) => {
+        const page = Number(new URL(request.url).searchParams.get('page') ?? 1);
+        const pages: Record<number, Array<{ id: number }>> = {
+          1: [{ id: 1 }, { id: 2 }],
+          2: [{ id: 3 }],
+        };
+        return HttpResponse.json(
+          { assets: pages[page] ?? [] },
+          { headers: { 'Total': '3', 'Per-Page': '2' } },
+        );
+      }),
+    );
+
+    const ids = await fetchAllSpaceAssetIds('123');
+
+    expect(ids).toEqual([1, 2, 3]);
+  });
+
+  it('should skip entries without a numeric id', async () => {
+    server.use(
+      http.get('https://mapi.storyblok.com/v1/spaces/123/assets', () =>
+        HttpResponse.json(
+          { assets: [{ id: 10 }, { id: null }, { filename: 'x.png' }] },
+          { headers: { 'Total': '3', 'Per-Page': '100' } },
+        )),
+    );
+
+    const ids = await fetchAllSpaceAssetIds('123');
+
+    expect(ids).toEqual([10]);
   });
 });

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -42,6 +42,34 @@ export const fetchAssets = async ({ spaceId, params }: {
 };
 
 /**
+ * Fetches the IDs of every asset in a space by paginating the Management API
+ * asset list. Used by `assets transfer --all` to resolve the full working set
+ * before transferring. Mirrors the pagination in `fetchAssetInternalTagsByName`.
+ */
+export const fetchAllSpaceAssetIds = async (spaceId: string): Promise<number[]> => {
+  try {
+    const client = getMapiClient();
+    const assets = await fetchAllPages(
+      (page: number) => client.assets.list({
+        path: { space_id: Number(spaceId) },
+        query: { page, per_page: 100 },
+        throwOnError: true,
+      }),
+      data => data?.assets ?? [],
+    );
+    return assets.reduce<number[]>((ids, asset) => {
+      if (typeof asset?.id === 'number') {
+        ids.push(asset.id);
+      }
+      return ids;
+    }, []);
+  }
+  catch (maybeError) {
+    handleAPIError('pull_assets', toError(maybeError));
+  }
+};
+
+/**
  * Fetches the space's internal tags of type `asset` keyed by name.
  *
  * Used by `assets push` to translate source-space tag names carried in pulled

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -66,7 +66,7 @@ export const fetchAllSpaceAssetIds = async (spaceId: string, params?: AssetListQ
     }, []);
   }
   catch (maybeError) {
-    handleAPIError('pull_assets', toError(maybeError));
+    handleAPIError('transfer_enumerate_assets', toError(maybeError));
   }
 };
 

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -359,11 +359,20 @@ export interface TransferResult {
 }
 
 /**
+ * Upper bound on promises allocated at once by `transferAssets`, so very large
+ * `--all` sets don't build one suspended promise per asset up front. Concurrency
+ * is still governed by the backpressure lock; this only caps promise allocation.
+ */
+const TRANSFER_CHUNK_SIZE = 500;
+
+/**
  * Transfers multiple assets into the shared asset library, bounding in-flight
  * requests with the shared pipeline backpressure lock (2× the configured rate
  * limit), matching the throttle headroom used by the asset and story streams.
  * Per-asset errors are captured as failed results rather than aborting the
- * whole batch.
+ * whole batch. Fan-out is chunked (`TRANSFER_CHUNK_SIZE`) so very large asset
+ * sets don't allocate one promise per asset up front, and `onProgress` reports
+ * completion count as each asset finishes.
  */
 export const transferAssets = async (
   spaceId: string,
@@ -372,26 +381,37 @@ export const transferAssets = async (
   callbacks: {
     onSuccess?: (result: { assetId: number; filename?: string }) => void;
     onError?: (error: Error, assetId: number) => void;
+    onProgress?: (completed: number, total: number) => void;
   } = {},
 ): Promise<TransferResult[]> => {
   const lock = createPipelineBackpressureLock();
+  const results: TransferResult[] = [];
+  let completed = 0;
 
-  return Promise.all(assetIds.map(async (assetId): Promise<TransferResult> => {
-    await lock.acquire();
-    try {
-      const asset = await transferAsset(spaceId, assetId, folderId);
-      callbacks.onSuccess?.({ assetId, filename: asset.filename });
-      return { assetId, status: 'transferred', filename: asset.filename };
-    }
-    catch (maybeError) {
-      const error = toError(maybeError);
-      callbacks.onError?.(error, assetId);
-      return { assetId, status: 'failed', reason: error.message };
-    }
-    finally {
-      lock.release();
-    }
-  }));
+  for (let start = 0; start < assetIds.length; start += TRANSFER_CHUNK_SIZE) {
+    const chunk = assetIds.slice(start, start + TRANSFER_CHUNK_SIZE);
+    const chunkResults = await Promise.all(chunk.map(async (assetId): Promise<TransferResult> => {
+      await lock.acquire();
+      try {
+        const asset = await transferAsset(spaceId, assetId, folderId);
+        callbacks.onSuccess?.({ assetId, filename: asset.filename });
+        return { assetId, status: 'transferred', filename: asset.filename };
+      }
+      catch (maybeError) {
+        const error = toError(maybeError);
+        callbacks.onError?.(error, assetId);
+        return { assetId, status: 'failed', reason: error.message };
+      }
+      finally {
+        lock.release();
+        completed += 1;
+        callbacks.onProgress?.(completed, assetIds.length);
+      }
+    }));
+    results.push(...chunkResults);
+  }
+
+  return results;
 };
 
 /**

--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -42,17 +42,18 @@ export const fetchAssets = async ({ spaceId, params }: {
 };
 
 /**
- * Fetches the IDs of every asset in a space by paginating the Management API
- * asset list. Used by `assets transfer --all` to resolve the full working set
- * before transferring. Mirrors the pagination in `fetchAssetInternalTagsByName`.
+ * Fetches the IDs of every asset in a space (optionally filtered) by
+ * paginating the Management API asset list. Used by `assets transfer --all`
+ * to resolve the full working set before transferring. Mirrors the
+ * pagination in `fetchAssetInternalTagsByName`.
  */
-export const fetchAllSpaceAssetIds = async (spaceId: string): Promise<number[]> => {
+export const fetchAllSpaceAssetIds = async (spaceId: string, params?: AssetListQuery): Promise<number[]> => {
   try {
     const client = getMapiClient();
     const assets = await fetchAllPages(
       (page: number) => client.assets.list({
         path: { space_id: Number(spaceId) },
-        query: { page, per_page: 100 },
+        query: { ...params, page, per_page: 100 },
         throwOnError: true,
       }),
       data => data?.assets ?? [],

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -30,13 +30,13 @@ storyblok assets transfer 123456 789012 --folder-id 789 --space YOUR_SPACE_ID --
 | `--folder-id <id>` | (Required) Destination folder ID in the shared asset library | - |
 | `-s, --space <id>` | Source space ID | Globally configured space |
 | `-d, --dry-run` | Print the transfer plan without making any API calls | `false` |
-| `--all` | Transfer every asset in the space. Cannot be combined with explicit asset IDs. | `false` |
-| `-q, --query <query>` | Transfer every asset in the space matching a Storyblok filter query. Cannot be combined with explicit asset IDs. Example: `search=my-file.jpg&with_tags=tag1,tag2` | - |
+| `--all` | Transfer every asset in the space. Cannot be combined with explicit asset IDs or `--query`. | `false` |
+| `-q, --query <query>` | Transfer every asset in the space matching a Storyblok filter query. Cannot be combined with explicit asset IDs or `--all`. Example: `search=my-file.jpg&with_tags=tag1,tag2` | - |
 
 ## Notes
 
 - **Endpoint mapping:** The CLI exposes this operation as `transfer`, but it currently calls the backend `convert` endpoint (`POST /v1/spaces/{space_id}/assets/{id}/convert`), mapping `--folder-id` to the required `target_asset_folder_id` query parameter. This mapping will be removed once the backend ships the rename from `convert` to `transfer`.
 - **Plan required:** `--folder-id` is required and has no implicit default. Omitting it fails with an error.
 - **403 errors:** A 403 response comes from the backend authorization policy: the target folder must exist in the shared asset library and the source space must have write access to it. Grant the space write access to the destination folder (or pick a folder it can write to), then retry.
-- **`--all`:** Transfers every asset in the space into `--folder-id`. It enumerates the space's assets first, so `--dry-run` reports an accurate count. `--all` cannot be combined with explicit asset IDs. If the space has no assets, the command exits 0 and prints a "No assets found" message.
-- **`--query`:** Transfers every asset in the space matching the filter, using the same filter syntax as `assets pull` (`search`, `with_tags`, `in_folder`, etc.). Like `--all`, it enumerates first (so `--dry-run` is accurate) and cannot be combined with explicit asset IDs. If nothing matches, the command exits 0 and prints a "no assets match" message.
+- **`--all`:** Transfers every asset in the space into `--folder-id`. It enumerates the space's assets first, so `--dry-run` reports an accurate count. `--all` cannot be combined with explicit asset IDs or `--query`. If the space has no assets, the command exits 0 and prints a "No assets found" message.
+- **`--query`:** Transfers every asset in the space matching the filter, using the same filter syntax as `assets pull` (`search`, `with_tags`, `in_folder`, etc.). Like `--all`, it enumerates first (so `--dry-run` is accurate) and cannot be combined with explicit asset IDs or `--all`. If nothing matches, the command exits 0 and prints a "no assets match" message.

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -37,7 +37,7 @@ storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID --dry-run
 **Transfer only assets matching a filter:**
 
 ```bash
-storyblok assets transfer --all --query "search=logo&with_tags=hero" --folder-id 789 --space YOUR_SPACE_ID
+storyblok assets transfer --query "search=logo&with_tags=hero" --folder-id 789 --space YOUR_SPACE_ID
 ```
 
 ## Options
@@ -49,7 +49,7 @@ storyblok assets transfer --all --query "search=logo&with_tags=hero" --folder-id
 | `-s, --space <id>` | Source space ID | Globally configured space |
 | `-d, --dry-run` | Print the transfer plan without making any API calls | `false` |
 | `--all` | Transfer every asset in the space. Cannot be combined with explicit asset IDs. | `false` |
-| `-q, --query <query>` | Filter assets using Storyblok filter query syntax (only with `--all`). Example: `search=my-file.jpg&with_tags=tag1,tag2` | - |
+| `-q, --query <query>` | Transfer every asset in the space matching a Storyblok filter query. Cannot be combined with explicit asset IDs. Example: `search=my-file.jpg&with_tags=tag1,tag2` | - |
 
 ## Notes
 
@@ -57,4 +57,4 @@ storyblok assets transfer --all --query "search=logo&with_tags=hero" --folder-id
 - **Plan required:** `--folder-id` is required and has no implicit default. Omitting it fails with an error.
 - **403 errors:** A 403 response comes from the backend authorization policy: the target folder must exist in the shared asset library and the source space must have write access to it. Grant the space write access to the destination folder (or pick a folder it can write to), then retry.
 - **`--all`:** Transfers every asset in the space into `--folder-id`. It enumerates the space's assets first, so `--dry-run` reports an accurate count. `--all` cannot be combined with explicit asset IDs. If the space has no assets, the command exits 0 and prints a "No assets found" message.
-- **`--query`:** Filters the set of assets enumerated by `--all` using the same filter syntax as `assets pull` (`search`, `with_tags`, `in_folder`, etc.). It is rejected with an error when used without `--all`.
+- **`--query`:** Transfers every asset in the space matching the filter, using the same filter syntax as `assets pull` (`search`, `with_tags`, `in_folder`, etc.). Like `--all`, it enumerates first (so `--dry-run` is accurate) and cannot be combined with explicit asset IDs. If nothing matches, the command exits 0 and prints a "no assets match" message.

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -22,17 +22,31 @@ storyblok assets transfer 123456 789012 345678 --folder-id 789 --space YOUR_SPAC
 storyblok assets transfer 123456 789012 --folder-id 789 --space YOUR_SPACE_ID --dry-run
 ```
 
+**Transfer every asset in a space:**
+
+```bash
+storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID
+```
+
+**Preview an `--all` transfer without making any API calls:**
+
+```bash
+storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID --dry-run
+```
+
 ## Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `<asset-id...>` | (Required) One or more numeric asset IDs to transfer | - |
+| `[asset-id...]` | One or more numeric asset IDs to transfer. Required unless `--all` is used. | - |
 | `--folder-id <id>` | (Required) Destination folder ID in the shared asset library | - |
 | `-s, --space <id>` | Source space ID | Globally configured space |
 | `-d, --dry-run` | Print the transfer plan without making any API calls | `false` |
+| `--all` | Transfer every asset in the space. Cannot be combined with explicit asset IDs. | `false` |
 
 ## Notes
 
 - **Endpoint mapping:** The CLI exposes this operation as `transfer`, but it currently calls the backend `convert` endpoint (`POST /v1/spaces/{space_id}/assets/{id}/convert`), mapping `--folder-id` to the required `target_asset_folder_id` query parameter. This mapping will be removed once the backend ships the rename from `convert` to `transfer`.
 - **Plan required:** `--folder-id` is required and has no implicit default. Omitting it fails with an error.
 - **403 errors:** A 403 response comes from the backend authorization policy: the target folder must exist in the shared asset library and the source space must have write access to it. Grant the space write access to the destination folder (or pick a folder it can write to), then retry.
+- **`--all`:** Transfers every asset in the space into `--folder-id`. It enumerates the space's assets first, so `--dry-run` reports an accurate count. `--all` cannot be combined with explicit asset IDs. If the space has no assets, the command exits 0 and prints a "No assets found" message.

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -22,12 +22,6 @@ storyblok assets transfer 123456 789012 345678 --folder-id 789 --space YOUR_SPAC
 storyblok assets transfer 123456 789012 --folder-id 789 --space YOUR_SPACE_ID --dry-run
 ```
 
-**Transfer every asset in a space:**
-
-```bash
-storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID
-```
-
 **Preview an `--all` transfer without making any API calls:**
 
 ```bash

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -34,6 +34,12 @@ storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID
 storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID --dry-run
 ```
 
+**Transfer only assets matching a filter:**
+
+```bash
+storyblok assets transfer --all --query "search=logo&with_tags=hero" --folder-id 789 --space YOUR_SPACE_ID
+```
+
 ## Options
 
 | Option | Description | Default |
@@ -43,6 +49,7 @@ storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID --dry-run
 | `-s, --space <id>` | Source space ID | Globally configured space |
 | `-d, --dry-run` | Print the transfer plan without making any API calls | `false` |
 | `--all` | Transfer every asset in the space. Cannot be combined with explicit asset IDs. | `false` |
+| `-q, --query <query>` | Filter assets using Storyblok filter query syntax (only with `--all`). Example: `search=my-file.jpg&with_tags=tag1,tag2` | - |
 
 ## Notes
 
@@ -50,3 +57,4 @@ storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID --dry-run
 - **Plan required:** `--folder-id` is required and has no implicit default. Omitting it fails with an error.
 - **403 errors:** A 403 response comes from the backend authorization policy: the target folder must exist in the shared asset library and the source space must have write access to it. Grant the space write access to the destination folder (or pick a folder it can write to), then retry.
 - **`--all`:** Transfers every asset in the space into `--folder-id`. It enumerates the space's assets first, so `--dry-run` reports an accurate count. `--all` cannot be combined with explicit asset IDs. If the space has no assets, the command exits 0 and prints a "No assets found" message.
+- **`--query`:** Filters the set of assets enumerated by `--all` using the same filter syntax as `assets pull` (`search`, `with_tags`, `in_folder`, etc.). It is rejected with an error when used without `--all`.

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -22,18 +22,6 @@ storyblok assets transfer 123456 789012 345678 --folder-id 789 --space YOUR_SPAC
 storyblok assets transfer 123456 789012 --folder-id 789 --space YOUR_SPACE_ID --dry-run
 ```
 
-**Preview an `--all` transfer without making any API calls:**
-
-```bash
-storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID --dry-run
-```
-
-**Transfer only assets matching a filter:**
-
-```bash
-storyblok assets transfer --query "search=logo&with_tags=hero" --folder-id 789 --space YOUR_SPACE_ID
-```
-
 ## Options
 
 | Option | Description | Default |

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -195,7 +195,19 @@ describe('assets transfer command', () => {
     expect(process.exitCode).toBe(0);
   });
 
-  it('should reject --query when --all is not set', async () => {
+  it('should transfer the filtered set when --query is used without --all', async () => {
+    let seen: URL | undefined;
+    preconditions.canListAssets([{ id: 42 }], { onRequest: (url) => { seen = url; } });
+    preconditions.canTransferAssets();
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--query', 'search=logo', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(seen?.searchParams.get('search')).toBe('logo');
+    expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42], 7, expect.anything());
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('should reject --query combined with explicit asset IDs', async () => {
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--query', 'search=logo', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
     expect(actions.transferAssets).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -39,6 +39,17 @@ const preconditions = {
         HttpResponse.json({ error: 'Forbidden' }, { status: 403 })),
     );
   },
+  canListAssets(assets: Array<{ id: number }>, { space = DEFAULT_SPACE }: { space?: string } = {}) {
+    server.use(
+      http.get(`https://mapi.storyblok.com/v1/spaces/${space}/assets`, ({ request }) => {
+        const page = Number(new URL(request.url).searchParams.get('page') ?? 1);
+        return HttpResponse.json(
+          { assets: page === 1 ? assets : [] },
+          { headers: { 'Total': String(assets.length), 'Per-Page': '100' } },
+        );
+      }),
+    );
+  },
 };
 
 describe('assets transfer command', () => {
@@ -106,5 +117,51 @@ describe('assets transfer command', () => {
 
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('write access'));
     expect(process.exitCode).toBe(1);
+  });
+
+  it('should transfer every space asset when --all is set', async () => {
+    preconditions.canListAssets([{ id: 42 }, { id: 43 }]);
+    preconditions.canTransferAssets();
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--all', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42, 43], 7, expect.anything());
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('should reject --all combined with explicit asset IDs', async () => {
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--all', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAssets).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--all'), '');
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('should fail when neither --all nor asset IDs are provided', async () => {
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAssets).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('should exit 0 without transferring when --all finds no assets', async () => {
+    preconditions.canListAssets([]);
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--all', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAssets).not.toHaveBeenCalled();
+    // `ui.info` calls `console.info` directly (see UI#info in utils/ui.ts).
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('No assets found'));
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('should enumerate but not transfer in --all --dry-run mode', async () => {
+    preconditions.canListAssets([{ id: 42 }, { id: 43 }]);
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--all', '--space', DEFAULT_SPACE, '--folder-id', '7', '--dry-run']);
+
+    expect(actions.transferAssets).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('DRY RUN MODE ENABLED'));
+    expect(process.exitCode).toBe(0);
   });
 });

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -197,27 +197,23 @@ describe('assets transfer command', () => {
     expect(process.exitCode).toBe(0);
   });
 
-  it('should forward --query filters to the asset list request when --all is set', async () => {
+  it('should reject --all combined with --query', async () => {
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--all', '--query', 'search=logo', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAssets).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--all with --query'), '');
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('should forward --query filters to the asset list request and transfer the filtered set', async () => {
     let seen: URL | undefined;
     preconditions.canListAssets([{ id: 42 }], { onRequest: (url) => { seen = url; } });
     preconditions.canTransferAssets();
 
-    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--all', '--query', 'search=logo&with_tags=hero', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--query', 'search=logo&with_tags=hero', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
     expect(seen?.searchParams.get('search')).toBe('logo');
     expect(seen?.searchParams.get('with_tags')).toBe('hero');
-    expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42], 7, expect.anything());
-    expect(process.exitCode).toBe(0);
-  });
-
-  it('should transfer the filtered set when --query is used without --all', async () => {
-    let seen: URL | undefined;
-    preconditions.canListAssets([{ id: 42 }], { onRequest: (url) => { seen = url; } });
-    preconditions.canTransferAssets();
-
-    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--query', 'search=logo', '--space', DEFAULT_SPACE, '--folder-id', '7']);
-
-    expect(seen?.searchParams.get('search')).toBe('logo');
     expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42], 7, expect.anything());
     expect(process.exitCode).toBe(0);
   });

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -79,18 +79,21 @@ describe('assets transfer command', () => {
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
     expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42], 7, expect.anything());
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('transferred'));
+    // `ui.info` (→ console.info) carries the summary; successes are not listed
+    // one row per asset (see UI#info / UI#list in utils/ui.ts).
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('1 transferred, 0 failed'));
     expect(process.exitCode).toBe(0);
   });
 
-  it('should transfer multiple asset IDs and report one row per ID', async () => {
+  it('should report a count summary rather than one row per asset', async () => {
     preconditions.canTransferAssets();
 
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '43', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
     expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42, 43], 7, expect.anything());
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('42'));
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('43'));
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('2 transferred, 0 failed (of 2)'));
+    // No per-asset success rows on the successful path.
+    expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining('✓'));
     expect(process.exitCode).toBe(0);
   });
 
@@ -124,6 +127,18 @@ describe('assets transfer command', () => {
     await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--space', DEFAULT_SPACE, '--folder-id', '7']);
 
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('write access'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should group repeated failure reasons into a single counted line', async () => {
+    preconditions.failsToTransferWithAuthError();
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '43', '44', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    // Summary counts, then one grouped reason line with the count — not three
+    // separate per-asset rows.
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('0 transferred, 3 failed (of 3)'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('(3)'));
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -39,10 +39,12 @@ const preconditions = {
         HttpResponse.json({ error: 'Forbidden' }, { status: 403 })),
     );
   },
-  canListAssets(assets: Array<{ id: number }>, { space = DEFAULT_SPACE }: { space?: string } = {}) {
+  canListAssets(assets: Array<{ id: number }>, { space = DEFAULT_SPACE, onRequest }: { space?: string; onRequest?: (url: URL) => void } = {}) {
     server.use(
       http.get(`https://mapi.storyblok.com/v1/spaces/${space}/assets`, ({ request }) => {
-        const page = Number(new URL(request.url).searchParams.get('page') ?? 1);
+        const url = new URL(request.url);
+        onRequest?.(url);
+        const page = Number(url.searchParams.get('page') ?? 1);
         return HttpResponse.json(
           { assets: page === 1 ? assets : [] },
           { headers: { 'Total': String(assets.length), 'Per-Page': '100' } },
@@ -178,5 +180,26 @@ describe('assets transfer command', () => {
     expect(actions.transferAssets).not.toHaveBeenCalled();
     expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('DRY RUN MODE ENABLED'));
     expect(process.exitCode).toBe(0);
+  });
+
+  it('should forward --query filters to the asset list request when --all is set', async () => {
+    let seen: URL | undefined;
+    preconditions.canListAssets([{ id: 42 }], { onRequest: (url) => { seen = url; } });
+    preconditions.canTransferAssets();
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--all', '--query', 'search=logo&with_tags=hero', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(seen?.searchParams.get('search')).toBe('logo');
+    expect(seen?.searchParams.get('with_tags')).toBe('hero');
+    expect(actions.transferAssets).toHaveBeenCalledWith(DEFAULT_SPACE, [42], 7, expect.anything());
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('should reject --query when --all is not set', async () => {
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '42', '--query', 'search=logo', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAssets).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--query'), '');
+    expect(process.exitCode).toBe(2);
   });
 });

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -50,6 +50,12 @@ const preconditions = {
       }),
     );
   },
+  failsToListAssets({ space = DEFAULT_SPACE }: { space?: string } = {}) {
+    server.use(
+      http.get(`https://mapi.storyblok.com/v1/spaces/${space}/assets`, () =>
+        HttpResponse.json({ message: 'Internal Server Error' }, { status: 500 })),
+    );
+  },
 };
 
 describe('assets transfer command', () => {
@@ -153,6 +159,15 @@ describe('assets transfer command', () => {
     // `ui.info` calls `console.info` directly (see UI#info in utils/ui.ts).
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('No assets found'));
     expect(process.exitCode).toBe(0);
+  });
+
+  it('should surface a friendly error and exit 2 when enumeration fails for --all', async () => {
+    preconditions.failsToListAssets();
+
+    await assetsCommand.parseAsync(['node', 'test', 'transfer', '--all', '--space', DEFAULT_SPACE, '--folder-id', '7']);
+
+    expect(actions.transferAssets).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(2);
   });
 
   it('should enumerate but not transfer in --all --dry-run mode', async () => {

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -14,6 +14,7 @@ const transferCmd = assetsCommand
   .option('-s, --space <space>', 'space ID')
   .option('--folder-id <folderId>', 'destination asset folder ID in the shared library')
   .option('--all', 'Transfer every asset in the space to the shared library')
+  .option('-q, --query <query>', 'Filter assets using Storyblok filter query syntax. Example: --query="search=my-file.jpg&with_tags=tag1,tag2"')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
   .description(`Transfer space assets into the organization's shared asset library.`);
 
@@ -57,10 +58,17 @@ transferCmd
       return;
     }
 
+    if (options.query && !options.all) {
+      handleError(new CommandError(`--query can only be used together with --all.`), verbose);
+      process.exitCode = 2;
+      return;
+    }
+
     let ids: number[];
     if (options.all) {
+      const params = options.query ? Object.fromEntries(new URLSearchParams(options.query)) : undefined;
       try {
-        ids = await fetchAllSpaceAssetIds(space);
+        ids = await fetchAllSpaceAssetIds(space, params);
       }
       catch (maybeError) {
         handleError(toError(maybeError), verbose);

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -52,9 +52,15 @@ transferCmd
       return;
     }
 
-    // `--query` selects a filtered subset of the space, so it implies the bulk
-    // path just like `--all`; either flag means "transfer what's in the space",
-    // which is mutually exclusive with naming explicit asset IDs.
+    // `--all` (the whole space) and `--query` (a filtered subset) both select
+    // the working set from the space itself, so they are mutually exclusive
+    // with each other and with naming explicit asset IDs.
+    if (options.all && options.query) {
+      handleError(new CommandError(`Cannot combine --all with --query. Use --all to transfer every asset, or --query to transfer a filtered subset.`), verbose);
+      process.exitCode = 2;
+      return;
+    }
+
     const bulk = Boolean(options.all || options.query);
 
     if (bulk && assetIds.length > 0) {
@@ -66,6 +72,7 @@ transferCmd
     let ids: number[];
     if (bulk) {
       const params = options.query ? Object.fromEntries(new URLSearchParams(options.query)) : undefined;
+      logger.info('Enumerating space assets', { space, query: options.query });
       try {
         ids = await fetchAllSpaceAssetIds(space, params);
       }
@@ -74,6 +81,7 @@ transferCmd
         process.exitCode = 2;
         return;
       }
+      logger.info('Enumerated space assets', { count: ids.length });
       if (ids.length === 0) {
         ui.info(options.query
           ? `No assets in space ${space} match the query. Nothing to transfer.`

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -6,7 +6,7 @@ import { getReporter } from '../../../lib/reporter/reporter';
 import { session } from '../../../session';
 import { requireAuthentication } from '../../../utils/auth';
 import { CommandError } from '../../../utils/error/command-error';
-import { handleError, logOnlyError } from '../../../utils/error/error';
+import { handleError, logOnlyError, toError } from '../../../utils/error/error';
 import { fetchAllSpaceAssetIds, transferAssets } from '../actions';
 
 const transferCmd = assetsCommand
@@ -59,7 +59,14 @@ transferCmd
 
     let ids: number[];
     if (options.all) {
-      ids = await fetchAllSpaceAssetIds(space);
+      try {
+        ids = await fetchAllSpaceAssetIds(space);
+      }
+      catch (maybeError) {
+        handleError(toError(maybeError), verbose);
+        process.exitCode = 2;
+        return;
+      }
       if (ids.length === 0) {
         ui.info(`No assets found in space ${space}. Nothing to transfer.`);
         logger.info('Transferring assets finished (no assets found)');

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -104,10 +104,16 @@ transferCmd
 
     // Per-ID errors are captured individually, so unlike push/pull this
     // command needs no outer fatalError try/catch wrapper.
+    const progress = ui.createProgressBar({ title: 'Transferring assets...' });
+    progress.setTotal(ids.length);
+
     const results = await transferAssets(space, ids, folderId, {
       onSuccess: ({ assetId, filename }) => logger.info('Transferred asset', { assetId, filename }),
       onError: (error, assetId) => logOnlyError(error, { assetId }),
+      onProgress: () => progress.increment(),
     });
+
+    ui.stopAllProgressBars();
 
     const succeeded = results.filter(result => result.status === 'transferred').length;
     const summary = { total: results.length, succeeded, failed: results.length - succeeded };

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -119,10 +119,27 @@ transferCmd
     const succeeded = results.filter(result => result.status === 'transferred').length;
     const summary = { total: results.length, succeeded, failed: results.length - succeeded };
 
-    ui.info(`Transfer results: ${summary.total} processed, ${summary.failed} failed`);
-    ui.list(results.map(result => result.status === 'transferred'
-      ? `${result.assetId}  ✓ transferred -> ${result.filename}`
-      : `${result.assetId}  ✗ failed: ${result.reason}`));
+    ui.info(`Transfer results: ${summary.succeeded} transferred, ${summary.failed} failed (of ${summary.total}).`);
+
+    if (summary.failed > 0) {
+      // Group failures by reason so the output stays a short summary even when
+      // thousands of assets fail with the same cause, instead of printing one
+      // line per failed asset. Per-asset detail is still in the log/report.
+      const countsByReason = new Map<string, number>();
+      for (const result of results) {
+        if (result.status === 'failed') {
+          const reason = result.reason ?? 'Unknown error';
+          countsByReason.set(reason, (countsByReason.get(reason) ?? 0) + 1);
+        }
+      }
+      const byReason = [...countsByReason.entries()].sort((a, b) => b[1] - a[1]);
+      const MAX_REASONS = 10;
+      const lines = byReason.slice(0, MAX_REASONS).map(([reason, count]) => `✗ ${reason} (${count})`);
+      if (byReason.length > MAX_REASONS) {
+        lines.push(`… and ${byReason.length - MAX_REASONS} more failure reason(s)`);
+      }
+      ui.list(lines);
+    }
 
     reporter.addSummary('transferResults', summary);
     reporter.finalize();

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -7,12 +7,13 @@ import { session } from '../../../session';
 import { requireAuthentication } from '../../../utils/auth';
 import { CommandError } from '../../../utils/error/command-error';
 import { handleError, logOnlyError } from '../../../utils/error/error';
-import { transferAssets } from '../actions';
+import { fetchAllSpaceAssetIds, transferAssets } from '../actions';
 
 const transferCmd = assetsCommand
-  .command('transfer <asset-id...>')
+  .command('transfer [asset-id...]')
   .option('-s, --space <space>', 'space ID')
   .option('--folder-id <folderId>', 'destination asset folder ID in the shared library')
+  .option('--all', 'Transfer every asset in the space to the shared library')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
   .description(`Transfer space assets into the organization's shared asset library.`);
 
@@ -50,11 +51,29 @@ transferCmd
       return;
     }
 
-    const ids = assetIds.map(id => Number(id)).filter(id => !Number.isNaN(id));
-    if (ids.length === 0) {
-      handleError(new CommandError(`Please provide at least one valid asset ID.`), verbose);
+    if (options.all && assetIds.length > 0) {
+      handleError(new CommandError(`Cannot combine --all with explicit asset IDs.`), verbose);
       process.exitCode = 2;
       return;
+    }
+
+    let ids: number[];
+    if (options.all) {
+      ids = await fetchAllSpaceAssetIds(space);
+      if (ids.length === 0) {
+        ui.info(`No assets found in space ${space}. Nothing to transfer.`);
+        logger.info('Transferring assets finished (no assets found)');
+        process.exitCode = 0;
+        return;
+      }
+    }
+    else {
+      ids = assetIds.map(id => Number(id)).filter(id => !Number.isNaN(id));
+      if (ids.length === 0) {
+        handleError(new CommandError(`Please provide at least one valid asset ID, or use --all.`), verbose);
+        process.exitCode = 2;
+        return;
+      }
     }
 
     if (options.dryRun) {

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -14,7 +14,7 @@ const transferCmd = assetsCommand
   .option('-s, --space <space>', 'space ID')
   .option('--folder-id <folderId>', 'destination asset folder ID in the shared library')
   .option('--all', 'Transfer every asset in the space to the shared library')
-  .option('-q, --query <query>', 'Filter assets using Storyblok filter query syntax. Example: --query="search=my-file.jpg&with_tags=tag1,tag2"')
+  .option('-q, --query <query>', 'Transfer every asset in the space matching a Storyblok filter query. Example: --query="search=my-file.jpg&with_tags=tag1,tag2"')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
   .description(`Transfer space assets into the organization's shared asset library.`);
 
@@ -52,20 +52,19 @@ transferCmd
       return;
     }
 
-    if (options.all && assetIds.length > 0) {
-      handleError(new CommandError(`Cannot combine --all with explicit asset IDs.`), verbose);
-      process.exitCode = 2;
-      return;
-    }
+    // `--query` selects a filtered subset of the space, so it implies the bulk
+    // path just like `--all`; either flag means "transfer what's in the space",
+    // which is mutually exclusive with naming explicit asset IDs.
+    const bulk = Boolean(options.all || options.query);
 
-    if (options.query && !options.all) {
-      handleError(new CommandError(`--query can only be used together with --all.`), verbose);
+    if (bulk && assetIds.length > 0) {
+      handleError(new CommandError(`Cannot combine explicit asset IDs with --all or --query.`), verbose);
       process.exitCode = 2;
       return;
     }
 
     let ids: number[];
-    if (options.all) {
+    if (bulk) {
       const params = options.query ? Object.fromEntries(new URLSearchParams(options.query)) : undefined;
       try {
         ids = await fetchAllSpaceAssetIds(space, params);
@@ -76,7 +75,9 @@ transferCmd
         return;
       }
       if (ids.length === 0) {
-        ui.info(`No assets found in space ${space}. Nothing to transfer.`);
+        ui.info(options.query
+          ? `No assets in space ${space} match the query. Nothing to transfer.`
+          : `No assets found in space ${space}. Nothing to transfer.`);
         logger.info('Transferring assets finished (no assets found)');
         process.exitCode = 0;
         return;

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -26,6 +26,7 @@ export const API_ACTIONS = {
   update_story: 'Failed to update story',
   pull_asset: 'Failed to pull asset',
   pull_assets: 'Failed to pull assets',
+  transfer_enumerate_assets: 'Failed to enumerate assets for transfer',
   pull_asset_folder: 'Failed to pull asset folder',
   pull_asset_folders: 'Failed to pull asset folders',
   push_asset_folder: 'Failed to push asset folder',


### PR DESCRIPTION
Adds an `--all` flag to `storyblok assets transfer` that transfers every asset in a space into the organization's shared asset library, so enterprise customers no longer need to pass individual asset IDs.

```bash
storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID
storyblok assets transfer --all --folder-id 789 --space YOUR_SPACE_ID --dry-run
```

## How

Enumerate-then-transfer. A new `fetchAllSpaceAssetIds` action paginates the space's asset list (via the existing `fetchAllPages` helper) to collect all asset IDs, then hands that array to the existing, unchanged `transferAssets`. The current per-ID reporting, backpressure lock, summary, and exit-code logic are reused as-is.

Behavior:

- `transfer --all` transfers every asset in the space.
- The positional `[asset-id...]` argument is now optional; it is required only when `--all` is not used.
- `--all` combined with explicit asset IDs is rejected (exit 2).
- Neither `--all` nor asset IDs provided is rejected (exit 2).
- `--all` on an empty space exits 0 with a "No assets found" message and transfers nothing.
- `--all --dry-run` enumerates the assets (read-only list calls, zero `convert` calls) and prints an accurate plan, then exits 0.
- An API failure while enumerating assets for `--all` exits cleanly through `handleError` (exit 2), matching the sibling `pull`/`push` commands, rather than surfacing as an unhandled rejection.

Safety for this bulk, one-way operation relies on `--dry-run` (no confirmation prompt), consistent with the existing command.

Fixes DX-457
