### PR TITLE
test(js-client): enforce write method return types via vitest typecheck

### DIFF
--- a/packages/js-client/vitest.config.ts
+++ b/packages/js-client/vitest.config.ts
@@ -2,10 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    // Run the type-level regression tests (`*.test-d.ts`) alongside the
-    // runtime unit tests so `expectTypeOf` assertions (e.g. DX-472's write
-    // method return types) are actually enforced by `vitest run`, not just
-    // by the standalone `test:types` tsc pass.
     typecheck: {
       enabled: true,
       include: ['./src/**/*.test-d.ts'],

--- a/packages/js-client/vitest.config.ts
+++ b/packages/js-client/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Run the type-level regression tests (`*.test-d.ts`) alongside the
+    // runtime unit tests so `expectTypeOf` assertions (e.g. DX-472's write
+    // method return types) are actually enforced by `vitest run`, not just
+    // by the standalone `test:types` tsc pass.
+    typecheck: {
+      enabled: true,
+      include: ['./src/**/*.test-d.ts'],
+    },
+  },
+});


### PR DESCRIPTION
Adds `packages/js-client/vitest.config.ts` enabling Vitest `typecheck` so `vitest run` collects and type-checks `src/**/*.test-d.ts`.

## Why

Follow-up to #677 (DX-472). That PR added `src/index.test-d.ts` with `expectTypeOf` assertions pinning the write methods (`post`/`put`/`patch`/`delete`) to `ISbResponse`, and described them as enforced by both `test:types` (tsc) and `vitest --typecheck`.

In reality only `test:types` enforced them:
- There was no `vitest.config.ts`, and `test:unit` is a plain `vitest run` with no `--typecheck` flag.
- Vitest's default `include` matches `*.{test,spec}.ts` — it never matches `*.test-d.ts`, so the file wasn't even collected by `vitest run`.

This change makes the "enforced by vitest" claim true.

Fixes DX-472