### PR TITLE
docs(capi-client,mapi-client,schema): link to the live package references

### DIFF
--- a/packages/capi-client/README.md
+++ b/packages/capi-client/README.md
@@ -38,9 +38,7 @@
 
 ## Documentation
 
-<!-- TODO: restore docs link once live — https://www.storyblok.com/docs/libraries/js/api-client (docs #536/#548) -->
-
-Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/alpha/packages/capi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/alpha/packages/schema/playground/astro).
+For complete documentation, please visit the [package reference](https://www.storyblok.com/docs/libraries/js/content-delivery-api-client).
 
 ## Contributing
 

--- a/packages/mapi-client/README.md
+++ b/packages/mapi-client/README.md
@@ -38,9 +38,7 @@
 
 ## Documentation
 
-<!-- TODO: restore docs link once live — https://www.storyblok.com/docs/libraries/js/management-api-client (docs #536/#548) -->
-
-Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/alpha/packages/mapi-client) or see it used in the [Astro playground](https://github.com/storyblok/monoblok/tree/alpha/packages/schema/playground/astro).
+For complete documentation, please visit the [package reference](https://www.storyblok.com/docs/libraries/js/management-api-client).
 
 ## Contributing
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -36,9 +36,7 @@
 
 ## Documentation
 
-<!-- TODO: restore docs link once live — https://www.storyblok.com/docs/packages/storyblok-schema (docs #536/#548) -->
-
-Full package documentation is coming soon. For now, browse the [package source on GitHub](https://github.com/storyblok/monoblok/tree/alpha/packages/schema) or explore a runnable example in the [Astro playground](https://github.com/storyblok/monoblok/tree/alpha/packages/schema/playground/astro).
+For complete documentation, please visit the [package reference](https://www.storyblok.com/docs/libraries/js/schema).
 
 ## Contributing
 


### PR DESCRIPTION
The Documentation sections of `@storyblok/api-client`, `@storyblok/management-api-client`, and `@storyblok/schema` still carried "coming soon" placeholders with TODO comments. The docs pages are live now, so this links to them using the same phrasing as the other package READMEs (`packages/migrations/README.md`).

| Package | Link |
| --- | --- |
| `@storyblok/api-client` | https://www.storyblok.com/docs/libraries/js/content-delivery-api-client |
| `@storyblok/management-api-client` | https://www.storyblok.com/docs/libraries/js/management-api-client |
| `@storyblok/schema` | https://www.storyblok.com/docs/libraries/js/schema |

Note: the capi-client TODO guessed `/docs/libraries/js/api-client`, which 404s. The actual slug is `/docs/libraries/js/content-delivery-api-client`.

## Checklist

- All three URLs were verified to resolve and to document the expected package.
- README-only change, no code or build impact.