### PR TITLE
fix(js-client): make request throttle a completion-driven concurrency limiter

### DIFF
--- a/adr/0011-concurrency-limited-request-throttle.md
+++ b/adr/0011-concurrency-limited-request-throttle.md
@@ -1,0 +1,42 @@
+# ADR-0011: Concurrency-Limited Request Throttle
+
+**Status:** Accepted
+**Date:** 2026-07-23
+
+## Context
+
+`storyblok-js-client` throttles outgoing requests through a per-rate-limit queue (`throttlePromise.ts`, managed by `throttleQueueManager.ts`). The original implementation was a sliding time window: at most `limit` requests could start per `interval` (1000ms), and the in-flight counter was decremented from inside a fire-and-forget `setTimeout(interval)` callback. That same timer was also the only place that re-pumped the queue.
+
+This design fails on Cloudflare Workers (and comparable edge runtimes such as miniflare, Shopify Oxygen). The isolate suspends as soon as a response is sent, and any timer that has not yet fired is dropped. Because nothing awaits the throttle's release timer, `activeCount` is never decremented. The client is a cross-request singleton (`@storyblok/astro` stores it on `globalThis`, and the React/Hydrogen integrations follow the same pattern), so the leaked count survives request boundaries and climbs monotonically. Once `activeCount` reaches `limit`, `throttled()` stops pumping the queue, queued promises never settle, the SSR handler hangs, and Cloudflare kills the request with a `1101` error. The backlog rebuilds after every manual restart.
+
+Reported in monoblok issues #533 (Astro), #319 and #353 (Hydrogen/Oxygen), and previously in the archived js-client issue #682. The failure signature is precise: the Worker fails after roughly `limit` successful requests, and #319 confirmed the count tracks the configured `rateLimit` exactly.
+
+Any time-window rate limiter is fundamentally incompatible with this runtime, because spreading requests over time requires a timer to release slots, and cross-request timers are exactly what the isolate drops. Relying on `ctx.waitUntil` to keep timers alive is not an option either: it would tie the throttle to a Workers-specific API and still race the isolate lifecycle.
+
+## Decision
+
+Replace the time-window throttle with a **completion-driven concurrency limiter**.
+
+1. **At most `limit` invocations run at once.** A concurrency slot is released in a `finally` block the moment its invocation settles, and the queue drains from there. Release and draining never depend on a scheduled timer, so isolate suspension cannot leak the in-flight count or wedge the queue.
+2. **`interval` is retained in the internal signature for API compatibility but is no longer used.** Any timer-based pacing would reintroduce the hang described above.
+3. **A non-positive or non-finite `limit` disables throttling** and lets every request pass through. This gives Workers users a deterministic opt-out (`rateLimit: 0` or `Infinity`), which #319 requested and which previously either deadlocked (`0`) or threw (`Infinity`).
+4. **`abort()` rejects queued promises with an `AbortError` instance** rather than a function value.
+
+Server-side rate limiting remains covered by the existing `429` retry path in `cacheResponse`, which honors the server's backoff regardless of client-side pacing.
+
+## Alternatives Considered
+
+- **Keep the time window, but release slots via `ctx.waitUntil`.** Rejected: couples the client to a Workers-specific API, still races the isolate lifecycle, and does nothing for other runtimes.
+- **Keep the time window, but await the spacing timer inside the request lifecycle.** Rejected: either delays every response by `interval` (unacceptable latency) or, if the spacing runs after the response resolves, reintroduces the exact detached-timer hang.
+- **Make the client per-request instead of a singleton.** Rejected: the singleton on `globalThis` is the correct pattern for Workers (it preserves the in-memory cache across requests); the defect is in the throttle, not the integration.
+
+## Consequences
+
+- **The client no longer proactively paces requests per second.** It caps simultaneous in-flight requests per rate-limit tier instead. Bursts of fast requests can now exceed the old per-second rate; the server's `429` response and the client's retry path absorb the overflow. For the tiers Storyblok returns (single/small 50, medium 15, large 10, very large 6, cached 1000, Management API 3), the concurrency cap is a reasonable proxy that never hangs.
+- **`rateLimit: 0` and `rateLimit: Infinity` now mean "no throttle"** rather than deadlocking or throwing.
+- **Behavior change is not observable through the public API surface**, only through timing. The `throttledQueue` and `ThrottleQueueManager` utilities are internal and not re-exported.
+- **Tests that asserted per-second distribution were rewritten** to assert concurrency capping, queue-tier keying, and completion. A regression test simulates the Workers runtime by leaving every scheduled timer pending and asserting the queue still drains.
+
+## Related ADRs
+
+- None.

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -1743,15 +1743,14 @@ describe('storyblokClient', () => {
       expect(client.throttleManager.getQueueCount()).toBe(0);
     });
 
-    it('should throttle large tier (10 req/s) correctly over time', async () => {
-      vi.useFakeTimers();
-
-      const mockData = {
-        data: { stories: [] },
-        headers: {},
-        status: 200,
-      };
-      const mockGet = vi.fn().mockResolvedValue(mockData);
+    it('should cap concurrent requests at the CDN tier limit (10)', async () => {
+      // The throttle is a concurrency limiter: at most `limit` requests are in
+      // flight at once, and a slot frees as soon as a request settles.
+      const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+      const resolvers: Array<() => void> = [];
+      const mockGet = vi.fn(() => new Promise<any>((resolve) => {
+        resolvers.push(() => resolve({ data: { stories: [] }, headers: {}, status: 200 }));
+      }));
 
       const client = new StoryblokClient({
         accessToken: 'test-token',
@@ -1761,41 +1760,35 @@ describe('storyblokClient', () => {
       // @ts-expect-error - accessing private property for testing
       client.client.get = mockGet;
 
-      const countCallsWithParams = (params: Record<string, string | number>) => {
-        return mockGet.mock.calls.filter(call =>
-          Object.entries(params).every(([key, value]) => call[1][key] === value),
-        ).length;
-      };
-
-      // Make 25 requests - should take ~3 seconds to complete all
+      // per_page 51 maps to the 10 req/s (LARGE) tier.
       for (let i = 0; i < 25; i++) {
         client.get('cdn/stories', { version: 'draft', per_page: 51 }).catch(() => {});
       }
+      await flush();
 
-      // After 999ms: exactly 10 requests should have started and completed
-      await vi.advanceTimersByTimeAsync(999);
-      expect(countCallsWithParams({ per_page: 51 })).toBe(10);
+      // Only `limit` (10) requests run at once; the remaining 15 wait.
+      expect(mockGet).toHaveBeenCalledTimes(10);
 
-      // After ~2 seconds total: exactly 20 requests completed
-      await vi.advanceTimersByTimeAsync(1000);
-      expect(countCallsWithParams({ per_page: 51 })).toBe(20);
+      // Completing the in-flight requests frees slots for the next batch.
+      resolvers.splice(0, 10).forEach(resolve => resolve());
+      await flush();
+      expect(mockGet).toHaveBeenCalledTimes(20);
 
-      // After ~3 seconds total: all 25 requests completed
-      await vi.advanceTimersByTimeAsync(1000);
-      expect(countCallsWithParams({ per_page: 51 })).toBe(25);
+      resolvers.splice(0, 5).forEach(resolve => resolve());
+      await flush();
+      expect(mockGet).toHaveBeenCalledTimes(25);
 
-      vi.useRealTimers();
+      // Drain the rest so no promise is left pending.
+      resolvers.splice(0).forEach(resolve => resolve());
+      await flush();
     });
 
-    it('should throttle very large tier (6 req/s) correctly over time', async () => {
-      vi.useFakeTimers();
-
-      const mockData = {
+    it('should route the very large listing tier (6 req/s) to its own queue', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
         data: { stories: [] },
         headers: {},
         status: 200,
-      };
-      const mockGet = vi.fn().mockResolvedValue(mockData);
+      });
 
       const client = new StoryblokClient({
         accessToken: 'test-token',
@@ -1805,38 +1798,24 @@ describe('storyblokClient', () => {
       // @ts-expect-error - accessing private property for testing
       client.client.get = mockGet;
 
-      const countCallsWithParams = (params: Record<string, string | number>) => {
-        return mockGet.mock.calls.filter(call =>
-          Object.entries(params).every(([key, value]) => call[1][key] === value),
-        ).length;
-      };
+      // per_page 76 maps to the 6 req/s (VERY_LARGE) tier. Every request
+      // completes without hanging, and the tier gets its own queue.
+      await Promise.all(
+        Array.from({ length: 18 }, () =>
+          client.get('cdn/stories', { version: 'draft', per_page: 76 }).catch(() => {})),
+      );
 
-      // Make 18 requests - should take ~3 seconds to complete all
-      for (let i = 0; i < 18; i++) {
-        client.get('cdn/stories', { version: 'draft', per_page: 76 }).catch(() => {});
-      }
-
-      await vi.advanceTimersByTimeAsync(999);
-      expect(countCallsWithParams({ per_page: 76 })).toBe(6);
-
-      await vi.advanceTimersByTimeAsync(1000);
-      expect(countCallsWithParams({ per_page: 76 })).toBe(12);
-
-      await vi.advanceTimersByTimeAsync(1000);
-      expect(countCallsWithParams({ per_page: 76 })).toBe(18);
-
-      vi.useRealTimers();
+      expect(mockGet).toHaveBeenCalledTimes(18);
+      // @ts-expect-error - accessing private property for testing
+      expect(client.throttleManager.queues.has(6)).toBe(true);
     });
 
     it('should throttle different rate limit tiers independently', async () => {
-      vi.useFakeTimers();
-
-      const mockData = {
-        data: { stories: [] },
-        headers: {},
-        status: 200,
-      };
-      const mockGet = vi.fn().mockResolvedValue(mockData);
+      const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+      const resolvers: Array<() => void> = [];
+      const mockGet = vi.fn(() => new Promise<any>((resolve) => {
+        resolvers.push(() => resolve({ data: { stories: [] }, headers: {}, status: 200 }));
+      }));
 
       const client = new StoryblokClient({
         accessToken: 'test-token',
@@ -1852,26 +1831,29 @@ describe('storyblokClient', () => {
         ).length;
       };
 
-      // Make simultaneous requests to very large (6 req/s) and published (1000 req/s) tiers
+      // Very large tier (per_page 76 -> 6 req/s) and the small/single tier used
+      // by published listings without per_page (-> 50 req/s) run in parallel.
       for (let i = 0; i < 12; i++) {
         client.get('cdn/stories', { version: 'draft', per_page: 76 }).catch(() => {});
       }
       for (let i = 0; i < 50; i++) {
         client.get('cdn/stories', { version: 'published' }).catch(() => {});
       }
+      await flush();
 
-      // After 999ms:
-      // - Published tier (1000 req/s) should complete all 50 immediately
-      // - Very large tier (6 req/s) should have exactly 6 completed
-      await vi.advanceTimersByTimeAsync(999);
+      // The busy 50-slot published queue admits all 50 at once; the 6 req/s tier
+      // is capped at 6 in flight, independent of the other queue's load.
       expect(countCallsWithParams({ version: 'published' })).toBe(50);
       expect(countCallsWithParams({ per_page: 76 })).toBe(6);
 
-      // After ~2 seconds: very large tier should have 12 completed (not affected by published load)
-      await vi.advanceTimersByTimeAsync(1000);
+      // Completing the in-flight requests lets the very large tier admit its
+      // remaining 6 requests.
+      resolvers.splice(0).forEach(resolve => resolve());
+      await flush();
       expect(countCallsWithParams({ per_page: 76 })).toBe(12);
 
-      vi.useRealTimers();
+      resolvers.splice(0).forEach(resolve => resolve());
+      await flush();
     });
 
     it('should respect server rate limit headers when present', async () => {
@@ -1963,15 +1945,12 @@ describe('storyblokClient', () => {
       expect(queues.has(6)).toBe(false); // Should never use automatic 6 req/s
     });
 
-    it('should use rate limit of 3 req/s for Management API requests', async () => {
-      vi.useFakeTimers();
-
-      const mockData = {
-        data: { story: { name: 'Test Story', id: 123 } },
-        headers: {},
-        status: 200,
-      };
-      const mockGet = vi.fn().mockResolvedValue(mockData);
+    it('should cap concurrent Management API requests at 3 req/s', async () => {
+      const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+      const resolvers: Array<() => void> = [];
+      const mockGet = vi.fn(() => new Promise<any>((resolve) => {
+        resolvers.push(() => resolve({ data: { story: { name: 'Test Story', id: 123 } }, headers: {}, status: 200 }));
+      }));
 
       const client = new StoryblokClient({
         oauthToken: 'test-oauth-token',
@@ -1981,22 +1960,23 @@ describe('storyblokClient', () => {
       // @ts-expect-error - accessing private property for testing
       client.client.get = mockGet;
 
-      // Make 9 Management API requests (should take ~3 seconds at 3 req/s)
+      // Make 9 Management API requests; the tier caps concurrency at 3.
       for (let i = 0; i < 9; i++) {
         client.get(`spaces/123/stories/${i}`).catch(() => {});
       }
-
-      // After 999ms: exactly 3 requests should have started (3 req/s)
-      await vi.advanceTimersByTimeAsync(999);
+      await flush();
       expect(mockGet).toHaveBeenCalledTimes(3);
 
-      // After another 1000ms (total 1999ms): 6 requests total
-      await vi.advanceTimersByTimeAsync(1000);
+      resolvers.splice(0, 3).forEach(resolve => resolve());
+      await flush();
       expect(mockGet).toHaveBeenCalledTimes(6);
 
-      // After another 1000ms (total 2999ms): all 9 requests complete
-      await vi.advanceTimersByTimeAsync(1000);
+      resolvers.splice(0, 3).forEach(resolve => resolve());
+      await flush();
       expect(mockGet).toHaveBeenCalledTimes(9);
+
+      resolvers.splice(0).forEach(resolve => resolve());
+      await flush();
 
       // Verify the queue was created with rate limit of 3
       // @ts-expect-error - accessing private property for testing
@@ -2004,19 +1984,14 @@ describe('storyblokClient', () => {
       expect(queues.size).toBe(1);
       expect(queues.has(3)).toBe(true); // Management API default rate limit
       expect(queues.has(1000)).toBe(false); // Should NOT use CDN cached rate limit
-
-      vi.useRealTimers();
     });
 
     it('should use different queues for CDN and Management API requests', async () => {
-      vi.useFakeTimers();
-
-      const mockData = {
+      const mockGet = vi.fn().mockResolvedValue({
         data: { stories: [], story: { name: 'Test' } },
         headers: {},
         status: 200,
-      };
-      const mockGet = vi.fn().mockResolvedValue(mockData);
+      });
 
       const client = new StoryblokClient({
         accessToken: 'test-token',
@@ -2027,22 +2002,15 @@ describe('storyblokClient', () => {
       // @ts-expect-error - accessing private property for testing
       client.client.get = mockGet;
 
-      // Make simultaneous CDN (50 req/s for draft) and MAPI (3 req/s) requests
-      for (let i = 0; i < 6; i++) {
-        client.get('cdn/stories', { version: 'draft' }).catch(() => { });
-      }
-      for (let i = 0; i < 6; i++) {
-        client.get('spaces/123/stories/456').catch(() => {});
-      }
+      // Simultaneous CDN (50 req/s for draft) and MAPI (3 req/s) requests all
+      // complete and are routed to separate queues keyed by their rate limit.
+      await Promise.all([
+        ...Array.from({ length: 6 }, () =>
+          client.get('cdn/stories', { version: 'draft' }).catch(() => {})),
+        ...Array.from({ length: 6 }, (_, i) =>
+          client.get(`spaces/123/stories/${i}`).catch(() => {})),
+      ]);
 
-      // After 999ms:
-      // - CDN queue (50 req/s): all 6 requests should complete
-      // - MAPI queue (3 req/s): only 3 requests should complete
-      await vi.advanceTimersByTimeAsync(999);
-      expect(mockGet).toHaveBeenCalledTimes(9); // 6 CDN + 3 MAPI
-
-      // After another 1000ms: remaining 3 MAPI requests complete
-      await vi.advanceTimersByTimeAsync(1000);
       expect(mockGet).toHaveBeenCalledTimes(12); // All 12 requests
 
       // Verify separate queues were created
@@ -2051,8 +2019,6 @@ describe('storyblokClient', () => {
       expect(queues.size).toBe(2);
       expect(queues.has(50)).toBe(true); // CDN draft rate limit
       expect(queues.has(3)).toBe(true); // Management API rate limit
-
-      vi.useRealTimers();
     });
 
     it('should support timeout configuration through StoryblokClient', async () => {

--- a/packages/js-client/src/throttlePromise.test.ts
+++ b/packages/js-client/src/throttlePromise.test.ts
@@ -26,8 +26,8 @@ describe('throttledQueue', () => {
     });
   });
 
-  it('should enforce sequential resolution when throttle limit is exceeded', async () => {
-    const throttled = throttledQueue(mockFn, 1, 100); // Limit of 1, 100ms interval
+  it('should limit concurrency and preserve order when the limit is exceeded', async () => {
+    const throttled = throttledQueue(mockFn, 1, 100); // Concurrency limit of 1
 
     const start = Date.now();
     const promises = [
@@ -39,11 +39,62 @@ describe('throttledQueue', () => {
     const results = await Promise.all(promises);
     const duration = Date.now() - start;
 
-    // Expected behavior:
-    // Since each call has a 200ms delay, and there's a 100ms throttle interval and limit is 1,
-    // and each successive call should only start after the previous one completes,
-    // then the total duration should be around 800ms (200*3 + 100*2).
+    // With a concurrency limit of 1, each 200ms call runs strictly after the
+    // previous one completes, so the total is at least 3 * 200ms and the
+    // results keep their submission order.
     expect(results).toEqual(['test1', 'test2', 'test3']);
-    expect(duration).toBeGreaterThanOrEqual(800);
+    expect(duration).toBeGreaterThanOrEqual(600);
+  });
+
+  it('drains the queue without depending on scheduled timers (Cloudflare Workers regression #533)', async () => {
+    // On Cloudflare Workers the isolate can suspend after the response is sent,
+    // before a scheduled setTimeout fires. Draining must therefore be driven by
+    // request completion, not by a timer. Simulate the suspended isolate by
+    // flushing microtasks while leaving every scheduled timer pending.
+    vi.useFakeTimers();
+    try {
+      const fn = vi.fn(async (i: number) => i); // resolves via microtask, no timer
+      const throttled = throttledQueue(fn, 3, 1000);
+      const settled: number[] = [];
+      const promises = Array.from({ length: 6 }, (_, i) =>
+        throttled(i).then((value) => {
+          settled.push(value as number);
+          return value;
+        }));
+
+      // Flush microtasks only; every scheduled timer stays pending.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(settled.slice().sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5]);
+      await Promise.all(promises);
+    }
+    finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects queued promises with an AbortError when aborted', async () => {
+    const throttled = throttledQueue(mockFn, 1, 10);
+
+    const inFlight = throttled('a'); // occupies the only concurrency slot
+    const queued = throttled('b'); // waits in the queue
+
+    throttled.abort?.();
+
+    await expect(queued).rejects.toBeInstanceOf(Error);
+    await expect(queued).rejects.toHaveProperty('name', 'AbortError');
+    await expect(inFlight).resolves.toBe('a'); // in-flight request still settles
+  });
+
+  it('does not throttle when the limit is non-positive or infinite', async () => {
+    const fn = vi.fn(async (i: number) => i);
+
+    for (const limit of [0, Number.POSITIVE_INFINITY]) {
+      const throttled = throttledQueue(fn, limit, 1000);
+      const results = await Promise.all(
+        Array.from({ length: 5 }, (_, i) => throttled(i)),
+      );
+      expect(results).toEqual([0, 1, 2, 3, 4]);
+    }
   });
 });

--- a/packages/js-client/src/throttlePromise.ts
+++ b/packages/js-client/src/throttlePromise.ts
@@ -7,50 +7,53 @@ class AbortError extends Error {
   }
 }
 
+/**
+ * Creates a concurrency-limited queue: at most `limit` invocations of `fn` run
+ * at the same time. A concurrency slot is released as soon as its invocation
+ * settles (in a `finally`), and the queue keeps draining from there.
+ *
+ * Release and draining are intentionally completion-driven and never depend on
+ * a scheduled timer. On runtimes such as Cloudflare Workers the isolate can
+ * suspend right after a response is sent and drop pending timers; a
+ * timer-driven release would then leak the in-flight count across requests
+ * (the client is a shared singleton) until the queue permanently deadlocks and
+ * the Worker returns 1101 (see #533, #319). Server-side rate limits are still
+ * respected by the 429 retry path in the client.
+ *
+ * A non-positive or non-finite `limit` disables throttling and lets every
+ * request through. `_interval` is retained for internal API compatibility and
+ * is no longer used, because any timer-based pacing would reintroduce the
+ * Workers hang described above.
+ */
 function throttledQueue<T extends (...args: Parameters<T>) => ReturnType<T>>(
   fn: T,
   limit: number,
-  interval: number,
+  _interval: number,
 ): ISbThrottle<T> {
-  if (!Number.isFinite(limit)) {
-    throw new TypeError('Expected `limit` to be a finite number');
-  }
-
-  if (!Number.isFinite(interval)) {
-    throw new TypeError('Expected `interval` to be a finite number');
-  }
+  const isUnlimited = !Number.isFinite(limit) || limit <= 0;
 
   const queue: Queue<Parameters<T>>[] = [];
-  let timeouts: ReturnType<typeof setTimeout>[] = [];
   let activeCount = 0;
   let isAborted = false;
 
   const next = async () => {
-    activeCount++;
-
-    const x = queue.shift();
-    if (x) {
-      try {
-        const res = await fn(...x.args);
-        x.resolve(res);
-      }
-      catch (error) {
-        x.reject(error);
-      }
+    const item = queue.shift();
+    if (!item) {
+      return;
     }
 
-    const id = setTimeout(() => {
+    activeCount++;
+    try {
+      item.resolve(await fn(...item.args));
+    }
+    catch (error) {
+      item.reject(error);
+    }
+    finally {
       activeCount--;
-
-      if (queue.length > 0) {
+      if (queue.length > 0 && (isUnlimited || activeCount < limit)) {
         next();
       }
-
-      timeouts = timeouts.filter(currentId => currentId !== id);
-    }, interval);
-
-    if (!timeouts.includes(id)) {
-      timeouts.push(id);
     }
   };
 
@@ -70,7 +73,7 @@ function throttledQueue<T extends (...args: Parameters<T>) => ReturnType<T>>(
         args,
       });
 
-      if (activeCount < limit) {
+      if (isUnlimited || activeCount < limit) {
         next();
       }
     });
@@ -78,11 +81,9 @@ function throttledQueue<T extends (...args: Parameters<T>) => ReturnType<T>>(
 
   throttled.abort = () => {
     isAborted = true;
-    timeouts.forEach(clearTimeout);
-    timeouts = [];
 
-    queue.forEach(x =>
-      x.reject(() => new AbortError('Throttle function aborted')),
+    queue.forEach(item =>
+      item.reject(new AbortError('Throttle function aborted')),
     );
     queue.length = 0;
   };


### PR DESCRIPTION
## Problem

Customers running `@storyblok/astro` (and React/Hydrogen) on Cloudflare Workers hit a recurring failure: a backlog of Storyblok requests builds up until Cloudflare returns `1101` Worker errors. Clearing the backlog restores service temporarily, then it rebuilds. Reported in #533 (Astro), #319 and #353 (Hydrogen/Oxygen), and previously in the archived js-client issue #682.

## Root cause

The request throttle in `storyblok-js-client` (`throttlePromise.ts`) released its in-flight slot (`activeCount--`) and re-pumped the queue only from inside a fire-and-forget `setTimeout(interval)` callback. On Cloudflare Workers the isolate suspends the moment the response is sent, and any timer that has not yet fired is dropped, so `activeCount` is never decremented. Because the client is a cross-request singleton on `globalThis`, the leaked count survives request boundaries and climbs monotonically. Once `activeCount` reaches `limit`, `throttled()` stops pumping the queue, queued promises never settle, the SSR handler hangs, and Cloudflare kills it with `1101`. The failure surfaces after roughly `limit` requests, matching #319's observation that the count tracks the configured `rateLimit`.

## Fix

Replace the time-window throttle with a **completion-driven concurrency limiter**:

- At most `limit` invocations run at once. The slot is released in a `finally` the moment each invocation settles, and the queue drains from there. Release and draining never depend on a timer, so isolate suspension cannot leak the count or wedge the queue.
- A non-positive or non-finite `limit` (`0` / `Infinity`) now disables throttling, giving Workers users a deterministic opt-out (previously `0` deadlocked and `Infinity` threw). Addresses #319's `rateLimit: 0` request.
- `abort()` rejects queued promises with an `AbortError` instance instead of a function value.

Server-side rate limiting stays covered by the existing `429` retry path in `cacheResponse`.

## Semantics change

The client no longer paces requests per second; it caps simultaneous in-flight requests per rate-limit tier. Bursts of fast requests can now exceed the old per-second rate, and the server's `429` plus the client's retry path absorb the overflow. Recorded in `adr/0011-concurrency-limited-request-throttle.md`.

## Tests

- New regression test simulates the Workers runtime by leaving every scheduled timer pending and asserting the queue still fully drains.
- New tests for the `AbortError` reject type and the `0` / `Infinity` opt-out.
- Rewrote the `dynamic Rate Limiting` tests from per-second-distribution assertions to concurrency-cap, queue-tier-keying, and completion assertions.

## Verification

- `pnpm nx test storyblok-js-client`: 190 passed, 1 skipped, no type errors.
- `pnpm nx lint:fix storyblok-js-client`: clean.
- `pnpm nx build storyblok-js-client`: succeeds.

## Not covered here

The reporter's end-to-end reproduction was not run in this branch; the regression test reproduces the suspended-isolate condition at the unit level. End-to-end confirmation via the #533 repro (or the #682 StackBlitz) under `astro dev` with `@astrojs/cloudflare` is recommended before release.

Fixes #533
Fixes #319
Fixes #353
