### PR TITLE
chore(ci): decouple build check name from matrix selector

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,19 @@ permissions:
 
 jobs:
   build:
+    name: build (${{ matrix.name }})
     environment: test
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
-            projects: tag:npm:public
+            name: linux
+            # `tag:npm:public` is inferred from publishability; `tag:scope:ci` opts
+            # in private packages (e.g. tooling, integration tests) that still need CI.
+            projects: "tag:npm:public,tag:scope:ci"
           - os: windows-latest
+            name: windows
             projects: storyblok
     runs-on: ${{ matrix.os }}
     defaults:

--- a/tools/openapi-codegen/package.json
+++ b/tools/openapi-codegen/package.json
@@ -28,6 +28,7 @@
     "test:types": "tsc --noEmit --skipLibCheck"
   },
   "nx": {
+    "tags": ["scope:ci"],
     "targets": {
       "build": {
         "inputs": [


### PR DESCRIPTION
GitHub derives a matrix job's check name from **every** matrix value. When a branch expands the `projects` selector (as `alpha` did — adding `@storyblok/openapi-codegen` and the integration-test packages), the job is renamed from `build (ubuntu-latest, tag:npm:public)` to `build (ubuntu-latest, tag:npm:public,@storyblok/…)`.

The `protect-release-branches` ruleset requires the literal context `build (ubuntu-latest, tag:npm:public)`. Since no check with that exact name ever reports, PRs sit at **"Expected — Waiting for status to be reported"** forever (e.g. #690).

## Fix

- **Static job name** (`build (linux)` / `build (windows)`) decoupled from the matrix, so the selector can change without ever renaming the required check again.
- **`scope:ci` nx tag** to opt *private* packages into CI declaratively, instead of hand-listing package names in the workflow. Seeded with `@storyblok/openapi-codegen`, which now runs `build/lint/test/test:types` in CI (previously untested).

## ⚠️ Coordinated rollout required

This **renames the required check** `build (ubuntu-latest, tag:npm:public)` → `build (linux)`, and the `protect-release-branches` ruleset (shared by `main` + release branches) must flip in lockstep:

1. Merge this PR to `main` via **admin bypass** — its own checks (`build (linux)`, `build (windows)`, `licenses`) pass, but the *old* required context won't report.
2. **Immediately** update the ruleset required context: `build (ubuntu-latest, tag:npm:public)` → `build (linux)`.
3. Propagate to `alpha` (**merge** `main` → `alpha`, don't rebase the published branch), then tag its two integration-test packages `scope:ci` and drop the hand-listed names. Unblocks #690.
4. Note: `rc` (dormant) and `feature/nuxt-release-v8` sit under the same ruleset and will lock against `build (linux)` until they adopt this workflow.

Refs #690