### PR TITLE
chore(schema): dogfood Block<TName> component-typing helper in astro playground

### DIFF
--- a/packages/schema/playground/astro/src/components/storyblok/hero.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/hero.astro
@@ -1,37 +1,31 @@
 ---
-import type { BlockContent } from '@storyblok/schema';
-import type { Blocks, FieldPlugins } from '../../schema/schema';
-import type { heroBlock } from '../../schema/blocks/hero';
-
-// Passing `FieldPlugins` as the third argument resolves the registered
-// `storyblok-colorpicker` custom field to `{ color: string; plugin: string }`.
-type HeroContent = BlockContent<typeof heroBlock, Blocks, FieldPlugins>;
+import type { Block } from '../../schema/schema';
 
 interface Props {
-  blok: HeroContent;
+  block: Block<'hero'>;
 }
 
-const { blok } = Astro.props;
+const { block } = Astro.props;
 
-// `blok.accent_color` is fully typed thanks to the registered color plugin.
-const accentColor = blok.accent_color?.color;
+// `block.accent_color` is fully typed thanks to the registered color plugin.
+const accentColor = block.accent_color?.color;
 ---
 
 <section class="relative flex min-h-[60vh] items-center bg-gray-900 px-6 py-24 text-white">
   <div class="mx-auto max-w-4xl">
-    {blok.eyebrow && (
+    {block.eyebrow && (
       <p
         class="mb-4 text-sm font-semibold tracking-widest text-indigo-400 uppercase"
         style={accentColor ? `color: ${accentColor}` : undefined}
       >
-        {blok.eyebrow}
+        {block.eyebrow}
       </p>
     )}
-    <h1 class="text-5xl leading-tight font-bold text-balance md:text-6xl">{blok.headline}</h1>
-    {blok.image?.filename && (
+    <h1 class="text-5xl leading-tight font-bold text-balance md:text-6xl">{block.headline}</h1>
+    {block.image?.filename && (
       <img
-        src={blok.image.filename}
-        alt={blok.image.alt ?? ''}
+        src={block.image.filename}
+        alt={block.image.alt ?? ''}
         class="mt-10 rounded-xl object-cover shadow-lg"
         width="1200"
         height="630"

--- a/packages/schema/playground/astro/src/components/storyblok/intro.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/intro.astro
@@ -1,27 +1,23 @@
 ---
-import type { BlockContent } from '@storyblok/schema';
-import type { Blocks } from '../../schema/schema';
-import type { introBlock } from '../../schema/blocks/intro';
-
-type IntroContent = BlockContent<typeof introBlock, Blocks>;
+import type { Block } from '../../schema/schema';
 
 interface Props {
-  blok: IntroContent;
+  block: Block<'intro'>;
 }
 
-const { blok } = Astro.props;
+const { block } = Astro.props;
 ---
 
 <section class="px-6 py-20">
   <div class="mx-auto max-w-3xl text-center">
-    {blok.eyebrow && (
+    {block.eyebrow && (
       <p class="mb-4 text-sm font-semibold tracking-widest text-indigo-600 uppercase">
-        {blok.eyebrow}
+        {block.eyebrow}
       </p>
     )}
-    <h2 class="mb-8 text-4xl font-bold text-balance text-gray-900">{blok.headline}</h2>
-    {blok.body && (
-      <div class="prose prose-lg mx-auto text-gray-600" set:html={blok.body} />
+    <h2 class="mb-8 text-4xl font-bold text-balance text-gray-900">{block.headline}</h2>
+    {block.body && (
+      <div class="prose prose-lg mx-auto text-gray-600" set:html={block.body} />
     )}
   </div>
 </section>

--- a/packages/schema/playground/astro/src/components/storyblok/media.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/media.astro
@@ -1,34 +1,30 @@
 ---
 import { marked } from 'marked';
-import type { BlockContent } from '@storyblok/schema';
-import type { Blocks } from '../../schema/schema';
-import type { mediaBlock } from '../../schema/blocks/media';
-
-type MediaContent = BlockContent<typeof mediaBlock, Blocks>;
+import type { Block } from '../../schema/schema';
 
 interface Props {
-  blok: MediaContent;
+  block: Block<'media'>;
 }
 
-const { blok } = Astro.props;
-const parsedText = blok.text ? await marked.parse(blok.text) : null;
+const { block } = Astro.props;
+const parsedText = block.text ? await marked.parse(block.text) : null;
 ---
 
-{blok.image?.filename && (
+{block.image?.filename && (
   <section class="px-6 py-12">
     <div class="mx-auto max-w-5xl lg:flex lg:items-start lg:gap-12">
       <figure class="lg:w-1/2">
         <div class="overflow-hidden rounded-2xl shadow-xl">
           <img
-            src={blok.image.filename}
-            alt={blok.image.alt ?? ''}
+            src={block.image.filename}
+            alt={block.image.alt ?? ''}
             class="h-auto w-full object-cover"
             width="1200"
             height="675"
           />
         </div>
-        {blok.caption && (
-          <figcaption class="mt-3 text-sm text-gray-500">{blok.caption}</figcaption>
+        {block.caption && (
+          <figcaption class="mt-3 text-sm text-gray-500">{block.caption}</figcaption>
         )}
       </figure>
       {parsedText && (

--- a/packages/schema/playground/astro/src/components/storyblok/storyblok-component.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/storyblok-component.astro
@@ -1,30 +1,27 @@
 ---
-import type { BlockContent } from '@storyblok/schema';
-import type { Blocks } from '../../schema/schema';
+import type { AnyBlock } from '../../schema/schema';
 import Hero from './hero.astro';
 import Intro from './intro.astro';
 import Media from './media.astro';
 import TeaserList from './teaser-list.astro';
 
-type AnyBlockContent = BlockContent<Blocks, Blocks>;
-
 interface Props {
-  blok: AnyBlockContent;
+  block: AnyBlock;
 }
 
-const { blok } = Astro.props;
+const { block } = Astro.props;
 ---
 
-{blok.component === 'page' && (
-  blok.blocks?.map(block => <Astro.self blok={block} />)
+{block.component === 'page' && (
+  block.blocks?.map(child => <Astro.self block={child} />)
 )}
-{blok.component === 'hero' && <Hero blok={blok} />}
-{blok.component === 'intro' && <Intro blok={blok} />}
-{blok.component === 'media' && <Media blok={blok} />}
-{blok.component === 'teaser_list' && <TeaserList blok={blok} />}
-{!['page', 'hero', 'intro', 'media', 'teaser_list'].includes(blok.component) && import.meta.env.DEV && (
+{block.component === 'hero' && <Hero block={block} />}
+{block.component === 'intro' && <Intro block={block} />}
+{block.component === 'media' && <Media block={block} />}
+{block.component === 'teaser_list' && <TeaserList block={block} />}
+{!['page', 'hero', 'intro', 'media', 'teaser_list'].includes(block.component) && import.meta.env.DEV && (
   <div class="rounded border border-yellow-400 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
-    Unknown component: <code>{blok.component}</code>
-    <pre>{JSON.stringify(blok, null, 2)}</pre>
+    Unknown component: <code>{block.component}</code>
+    <pre>{JSON.stringify(block, null, 2)}</pre>
   </div>
 )}

--- a/packages/schema/playground/astro/src/components/storyblok/teaser-list.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/teaser-list.astro
@@ -1,26 +1,22 @@
 ---
-import type { BlockContent } from '@storyblok/schema';
-import type { Blocks } from '../../schema/schema';
-import type { teaserListBlock } from '../../schema/blocks/teaser-list';
+import type { Block } from '../../schema/schema';
 import Teaser from './teaser.astro';
 
-type TeaserListContent = BlockContent<typeof teaserListBlock, Blocks>;
-
 interface Props {
-  blok: TeaserListContent;
+  block: Block<'teaser_list'>;
 }
 
-const { blok } = Astro.props;
+const { block } = Astro.props;
 ---
 
 <section class="px-6 py-16">
   <div class="mx-auto max-w-6xl">
-    {blok.headline && (
-      <h2 class="mb-10 text-center text-3xl font-bold text-balance text-gray-900">{blok.headline}</h2>
+    {block.headline && (
+      <h2 class="mb-10 text-center text-3xl font-bold text-balance text-gray-900">{block.headline}</h2>
     )}
     <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-      {blok.items?.map(item => (
-        <Teaser blok={item} />
+      {block.items?.map(item => (
+        <Teaser block={item} />
       ))}
     </div>
   </div>

--- a/packages/schema/playground/astro/src/components/storyblok/teaser.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/teaser.astro
@@ -1,27 +1,23 @@
 ---
-import type { BlockContent } from '@storyblok/schema';
-import type { Blocks } from '../../schema/schema';
-import type { teaserBlock } from '../../schema/blocks/teaser';
-
-type TeaserContent = BlockContent<typeof teaserBlock, Blocks>;
+import type { Block } from '../../schema/schema';
 
 interface Props {
-  blok: TeaserContent;
+  block: Block<'teaser'>;
 }
 
-const { blok } = Astro.props;
+const { block } = Astro.props;
 const href =
-  blok.link?.linktype === 'story'
-    ? `/${blok.link.cached_url ?? ''}`
-    : blok.link?.url ?? undefined;
+  block.link?.linktype === 'story'
+    ? `/${block.link.cached_url ?? ''}`
+    : block.link?.url ?? undefined;
 ---
 
 <article class="flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
-  {blok.image?.filename && (
+  {block.image?.filename && (
     <div class="aspect-video overflow-hidden">
       <img
-        src={blok.image.filename}
-        alt={blok.image.alt ?? ''}
+        src={block.image.filename}
+        alt={block.image.alt ?? ''}
         class="h-full w-full object-cover"
         width="600"
         height="337"
@@ -29,8 +25,8 @@ const href =
     </div>
   )}
   <div class="flex flex-1 flex-col p-6">
-    <h3 class="mb-2 text-xl font-semibold text-balance text-gray-900">{blok.title}</h3>
-    {blok.description && <p class="flex-1 text-gray-600">{blok.description}</p>}
+    <h3 class="mb-2 text-xl font-semibold text-balance text-gray-900">{block.title}</h3>
+    {block.description && <p class="flex-1 text-gray-600">{block.description}</p>}
     {href && (
       <a
         href={href}

--- a/packages/schema/playground/astro/src/pages/[...slug].astro
+++ b/packages/schema/playground/astro/src/pages/[...slug].astro
@@ -29,7 +29,7 @@ const description = content?.seo_description ?? '';
   </head>
   <body>
     <main>
-      <StoryblokComponent blok={story.content} />
+      <StoryblokComponent block={story.content} />
     </main>
   </body>
 </html>

--- a/packages/schema/playground/astro/src/pages/index.astro
+++ b/packages/schema/playground/astro/src/pages/index.astro
@@ -23,7 +23,7 @@ const description = content?.seo_description ?? '';
   </head>
   <body>
     {story
-      ? <main><StoryblokComponent blok={story.content} /></main>
+      ? <main><StoryblokComponent block={story.content} /></main>
       : (
         <main class="flex min-h-screen items-center justify-center">
           <p class="text-gray-500">

--- a/packages/schema/playground/astro/src/schema/schema.ts
+++ b/packages/schema/playground/astro/src/schema/schema.ts
@@ -1,5 +1,10 @@
 import { defineSchema } from '@storyblok/schema';
-import type { Schema as InferSchema, Story as InferStory, MapiStory as InferStoryMapi } from '@storyblok/schema';
+import type {
+  BlockContent,
+  Schema as InferSchema,
+  Story as InferStory,
+  MapiStory as InferStoryMapi,
+} from '@storyblok/schema';
 import { storyblokColorField } from '@storyblok/schema/field-plugins';
 
 import { articleBlock } from './blocks/article';
@@ -47,3 +52,15 @@ export type Blocks = Schema['blocks'];
 export type FieldPlugins = Schema['fieldPlugins'];
 export type Story = InferStory<Blocks, FieldPlugins>;
 export type StoryMapi = InferStoryMapi<Blocks, FieldPlugins>;
+
+// Type a component's props by block name: `Block<"hero">`.
+// Wraps `BlockContent`, selecting the block definition whose `name` matches and
+// baking in the schema's blocks + registered field plugins.
+export type Block<TName extends Blocks['name']> = BlockContent<
+  Extract<Blocks, { name: TName }>,
+  Blocks,
+  FieldPlugins
+>;
+
+// Loose union of every block's content, used by the dynamic component dispatcher.
+export type AnyBlock = BlockContent<Blocks, Blocks, FieldPlugins>;


### PR DESCRIPTION
Playground-only change: dogfoods a userland `Block<TName>` helper for typing framework components against a `@storyblok/schema` schema across the Astro playground. No published package code is affected.

```ts
// playground/astro/src/schema/schema.ts
export type Block<TName extends Blocks['name']> = BlockContent<
  Extract<Blocks, { name: TName }>,
  Blocks,
  FieldPlugins
>;
```

Components now type props by block name (`Block<'hero'>`) instead of the verbose `BlockContent<typeof heroBlock, Blocks, FieldPlugins>` + block-def import. Also renames the `blok` prop/variable to `block` throughout the playground (intentional divergence from the SDK `blok` convention, for clarity in this example app).

## Why

The verbose per-component pattern needed four imports and a block-def reference. `Block<TName>` collapses that to one name-keyed lookup, with `FieldPlugins` baked in so custom-field types resolve automatically. This proves the pattern documented in the companion docs PR.

## Changes

- Add `Block<TName>` and `AnyBlock` exports to the playground `schema.ts`.
- Retype all 6 Astro components (`hero`, `intro`, `media`, `teaser`, `teaser-list`, `storyblok-component`) via `Block<'...'>` / `AnyBlock`.
- Rename `blok` -> `block` prop/variable (dispatcher's inner `.map` var renamed to `child` to avoid shadowing); update both `<StoryblokComponent>` call sites.
- Untouched: `storyblok` import paths, the `bloks` field type, `blocks` field names.

## Companion PR

Docs: storyblok/storyblok-docs-platform#591 - adds a "Typing components" section documenting this helper.

Fixes DX-518
