### PR TITLE
fix(react): re-export bridge functions from /rsc entry

### DIFF
--- a/packages/react/src/__tests__/rsc-exports.test.ts
+++ b/packages/react/src/__tests__/rsc-exports.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import * as rsc from '../rsc';
+
+// Regression test for DX-498 / #697: the `./rsc` entry declared the bridge
+// functions in its type definitions but did not re-export them at runtime,
+// causing `TypeError: useStoryblokBridge is not a function` in client
+// components importing from `@storyblok/react/rsc`.
+describe('rsc entry runtime exports', () => {
+  it.each(['useStoryblokBridge', 'loadStoryblokBridge', 'registerStoryblokBridge'] as const)(
+    'exports %s as a function',
+    (name) => {
+      expect(typeof rsc[name]).toBe('function');
+    },
+  );
+});

--- a/packages/react/src/rsc/index.ts
+++ b/packages/react/src/rsc/index.ts
@@ -5,7 +5,8 @@ export { useStoryblokServerRichText } from '../server/richtext';
 export { default as StoryblokServerComponent } from '../server/server-component';
 export { default as StoryblokServerStory } from '../server/server-story';
 export { StoryblokServerRichText } from '../server/server-storyblok-richtext';
-
 export * from '../types';
+
 export { default as StoryblokLiveEditing } from './live-editing';
 export { default as StoryblokStory } from './story';
+export { loadStoryblokBridge, registerStoryblokBridge, useStoryblokBridge } from '@storyblok/js';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -42,5 +42,4 @@ export type {
   StoryblokBridgeV2,
   StoryblokClient,
   StoryblokComponentType,
-  useStoryblokBridge,
 } from '@storyblok/js';

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,9 +1,15 @@
 /// <reference types="vitest" />
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],


### PR DESCRIPTION
`@storyblok/react@7.2.0`'s `/rsc` entry declares `useStoryblokBridge` in its type definitions (`dist/rsc.d.ts`) but does **not** re-export it at runtime from `rsc.js` / `rsc.mjs`. Any client component importing it crashes:

```ts
'use client';
import { useStoryblokBridge } from '@storyblok/react/rsc';
// ⨯ TypeError: useStoryblokBridge is not a function
```

`loadStoryblokBridge` and `registerStoryblokBridge` are silently missing too.

## Root cause

PR #624 (commit `90f1ca1f4`, shipped in 7.2.0) replaced the explicit runtime re-export block in `packages/react/src/rsc/index.ts` with `export * from '../core/init'` + `export * from '../core/richtext'`. Those barrels restore `apiPlugin` / `storyblokEditable` / `renderRichText`, but **not** the three bridge functions.

The `.d.ts` kept advertising `useStoryblokBridge` only because of a type-only re-export in `types.ts` (`export type { … useStoryblokBridge … }`), which emits a `.d.ts` declaration but zero runtime code — a type-vs-runtime mismatch.

The `.` and `./ssr` entries were unaffected because they use `export * from '../core'` (`core/index.ts`), which does a proper value re-export.

> Note: the bug only reproduces from a **fresh build** — the gitignored `dist/` in the tree was stale (pre-#624) and still contained the working exports.

## Fix

- Re-export `loadStoryblokBridge`, `registerStoryblokBridge`, `useStoryblokBridge` from `@storyblok/js` in `src/rsc/index.ts` (restores what #624 removed; import-safe for RSC since the bridge loader keeps all `window`/`document` access inside function bodies).
- Drop the misleading type-only `useStoryblokBridge` entry from `src/types.ts` (it's a value, not a type).
- Add a regression test (`src/__tests__/rsc-exports.test.ts`) asserting the `/rsc` entry exports all three as functions.
- Resolve the `@/` path alias in `vitest.config.ts` so the barrel's transitive imports resolve under test.

Fixes DX-498
Fixes #697