### PR TITLE
fix(capi-client): restore removed exports as deprecated; keep 0.x line

### DIFF
--- a/packages/capi-client/package.json
+++ b/packages/capi-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyblok/api-client",
   "type": "module",
-  "version": "1.0.0-alpha.5",
+  "version": "0.5.0",
   "private": false,
   "description": "Storyblok Content Delivery API Client",
   "author": "",

--- a/packages/capi-client/src/index.ts
+++ b/packages/capi-client/src/index.ts
@@ -7,6 +7,17 @@
  */
 
 // Client
+// Rate limiting (deprecated)
+// Kept for backwards compatibility with `0.x`. Rate limiting is configured via
+// the `rateLimit` option on `createApiClient`; these standalone helpers are
+// internal and will be removed in a future release. Declared as local aliases
+// (not re-export specifiers) so the `@deprecated` JSDoc survives DTS bundling.
+import {
+  createThrottle as createThrottleInternal,
+  parseRateLimitPolicyHeader as parseRateLimitPolicyHeaderInternal,
+} from './utils/rate-limit';
+import type { RateLimitConfig as RateLimitConfigInternal } from './utils/rate-limit';
+
 export { createApiClient } from './client';
 export type {
   ApiResponse,
@@ -48,3 +59,10 @@ export type { Story } from './generated/types/story';
 export type { StoryWithInlinedRelations } from './resources/stories';
 // Cache types
 export type { CacheProvider, CacheStrategy, CacheStrategyHandler } from './utils/cache';
+
+/** @deprecated Configure rate limiting via `createApiClient({ rateLimit })`. Will be removed in a future release. */
+export const createThrottle = createThrottleInternal;
+/** @deprecated Configure rate limiting via `createApiClient({ rateLimit })`. Will be removed in a future release. */
+export const parseRateLimitPolicyHeader = parseRateLimitPolicyHeaderInternal;
+/** @deprecated Configure rate limiting via `createApiClient({ rateLimit })`. Will be removed in a future release. */
+export type RateLimitConfig = RateLimitConfigInternal;

--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -21,6 +21,7 @@ import {
 // drops member-specific optional fields. We re-add the ones used in this file
 // so that casts from the untyped component schema are properly narrowed.
 type FieldSchema = ComponentPropertySchema & {
+  required?: boolean;
   source?: string;
   datasource_slug?: string;
   filter_content_type?: string[];

--- a/packages/experiments/test/specs/experiments-round-trip.spec.e2e.ts
+++ b/packages/experiments/test/specs/experiments-round-trip.spec.e2e.ts
@@ -163,7 +163,6 @@ describe('@storyblok/experiments CDN round-trip', () => {
         story: {
           name: 'E2E Experiments Home',
           slug: ORIGINAL_SLUG,
-          // @ts-expect-error the generated `content` type wrongly requires `_uid`; this will be fixed upstream.
           content: { component: COMPONENT_NAME, title: 'Home' },
         },
       },

--- a/packages/mapi-client/package.json
+++ b/packages/mapi-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyblok/management-api-client",
   "type": "module",
-  "version": "1.0.0-alpha.5",
+  "version": "0.5.1",
   "private": false,
   "description": "Storyblok Management API Client",
   "author": "",

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyblok/migrations",
   "type": "module",
-  "version": "1.0.0-alpha.5",
+  "version": "0.2.2",
   "private": false,
   "description": "Migration utilities for Storyblok",
   "author": "Storyblok",


### PR DESCRIPTION
Two related changes that keep the alpha line backwards-compatible so it can ship as a **0.x minor** instead of a breaking **1.0.0**.

### 1. Restore removed capi-client exports as `@deprecated`
The 1.0 rewrite dropped three root exports from `@storyblok/api-client`, a **runtime-breaking** change for `0.x` consumers:
- `createThrottle` (value)
- `parseRateLimitPolicyHeader` (value)
- `RateLimitConfig` (type)

They're re-added, marked `@deprecated`, pointing consumers at `createApiClient({ rateLimit })`. Declared as local alias declarations (not `export { … } from`) so the `@deprecated` JSDoc survives tsdown's DTS bundling and actually reaches consumers' `.d.ts`.

### 2. Reset the three packages to their published stable versions
Rolled back from `1.0.0-alpha.5` to `0.5.0` / `0.5.1` / `0.2.2` so the next release continues the 0.x line.

| Package | Was | Now |
|---|---|---|
| `@storyblok/api-client` | 1.0.0-alpha.5 | 0.5.0 |
| `@storyblok/management-api-client` | 1.0.0-alpha.5 | 0.5.1 |
| `@storyblok/migrations` | 1.0.0-alpha.5 | 0.2.2 |

## Still outstanding (not in this PR)

The version number alone won't land on 0.x — the two `feat(...)!:` breaking-marker commits (`capi-client` + `mapi-client` type-safe schema support) still drive nx to a major. To ship 0.6.x the merge must avoid carrying the `!`/`BREAKING CHANGE` markers (squash-merge message or explicit `--version` pin at release time).

`@storyblok/management-api-client` also has ~11 removed/renamed **type** exports (e.g. `MultilinkField`→`MultilinkFieldValue`, `StoryContent`, `AssetField`). Those are type-only breaks; deprecated type aliases could be added for a gentler migration but are not included here.