### PR TITLE
fix(live-preview): narrow storyblokEditable parameter type and tighten guard

### DIFF
--- a/packages/live-preview/src/editable.ts
+++ b/packages/live-preview/src/editable.ts
@@ -1,13 +1,11 @@
-import type { BlockContent } from './generated/types/field';
-
 interface EditableOptions {
   id: string;
   uid: string;
 }
 
-export default function storyblokEditable(block?: Pick<BlockContent, '_editable'>) {
+export default function storyblokEditable(block?: { _editable?: string }) {
   const editable = block?._editable;
-  if (!editable) {
+  if (typeof editable !== 'string' || !editable) {
     return {};
   }
 


### PR DESCRIPTION
Mirrors the type fix from #685 for the `@storyblok/live-preview` package.

- Narrows the `storyblokEditable` parameter type to `{ _editable?: string }` — removes the dependency on the generated `BlockContent` type for this function
- Tightens the internal guard to `typeof editable !== 'string' || !editable` to catch non-string values at runtime

Fixes DX-489