### PR TITLE
chore(deps): migrate pnpm overrides from package.json to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,6 @@
   "resolutions": {
     "cypress": "^14.3.3"
   },
-  "pnpm": {
-    "overrides": {
-      "happy-dom": "^20.8.8"
-    }
-  },
   "dependencies": {
     "cypress": "^14.3.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   cypress: ^14.3.3
-  happy-dom: ^20.8.8
 
 importers:
 
@@ -5086,7 +5085,7 @@ packages:
       '@testing-library/vue': ^7.0.0 || ^8.0.1
       '@vitest/ui': '*'
       '@vue/test-utils': ^2.4.2
-      happy-dom: ^20.8.8
+      happy-dom: '*'
       jsdom: '*'
       playwright-core: ^1.43.1
       vitest: ^3.2.0
@@ -7192,7 +7191,7 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.22.3
       '@tiptap/pm': ^3.22.3
-      happy-dom: ^20.8.8
+      happy-dom: ^20.8.9
 
   '@tiptap/pm@3.22.3':
     resolution: {integrity: sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==}
@@ -15955,7 +15954,7 @@ packages:
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       '@vitest/browser': 3.2.4
       '@vitest/ui': 3.2.4
-      happy-dom: ^20.8.8
+      happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
@@ -15985,7 +15984,7 @@ packages:
       '@vitest/browser-preview': 4.0.18
       '@vitest/browser-webdriverio': 4.0.18
       '@vitest/ui': 4.0.18
-      happy-dom: ^20.8.8
+      happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,5 @@ packages:
 onlyBuiltDependencies:
   - cypress
   - esbuild
+overrides:
+  happy-dom: "^20.8.8"


### PR DESCRIPTION
## Summary

Move the `happy-dom` version override from the legacy `pnpm.overrides` field in `package.json` to the top-level `overrides` field in `pnpm-workspace.yaml`, which is the correct location for pnpm v9+ workspaces.

## Changes

- `package.json`: removed `pnpm.overrides` block
- `pnpm-workspace.yaml`: added top-level `overrides: happy-dom: "^20.8.8"`
- `pnpm-lock.yaml`: regenerated — `happy-dom@20.8.9` resolves correctly across all vitest peer deps

Fixes DX-496