### PR TITLE
fix(js): accept any blok type in storyblokEditable

### DIFF
--- a/packages/js/src/editable.ts
+++ b/packages/js/src/editable.ts
@@ -1,11 +1,17 @@
-export default (blok?: { _editable?: string }) => {
-  if (typeof blok !== 'object' || typeof blok._editable !== 'string') {
+export default (blok?: unknown) => {
+  if (typeof blok !== 'object' || blok === null) {
+    return {};
+  }
+
+  const _editable = (blok as Record<string, unknown>)._editable;
+
+  if (typeof _editable !== 'string') {
     return {};
   }
 
   try {
     const options = JSON.parse(
-      blok._editable.replace(/^<!--#storyblok#/, '').replace(/-->$/, ''),
+      _editable.replace(/^<!--#storyblok#/, '').replace(/-->$/, ''),
     );
 
     if (options) {

--- a/packages/js/src/index.test.ts
+++ b/packages/js/src/index.test.ts
@@ -279,6 +279,50 @@ describe('@storyblok/js', () => {
       expect(editableResult['data-blok-uid']).toBeDefined();
       expect(fetchSpy).toHaveBeenCalled();
     });
+
+    it('accepts a blok type that does not declare _editable', () => {
+      // FeatureStoryblok has no _editable and shares no property names with
+      // { _editable?: string }, which would trigger ts(2559) (weak type check).
+      // The parameter type `unknown` accepts any value, resolving this entirely.
+      interface FeatureStoryblok {
+        headline?: string;
+        component: 'feature';
+        _uid: string;
+      }
+
+      const blok: FeatureStoryblok = { component: 'feature', _uid: 'test-uid' };
+
+      // No @ts-expect-error needed — this must compile cleanly.
+      const result = storyblokEditable(blok);
+
+      // No _editable at runtime → returns empty object, no throw.
+      expect(result).toEqual({});
+    });
+
+    it('returns {} when blok has no _editable at runtime', () => {
+      expect(storyblokEditable({ component: 'feature', _uid: 'test-uid' })).toEqual({});
+    });
+
+    it('returns data attributes when _editable is present at runtime even if not in the declared type', () => {
+      interface FeatureStoryblok {
+        headline?: string;
+        component: 'feature';
+        _uid: string;
+      }
+
+      // _editable exists at runtime but is not declared on FeatureStoryblok.
+      // Cast through intersection so TypeScript knows the value is valid.
+      const blok = {
+        component: 'feature' as const,
+        _uid: 'test-uid',
+        _editable: '<!--#storyblok#{"id":"999","uid":"abc-123"}-->',
+      } satisfies FeatureStoryblok & { _editable: string };
+
+      const result = storyblokEditable(blok);
+
+      expect(result['data-blok-c']).toBe(JSON.stringify({ id: '999', uid: 'abc-123' }));
+      expect(result['data-blok-uid']).toBe('999-abc-123');
+    });
   });
 
   describe('rich text', () => {

--- a/packages/js/tsconfig.test.json
+++ b/packages/js/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.cy.ts"]
+}


### PR DESCRIPTION
## Problem

`storyblokEditable` was typed as:

```ts
(blok?: { _editable?: string }) => ...
```

`{ _editable?: string }` is a **weak type** — all properties are optional. TypeScript's weak-type check ([ts(2559)](https://www.typescriptlang.org/tsconfig#strict)) rejects any argument whose declared type shares **zero property names** with the parameter type.

User-defined blok interfaces like:

```ts
interface FeatureBlok {
  headline?: string;
  component: 'feature';
  _uid: string;
}

declare const blok: FeatureBlok;
storyblokEditable(blok); // ❌ ts(2559): Type 'FeatureBlok' has no properties in common with type '{ _editable?: string | undefined; }'
```

have no property named `_editable`, so TypeScript refused the call even though the function handles the absent field gracefully at runtime (returning `{}`).

## Why not `Record<string, unknown>` or `{ [key: string]: unknown }`?

Both require the argument type to carry an index signature. Interfaces without one (the common case for user blok types) produce the same error in a different form: ts(2345) `Index signature for type 'string' is missing in type 'FeatureBlok'`.

## Fix

Widen the parameter to `unknown`:

```ts
(blok?: unknown) => ...
```

The function already defensively narrows the value at runtime (`typeof blok !== 'object'`, `typeof _editable !== 'string'`), so no structural constraint should be imposed on the caller. `unknown` is the honest type: accept anything, prove safety internally.

## Testing

- Existing test preserved and passing
- 3 new tests added: type-level assertion (no `@ts-expect-error`), runtime `{}` when `_editable` absent, runtime data attributes when `_editable` present on a typed blok
- Added `tsconfig.test.json` — the main tsconfig explicitly excludes `*.test.ts`, so type-level assertions in tests were never verified. The new config extends the base but re-includes test files, enabling `tsc --noEmit --project tsconfig.test.json`

Fixes DX-519
Fixes #711