### PR TITLE
test: demonstrate bugs by adding a kitchen sink schema + component

### DIFF
--- a/packages/schema/playground/astro/.storyblok/stories/seed/kitchen-sink_story-kitchen-sink.json
+++ b/packages/schema/playground/astro/.storyblok/stories/seed/kitchen-sink_story-kitchen-sink.json
@@ -1,0 +1,84 @@
+{
+  "name": "Kitchen Sink",
+  "parent_id": 0,
+  "id": 1004,
+  "uuid": "story-kitchen-sink",
+  "is_folder": false,
+  "content": {
+    "_uid": "c73b8e02-1a45-4d97-b6f8-3e91d5c0a827",
+    "blocks": [
+      {
+        "_uid": "4f8a91c2-7d3e-4b16-9a05-e2c7b4d81f30",
+        "text": "Every Field Type",
+        "textarea": "A single block exercising one field of each of the seventeen Storyblok field types.\nEach field is named after its own type.",
+        "richtext": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                { "text": "Rich text supports ", "type": "text" },
+                { "text": "bold", "type": "text", "marks": [{ "type": "bold" }] },
+                { "text": ", ", "type": "text" },
+                { "text": "italic", "type": "text", "marks": [{ "type": "italic" }] },
+                { "text": " and inline formatting.", "type": "text" }
+              ]
+            },
+            {
+              "type": "bullet_list",
+              "content": [
+                { "type": "list_item", "content": [{ "type": "paragraph", "content": [{ "text": "Rendered with renderRichText", "type": "text" }] }] },
+                { "type": "list_item", "content": [{ "type": "paragraph", "content": [{ "text": "Structured as a Prosemirror document", "type": "text" }] }] }
+              ]
+            }
+          ]
+        },
+        "markdown": "Markdown is stored as a **raw string** and parsed at render time with [marked](https://marked.js.org).\n\n- Portable\n- Diff-friendly",
+        "number": "7",
+        "datetime": "2026-07-27 09:30",
+        "boolean": true,
+        "option": "beta",
+        "options": ["one", "three"],
+        "asset": { "id": 2000, "alt": "Single asset field", "filename": "", "fieldtype": "asset" },
+        "multiasset": [
+          { "id": 2000, "alt": "First of many", "filename": "", "fieldtype": "asset" },
+          { "id": 2000, "alt": "Second of many", "filename": "", "fieldtype": "asset" },
+          { "id": 2000, "alt": "Third of many", "filename": "", "fieldtype": "asset" }
+        ],
+        "multilink": { "id": "", "url": "/about", "linktype": "url", "fieldtype": "multilink", "cached_url": "/about" },
+        "table": {
+          "tbody": [
+            { "_uid": "ks-tr-1", "body": [{ "_uid": "ks-td-1-1", "value": "number", "component": "_table_col" }, { "_uid": "ks-td-1-2", "value": "string", "component": "_table_col" }], "component": "_table_row" },
+            { "_uid": "ks-tr-2", "body": [{ "_uid": "ks-td-2-1", "value": "datetime", "component": "_table_col" }, { "_uid": "ks-td-2-2", "value": "YYYY-MM-DD HH:mm", "component": "_table_col" }], "component": "_table_row" },
+            { "_uid": "ks-tr-3", "body": [{ "_uid": "ks-td-3-1", "value": "options", "component": "_table_col" }, { "_uid": "ks-td-3-2", "value": "string[]", "component": "_table_col" }], "component": "_table_row" }
+          ],
+          "thead": [
+            { "_uid": "ks-th-1", "value": "Field type", "component": "_table_head" },
+            { "_uid": "ks-th-2", "value": "Stored as", "component": "_table_head" }
+          ]
+        },
+        "bloks": [
+          {
+            "_uid": "b1e6c40d-52a7-4f8b-9c31-7ad0e5f92b64",
+            "title": "Nested teaser",
+            "image": { "id": 2000, "alt": "Nested teaser image", "filename": "", "fieldtype": "asset" },
+            "link": { "id": "", "url": "/kitchen-sink", "linktype": "url", "fieldtype": "multilink", "cached_url": "/kitchen-sink" },
+            "component": "teaser",
+            "description": "The bloks field uses allow: [teaser], so this is the only component it accepts."
+          }
+        ],
+        "custom": { "plugin": "storyblok-colorpicker", "color": "#818cf8" },
+        "component": "kitchen_sink"
+      }
+    ],
+    "component": "page",
+    "seo_title": "Kitchen Sink — One Field of Every Type",
+    "seo_description": "A single block using one field of each of the seventeen Storyblok field types, for exercising schema type resolution."
+  },
+  "published": true,
+  "slug": "kitchen-sink",
+  "path": null,
+  "full_slug": "kitchen-sink",
+  "is_startpage": false,
+  "position": -30
+}

--- a/packages/schema/playground/astro/src/components/storyblok/kitchen-sink.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/kitchen-sink.astro
@@ -27,41 +27,36 @@ import Teaser from './teaser.astro';
  * | ------------ | ------------------------------------------------------------- |
  * | `text`       | `string`                                                      |
  * | `textarea`   | `string`                                                      |
- * | `richtext`   | `{ type: 'doc'; content?: { [key: string]: unknown }[] }`      |
+ * | `richtext`   | `{ type: 'doc'; content?: { [key: string]: unknown }[] }`     |
  * | `markdown`   | `string`                                                      |
  * | `number`     | `number`                                                      |
- * | `datetime`   | `string` — `"YYYY-MM-DD HH:mm"`, not ISO 8601                  |
+ * | `datetime`   | `string` — `"YYYY-MM-DD HH:mm"`, not ISO 8601                 |
  * | `boolean`    | `boolean`                                                     |
  * | `option`     | `string`                                                      |
  * | `options`    | `string[]`                                                    |
  * | `asset`      | `AssetFieldValue` (expanded)                                  |
  * | `multiasset` | `AssetFieldValueRoot[]`                                       |
- * | `multilink`  | `MultilinkFieldValue`, discriminated on `linktype`             |
- * | `table`      | `{ thead: [...]; tbody: [...] }`                               |
- * | `bloks`      | narrowed to `component: 'teaser'` — `allow` narrowing works    |
- * | `custom`     | `{ color: string; plugin: string }` — plugin resolution works  |
+ * | `multilink`  | `MultilinkFieldValue`, discriminated on `linktype`            |
+ * | `table`      | `{ thead: [...]; tbody: [...] }`                              |
+ * | `bloks`      | narrowed to `component: 'teaser'` — `allow` narrowing works   |
+ * | `custom`     | `{ color: string; plugin: string }` — plugin resolution works |
  *
  * ## Known gaps
  *
- * 1. **`richtext` cannot be rendered.** The line below that calls
- *    `renderRichText(blok.richtext)` does not compile, even after a truthiness
- *    guard has removed `null | undefined`:
+ * 1. **`richtext` type is incompatible with renderRichText.**
+ *    The line below that calls `renderRichText(blok.richtext)` does not compile:
  *
  *    > Argument of type `{ type: "doc"; content?: { [key: string]: unknown }[] }`
  *    > is not assignable to parameter of type `SbRichTextInput`. Types of
  *    > property `content` are incompatible. Type `{ [key: string]: unknown }[] |
  *    > undefined` is not assignable to type `SbRichTextNode<unknown>[]`.
  *
- *    `RichtextFieldValue` has an optional `content` of loose records, while
- *    `SbRichTextDoc` requires `content: SbRichTextNode[]`. The two first-party
- *    packages therefore do not compose: `@storyblok/schema` cannot feed
- *    `@storyblok/richtext`, which is the only renderer it ships. A richtext field
- *    is declarable and pushable but not consumable, so the type is unusable for
- *    the single purpose the field exists to serve.
+ *    `RichtextFieldValue` has an optional `content` of loose records;
+ *    `SbRichTextDoc` requires `content: SbRichTextNode[]`. So
+ *    `@storyblok/schema` cannot feed `@storyblok/richtext`.
  *
- * 2. **`number` is typed as `number` but delivered as a string.** This one is a
- *    genuine unsoundness, not just friction, and it is verified against a live
- *    space in both directions:
+ * 2. **`number` is typed as `number` but delivered as a string.** This one is
+ *    verifiable against a live space in both directions:
  *
  *    - Pushing `"number": 7` (a JSON number) is rejected by the Management API:
  *      *"The value of the field number in the component kitchen_sink […] must be
@@ -74,10 +69,9 @@ import Teaser from './teaser.astro';
  *      (*"Expected number, received string"*), so the only story content the CMS
  *      accepts is content the package's own validator calls invalid.
  *
- *    This is worse than gap 1 because nothing fails loudly: arithmetic on
- *    `blok.number` typechecks and silently produces the wrong answer
- *    (`blok.number + 1` → `"71"`). The template below only reads the value, so it
- *    compiles clean and renders correctly, and the defect stays invisible here.
+ *    Nothing fails loudly: arithmetic on `blok.number` typechecks and silently produces
+ *    the wrong answer (`blok.number + 1` → `"71"`). The template below only reads the value,
+ *    so it compiles clean and renders correctly, and the defect stays invisible here.
  *    The seed story stores `"7"`, matching the API and contradicting both the
  *    declared type and the validator.
  *

--- a/packages/schema/playground/astro/src/components/storyblok/kitchen-sink.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/kitchen-sink.astro
@@ -1,0 +1,299 @@
+---
+import { marked } from 'marked';
+import { renderRichText } from '@storyblok/richtext';
+import type { BlockContent } from '@storyblok/schema';
+import type { Blocks, FieldPlugins } from '../../schema/schema';
+import type { kitchenSinkBlock } from '../../schema/blocks/kitchen-sink';
+import Teaser from './teaser.astro';
+
+/**
+ * Renders every field of `kitchenSinkBlock` — one per Storyblok field type.
+ *
+ * This component is a conformance fixture for `@storyblok/schema`, not example
+ * application code. It consumes each field exactly one way: `BlockContent`
+ * straight off the block definition, then the value as the schema hands it over.
+ *
+ * That is the whole contract, and it is what the schema types have to support on
+ * their own. A field whose type does not fit the consumer it exists to feed is a
+ * field that cannot be used, and the type error left in place below is the report
+ * of that. Each gap has to be closed in the schema types themselves.
+ *
+ * ## Resolved types (verified against the current schema package)
+ *
+ * `text` is the block's only required field, so it resolves to a bare `string`.
+ * Every other value field resolves to `T | null | undefined`.
+ *
+ * | Field        | Resolves to                                                   |
+ * | ------------ | ------------------------------------------------------------- |
+ * | `text`       | `string`                                                      |
+ * | `textarea`   | `string`                                                      |
+ * | `richtext`   | `{ type: 'doc'; content?: { [key: string]: unknown }[] }`      |
+ * | `markdown`   | `string`                                                      |
+ * | `number`     | `number`                                                      |
+ * | `datetime`   | `string` — `"YYYY-MM-DD HH:mm"`, not ISO 8601                  |
+ * | `boolean`    | `boolean`                                                     |
+ * | `option`     | `string`                                                      |
+ * | `options`    | `string[]`                                                    |
+ * | `asset`      | `AssetFieldValue` (expanded)                                  |
+ * | `multiasset` | `AssetFieldValueRoot[]`                                       |
+ * | `multilink`  | `MultilinkFieldValue`, discriminated on `linktype`             |
+ * | `table`      | `{ thead: [...]; tbody: [...] }`                               |
+ * | `bloks`      | narrowed to `component: 'teaser'` — `allow` narrowing works    |
+ * | `custom`     | `{ color: string; plugin: string }` — plugin resolution works  |
+ *
+ * ## Known gaps
+ *
+ * 1. **`richtext` cannot be rendered.** The line below that calls
+ *    `renderRichText(blok.richtext)` does not compile, even after a truthiness
+ *    guard has removed `null | undefined`:
+ *
+ *    > Argument of type `{ type: "doc"; content?: { [key: string]: unknown }[] }`
+ *    > is not assignable to parameter of type `SbRichTextInput`. Types of
+ *    > property `content` are incompatible. Type `{ [key: string]: unknown }[] |
+ *    > undefined` is not assignable to type `SbRichTextNode<unknown>[]`.
+ *
+ *    `RichtextFieldValue` has an optional `content` of loose records, while
+ *    `SbRichTextDoc` requires `content: SbRichTextNode[]`. The two first-party
+ *    packages therefore do not compose: `@storyblok/schema` cannot feed
+ *    `@storyblok/richtext`, which is the only renderer it ships. A richtext field
+ *    is declarable and pushable but not consumable, so the type is unusable for
+ *    the single purpose the field exists to serve.
+ *
+ * 2. **`number` is typed as `number` but delivered as a string.** This one is a
+ *    genuine unsoundness, not just friction, and it is verified against a live
+ *    space in both directions:
+ *
+ *    - Pushing `"number": 7` (a JSON number) is rejected by the Management API:
+ *      *"The value of the field number in the component kitchen_sink […] must be
+ *      a string with numbers and allow '-' and '.'"*
+ *    - Pushing `"number": "7"` succeeds, and the Content Delivery API then
+ *      returns `"7"` — a string.
+ *    - But `FieldTypeValueMap` maps `number` to `number`, so `blok.number` is
+ *      typed `number | null | undefined` while actually holding `"7"`.
+ *    - And `validateStory` rejects the string form the API requires
+ *      (*"Expected number, received string"*), so the only story content the CMS
+ *      accepts is content the package's own validator calls invalid.
+ *
+ *    This is worse than gap 1 because nothing fails loudly: arithmetic on
+ *    `blok.number` typechecks and silently produces the wrong answer
+ *    (`blok.number + 1` → `"71"`). The template below only reads the value, so it
+ *    compiles clean and renders correctly, and the defect stays invisible here.
+ *    The seed story stores `"7"`, matching the API and contradicting both the
+ *    declared type and the validator.
+ *
+ * Everything else — including `table`, `multiasset`, `multilink`, `bloks`
+ * narrowing and `custom` plugin resolution — typechecks as consumed here and
+ * round-trips through a real space correctly.
+ */
+type KitchenSinkContent = BlockContent<typeof kitchenSinkBlock, Blocks, FieldPlugins>;
+
+interface Props {
+  blok: KitchenSinkContent;
+}
+
+const { blok } = Astro.props;
+
+// The only way to render a richtext field. Does not compile — see gap 1 above.
+const richtextHtml = blok.richtext ? renderRichText(blok.richtext) : null;
+
+const markdownHtml = blok.markdown ? await marked.parse(blok.markdown) : null;
+
+// Storyblok returns `"YYYY-MM-DD HH:mm"` — a space separator, which the spec's
+// date time string format does not cover, so parsing it is implementation-defined
+// (V8 accepts it, older JavaScriptCore did not). Swapping in `T` makes it a
+// conforming date-time string.
+const formattedDatetime = blok.datetime
+  ? new Date(blok.datetime.replace(' ', 'T')).toLocaleString('en-US', {
+      dateStyle: 'long',
+      timeStyle: 'short',
+    })
+  : null;
+
+const multilinkHref =
+  blok.multilink?.linktype === 'story'
+    ? `/${blok.multilink.cached_url ?? ''}`
+    : blok.multilink?.url ?? undefined;
+---
+
+<section class="px-6 py-16">
+  <div class="mx-auto max-w-4xl">
+    <header class="mb-10 border-b border-gray-200 pb-6">
+      <p class="mb-2 text-sm font-semibold tracking-widest text-indigo-600 uppercase">
+        Kitchen Sink
+      </p>
+      <h2 class="text-3xl font-bold text-balance text-gray-900">{blok.text}</h2>
+      <p class="mt-2 text-sm text-gray-500">
+        One field of every Storyblok field type, each named after its own type.
+      </p>
+    </header>
+
+    <dl class="divide-y divide-gray-200">
+      <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+        <dt class="font-mono text-sm text-gray-500">text</dt>
+        <dd class="text-gray-900">{blok.text}</dd>
+      </div>
+
+      {blok.textarea && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">textarea</dt>
+          <dd class="whitespace-pre-line text-gray-900">{blok.textarea}</dd>
+        </div>
+      )}
+
+      {richtextHtml && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">richtext</dt>
+          <dd class="prose text-gray-900" set:html={richtextHtml} />
+        </div>
+      )}
+
+      {markdownHtml && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">markdown</dt>
+          <dd class="prose text-gray-900" set:html={markdownHtml} />
+        </div>
+      )}
+
+      {blok.number != null && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">number</dt>
+          <dd class="text-gray-900">{blok.number}</dd>
+        </div>
+      )}
+
+      {formattedDatetime && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">datetime</dt>
+          <dd class="text-gray-900">
+            <time datetime={blok.datetime}>{formattedDatetime}</time>
+          </dd>
+        </div>
+      )}
+
+      {blok.boolean != null && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">boolean</dt>
+          <dd class="text-gray-900">{blok.boolean ? 'true' : 'false'}</dd>
+        </div>
+      )}
+
+      {blok.option && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">option</dt>
+          <dd class="text-gray-900">
+            <code class="rounded bg-gray-100 px-2 py-1 text-sm">{blok.option}</code>
+          </dd>
+        </div>
+      )}
+
+      {blok.options && blok.options.length > 0 && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">options</dt>
+          <dd class="flex flex-wrap gap-2">
+            {blok.options.map(value => (
+              <code class="rounded bg-gray-100 px-2 py-1 text-sm text-gray-900">{value}</code>
+            ))}
+          </dd>
+        </div>
+      )}
+
+      {blok.asset?.filename && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">asset</dt>
+          <dd>
+            <img
+              src={blok.asset.filename}
+              alt={blok.asset.alt ?? ''}
+              class="h-auto w-full max-w-sm rounded-lg object-cover shadow-sm"
+              width="600"
+              height="337"
+            />
+          </dd>
+        </div>
+      )}
+
+      {blok.multiasset && blok.multiasset.length > 0 && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">multiasset</dt>
+          <dd class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {blok.multiasset.map(asset => (
+              <img
+                src={asset.filename}
+                alt={asset.alt ?? ''}
+                class="aspect-video w-full rounded-lg object-cover shadow-sm"
+                width="300"
+                height="169"
+              />
+            ))}
+          </dd>
+        </div>
+      )}
+
+      {multilinkHref && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">multilink</dt>
+          <dd>
+            <a
+              href={multilinkHref}
+              target={blok.multilink?.target ?? undefined}
+              class="text-indigo-600 underline hover:text-indigo-800"
+            >
+              {multilinkHref}
+            </a>
+            <span class="ml-2 text-sm text-gray-500">({blok.multilink?.linktype})</span>
+          </dd>
+        </div>
+      )}
+
+      {blok.table && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">table</dt>
+          <dd class="overflow-x-auto">
+            <table class="w-full border-collapse text-left text-sm">
+              <thead>
+                <tr class="border-b border-gray-300">
+                  {blok.table.thead.map(cell => (
+                    <th class="px-3 py-2 font-semibold text-gray-900">{cell.value}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {blok.table.tbody.map(row => (
+                  <tr class="border-b border-gray-200">
+                    {row.body?.map(cell => (
+                      <td class="px-3 py-2 text-gray-600">{cell.value}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </dd>
+        </div>
+      )}
+
+      {blok.bloks && blok.bloks.length > 0 && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">bloks</dt>
+          <dd class="grid gap-4 sm:grid-cols-2">
+            {blok.bloks.map(item => <Teaser blok={item} />)}
+          </dd>
+        </div>
+      )}
+
+      {blok.custom?.color && (
+        <div class="grid gap-2 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6">
+          <dt class="font-mono text-sm text-gray-500">custom</dt>
+          <dd class="flex items-center gap-3">
+            <span
+              class="inline-block h-8 w-8 rounded-full border border-gray-300"
+              style={`background-color: ${blok.custom.color}`}
+            />
+            <code class="text-sm text-gray-900">{blok.custom.color}</code>
+            <span class="text-sm text-gray-500">({blok.custom.plugin})</span>
+          </dd>
+        </div>
+      )}
+
+    </dl>
+  </div>
+</section>

--- a/packages/schema/playground/astro/src/components/storyblok/kitchen-sink.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/kitchen-sink.astro
@@ -87,7 +87,7 @@ interface Props {
 
 const { blok } = Astro.props;
 
-// The only way to render a richtext field. Does not compile — see gap 1 above.
+// richtext type incompatible with renderRichText — see gap 1 above.
 const richtextHtml = blok.richtext ? renderRichText(blok.richtext) : null;
 
 const markdownHtml = blok.markdown ? await marked.parse(blok.markdown) : null;

--- a/packages/schema/playground/astro/src/components/storyblok/storyblok-component.astro
+++ b/packages/schema/playground/astro/src/components/storyblok/storyblok-component.astro
@@ -1,12 +1,13 @@
 ---
 import type { BlockContent } from '@storyblok/schema';
-import type { Blocks } from '../../schema/schema';
+import type { Blocks, FieldPlugins } from '../../schema/schema';
 import Hero from './hero.astro';
 import Intro from './intro.astro';
+import KitchenSink from './kitchen-sink.astro';
 import Media from './media.astro';
 import TeaserList from './teaser-list.astro';
 
-type AnyBlockContent = BlockContent<Blocks, Blocks>;
+type AnyBlockContent = BlockContent<Blocks, Blocks, FieldPlugins>;
 
 interface Props {
   blok: AnyBlockContent;
@@ -22,7 +23,8 @@ const { blok } = Astro.props;
 {blok.component === 'intro' && <Intro blok={blok} />}
 {blok.component === 'media' && <Media blok={blok} />}
 {blok.component === 'teaser_list' && <TeaserList blok={blok} />}
-{!['page', 'hero', 'intro', 'media', 'teaser_list'].includes(blok.component) && import.meta.env.DEV && (
+{blok.component === 'kitchen_sink' && <KitchenSink blok={blok} />}
+{!['page', 'hero', 'intro', 'media', 'teaser_list', 'kitchen_sink'].includes(blok.component) && import.meta.env.DEV && (
   <div class="rounded border border-yellow-400 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
     Unknown component: <code>{blok.component}</code>
     <pre>{JSON.stringify(blok, null, 2)}</pre>

--- a/packages/schema/playground/astro/src/schema/blocks/kitchen-sink.ts
+++ b/packages/schema/playground/astro/src/schema/blocks/kitchen-sink.ts
@@ -1,0 +1,82 @@
+import { defineBlock, defineField } from '@storyblok/schema';
+
+import { markdownField, richtextField } from '../fields';
+import { teaserBlock } from './teaser';
+
+/**
+ * One field of every Storyblok field type, each named after its own type.
+ *
+ * This is a fixture for exercising schema type resolution end to end: the
+ * matching `kitchen-sink.astro` component consumes every field the way an ideal
+ * consumer should be able to, so any gap in `BlockContent` surfaces as a type
+ * error there rather than staying hidden.
+ *
+ * Covers 15 of the 17 field types. The two layout-only types, `tab` and
+ * `section`, are deliberately omitted: they group other fields in the editor and
+ * carry no content value, so every field here maps to a real value in story JSON.
+ */
+export const kitchenSinkBlock = defineBlock({
+  name: 'kitchen_sink',
+  display_name: 'Kitchen Sink',
+  description: 'One field of every Storyblok field type. Fixture for schema type-resolution testing.',
+  is_nestable: true,
+  preview_field: 'text',
+  fields: [
+    // The only required field, so it resolves to a bare `string` rather than
+    // `string | null | undefined` like every other field here.
+    defineField('text', {
+      type: 'text',
+      max_length: 120,
+      translatable: true,
+      required: true,
+    }),
+    defineField('textarea', { type: 'textarea', max_length: 300 }),
+    // Both shared fields are named `body`, so re-stamp them with the type name.
+    defineField('richtext', richtextField),
+    defineField('markdown', markdownField),
+    defineField('number', {
+      type: 'number',
+      min_value: 0,
+      max_value: 10,
+      steps: 1,
+      decimals: 0,
+      default_value: '2',
+    }),
+    defineField('datetime', { type: 'datetime', disable_time: false }),
+    defineField('boolean', {
+      type: 'boolean',
+      inline_label: true,
+      default_value: 'false',
+    }),
+    // Self-sourced: choices live on the field itself, no datasource involved.
+    defineField('option', {
+      type: 'option',
+      options: [
+        { name: 'Alpha', value: 'alpha' },
+        { name: 'Beta', value: 'beta' },
+        { name: 'Gamma', value: 'gamma' },
+      ],
+      default_value: 'alpha',
+    }),
+    defineField('options', {
+      type: 'options',
+      options: [
+        { name: 'One', value: 'one' },
+        { name: 'Two', value: 'two' },
+        { name: 'Three', value: 'three' },
+      ],
+    }),
+    defineField('asset', { type: 'asset', filetypes: ['images'] }),
+    defineField('multiasset', {
+      type: 'multiasset',
+      filetypes: ['images'],
+      maximum_entries: 4,
+    }),
+    defineField('multilink', { type: 'multilink', allow_target_blank: true }),
+    defineField('table', { type: 'table' }),
+    // `allow` makes the narrowing observable: the resolved array should be
+    // exactly the teaser shape, not the whole registry.
+    defineField('bloks', { type: 'bloks', allow: [teaserBlock.name] }),
+    defineField('custom', { type: 'custom', field_type: 'storyblok-colorpicker' }),
+  ],
+});

--- a/packages/schema/playground/astro/src/schema/blocks/page.ts
+++ b/packages/schema/playground/astro/src/schema/blocks/page.ts
@@ -6,6 +6,7 @@ import { faqBlock } from './faq';
 import { galleryBlock } from './gallery';
 import { heroBlock } from './hero';
 import { introBlock } from './intro';
+import { kitchenSinkBlock } from './kitchen-sink';
 import { mediaBlock } from './media';
 import { statsBlock } from './stats';
 import { teaserListBlock } from './teaser-list';
@@ -30,6 +31,7 @@ export const pageBlock = defineBlock({
         faqBlock.name,
         statsBlock.name,
         comparisonTableBlock.name,
+        kitchenSinkBlock.name,
       ],
     }),
   ],

--- a/packages/schema/playground/astro/src/schema/schema.ts
+++ b/packages/schema/playground/astro/src/schema/schema.ts
@@ -9,6 +9,7 @@ import { faqBlock, faqItemBlock } from './blocks/faq';
 import { galleryBlock } from './blocks/gallery';
 import { heroBlock } from './blocks/hero';
 import { introBlock } from './blocks/intro';
+import { kitchenSinkBlock } from './blocks/kitchen-sink';
 import { mediaBlock } from './blocks/media';
 import { statItemBlock, statsBlock } from './blocks/stats';
 import { teaserListBlock } from './blocks/teaser-list';
@@ -32,6 +33,7 @@ export const schema = defineSchema({
     statsBlock,
     statItemBlock,
     comparisonTableBlock,
+    kitchenSinkBlock,
   },
   datasources: {
     bannerThemesDatasource,


### PR DESCRIPTION
## Objective
Add a kitchen_sink block and component to the @storyblok/schema Astro playground using one field of every Storyblok field type as a test fixture for the schema package. This PR is purely to demonstrate bugs, not actually be merged.

Field-type coverage was previously scattered across 14 blocks, with several types never rendered by any component — so nothing forced the resolved types to be checked against a consumer. The component here consumes each field exactly one way, with no workarounds: where that doesn't compile, the type error is left in place as the finding.

## Findings
Three defects surfaced, all documented inline:

1. `richtext` cannot be rendered — @storyblok/schema types don't compose with @storyblok/richtext. This is the one intentional type error on the branch.
2. `number` is typed number but the API requires and returns a string — silently fails tests but it meant the committed showcase and kitchen_sink stories were not pushable.

## Verification
Schema pushed and seeded against a live space; story renders all fields.