### PR TITLE
fix(cli,mapi-client): preserve datasource per-dimension entry values

### DIFF
--- a/adr/0005-datasource-per-dimension-entry-values.md
+++ b/adr/0005-datasource-per-dimension-entry-values.md
@@ -1,0 +1,28 @@
+# ADR-0005: Datasource per-dimension entry values
+
+**Status:** Accepted
+**Date:** 2026-07-07
+
+## Context
+
+`storyblok datasources pull` exported each entry with its default-dimension value only. The Storyblok Management API fills an entry's `dimension_value` only when a request passes the numeric `dimension` id, and it returns a single scalar per request. The pull command never passed `dimension`, so entries for datasources with dimensions (for example a per-language `en` dimension) lost all dimension-specific values locally, and `push` could not restore them (DX-466).
+
+Three decisions shaped the fix: how to represent multiple dimension values on disk, how to create the dimensions themselves on a target space, and how to send the `dimension_id` write parameter that the API accepts but the OpenAPI spec does not model.
+
+## Decision
+
+**Store per-dimension values keyed by dimension code.** Each local entry carries an optional `dimension_values` map keyed by the dimension code (`entry_value`, e.g. `en`) rather than the numeric dimension id. Codes are stable across spaces; ids are not. This keeps datasources portable: `push` resolves each code to the target space's dimension id via the target datasource's `dimensions` array, skips codes with no matching target dimension (with a warning), and clears a dimension removed locally by sending a blank value. Pull runs one entry sweep per dimension in addition to the default sweep and merges non-empty values into the map; the transient scalar `dimension_value` is not written to disk.
+
+**Create dimensions on push by mapping to `dimensions_attributes`.** The MAPI datasource create endpoint models dimensions only through the Rails nested-attributes field `dimensions_attributes` (`name` + `entry_value`); the pulled `dimensions` array (which carries source-space ids) is otherwise ignored. On create, `pushDatasource` maps `dimensions` to `dimensions_attributes` so a fresh target space gets its dimensions created and the target assigns new ids, after which per-dimension entry values resolve by code. This mapping is applied on create only: sending `dimensions_attributes` without ids on update would create duplicate dimensions, so updates leave existing dimensions untouched, and a code missing from an already-existing target datasource still falls through to the warn-and-skip path.
+
+**Forward `dimension_id` from the mapi-client wrapper instead of patching the spec.** The MAPI update endpoint reads `params[:dimension_id]` to write a dimension child row, but `storyblok/openapi-wdx` does not model that query parameter, so the generated `UpdateData['query']` is `never`. The generated sdk forwards `query` verbatim at runtime, so the hand-written `datasourceEntries.update` wrapper exposes `query.dimension_id` and passes it through with a localized cast. This keeps the fix within the monorepo, with no cross-repo spec change or `spec.lock` bump.
+
+## Consequences
+
+- Datasources round-trip fully into a fresh target space: push creates the datasource with its dimensions, then writes per-dimension entry values resolved by code. The on-disk file format changes from a scalar `dimension_value` to a `dimension_values` map.
+- Pull issues `1 + dimensionCount` sweeps per datasource; dimension sweeps run sequentially per datasource to bound request volume against the rate limit.
+- Files pulled before this change (scalar `dimension_value`) still read and push without error; they simply carry no `dimension_values`.
+- Dimensions are created but not reconciled on update: adding a dimension to an already-pushed target datasource, or removing one, is out of scope and would require id-aware `dimensions_attributes` diffing. Values for a code with no matching target dimension are skipped with a warning.
+- The wrapper cast is a deliberate, documented divergence from the generated types. Modeling `dimension_id` upstream in `openapi-wdx` and regenerating would remove the cast; that is a follow-up, not a prerequisite.
+
+Links: DX-466, GitHub #656.

--- a/packages/cli/src/commands/datasources/constants.ts
+++ b/packages/cli/src/commands/datasources/constants.ts
@@ -4,8 +4,18 @@ export type { DatasourceEntry };
 
 export const DEFAULT_DATASOURCES_FILENAME = 'datasources';
 
+/**
+ * Local representation of a datasource entry. Where the API returns a single
+ * scalar `dimension_value` per request, the local file stores the value for
+ * every defined dimension in `dimension_values`, keyed by dimension code
+ * (`entry_value`, e.g. `en`) so datasources stay portable across spaces.
+ */
+export type SpaceDatasourceEntry = Omit<DatasourceEntry, 'dimension_value'> & {
+  dimension_values?: Record<string, string>;
+};
+
 export type SpaceDatasource = Datasource & {
-  entries?: DatasourceEntry[];
+  entries?: SpaceDatasourceEntry[];
 };
 
 export interface SpaceDatasourcesData {

--- a/packages/cli/src/commands/datasources/pull/README.md
+++ b/packages/cli/src/commands/datasources/pull/README.md
@@ -139,3 +139,4 @@ Where:
 - The command will create the necessary directories if they don't exist
 - When using `--separate-files` or single datasource, each datasource is saved in its own file
 - All files include the datasource entries resolved automatically
+- Entries include a `dimension_values` map with the value for every defined dimension, keyed by the dimension code (`entry_value`, e.g. `en`). The command fetches one page set per dimension, so datasources with many dimensions issue more requests.

--- a/packages/cli/src/commands/datasources/pull/actions.test.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.test.ts
@@ -118,13 +118,73 @@ describe('pull datasources actions', () => {
         id: 99540095392100,
         name: 'Red',
         value: 'red',
-        dimension_value: '',
         datasource_id: 1,
       });
+      // Datasource has no dimensions, so no per-dimension values are stored and
+      // the transient scalar dimension_value is dropped
+      expect(colorsDatasource?.entries?.[0]).not.toHaveProperty('dimension_value');
+      expect(colorsDatasource?.entries?.[0]?.dimension_values).toBeUndefined();
       // Verify some specific entries to ensure all pages were fetched
       const entryNames = colorsDatasource?.entries?.map(e => e.name);
       expect(entryNames).toContain('Red'); // First page
       expect(entryNames).toContain('white'); // Second page (entry 33)
+    });
+
+    it('should fetch per-dimension values for datasources with dimensions', async () => {
+      const datasource = {
+        id: 900,
+        name: 'greetings',
+        slug: 'greetings',
+        dimensions: [
+          { id: 11, name: 'English', entry_value: 'en', datasource_id: 900 },
+          { id: 22, name: 'German', entry_value: 'de', datasource_id: 900 },
+        ],
+        created_at: '2025-01-01T00:00:00.000Z',
+        updated_at: '2025-01-01T00:00:00.000Z',
+      };
+      const baseEntries = [
+        { id: 1, name: 'hello', value: 'hello', datasource_id: 900 },
+        { id: 2, name: 'bye', value: 'bye', datasource_id: 900 },
+        { id: 3, name: 'thanks', value: 'thanks', datasource_id: 900 },
+      ];
+      // Per-dimension values keyed by dimension id, then entry id. Entry 3 has no
+      // value in the "de" dimension, so it must be omitted from dimension_values.
+      const dimensionValues: Record<string, Record<number, string>> = {
+        11: { 1: 'hi', 2: 'cya', 3: 'thx' },
+        22: { 1: 'hallo', 2: 'tschuess' },
+      };
+      const dimensionRequests: string[] = [];
+
+      server.use(
+        http.get('https://mapi.storyblok.com/v1/spaces/12345/datasources', () =>
+          HttpResponse.json({ datasources: [datasource] }, { headers: { total: '1' } })),
+        http.get('https://mapi.storyblok.com/v1/spaces/12345/datasource_entries', ({ request }) => {
+          const url = new URL(request.url);
+          const dimension = url.searchParams.get('dimension');
+          dimensionRequests.push(dimension ?? 'default');
+          const entries = baseEntries.map(entry => ({
+            ...entry,
+            dimension_value: dimension ? (dimensionValues[dimension]?.[entry.id] ?? '') : '',
+          }));
+          return HttpResponse.json({ datasource_entries: entries }, { headers: { total: String(entries.length) } });
+        }),
+      );
+
+      const resultPromise = fetchDatasources('12345');
+      await vi.advanceTimersByTimeAsync(MAX_RETRY_DURATION);
+      const result = await resultPromise;
+
+      const greetings = result?.find(ds => ds.name === 'greetings');
+      expect(greetings?.entries?.[0]).toMatchObject({
+        name: 'hello',
+        value: 'hello',
+        dimension_values: { en: 'hi', de: 'hallo' },
+      });
+      expect(greetings?.entries?.[1]?.dimension_values).toEqual({ en: 'cya', de: 'tschuess' });
+      // Empty dimension values are omitted, not stored as ''
+      expect(greetings?.entries?.[2]?.dimension_values).toEqual({ en: 'thx' });
+      // One default pass plus one pass per defined dimension
+      expect(dimensionRequests).toEqual(['default', '11', '22']);
     });
 
     it('should handle pagination headers correctly', async () => {

--- a/packages/cli/src/commands/datasources/pull/actions.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.ts
@@ -3,7 +3,7 @@ import { getMapiClient } from '../../../api';
 import { join, resolve } from 'pathe';
 import { resolvePath, sanitizeFilename, saveToFile } from '../../../utils/filesystem';
 import { fetchAllPages } from '../../../utils/pagination';
-import type { DatasourceEntry, SpaceDatasource } from '../constants';
+import type { DatasourceEntry, SpaceDatasource, SpaceDatasourceEntry } from '../constants';
 import { DEFAULT_DATASOURCES_FILENAME } from '../constants';
 import type { SaveDatasourcesOptions } from './constants';
 
@@ -11,11 +11,14 @@ import type { SaveDatasourcesOptions } from './constants';
  * Fetches entries for a given datasource id in a space.
  * @param spaceId - The space ID
  * @param datasourceId - The datasource ID
+ * @param dimensionId - Optional dimension id; when provided the API fills each
+ *   entry's `dimension_value` with the value for that dimension
  * @returns Array of datasource entries
  */
 export const fetchDatasourceEntries = async (
   spaceId: string,
   datasourceId: number,
+  dimensionId?: number,
 ): Promise<DatasourceEntry[] | undefined> => {
   try {
     const client = getMapiClient();
@@ -27,6 +30,8 @@ export const fetchDatasourceEntries = async (
         query: {
           datasource_id: datasourceId,
           page,
+          // MAPI matches `dimension` against the numeric dimension id.
+          ...(dimensionId != null && { dimension: String(dimensionId) }),
         },
         throwOnError: true,
       }),
@@ -37,6 +42,54 @@ export const fetchDatasourceEntries = async (
     // Use 'pull_datasources' as the closest valid action for datasource entries errors
     handleAPIError('pull_datasources', error as Error);
   }
+};
+
+/**
+ * Fetches a datasource's entries with their values for every defined dimension.
+ * Runs the default (dimensionless) pass, then one pass per dimension, merging
+ * each non-empty `dimension_value` into `entry.dimension_values` keyed by the
+ * dimension code (`entry_value`). Dimension passes run sequentially to avoid
+ * multiplying request volume against the rate limit.
+ * @param spaceId - The space ID
+ * @param datasource - The datasource, including its `dimensions`
+ * @returns Array of local datasource entries
+ */
+const fetchDatasourceEntriesWithDimensions = async (
+  spaceId: string,
+  datasource: SpaceDatasource,
+): Promise<SpaceDatasourceEntry[]> => {
+  const defaultEntries = await fetchDatasourceEntries(spaceId, datasource.id) ?? [];
+  // Drop the transient scalar `dimension_value`; per-dimension values are
+  // stored in `dimension_values` instead.
+  const entries: SpaceDatasourceEntry[] = defaultEntries.map(({ dimension_value, ...rest }) => rest);
+
+  const dimensions = datasource.dimensions ?? [];
+  if (!dimensions.length) {
+    return entries;
+  }
+
+  const entriesById = new Map(entries.map(entry => [entry.id, entry]));
+
+  for (const dimension of dimensions) {
+    if (dimension.id == null || !dimension.entry_value) {
+      continue;
+    }
+    const dimensionEntries = await fetchDatasourceEntries(spaceId, datasource.id, dimension.id) ?? [];
+    for (const dimensionEntry of dimensionEntries) {
+      const value = dimensionEntry.dimension_value;
+      if (!value) {
+        continue;
+      }
+      const entry = entriesById.get(dimensionEntry.id);
+      if (!entry) {
+        continue;
+      }
+      entry.dimension_values ??= {};
+      entry.dimension_values[dimension.entry_value] = value;
+    }
+  }
+
+  return entries;
 };
 
 export const fetchDatasources = async (spaceId: string): Promise<SpaceDatasource[] | undefined> => {
@@ -60,7 +113,7 @@ export const fetchDatasources = async (spaceId: string): Promise<SpaceDatasource
         if (!ds.id) {
           return { ...ds, entries: [] };
         }
-        const entries = await fetchDatasourceEntries(spaceId, ds.id);
+        const entries = await fetchDatasourceEntriesWithDimensions(spaceId, ds);
         return { ...ds, entries };
       }),
     );
@@ -90,8 +143,8 @@ export const fetchDatasource = async (spaceId: string, datasourceName: string): 
     const found = matches.find((d: SpaceDatasource) => d.name === datasourceName);
     if (!found) { return undefined; }
     // Fetch entries for the found datasource
-    const entries = await fetchDatasourceEntries(spaceId, found.id as number);
-    return { ...found, entries: entries || [] } as SpaceDatasource;
+    const entries = await fetchDatasourceEntriesWithDimensions(spaceId, found);
+    return { ...found, entries };
   }
   catch (error) {
     handleAPIError('pull_datasources', error as Error, `Failed to fetch datasource ${datasourceName}`);

--- a/packages/cli/src/commands/datasources/push/README.md
+++ b/packages/cli/src/commands/datasources/push/README.md
@@ -172,23 +172,27 @@ The command performs the following operations:
 
 Each datasource file contains:
 - **Datasource metadata**: `id`, `name`, `slug`, `dimensions`, timestamps
-- **Entries**: Array of datasource entries with `id`, `name`, `value`, `dimension_value`
+- **Entries**: Array of datasource entries with `id`, `name`, `value`, and an optional `dimension_values` map
+
+`dimension_values` holds the value of an entry for each defined dimension, keyed by the dimension code (`entry_value`, e.g. `en`). Codes stay stable across spaces, so datasources push cleanly into a target space. When push creates a datasource, it also creates its dimensions in the target, which assigns fresh ids. On push, each code is resolved to the target space's dimension id; a code with no matching dimension in the target space is skipped with a warning, and a dimension removed locally is cleared in the target. Push does not reconcile dimensions on an existing target datasource: dimensions are created only when the datasource itself is created.
 
 Example datasource file:
 ```json
 {
   "id": 1,
-  "name": "colors",
-  "slug": "colors",
-  "dimensions": [],
+  "name": "greetings",
+  "slug": "greetings",
+  "dimensions": [
+    { "id": 1, "name": "English", "entry_value": "en", "datasource_id": 1 }
+  ],
   "created_at": "2024-01-01T00:00:00.000Z",
   "updated_at": "2024-01-01T00:00:00.000Z",
   "entries": [
     {
       "id": 101,
-      "name": "blue",
-      "value": "#0000ff",
-      "dimension_value": "",
+      "name": "hello",
+      "value": "hello",
+      "dimension_values": { "en": "hi" },
       "datasource_id": 1
     }
   ]

--- a/packages/cli/src/commands/datasources/push/README.md
+++ b/packages/cli/src/commands/datasources/push/README.md
@@ -174,8 +174,6 @@ Each datasource file contains:
 - **Datasource metadata**: `id`, `name`, `slug`, `dimensions`, timestamps
 - **Entries**: Array of datasource entries with `id`, `name`, `value`, and an optional `dimension_values` map
 
-`dimension_values` holds the value of an entry for each defined dimension, keyed by the dimension code (`entry_value`, e.g. `en`). Codes stay stable across spaces, so datasources push cleanly into a target space. When push creates a datasource, it also creates its dimensions in the target, which assigns fresh ids. On push, each code is resolved to the target space's dimension id; a code with no matching dimension in the target space is skipped with a warning, and a dimension removed locally is cleared in the target. Push does not reconcile dimensions on an existing target datasource: dimensions are created only when the datasource itself is created.
-
 Example datasource file:
 ```json
 {

--- a/packages/cli/src/commands/datasources/push/actions.test.ts
+++ b/packages/cli/src/commands/datasources/push/actions.test.ts
@@ -1,8 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { vol } from 'memfs';
-import { readDatasourcesFiles } from './actions';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { pushDatasource, readDatasourcesFiles } from './actions';
 import type { SpaceDatasource } from '../constants';
+import { getMapiClient } from '../../../api';
 import { FileSystemError } from '../../../utils/error/filesystem-error';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 // Mock datasources data that matches the SpaceDatasource interface
 const mockDatasource1: SpaceDatasource = {
@@ -353,6 +362,46 @@ describe('push datasources actions', () => {
         expect(result.datasources).toContainEqual(mockDatasource1);
         expect(result.datasources).toContainEqual(mockDatasource2);
       });
+    });
+  });
+
+  describe('pushDatasource', () => {
+    beforeEach(() => {
+      getMapiClient({ personalAccessToken: 'valid-token', region: 'eu' });
+    });
+
+    it('should map the local dimensions array to dimensions_attributes so a fresh target gets them created', async () => {
+      let createdBody: any;
+      server.use(
+        http.post('https://mapi.storyblok.com/v1/spaces/12345/datasources', async ({ request }) => {
+          createdBody = await request.json();
+          return HttpResponse.json({ datasource: { id: 99, name: 'Countries', slug: 'countries' } }, { status: 201 });
+        }),
+      );
+
+      const { entries, ...definition } = mockDatasource1;
+      await pushDatasource('12345', definition);
+
+      // Dimensions are sent as dimensions_attributes (name + entry_value only), not as the raw `dimensions` array.
+      expect(createdBody.datasource.dimensions_attributes).toEqual([
+        { name: 'United States', entry_value: 'us' },
+        { name: 'Canada', entry_value: 'ca' },
+      ]);
+      expect(createdBody.datasource.dimensions).toBeUndefined();
+    });
+
+    it('should omit dimensions_attributes for a datasource without dimensions', async () => {
+      let createdBody: any;
+      server.use(
+        http.post('https://mapi.storyblok.com/v1/spaces/12345/datasources', async ({ request }) => {
+          createdBody = await request.json();
+          return HttpResponse.json({ datasource: { id: 1, name: 'colors', slug: 'colors' } }, { status: 201 });
+        }),
+      );
+
+      await pushDatasource('12345', { name: 'colors', slug: 'colors', dimensions: [] });
+
+      expect(createdBody.datasource.dimensions_attributes).toBeUndefined();
     });
   });
 });

--- a/packages/cli/src/commands/datasources/push/actions.ts
+++ b/packages/cli/src/commands/datasources/push/actions.ts
@@ -1,7 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import { join } from 'pathe';
 import chalk from 'chalk';
-import type { DatasourceEntry, SpaceDatasource, SpaceDatasourcesData } from '../constants';
+import type { DatasourceEntry, SpaceDatasource, SpaceDatasourceEntry, SpaceDatasourcesData } from '../constants';
 import type { DatasourceCreate, DatasourceUpdate } from '../../../types';
 import type { ReadDatasourcesOptions } from './constants';
 import { filterJsonBySuffix, readJsonFile, resolvePath } from '../../../utils/filesystem';
@@ -9,15 +9,30 @@ import { getMapiClient } from '../../../api';
 import { handleAPIError } from '../../../utils/error/api-error';
 import { FileSystemError, handleFileSystemError } from '../../../utils/error/filesystem-error';
 
-export const pushDatasource = async (spaceId: string, datasource: DatasourceCreate): Promise<SpaceDatasource | undefined> => {
+export const pushDatasource = async (spaceId: string, datasource: DatasourceCreate & { dimensions?: SpaceDatasource['dimensions'] }): Promise<SpaceDatasource | undefined> => {
   try {
     const client = getMapiClient();
+
+    const { dimensions, ...datasourceFields } = datasource;
+    // The create endpoint models dimensions only through `dimensions_attributes`
+    // (name + entry_value); the pulled `dimensions` array (with source-space ids)
+    // is otherwise ignored. Map it so a fresh target space gets its dimensions
+    // created, with the target assigning new ids. Per-dimension entry values then
+    // resolve by dimension code against those ids.
+    const dimensionsAttributes = (dimensions ?? [])
+      .filter(dimension => dimension.entry_value)
+      .map(dimension => ({ name: dimension.name ?? dimension.entry_value ?? '', entry_value: dimension.entry_value ?? '' }));
 
     const { data } = await client.datasources.create({
       path: {
         space_id: Number(spaceId),
       },
-      body: { datasource },
+      body: {
+        datasource: {
+          ...datasourceFields,
+          ...(dimensionsAttributes.length > 0 && { dimensions_attributes: dimensionsAttributes }),
+        },
+      },
       throwOnError: true,
     });
 
@@ -49,7 +64,7 @@ export const updateDatasource = async (spaceId: string, datasourceId: number, da
   }
 };
 
-export const upsertDatasource = async (space: string, datasource: DatasourceCreate, existingId?: number): Promise<SpaceDatasource | undefined> => {
+export const upsertDatasource = async (space: string, datasource: DatasourceCreate & { dimensions?: SpaceDatasource['dimensions'] }, existingId?: number): Promise<SpaceDatasource | undefined> => {
   if (existingId) {
     return await updateDatasource(space, existingId, datasource);
   }
@@ -66,9 +81,12 @@ export const upsertDatasource = async (space: string, datasource: DatasourceCrea
  * @param position - Optional position index to control ordering
  * @returns The created datasource entry
  */
-export const pushDatasourceEntry = async (spaceId: string, datasourceId: number, entry: DatasourceEntry, position?: number): Promise<DatasourceEntry | undefined> => {
+export const pushDatasourceEntry = async (spaceId: string, datasourceId: number, entry: SpaceDatasourceEntry, position?: number): Promise<DatasourceEntry | undefined> => {
   try {
     const client = getMapiClient();
+
+    // Per-dimension values are written separately via updateDatasourceEntryDimension.
+    const { dimension_values, ...entryFields } = entry;
 
     const { data } = await client.datasourceEntries.create({
       path: {
@@ -76,7 +94,7 @@ export const pushDatasourceEntry = async (spaceId: string, datasourceId: number,
       },
       body: {
         datasource_entry: {
-          ...entry,
+          ...entryFields,
           value: entry.value ?? '',
           datasource_id: datasourceId,
           ...(position != null && { position }),
@@ -99,16 +117,20 @@ export const pushDatasourceEntry = async (spaceId: string, datasourceId: number,
  * @param entry - The updated datasource entry data
  * @param position - Optional position index to control ordering
  */
-export const updateDatasourceEntry = async (spaceId: string, entryId: number, entry: DatasourceEntry, position?: number): Promise<void> => {
+export const updateDatasourceEntry = async (spaceId: string, entryId: number, entry: SpaceDatasourceEntry, position?: number): Promise<void> => {
   try {
     const client = getMapiClient();
+
+    // Per-dimension values are written separately via updateDatasourceEntryDimension.
+    const { dimension_values, ...entryFields } = entry;
+
     await client.datasourceEntries.update(entryId, {
       path: {
         space_id: Number(spaceId),
       },
       body: {
         datasource_entry: {
-          ...entry,
+          ...entryFields,
           ...(position != null && { position }),
         },
       } as any,
@@ -117,6 +139,45 @@ export const updateDatasourceEntry = async (spaceId: string, entryId: number, en
   }
   catch (error) {
     handleAPIError('update_datasource', error as Error, `Failed to update datasource entry ${entry.name}`);
+  }
+};
+
+/**
+ * Writes a single per-dimension value for an entry. The MAPI update endpoint
+ * upserts the dimension child row identified by `dimensionId`; a blank
+ * `dimensionValue` clears it.
+ * @param spaceId - The space ID
+ * @param entryId - The ID of the entry to update
+ * @param entry - The entry providing `name`/`value` context
+ * @param dimensionId - The target dimension id
+ * @param dimensionValue - The value to write for that dimension (blank clears)
+ */
+export const updateDatasourceEntryDimension = async (
+  spaceId: string,
+  entryId: number,
+  entry: SpaceDatasourceEntry,
+  dimensionId: number,
+  dimensionValue: string,
+): Promise<void> => {
+  try {
+    const client = getMapiClient();
+    await client.datasourceEntries.update(entryId, {
+      path: {
+        space_id: Number(spaceId),
+      },
+      query: { dimension_id: dimensionId },
+      body: {
+        datasource_entry: {
+          name: entry.name,
+          value: entry.value ?? '',
+          dimension_value: dimensionValue,
+        },
+      },
+      throwOnError: true,
+    });
+  }
+  catch (error) {
+    handleAPIError('update_datasource', error as Error, `Failed to update datasource entry ${entry.name} for dimension ${dimensionId}`);
   }
 };
 
@@ -132,7 +193,7 @@ export const updateDatasourceEntry = async (spaceId: string, entryId: number, en
 export const upsertDatasourceEntry = async (
   space: string,
   datasourceId: number,
-  entry: DatasourceEntry,
+  entry: SpaceDatasourceEntry,
   existingId?: number,
   position?: number,
 ): Promise<DatasourceEntry | undefined> => {

--- a/packages/cli/src/commands/datasources/push/index.test.ts
+++ b/packages/cli/src/commands/datasources/push/index.test.ts
@@ -8,7 +8,7 @@ import '../index';
 import { datasourcesCommand } from '../command';
 import { loggedOutSessionState } from '../../../../test/setup';
 import { fetchDatasources } from '../pull/actions';
-import { deleteDatasourceEntry, upsertDatasource, upsertDatasourceEntry } from './actions';
+import { deleteDatasourceEntry, updateDatasourceEntryDimension, upsertDatasource, upsertDatasourceEntry } from './actions';
 
 const loggerInfoMock = vi.hoisted(() => vi.fn());
 
@@ -33,6 +33,7 @@ vi.mock('./actions', async () => {
     pushDatasourceEntry: vi.fn(),
     updateDatasourceEntry: vi.fn(),
     upsertDatasourceEntry: vi.fn(),
+    updateDatasourceEntryDimension: vi.fn(),
     deleteDatasourceEntry: vi.fn(),
   };
 });
@@ -412,6 +413,123 @@ describe('push datasources', () => {
       expect(deleteDatasourceEntry).toHaveBeenCalledWith('12345', 10);
       expect(deleteDatasourceEntry).toHaveBeenCalledWith('12345', 11);
       expect(deleteDatasourceEntry).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('dimension values', () => {
+    const localDatasource: SpaceDatasource = {
+      id: 1,
+      name: 'greetings',
+      slug: 'greetings',
+      created_at: '',
+      updated_at: '',
+      dimensions: [
+        { id: 1, name: 'English', entry_value: 'en', datasource_id: 1 },
+        { id: 2, name: 'German', entry_value: 'de', datasource_id: 1 },
+      ],
+      entries: [
+        { id: 10, name: 'hello', value: 'hello', dimension_values: { en: 'hi', de: 'hallo' }, datasource_id: 1 },
+      ],
+    };
+    // Target space uses different dimension ids for the same codes.
+    const targetDimensions = [
+      { id: 101, name: 'English', entry_value: 'en', datasource_id: 1 },
+      { id: 102, name: 'German', entry_value: 'de', datasource_id: 1 },
+    ];
+
+    it('should write per-dimension values resolved to target dimension ids', async () => {
+      vi.mocked(upsertDatasource).mockResolvedValue({ id: 1, name: 'greetings', slug: 'greetings', created_at: '', updated_at: '', dimensions: targetDimensions });
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify([localDatasource]),
+      });
+      // Target entry exists with the same default value but no dimension values yet.
+      vi.mocked(fetchDatasources).mockResolvedValue([
+        {
+          ...localDatasource,
+          dimensions: targetDimensions,
+          entries: [{ id: 10, name: 'hello', value: 'hello', datasource_id: 1 }],
+        },
+      ]);
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      expect(updateDatasourceEntryDimension).toHaveBeenCalledWith('12345', 10, expect.objectContaining({ name: 'hello' }), 101, 'hi');
+      expect(updateDatasourceEntryDimension).toHaveBeenCalledWith('12345', 10, expect.objectContaining({ name: 'hello' }), 102, 'hallo');
+      expect(updateDatasourceEntryDimension).toHaveBeenCalledTimes(2);
+    });
+
+    it('should skip entries whose value and dimension values are unchanged', async () => {
+      vi.mocked(upsertDatasource).mockResolvedValue({ id: 1, name: 'greetings', slug: 'greetings', created_at: '', updated_at: '', dimensions: targetDimensions });
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify([localDatasource]),
+      });
+      // Target matches local exactly (same dimension values).
+      vi.mocked(fetchDatasources).mockResolvedValue([{ ...localDatasource, dimensions: targetDimensions }]);
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      expect(upsertDatasourceEntry).not.toHaveBeenCalled();
+      expect(updateDatasourceEntryDimension).not.toHaveBeenCalled();
+    });
+
+    it('should not rewrite dimension values when only the default value changed', async () => {
+      // Local changed only the default value; dimension values match the target.
+      const changedDefault: SpaceDatasource = {
+        ...localDatasource,
+        entries: [{ id: 10, name: 'hello', value: 'hello-updated', dimension_values: { en: 'hi', de: 'hallo' }, datasource_id: 1 }],
+      };
+      vi.mocked(upsertDatasource).mockResolvedValue({ id: 1, name: 'greetings', slug: 'greetings', created_at: '', updated_at: '', dimensions: targetDimensions });
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify([changedDefault]),
+      });
+      // Target has the old default value but identical dimension values.
+      vi.mocked(fetchDatasources).mockResolvedValue([{ ...localDatasource, dimensions: targetDimensions }]);
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      // The entry is upserted (default value changed) but no per-dimension writes happen.
+      expect(upsertDatasourceEntry).toHaveBeenCalledTimes(1);
+      expect(updateDatasourceEntryDimension).not.toHaveBeenCalled();
+    });
+
+    it('should clear a dimension value removed locally by sending a blank value', async () => {
+      // Local dropped the "de" value.
+      const withoutDe: SpaceDatasource = {
+        ...localDatasource,
+        entries: [{ id: 10, name: 'hello', value: 'hello', dimension_values: { en: 'hi' }, datasource_id: 1 }],
+      };
+      vi.mocked(upsertDatasource).mockResolvedValue({ id: 1, name: 'greetings', slug: 'greetings', created_at: '', updated_at: '', dimensions: targetDimensions });
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify([withoutDe]),
+      });
+      // Target still carries the "de" value.
+      vi.mocked(fetchDatasources).mockResolvedValue([{ ...localDatasource, dimensions: targetDimensions }]);
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      expect(updateDatasourceEntryDimension).toHaveBeenCalledWith('12345', 10, expect.objectContaining({ name: 'hello' }), 102, '');
+    });
+
+    it('should warn and skip a dimension with no matching dimension in the target space', async () => {
+      // Target only defines the "en" dimension.
+      const enOnly = [{ id: 101, name: 'English', entry_value: 'en', datasource_id: 1 }];
+      vi.mocked(upsertDatasource).mockResolvedValue({ id: 1, name: 'greetings', slug: 'greetings', created_at: '', updated_at: '', dimensions: enOnly });
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify([localDatasource]),
+      });
+      vi.mocked(fetchDatasources).mockResolvedValue([
+        {
+          ...localDatasource,
+          dimensions: enOnly,
+          entries: [{ id: 10, name: 'hello', value: 'hello', datasource_id: 1 }],
+        },
+      ]);
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      expect(updateDatasourceEntryDimension).toHaveBeenCalledWith('12345', 10, expect.objectContaining({ name: 'hello' }), 101, 'hi');
+      expect(updateDatasourceEntryDimension).toHaveBeenCalledTimes(1);
+      expect(konsola.warn).toHaveBeenCalledWith(expect.stringContaining('de'));
     });
   });
 });

--- a/packages/cli/src/commands/datasources/push/index.test.ts
+++ b/packages/cli/src/commands/datasources/push/index.test.ts
@@ -510,6 +510,26 @@ describe('push datasources', () => {
       expect(updateDatasourceEntryDimension).toHaveBeenCalledWith('12345', 10, expect.objectContaining({ name: 'hello' }), 102, '');
     });
 
+    it('should not touch target dimension values when the local entry has no dimension_values key', async () => {
+      // Local entry is not dimension-aware (no `dimension_values` key at all),
+      // e.g. pulled before this feature or from a dimensionless space.
+      const withoutDimensionValues: SpaceDatasource = {
+        ...localDatasource,
+        entries: [{ id: 10, name: 'hello', value: 'hello', datasource_id: 1 }],
+      };
+      vi.mocked(upsertDatasource).mockResolvedValue({ id: 1, name: 'greetings', slug: 'greetings', created_at: '', updated_at: '', dimensions: targetDimensions });
+      vol.fromJSON({
+        '.storyblok/datasources/12345/datasources.json': JSON.stringify([withoutDimensionValues]),
+      });
+      // Target already carries per-dimension values that must be preserved.
+      vi.mocked(fetchDatasources).mockResolvedValue([{ ...localDatasource, dimensions: targetDimensions }]);
+
+      await datasourcesCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
+
+      // No blank writes: the target's existing per-dimension values are left intact.
+      expect(updateDatasourceEntryDimension).not.toHaveBeenCalled();
+    });
+
     it('should warn and skip a dimension with no matching dimension in the target space', async () => {
       // Target only defines the "en" dimension.
       const enOnly = [{ id: 101, name: 'English', entry_value: 'en', datasource_id: 1 }];

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -133,6 +133,10 @@ pushCmd
           const localEntries = entries ?? [];
           const existingEntries = existingDatasource?.entries ?? [];
 
+          // Collect per-dimension skip warnings and flush them after the spinner
+          // stops, so they aren't overwritten by the spinner's live redraw.
+          const dimensionWarnings: string[] = [];
+
           // Index existing entries by name with their position for O(1) lookup
           const existingEntryMap = new Map(existingEntries.map((e, idx) => [e.name, { entry: e, position: idx + 1 }]));
 
@@ -172,7 +176,7 @@ pushCmd
                   }
                   const dimension = result.dimensions?.find(d => d.entry_value === code);
                   if (!dimension?.id) {
-                    konsola.warn(`Skipping dimension "${code}" for entry "${entry.name}": no matching dimension in target space ${space}`);
+                    dimensionWarnings.push(`Skipping dimension "${code}" for entry "${entry.name}": no matching dimension in target space ${space}`);
                     continue;
                   }
                   await updateDatasourceEntryDimension(space, entryId, entry, dimension.id, localValue);
@@ -200,6 +204,9 @@ pushCmd
           }
 
           spinner.succeed(`${chalk.hex(colorPalette.DATASOURCES)(datasource.name)} - Completed in ${spinner.elapsedTime.toFixed(2)}ms`);
+
+          // Flush any per-dimension skip warnings now that the spinner has stopped.
+          dimensionWarnings.forEach(warning => konsola.warn(warning));
         }
         else {
           results.failed.push({ name: datasource.name, error: result });

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -162,8 +162,17 @@ pushCmd
 
               // Write per-dimension values. Iterate the union of local and target
               // dimension codes so values removed locally are cleared (blank) too.
-              if (entryId != null) {
-                const localDimensionValues = entry.dimension_values ?? {};
+              //
+              // Only reconcile when the local entry actually carries a
+              // `dimension_values` map. A missing key means the source is not
+              // dimension-aware (e.g. pulled before this feature, or from a
+              // dimensionless space); treating it as an empty map would blank out
+              // per-dimension values that already exist in the target. Pull omits
+              // the key for entries without per-dimension values, so this cannot
+              // propagate a full clear of the last remaining value — an acceptable
+              // trade-off to avoid silent data loss.
+              if (entryId != null && entry.dimension_values !== undefined) {
+                const localDimensionValues = entry.dimension_values;
                 const targetDimensionValues = existing?.entry.dimension_values ?? {};
                 const dimensionCodes = new Set([...Object.keys(localDimensionValues), ...Object.keys(targetDimensionValues)]);
 

--- a/packages/cli/src/commands/datasources/push/index.ts
+++ b/packages/cli/src/commands/datasources/push/index.ts
@@ -7,10 +7,23 @@ import type { PushDatasourcesOptions } from './constants';
 import { session } from '../../../session';
 import chalk from 'chalk';
 import type { SpaceDatasource, SpaceDatasourcesDataState } from '../constants';
-import { deleteDatasourceEntry, readDatasourcesFiles, upsertDatasource, upsertDatasourceEntry } from './actions';
+import { deleteDatasourceEntry, readDatasourcesFiles, updateDatasourceEntryDimension, upsertDatasource, upsertDatasourceEntry } from './actions';
 import { fetchDatasources } from '../pull/actions';
 import { getUI } from '../../../utils/ui';
 import { getLogger } from '../../../lib/logger/logger';
+
+/**
+ * Compares two per-dimension value maps for equality, treating an absent map
+ * as empty.
+ */
+function dimensionValuesEqual(a?: Record<string, string>, b?: Record<string, string>): boolean {
+  const aKeys = Object.keys(a ?? {});
+  const bKeys = Object.keys(b ?? {});
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  return aKeys.every(key => a?.[key] === b?.[key]);
+}
 
 const pushCmd = datasourcesCommand
   .command('push [datasourceName]')
@@ -129,18 +142,42 @@ pushCmd
             const existingEntryId = existing?.entry.id;
             const targetPosition = i + 1;
 
-            // Skip update when all mutable fields and position are identical
+            // Skip update when all mutable fields, per-dimension values, and position are identical
             if (existing
               && existing.entry.value === entry.value
-              && existing.entry.dimension_value === entry.dimension_value
+              && dimensionValuesEqual(existing.entry.dimension_values, entry.dimension_values)
               && existing.position === targetPosition) {
               logger.info('Skipped datasource entry (unchanged)', { datasource: datasource.name, entry: entry.name, position: targetPosition });
               continue;
             }
 
             try {
-              await upsertDatasourceEntry(space, result.id, entry, existingEntryId, i + 1);
+              const upserted = await upsertDatasourceEntry(space, result.id, entry, existingEntryId, i + 1);
+              const entryId = existingEntryId ?? upserted?.id;
               logger.info(existingEntryId ? 'Updated datasource entry' : 'Created datasource entry', { datasource: datasource.name, entry: entry.name, position: i + 1 });
+
+              // Write per-dimension values. Iterate the union of local and target
+              // dimension codes so values removed locally are cleared (blank) too.
+              if (entryId != null) {
+                const localDimensionValues = entry.dimension_values ?? {};
+                const targetDimensionValues = existing?.entry.dimension_values ?? {};
+                const dimensionCodes = new Set([...Object.keys(localDimensionValues), ...Object.keys(targetDimensionValues)]);
+
+                for (const code of dimensionCodes) {
+                  const localValue = localDimensionValues[code] ?? '';
+                  const targetValue = targetDimensionValues[code] ?? '';
+                  // Skip dimensions already in sync to avoid redundant writes (e.g. when only the default value or position changed).
+                  if (localValue === targetValue) {
+                    continue;
+                  }
+                  const dimension = result.dimensions?.find(d => d.entry_value === code);
+                  if (!dimension?.id) {
+                    konsola.warn(`Skipping dimension "${code}" for entry "${entry.name}": no matching dimension in target space ${space}`);
+                    continue;
+                  }
+                  await updateDatasourceEntryDimension(space, entryId, entry, dimension.id, localValue);
+                }
+              }
             }
             catch (entryError) {
               results.failed.push({ name: datasource.name, error: entryError });

--- a/packages/mapi-client/src/resources/datasource-entries.test.ts
+++ b/packages/mapi-client/src/resources/datasource-entries.test.ts
@@ -121,4 +121,33 @@ describe('datasourceEntries.update()', () => {
     expect(result.error).toBeUndefined();
     expect(result.data).toBeNull();
   });
+
+  it('should forward the dimension_id query param', async () => {
+    let requestUrl: string | undefined;
+    server.use(
+      http.put('https://mapi.storyblok.com/v1/spaces/:space_id/datasource_entries/:datasource_entry_id', ({ request }) => {
+        requestUrl = request.url;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const client = createManagementApiClient({
+      personalAccessToken: 'test-token',
+      spaceId: 123,
+      region: 'eu',
+      rateLimit: false,
+    });
+
+    await client.datasourceEntries.update(456, {
+      query: { dimension_id: 42 },
+      body: {
+        datasource_entry: {
+          name: 'Updated Entry',
+          value: 'updated-value',
+          datasource_id: 789,
+        },
+      },
+    });
+
+    expect(new URL(requestUrl!).searchParams.get('dimension_id')).toBe('42');
+  });
 });

--- a/packages/mapi-client/src/resources/datasource-entries.ts
+++ b/packages/mapi-client/src/resources/datasource-entries.ts
@@ -44,15 +44,20 @@ export function createDatasourceEntriesResource(deps: MapiResourceDeps) {
 
     update<ThrowOnError extends boolean = false>(
       datasourceEntryId: number,
-      options: { body: UpdateData['body']; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
+      options: { body: UpdateData['body']; query?: { dimension_id?: number }; signal?: AbortSignal; throwOnError?: ThrowOnError; fetchOptions?: FetchOptions } & SpaceIdPathOverride,
     ): Promise<ApiResponse<void, ThrowOnError>> {
-      const { body, signal, path, throwOnError, fetchOptions } = options;
+      const { body, query, signal, path, throwOnError, fetchOptions } = options;
       const resolvedSpaceId = getSpaceId(path);
       return wrapRequest<void, ThrowOnError>(() =>
         datasourceEntriesApi.update({
           client,
           path: { space_id: resolvedSpaceId, datasource_entry_id: datasourceEntryId },
           body,
+          // The update endpoint accepts a `dimension_id` query param to write a
+          // per-dimension child value, but it is not modeled in the OpenAPI spec
+          // yet (generated `UpdateData['query']` is `never`). The generated sdk
+          // forwards `query` verbatim, so pass it through with a localized cast.
+          ...(query ? { query } as { query: never } : {}),
           signal,
           ...(throwOnError === undefined ? {} : { throwOnError }),
           ...(fetchOptions ? { kyOptions: { ...client.getConfig().kyOptions, ...fetchOptions } } : {}),


### PR DESCRIPTION
Datasource pull previously exported only the default-dimension value, so datasources with dimensions lost their per-dimension entry values on pull and push could not restore them. This PR makes the per-dimension entry values survive a full pull → push round-trip, including across spaces.

- **Pull** runs one entries sweep per dimension (in addition to the default sweep) and stores each non-empty value in a `dimension_values` map keyed by the dimension **code** (`entry_value`, e.g. `en`), not the numeric id, so the data is portable across spaces.
- **Push** creates a fresh datasource's dimensions via `dimensions_attributes`, then resolves each local `dimension_values` code to the target space's dimension id and writes it through the `dimension_id` query param on the datasource-entry update endpoint. It iterates the union of local and target dimension codes so a value removed locally is cleared in the target too.
- The `@storyblok/management-api-client` datasource-entries `update` wrapper gained an optional `query: { dimension_id }` (forwarded to the endpoint; the param is not yet modeled in the OpenAPI spec).
- Follow-up commit: per-dimension "Skipping dimension" warnings are buffered and flushed after the spinner stops, so the spinner's live redraw no longer overwrites them.

See `adr/0005-datasource-per-dimension-entry-values.md` for the design decisions and scope limits.

## Scope / known limitation

Dimensions are only created on datasource **create** (`dimensions_attributes`); the update path has no equivalent, so a newly added dimension cannot be propagated onto an already-existing target datasource via push (it is skipped with a warning). Documented in ADR 0005.

Fixes DX-466
Fixes #656
