### PR TITLE
fix(cli): add `_editable` field to generated component interfaces

### DIFF
--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -404,6 +404,9 @@ export const generateTypes = async (
           _uid: {
             type: 'string',
           },
+          _editable: {
+            tsType: 'string | undefined',
+          },
         },
       };
 


### PR DESCRIPTION
## What

Add `_editable?: string | undefined` to every component interface generated by `storyblok types generate`.

## Why

The Storyblok visual editor injects `_editable` onto story data at runtime, but it was missing from the generated TypeScript interfaces, causing type errors when consuming the field.

## Changes

- `packages/cli/src/commands/types/generate/actions.ts`: Added `_editable` property (via `tsType: 'string | undefined'`) to the component JSON schema so `json-schema-to-typescript` emits `_editable?: string | undefined` on every generated interface.

Fixes DX-519
Fixes #711