### PR TITLE
chore(repo): replace bridge DOM assertions with window global checks

### DIFF
--- a/packages/astro/cypress/e2e/index.cy.js
+++ b/packages/astro/cypress/e2e/index.cy.js
@@ -9,7 +9,8 @@ Tests:
 describe("@storyblok/astro", () => {
   it("is loaded", () => {
     cy.visit("http://localhost:4321/");
-    cy.get("#storyblok-javascript-bridge").should("exist");
+    cy.window().its("storyblokRegisterEvent").should("be.a", "function");
+    cy.window().its("StoryblokBridge").should("be.a", "function");
   });
   it("storyblokEditable adds correct attributes", () => {
     cy.visit("http://localhost:4321/");

--- a/packages/js/cypress/e2e/index.cy.ts
+++ b/packages/js/cypress/e2e/index.cy.ts
@@ -26,15 +26,13 @@ describe('@storyblok/js', () => {
     it('Is loaded by default', () => {
       cy.visit(`${TEST_URL}?_storyblok_tk[timestamp]=1677494658`);
       cy.get('.with-bridge').click();
-      cy.get('#storyblok-javascript-bridge')
-        .should('exist')
-        .and('have.attr', 'src')
-        .and('include', 'storyblok-v2-latest.js');
+      cy.window().its('storyblokRegisterEvent').should('be.a', 'function');
+      cy.window().its('StoryblokBridge').should('be.a', 'function');
     });
 
     it('Is not loaded if options.bridge: false and no errors are printed', () => {
       cy.get('.without-bridge').click();
-      cy.get('#storyblok-javascript-bridge').should('not.exist');
+      cy.window().should('not.have.property', 'storyblokRegisterEvent');
       cy.get('@consoleError').should('not.be.called');
     });
   });
@@ -53,8 +51,8 @@ describe('@storyblok/js', () => {
         .should('be.visible')
         .click();
 
-      cy.get('#storyblok-javascript-bridge')
-        .should('exist');
+      cy.window().its('storyblokRegisterEvent').should('be.a', 'function');
+      cy.window().its('StoryblokBridge').should('be.a', 'function');
 
       cy.get('@consoleError')
         .should('not.be.called');

--- a/packages/react/cypress/e2e/index.cy.ts
+++ b/packages/react/cypress/e2e/index.cy.ts
@@ -2,7 +2,8 @@ describe('@storyblok/react/rsc', () => {
   describe('Bridge', () => {
     it('Is loaded by default', () => {
       cy.visit('http://localhost:3000/?_storyblok_tk[timestamp]=1677494658');
-      cy.get('#storyblok-javascript-bridge').should('exist');
+      cy.window().its('storyblokRegisterEvent').should('be.a', 'function');
+      cy.window().its('StoryblokBridge').should('be.a', 'function');
     });
   });
 

--- a/packages/react/src/__tests__/testing-components/Test.cy.tsx
+++ b/packages/react/src/__tests__/testing-components/Test.cy.tsx
@@ -11,7 +11,7 @@ describe('@storyblok/react', () => {
     cy.spy(window.console, 'log').as('log');
     cy.spy(window.console, 'error').as('error');
     delete window.storyblokRegisterEvent;
-    document.getElementById('storyblok-javascript-bridge')?.remove();
+    delete (window as any).StoryblokBridge;
   });
 
   describe('getStoryblokApi', () => {

--- a/packages/svelte/cypress/e2e/index.cy.ts
+++ b/packages/svelte/cypress/e2e/index.cy.ts
@@ -2,7 +2,8 @@ describe('@storyblok/svelte', () => {
   describe('Bridge', () => {
     it('Is loaded by default', () => {
       cy.visit('https://localhost:5173/?_storyblok_tk[timestamp]=1677494658');
-      cy.get('#storyblok-javascript-bridge').should('exist');
+      cy.window().its('storyblokRegisterEvent').should('be.a', 'function');
+      cy.window().its('StoryblokBridge').should('be.a', 'function');
     });
   });
 

--- a/packages/vue/cypress/components/index.cy.ts
+++ b/packages/vue/cypress/components/index.cy.ts
@@ -32,7 +32,7 @@ describe('@storyblok/vue', () => {
     cy.spy(window.console, 'log').as('log');
     cy.spy(window.console, 'error').as('error');
     delete (window as any).storyblokRegisterEvent;
-    document.getElementById('storyblok-javascript-bridge')?.remove();
+    delete (window as any).StoryblokBridge;
   });
 
   describe('v-editable directive', () => {


### PR DESCRIPTION
## Problem

All bridge-related E2E and component tests were asserting the existence of `#storyblok-javascript-bridge` in the DOM. This couples tests to an implementation detail — the CDN script-tag injection mechanism — rather than the actual observable behaviour: the bridge being available for use.

## Changes

### Assertion replacement (e2e tests)

**Before:**
```ts
cy.get('#storyblok-javascript-bridge').should('exist')
cy.get('#storyblok-javascript-bridge').should('exist').and('have.attr', 'src').and('include', 'storyblok-v2-latest.js')
cy.get('#storyblok-javascript-bridge').should('not.exist')
```

**After:**
```ts
// bridge is ready
cy.window().its('storyblokRegisterEvent').should('be.a', 'function')
cy.window().its('StoryblokBridge').should('be.a', 'function')

// bridge is disabled
cy.window().should('not.have.property', 'storyblokRegisterEvent')
```

### beforeEach cleanup (component tests)

**Before:**
```ts
document.getElementById('storyblok-javascript-bridge')?.remove()
```

**After:**
```ts
delete window.storyblokRegisterEvent
delete (window as any).StoryblokBridge
```

## Affected files

| Package | File |
|---|---|
| `js` | `cypress/e2e/index.cy.ts` |
| `react` | `cypress/e2e/index.cy.ts`, `src/__tests__/testing-components/Test.cy.tsx` |
| `svelte` | `cypress/e2e/index.cy.ts` |
| `astro` | `cypress/e2e/index.cy.js` |
| `vue` | `cypress/components/index.cy.ts` |