### PR TITLE
fix(live-preview): accept any blok type in storyblokEditable

### DIFF
--- a/packages/live-preview/src/editable.test.ts
+++ b/packages/live-preview/src/editable.test.ts
@@ -45,4 +45,24 @@ describe('storyblokEditable', () => {
 
     expect(storyblokEditable(block)).toEqual({});
   });
+
+  it('accepts a blok type that does not declare _editable', () => {
+    // A user-defined blok interface typically has component and _uid but no _editable.
+    // The previous parameter type `{ _editable?: string }` is a weak type (all props
+    // optional). TypeScript's weak-type check (ts(2559)) rejects any argument whose
+    // type shares zero property names with the parameter type — exactly the case here.
+    // Widening the parameter to `unknown` removes the constraint entirely.
+    interface FeatureBlok {
+      headline?: string;
+      component: 'feature';
+      _uid: string;
+    }
+
+    const blok: FeatureBlok = { component: 'feature', _uid: 'test-uid' };
+
+    // Must compile without @ts-expect-error.
+    const result = storyblokEditable(blok);
+
+    expect(result).toEqual({});
+  });
 });

--- a/packages/live-preview/src/editable.ts
+++ b/packages/live-preview/src/editable.ts
@@ -3,8 +3,13 @@ interface EditableOptions {
   uid: string;
 }
 
-export default function storyblokEditable(block?: { _editable?: string }) {
-  const editable = block?._editable;
+export default function storyblokEditable(block?: unknown) {
+  if (typeof block !== 'object' || block === null) {
+    return {};
+  }
+
+  const editable = (block as Record<string, unknown>)._editable;
+
   if (typeof editable !== 'string' || !editable) {
     return {};
   }


### PR DESCRIPTION
## Problem

`storyblokEditable` was typed as:

```ts
function storyblokEditable(block?: { _editable?: string })
```

`{ _editable?: string }` is a **weak type** — all properties are optional. TypeScript's weak-type check ([ts(2559)](https://www.typescriptlang.org/tsconfig#strict)) rejects any argument whose declared type shares **zero property names** with the parameter type.

User-defined blok interfaces like:

```ts
interface FeatureBlok {
  headline?: string;
  component: 'feature';
  _uid: string;
}

declare const blok: FeatureBlok;
storyblokEditable(blok); // ❌ ts(2559): Type 'FeatureBlok' has no properties in common with type '{ _editable?: string | undefined; }'
```

have no property named `_editable`, so TypeScript refused the call even though the function handles the absent field gracefully at runtime (returning `{}`).

## Why not `Record<string, unknown>` or `{ [key: string]: unknown }`?

Both require the argument type to carry an index signature. Interfaces without one (the common case for user blok types) produce the same error in a different form: ts(2345) `Index signature for type 'string' is missing in type 'FeatureBlok'`.

## Fix

Widen the parameter to `unknown`:

```ts
function storyblokEditable(block?: unknown)
```

The function already defensively narrows the value at runtime (`typeof block !== 'object'`, `typeof editable !== 'string'`), so no structural constraint should be imposed on the caller. `unknown` is the honest type: accept anything, prove safety internally.

## Testing

- Existing 5 tests preserved and passing
- Added type-level test: passes a `FeatureBlok` (no `_editable` in type) without `@ts-expect-error` — verified by `tsc --noEmit` which includes test files in this package

Fixes DX-519