### PR TITLE
feat(js): replace CDN bridge loading with bundled @storyblok/preview-bridge

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -44,6 +44,7 @@
     "cy:open": "cypress open"
   },
   "dependencies": {
+    "@storyblok/preview-bridge": "^2.1.6",
     "@storyblok/richtext": "workspace:*",
     "storyblok-js-client": "workspace:*"
   },

--- a/packages/js/src/bridge.ts
+++ b/packages/js/src/bridge.ts
@@ -1,43 +1,53 @@
+import type StoryblokBridge from '@storyblok/preview-bridge';
+
 let loaded = false;
+let loadPromise: Promise<void> | undefined;
 const callbacks: Array<() => void> = [];
 
-export const loadBridge = (src: string) => {
-  return new Promise((resolve, reject) => {
-    if (typeof window === 'undefined') {
-      reject(new Error('Cannot load Storyblok bridge: window is undefined (server-side environment)'));
+export const loadBridge = (): Promise<void> => {
+  if (typeof window === 'undefined') {
+    return Promise.reject(
+      new Error('Cannot load Storyblok bridge: window is undefined (server-side environment)'),
+    );
+  }
+
+  // Set up the callback queue synchronously so useStoryblokBridge can register
+  // callbacks immediately after loadBridge() is called, before the async
+  // import has settled. Matches the original CDN script behaviour.
+  window.storyblokRegisterEvent = (cb: () => void) => {
+    if (!window.location.search.includes('_storyblok')) {
+      console.warn('You are not in Draft Mode or in the Visual Editor.');
       return;
     }
 
-    // Way to make sure all event handlers are called after loading
-    window.storyblokRegisterEvent = (cb: () => void) => {
-      if (!window.location.search.includes('_storyblok')) {
-        console.warn('You are not in Draft Mode or in the Visual Editor.');
-        return;
-      }
-
-      if (!loaded) {
-        callbacks.push(cb);
-      }
-      else { cb(); }
-    };
-
-    if (document.getElementById('storyblok-javascript-bridge')) {
-      resolve(undefined);
-      return;
+    if (!loaded) {
+      callbacks.push(cb);
     }
+    else {
+      cb();
+    }
+  };
 
-    const script = document.createElement('script');
-    script.async = true;
-    script.src = src;
-    script.id = 'storyblok-javascript-bridge';
+  if (loaded) {
+    return Promise.resolve();
+  }
 
-    script.onerror = error => reject(error);
-    script.onload = (ev) => {
+  if (loadPromise) {
+    return loadPromise;
+  }
+
+  loadPromise = import('@storyblok/preview-bridge')
+    .then(({ default: StoryblokBridgeClass }: { default: typeof StoryblokBridge }) => {
+      // Expose the class on window so that code using the legacy pattern
+      // `new window.StoryblokBridge(options)` continues to work.
+      (window as any).StoryblokBridge = StoryblokBridgeClass;
       callbacks.forEach(cb => cb());
       loaded = true;
-      resolve(ev);
-    };
+    })
+    .catch((error) => {
+      loadPromise = undefined;
+      throw error;
+    });
 
-    document.getElementsByTagName('head')[0].appendChild(script);
-  });
+  return loadPromise;
 };

--- a/packages/js/src/index.test.ts
+++ b/packages/js/src/index.test.ts
@@ -3,11 +3,24 @@ import {
   renderRichText,
   storyblokEditable,
   storyblokInit,
+  useStoryblokBridge,
 } from '../src';
 import type { SbInitResult, SbPluginFactory, SbRichTextDoc } from '../src';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { loadBridge } from './bridge';
+
+// Mock @storyblok/preview-bridge so dynamic import() in bridge.ts resolves
+// synchronously in tests without triggering any real browser bridge logic.
+const MockStoryblokBridge = vi.fn();
+vi.mock('@storyblok/preview-bridge', () => ({
+  default: MockStoryblokBridge,
+}));
+
+/** Flush all pending microtasks (lets the dynamic import .then() chains run). */
+async function flushPromises() {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
 
 describe('@storyblok/js', () => {
   afterEach(() => {
@@ -24,7 +37,6 @@ describe('@storyblok/js', () => {
     });
 
     it('is loaded correctly when using the apiPlugin', async () => {
-      // Mock fetch to return a successful response
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(new Response(JSON.stringify({
           stories: [
@@ -65,7 +77,6 @@ describe('@storyblok/js', () => {
     });
 
     it('should handle failed API calls', async () => {
-      // Create an isolated mock just for this test
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockRejectedValueOnce(new Error('API Error'));
 
@@ -75,13 +86,10 @@ describe('@storyblok/js', () => {
       });
 
       await expect(storyblokApi!.get('cdn/stories/test')).rejects.toThrow();
-
-      // Verify the mock was called
       expect(fetchSpy).toHaveBeenCalled();
     });
 
     it('should support different API endpoints', async () => {
-      // Create a spy that returns successful responses
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(new Response(JSON.stringify({ stories: [] })))
         .mockResolvedValueOnce(new Response(JSON.stringify({ links: [] })))
@@ -96,7 +104,6 @@ describe('@storyblok/js', () => {
       await storyblokApi!.get('cdn/links');
       await storyblokApi!.get('cdn/datasources');
 
-      // Verify different endpoints were called
       expect(fetchSpy).toHaveBeenCalledTimes(3);
       expect(fetchSpy.mock.calls[0][0].toString()).toContain('cdn/stories');
       expect(fetchSpy.mock.calls[1][0].toString()).toContain('cdn/links');
@@ -104,7 +111,6 @@ describe('@storyblok/js', () => {
     });
 
     it('should handle pagination correctly', async () => {
-      // Mock fetch to return paginated responses
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(new Response(JSON.stringify({
           stories: [{ id: 1 }, { id: 2 }],
@@ -124,147 +130,137 @@ describe('@storyblok/js', () => {
         use: [apiPlugin],
       }) as { storyblokApi: any };
 
-      // Define type for stories
       const allStories: Array<{ id: number }> = [];
       let page = 1;
       const perPage = 2;
 
-      // First page
-      let response = await storyblokApi.get('cdn/stories', {
-        page,
-        perPage,
-      });
-
+      let response = await storyblokApi.get('cdn/stories', { page, perPage });
       const total = response.data.total;
       allStories.push(...response.data.stories);
 
-      // Get remaining pages
       while (allStories.length < total) {
         page++;
-        response = await storyblokApi.get('cdn/stories', {
-          page,
-          perPage,
-        });
+        response = await storyblokApi.get('cdn/stories', { page, perPage });
         allStories.push(...response.data.stories);
       }
 
-      // Verify pagination results
       expect(allStories).toHaveLength(4);
-      expect(allStories).toEqual([
-        { id: 1 },
-        { id: 2 },
-        { id: 3 },
-        { id: 4 },
-      ]);
-
-      // Verify that fetch was called twice for the two pages
+      expect(allStories).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('initialization', () => {
     it('should initialize multiple plugins', () => {
-      // Create two mock plugins with proper typing
       const plugin1: SbPluginFactory = () => ({ feature1: 'value1' });
       const plugin2: SbPluginFactory = () => ({ feature2: 'value2' });
 
       const result = storyblokInit({
         accessToken: 'test-token',
         use: [plugin1, plugin2],
-      }) as SbInitResult & {
-        feature1: string;
-        feature2: string;
-      };
+      }) as SbInitResult & { feature1: string; feature2: string };
 
-      // Verify both plugins were initialized
-      expect(result).toEqual({
-        feature1: 'value1',
-        feature2: 'value2',
-      });
-
-      // Verify the result has both plugin features
+      expect(result).toEqual({ feature1: 'value1', feature2: 'value2' });
       expect(result.feature1).toBe('value1');
       expect(result.feature2).toBe('value2');
     });
 
-    it('should handle custom bridge URLs', () => {
-      const customBridgeUrl = 'https://custom-bridge.com/bridge.js';
-
-      // Mock window.location to simulate being in the editor
-      const originalLocation = window.location;
-      Object.defineProperty(window, 'location', {
-        value: { search: '?_storyblok_tk=123' },
-        writable: true,
-      });
+    it('should emit a deprecation warning for bridgeUrl', () => {
+      const warnSpy = vi.spyOn(console, 'warn');
 
       storyblokInit({
         accessToken: 'test-token',
-        bridgeUrl: customBridgeUrl,
+        bridgeUrl: 'https://custom-bridge.com/bridge.js',
       });
 
-      // Get the bridge script element
-      const bridgeScript = document.querySelector('#storyblok-javascript-bridge');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('bridgeUrl` option is deprecated'),
+      );
 
-      // Verify bridge script was added with correct URL
-      expect(bridgeScript).toBeTruthy();
-      expect(bridgeScript?.getAttribute('src')).toBe(customBridgeUrl);
+      // The bridge is now bundled — no CDN script tag is injected.
+      expect(document.querySelector('#storyblok-javascript-bridge')).toBeNull();
+    });
+  });
 
-      // Restore original window.location
+  describe('normalizeBridgeOptions (via useStoryblokBridge)', () => {
+    const mockOn = vi.fn();
+
+    beforeEach(() => {
+      mockOn.mockClear();
+      MockStoryblokBridge.mockClear();
+      // Make the constructor return an object with .on() so useStoryblokBridge
+      // doesn't throw when it calls sbBridge.on(...)
+      MockStoryblokBridge.mockImplementation(() => ({ on: mockOn }));
+
+      // Simulate bridge already loaded: storyblokRegisterEvent executes
+      // callbacks immediately and window.StoryblokBridge is available.
       Object.defineProperty(window, 'location', {
-        value: originalLocation,
+        value: { search: '?_storyblok=42', href: 'http://localhost?_storyblok=42' },
         writable: true,
+        configurable: true,
       });
+      (window as any).storyblokRegisterEvent = (cb: () => void) => cb();
+      (window as any).StoryblokBridge = MockStoryblokBridge;
     });
 
-    it('should handle custom bridge URL with query params', () => {
-      const baseUrl = 'https://custom-bridge.com/bridge.js';
-      const queryParams = '?version=2&debug=true';
-      const customBridgeUrl = `${baseUrl}${queryParams}`;
+    afterEach(() => {
+      delete (window as any).storyblokRegisterEvent;
+      delete (window as any).StoryblokBridge;
+    });
 
-      // Mock window.location to simulate being in the editor
-      const originalLocation = window.location;
-      Object.defineProperty(window, 'location', {
-        value: {
-          search: '?_storyblok_tk=123',
-          href: 'http://localhost?_storyblok_tk=123',
-        },
-        writable: true,
-      });
+    it('normalises resolveRelations string to a single-element array', () => {
+      useStoryblokBridge(42, vi.fn(), { resolveRelations: 'global-author.author' });
 
-      storyblokInit({
-        accessToken: 'test-token',
-        bridge: true,
-        bridgeUrl: customBridgeUrl,
-      });
+      expect(MockStoryblokBridge).toHaveBeenCalledWith(
+        expect.objectContaining({ resolveRelations: ['global-author.author'] }),
+      );
+    });
 
-      // Get the bridge script element
-      const bridgeScript = document.querySelector('#storyblok-javascript-bridge');
+    it('keeps resolveRelations array unchanged', () => {
+      useStoryblokBridge(42, vi.fn(), { resolveRelations: ['a.b', 'c.d'] });
 
-      // Verify the script was created
-      expect(bridgeScript).toBeTruthy();
-      // Verify base URL is present (browser strips query params)
-      expect(bridgeScript?.getAttribute('src')).toBe(baseUrl);
+      expect(MockStoryblokBridge).toHaveBeenCalledWith(
+        expect.objectContaining({ resolveRelations: ['a.b', 'c.d'] }),
+      );
+    });
 
-      // Restore original window.location
-      Object.defineProperty(window, 'location', {
-        value: originalLocation,
-        writable: true,
-      });
+    it('warns and removes the language option', () => {
+      const warnSpy = vi.spyOn(console, 'warn');
+
+      useStoryblokBridge(42, vi.fn(), { language: 'de' });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('language` bridge option is no longer supported'),
+      );
+      const passedOptions = MockStoryblokBridge.mock.calls[0][0];
+      expect(passedOptions.language).toBeUndefined();
+    });
+
+    it('passes resolveLinks "link" through unchanged (valid per official docs)', () => {
+      useStoryblokBridge(42, vi.fn(), { resolveLinks: 'link' });
+
+      expect(MockStoryblokBridge).toHaveBeenCalledWith(
+        expect.objectContaining({ resolveLinks: 'link' }),
+      );
+    });
+
+    it('passes other resolveLinks values through unchanged', () => {
+      useStoryblokBridge(42, vi.fn(), { resolveLinks: 'story' });
+
+      expect(MockStoryblokBridge).toHaveBeenCalledWith(
+        expect.objectContaining({ resolveLinks: 'story' }),
+      );
     });
   });
 
   describe('editable', () => {
     it('gets data-blok-c and data-blok-uid', async () => {
-      // Mock fetch to return a story response
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(new Response(JSON.stringify({
           story: {
             id: 123456,
             uid: 'test-uid-123',
-            content: {
-              component: 'page',
-              body: [],
-            },
+            content: { component: 'page', body: [] },
           },
         })));
 
@@ -274,7 +270,6 @@ describe('@storyblok/js', () => {
       });
 
       const { data } = await storyblokApi!.get('cdn/stories/demo');
-
       const blok = data.story.content;
       blok._editable = `<!--#storyblok#{"id":${data.story.id},"uid":"${data.story.uid}"}-->`;
 
@@ -293,10 +288,7 @@ describe('@storyblok/js', () => {
 
     it('should call render with the provided data', () => {
       const data: SbRichTextDoc = { type: 'doc', content: [] };
-
-      const html = renderRichText(data);
-
-      expect(html).toBe('');
+      expect(renderRichText(data)).toBe('');
     });
 
     it('should use renderers for customize elements', () => {
@@ -315,148 +307,163 @@ describe('@storyblok/js', () => {
 
   describe('bridge functionality', () => {
     beforeEach(() => {
-      // Clear DOM and reset window properties
-      document.head.innerHTML = '';
-      window.storyblokRegisterEvent = () => {};
-      vi.clearAllMocks();
+      // Reset module-level state in bridge.ts between tests by clearing the
+      // window globals and re-importing fresh state via vi.resetModules().
+      vi.resetModules();
+      MockStoryblokBridge.mockClear();
+      delete (window as any).storyblokRegisterEvent;
+      delete (window as any).StoryblokBridge;
     });
 
-    it('should load bridge script correctly', async () => {
-      const bridgeUrl = 'https://app.storyblok.com/f/storyblok-v2-latest.js';
-      const loadPromise = loadBridge(bridgeUrl);
+    it('sets window.storyblokRegisterEvent synchronously and window.StoryblokBridge after load', async () => {
+      const { loadBridge: fresh } = await import('./bridge');
 
-      // Check if script was added to DOM
-      const script = document.querySelector('#storyblok-javascript-bridge') as HTMLScriptElement;
-      expect(script).toBeTruthy();
-      expect(script?.getAttribute('src')).toBe(bridgeUrl);
-      expect(script?.async).toBe(true);
-
-      // Simulate script load
-      const event = new Event('load');
-      script?.dispatchEvent(event);
-
-      await expect(loadPromise).resolves.toBeDefined();
-    });
-
-    it('should handle bridge loading errors', async () => {
-      const bridgeUrl = 'https://invalid-url.com/bridge.js';
-      const loadPromise = loadBridge(bridgeUrl);
-
-      const script = document.querySelector('#storyblok-javascript-bridge');
-
-      // Simulate script error
-      const event = new ErrorEvent('error', { error: new Error('Failed to load script') });
-      script?.dispatchEvent(event);
-
-      await expect(loadPromise).rejects.toBeDefined();
-    });
-
-    it('should register callbacks correctly', () => {
-      const callback = vi.fn();
-
-      // Mock being in an iframe
-      const originalLocation = window.location;
-      delete (window as any).location;
-      (window as any).location = {
-        ...originalLocation,
-        href: 'http://localhost',
-      };
       Object.defineProperty(window, 'location', {
-        value: { search: '?_storyblok' },
+        value: { search: '?_storyblok=123', href: 'http://localhost?_storyblok=123' },
         writable: true,
+        configurable: true,
       });
 
-      loadBridge('https://app.storyblok.com/f/storyblok-v2-latest.js');
+      fresh();
 
-      // Register callback
-      window.storyblokRegisterEvent(callback);
+      // storyblokRegisterEvent must be available synchronously
+      expect(typeof (window as any).storyblokRegisterEvent).toBe('function');
 
-      // Simulate script load
-      const script = document.querySelector('#storyblok-javascript-bridge');
-      const event = new Event('load');
-      script?.dispatchEvent(event);
+      await flushPromises();
 
-      expect(callback).toHaveBeenCalled();
-
-      // Restore original location
-      Object.defineProperty(window, 'location', {
-        value: originalLocation,
-        writable: true,
-      });
+      // StoryblokBridge must be set after the dynamic import resolves
+      expect((window as any).StoryblokBridge).toBe(MockStoryblokBridge);
     });
 
-    it('should warn when not in editor mode', () => {
-      const consoleSpy = vi.spyOn(console, 'warn');
-      const callback = vi.fn();
+    it('queues callbacks registered before load and flushes them after', async () => {
+      const { loadBridge: fresh } = await import('./bridge');
 
-      // Ensure we're not in an iframe
       Object.defineProperty(window, 'location', {
-        value: { search: '?test=123' },
+        value: { search: '?_storyblok=123', href: 'http://localhost?_storyblok=123' },
         writable: true,
+        configurable: true,
       });
 
-      loadBridge('https://app.storyblok.com/f/storyblok-v2-latest.js');
-      window.storyblokRegisterEvent(callback);
+      fresh();
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'You are not in Draft Mode or in the Visual Editor.',
-      );
-      expect(callback).not.toHaveBeenCalled();
+      const cb = vi.fn();
+      (window as any).storyblokRegisterEvent(cb);
+
+      expect(cb).not.toHaveBeenCalled();
+
+      await flushPromises();
+
+      expect(cb).toHaveBeenCalledOnce();
     });
 
-    it('should execute callbacks in order of registration', async () => {
-      const executionOrder: number[] = [];
-      const callback1 = vi.fn(() => executionOrder.push(1));
-      const callback2 = vi.fn(() => executionOrder.push(2));
-      const callback3 = vi.fn(() => executionOrder.push(3));
+    it('executes callbacks immediately when bridge is already loaded', async () => {
+      const { loadBridge: fresh } = await import('./bridge');
 
-      // Mock being in an iframe
       Object.defineProperty(window, 'location', {
-        value: { search: '?_storyblok' },
+        value: { search: '?_storyblok=123', href: 'http://localhost?_storyblok=123' },
         writable: true,
+        configurable: true,
       });
 
-      loadBridge('https://app.storyblok.com/f/storyblok-v2-latest.js');
+      await fresh();
+      await flushPromises();
 
-      window.storyblokRegisterEvent(callback1);
-      window.storyblokRegisterEvent(callback2);
-      window.storyblokRegisterEvent(callback3);
+      const cb = vi.fn();
+      (window as any).storyblokRegisterEvent(cb);
 
-      // Simulate script load
-      const script = document.querySelector('#storyblok-javascript-bridge');
-      const event = new Event('load');
-      script?.dispatchEvent(event);
-
-      expect(executionOrder).toEqual([1, 2, 3]);
+      expect(cb).toHaveBeenCalledOnce();
     });
 
-    it('should reject promise when window is undefined', async () => {
-      // Mock window being undefined (server-side)
-      const originalWindow = globalThis.window;
+    it('executes callbacks in registration order', async () => {
+      const { loadBridge: fresh } = await import('./bridge');
+
+      Object.defineProperty(window, 'location', {
+        value: { search: '?_storyblok=123', href: 'http://localhost?_storyblok=123' },
+        writable: true,
+        configurable: true,
+      });
+
+      fresh();
+
+      const order: number[] = [];
+      (window as any).storyblokRegisterEvent(() => order.push(1));
+      (window as any).storyblokRegisterEvent(() => order.push(2));
+      (window as any).storyblokRegisterEvent(() => order.push(3));
+
+      await flushPromises();
+
+      expect(order).toEqual([1, 2, 3]);
+    });
+
+    it('warns and does not queue when not in draft mode', async () => {
+      const { loadBridge: fresh } = await import('./bridge');
+
+      Object.defineProperty(window, 'location', {
+        value: { search: '?foo=bar', href: 'http://localhost?foo=bar' },
+        writable: true,
+        configurable: true,
+      });
+
+      fresh();
+
+      const warnSpy = vi.spyOn(console, 'warn');
+      const cb = vi.fn();
+      (window as any).storyblokRegisterEvent(cb);
+
+      expect(warnSpy).toHaveBeenCalledWith('You are not in Draft Mode or in the Visual Editor.');
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('rejects when window is undefined (SSR)', async () => {
+      const originalWindow = (globalThis as any).window;
       delete (globalThis as any).window;
 
-      await expect(loadBridge('https://app.storyblok.com/f/storyblok-v2-latest.js'))
-        .rejects
-        .toThrow('Cannot load Storyblok bridge: window is undefined (server-side environment)');
+      const { loadBridge: fresh } = await import('./bridge');
 
-      // Restore window
-      globalThis.window = originalWindow;
+      await expect(fresh()).rejects.toThrow(
+        'Cannot load Storyblok bridge: window is undefined (server-side environment)',
+      );
+
+      (globalThis as any).window = originalWindow;
     });
 
-    it('should resolve promise when bridge script already exists', async () => {
-      // Add existing bridge script to DOM
-      const existingScript = document.createElement('script');
-      existingScript.id = 'storyblok-javascript-bridge';
-      existingScript.src = 'https://app.storyblok.com/f/storyblok-v2-latest.js';
-      document.head.appendChild(existingScript);
+    it('returns the same promise on concurrent calls', async () => {
+      const { loadBridge: fresh } = await import('./bridge');
 
-      // Should resolve immediately since script already exists
-      await expect(loadBridge('https://app.storyblok.com/f/storyblok-v2-latest.js'))
-        .resolves
-        .toBe(undefined);
+      Object.defineProperty(window, 'location', {
+        value: { search: '?_storyblok=1', href: 'http://localhost?_storyblok=1' },
+        writable: true,
+        configurable: true,
+      });
 
-      // Clean up
-      existingScript.remove();
+      const p1 = fresh();
+      const p2 = fresh();
+
+      expect(p1).toBe(p2);
+    });
+  });
+
+  // Keep a thin smoke-test for the re-exported loadBridge to ensure
+  // the module-level singleton resets work in test isolation.
+  describe('loadBridge (direct import)', () => {
+    beforeEach(() => {
+      vi.resetModules();
+      MockStoryblokBridge.mockClear();
+      delete (window as any).storyblokRegisterEvent;
+      delete (window as any).StoryblokBridge;
+    });
+
+    it('resolves and sets window.StoryblokBridge', async () => {
+      Object.defineProperty(window, 'location', {
+        value: { search: '?_storyblok=1', href: 'http://localhost?_storyblok=1' },
+        writable: true,
+        configurable: true,
+      });
+
+      await loadBridge();
+      await flushPromises();
+
+      expect((window as any).StoryblokBridge).toBeDefined();
     });
   });
 });

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -9,12 +9,46 @@ import type {
   StoryblokComponentType,
 } from './types';
 
-let bridgeLatest = 'https://app.storyblok.com/f/storyblok-v2-latest.js';
-
 export interface StoryblokBridgeEvent {
   action: string;
   storyId: number;
   story: ISbStoryData;
+}
+
+/**
+ * Normalises StoryblokBridgeConfigV2 options for the bundled
+ * @storyblok/preview-bridge constructor, which has a slightly different
+ * BridgeParams shape than the legacy CDN bridge.
+ *
+ * Changes applied:
+ * - `resolveRelations` string → string[] (CDN bridge accepted both; bundled
+ *    bridge only accepts string[])
+ * - `language` → removed with a deprecation warning (the new bridge receives
+ *    language context via the `_storyblok_lang` URL parameter set by the
+ *    Visual Editor; it no longer needs to be passed as a constructor option)
+ * - `resolveLinks: 'link'` → passed through unchanged. The official docs list
+ *    it as a valid value; the TypeScript BridgeParams type omitting it is a
+ *    types/docs gap, not a runtime restriction.
+ */
+function normalizeBridgeOptions(options: StoryblokBridgeConfigV2): Omit<StoryblokBridgeConfigV2, 'language'> {
+  const { language, resolveRelations, ...rest } = options;
+
+  if (language) {
+    console.warn(
+      '[Storyblok] The `language` bridge option is no longer supported by the bundled bridge. '
+      + 'Language context is now passed automatically by the Visual Editor via the '
+      + '`_storyblok_lang` URL parameter.',
+    );
+  }
+
+  return {
+    ...rest,
+    ...(resolveRelations !== undefined && {
+      resolveRelations: Array.isArray(resolveRelations)
+        ? resolveRelations
+        : [resolveRelations],
+    }),
+  };
 }
 
 export const useStoryblokBridge = <
@@ -42,7 +76,9 @@ export const useStoryblokBridge = <
   }
 
   window.storyblokRegisterEvent(() => {
-    const sbBridge: StoryblokBridgeV2 = new window.StoryblokBridge(options);
+    const sbBridge: StoryblokBridgeV2 = new window.StoryblokBridge(
+      normalizeBridgeOptions(options),
+    );
     sbBridge.on(['input', 'published', 'change'], (event: ISbEventPayload<T> | undefined) => {
       if (!event) {
         return;
@@ -69,6 +105,13 @@ export const storyblokInit = (pluginOptions: SbSDKOptions = {}) => {
     bridgeUrl,
   } = pluginOptions;
 
+  if (bridgeUrl) {
+    console.warn(
+      '[Storyblok] The `bridgeUrl` option is deprecated and will be removed in a future major version. '
+      + 'The Storyblok bridge is now bundled and is no longer loaded from a CDN URL.',
+    );
+  }
+
   apiOptions.accessToken = apiOptions.accessToken || accessToken;
 
   // Initialize plugins
@@ -79,24 +122,20 @@ export const storyblokInit = (pluginOptions: SbSDKOptions = {}) => {
     result = { ...result, ...pluginFactory(options) };
   });
 
-  if (bridgeUrl) {
-    bridgeLatest = bridgeUrl;
-  }
-
   /*
-  ** Load bridge if you are on the Visual Editor
+  ** Load bridge if you are on the Visual Editor.
   ** For more security: https://www.storyblok.com/faq/how-to-verify-the-preview-query-parameters-of-the-visual-editor
   */
   const isServer = typeof window === 'undefined';
   const inEditor = !isServer && window.location?.search?.includes('_storyblok_tk');
   if (bridge !== false && inEditor) {
-    loadBridge(bridgeLatest);
+    loadBridge();
   }
 
   return result;
 };
 
-export const loadStoryblokBridge = () => loadBridge(bridgeLatest);
+export const loadStoryblokBridge = () => loadBridge();
 
 export { useStoryblokBridge as registerStoryblokBridge };
 
@@ -105,6 +144,8 @@ export { default as storyblokEditable } from './editable';
 
 // Reexport all types so users can have access to them
 export * from './types';
+
+export type { BridgeParams } from '@storyblok/preview-bridge';
 
 // Re-exporting same exports from @storyblok/richtext
 export { buildStoryblokImage, renderRichText, splitTableRows } from '@storyblok/richtext';

--- a/packages/js/src/types/index.ts
+++ b/packages/js/src/types/index.ts
@@ -57,7 +57,7 @@ export interface StoryblokBridgeConfigV2 {
   preventClicks?: boolean;
   language?: string;
   resolveLinks?: 'url' | 'story' | '0' | '1' | 'link';
-  fallbackLang?: 'string';
+  fallbackLang?: string;
 }
 
 export interface StoryblokBridgeV2 {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,7 +268,7 @@ importers:
         version: 9.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       '@astrojs/vercel':
         specifier: ^11.0.0
-        version: 11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
+        version: 11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
       '@astrojs/vue':
         specifier: ^7.0.0
         version: 7.0.0(@types/node@24.11.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.30(typescript@6.0.3))(yaml@2.8.2)
@@ -550,6 +550,9 @@ importers:
 
   packages/js:
     dependencies:
+      '@storyblok/preview-bridge':
+        specifier: ^2.1.6
+        version: 2.1.6
       '@storyblok/richtext':
         specifier: workspace:*
         version: link:../richtext
@@ -17033,10 +17036,10 @@ snapshots:
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
 
-  '@astrojs/vercel@11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
+  '@astrojs/vercel@11.0.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.11.0)(@vercel/functions@3.4.3)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(less@4.6.4)(rollup@4.60.2)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(rollup@4.60.2)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
-      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
+      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))
       '@vercel/functions': 3.4.3
       '@vercel/nft': 1.3.2(rollup@4.60.2)
       '@vercel/routing-utils': 5.3.3
@@ -23229,10 +23232,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react@19.2.4)(svelte@5.55.0)(vue-router@4.6.4(vue@3.5.30(typescript@6.0.3)))(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.0)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      next: 16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react: 19.2.4
       svelte: 5.55.0
       vue: 3.5.30(typescript@6.0.3)
@@ -29916,6 +29919,33 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
+    dependencies:
+      '@next/env': 16.1.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001775
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.1.6
+      '@next/swc-darwin-x64': 16.1.6
+      '@next/swc-linux-arm64-gnu': 16.1.6
+      '@next/swc-linux-arm64-musl': 16.1.6
+      '@next/swc-linux-x64-gnu': 16.1.6
+      '@next/swc-linux-x64-musl': 16.1.6
+      '@next/swc-win32-arm64-msvc': 16.1.6
+      '@next/swc-win32-x64-msvc': 16.1.6
+      '@opentelemetry/api': 1.9.0
+      sass: 1.99.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    optional: true
+
   next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
     dependencies:
       '@next/env': 16.1.6
@@ -33054,6 +33084,14 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@babel/core': 7.29.7
+
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
+    optional: true
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

Replaces the CDN script-tag bridge loading in `@storyblok/js` with a direct dependency on the bundled `@storyblok/preview-bridge` package. No breaking changes to the public API.

## Changes

### `bridge.ts`
- Replaces `document.createElement('script')` + CDN URL with `import('@storyblok/preview-bridge')`
- `window.storyblokRegisterEvent` and `window.StoryblokBridge` are still set up for backward compatibility
- Same singleton behaviour via `loadPromise` flag instead of DOM element check

### `index.ts`
- Adds `normalizeBridgeOptions()` to bridge the `StoryblokBridgeConfigV2` → `BridgeParams` shape differences before passing options to `new window.StoryblokBridge()`:
  - `resolveRelations: string` → `string[]` (bundled bridge requires array)
  - `language`: dropped with `console.warn` — now automatic via `_storyblok_lang` URL param set by the Visual Editor
  - `resolveLinks: 'link'`: passes through unchanged (valid per [official docs](https://www.storyblok.com/docs/libraries/js/preview-bridge))
  - `fallbackLang`: passes through unchanged
- `bridgeUrl` option emits a deprecation warning and is ignored (bridge is now bundled)

### `types/index.ts`
- Fixes pre-existing type bug: `fallbackLang?: 'string'` → `fallbackLang?: string` (was a literal type, not the `string` primitive)

### `package.json`
- Adds `@storyblok/preview-bridge ^2.1.6` as a direct dependency

## Backward compatibility

| Behaviour | Status |
|---|---|
| `window.storyblokRegisterEvent` | ✅ Preserved |
| `window.StoryblokBridge` | ✅ Preserved |
| `useStoryblokBridge` signature | ✅ Unchanged |
| `storyblokInit` signature | ✅ Unchanged (`bridgeUrl` deprecated) |
| `loadStoryblokBridge()` | ✅ Unchanged |
| `resolveRelations: string` | ✅ Normalised to array |
| `language` option | ⚠️ Deprecated with warning |
| `bridgeUrl` option | ⚠️ Deprecated with warning |