### PR TITLE
fix(schema): type field default_value per field type

### DIFF
--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -25,6 +25,10 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'text';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Maximum length of the input string
      */
     max_length?: number;
@@ -51,6 +55,10 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'textarea';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Maximum length of the input string
      */
@@ -86,6 +94,10 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'richtext';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Whether to allow toolbar customization
      */
@@ -150,6 +162,10 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'markdown';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to display markdown as rich text
      */
     rich_markdown?: boolean;
@@ -181,6 +197,10 @@ export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'number';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Minimum value allowed
      */
     min_value?: number;
@@ -204,6 +224,10 @@ export type DatetimeFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'datetime';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to disable time selection (date-only mode)
      */
     disable_time?: boolean;
@@ -215,6 +239,10 @@ export type BooleanFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'boolean';
     /**
+     * Default value for the field
+     */
+    default_value?: boolean;
+    /**
      * Whether to display the label next to the toggle
      */
     inline_label?: boolean;
@@ -225,6 +253,10 @@ export type OptionFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'option';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Array of selectable options
      */
@@ -293,6 +325,12 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'options';
     /**
+     * Default value for the field: either a space-separated list of option
+     * values or the array of values itself.
+     *
+     */
+    default_value?: string | Array<string>;
+    /**
      * Array of selectable options
      */
     options?: Array<{
@@ -356,6 +394,10 @@ export type AssetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'asset';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Allowed file types (images, videos, audios, texts)
      */
     filetypes?: Array<string>;
@@ -390,6 +432,10 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'multiasset';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Allowed file types (images, videos, audios, texts)
      */
@@ -434,6 +480,10 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'multilink';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to restrict linkable content types
      */
     restrict_content_types?: boolean;
@@ -476,6 +526,14 @@ export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'bloks';
+    /**
+     * Default value for the field: either a JSON-encoded array of blocks or
+     * the array itself.
+     *
+     */
+    default_value?: string | Array<{
+        [key: string]: unknown;
+    }>;
     /**
      * Restriction type for component selection (groups, tags, or empty for specific blocks)
      */
@@ -531,6 +589,10 @@ export type TableFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'table';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
 };
 
 export type SectionFieldRoot = BaseFieldRoot & {
@@ -581,6 +643,10 @@ export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'custom';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Technical name of the field plugin
      */
@@ -840,6 +906,11 @@ export type BaseFieldRoot = {
  * Properties shared by content-bearing fields (i.e. fields that hold a value).
  * Layout-only field types like `section` and `tab` do not include these.
  *
+ * `default_value` is deliberately NOT here: its type depends on the field type
+ * (boolean fields hold a real boolean, bloks/options also accept an array), and
+ * these properties are merged via `allOf`, so a per-field-type override would
+ * intersect into `never` instead of replacing. Each field type declares its own.
+ *
  */
 export type ValueFieldRoot = {
     /**
@@ -850,10 +921,6 @@ export type ValueFieldRoot = {
      * Regular expression for validation
      */
     regex?: string;
-    /**
-     * Default value for the field (can be escaped JSON)
-     */
-    default_value?: string;
     /**
      * Whether the field is translatable
      */

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -25,6 +25,10 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'text';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Maximum length of the input string
      */
     max_length?: number;
@@ -51,6 +55,10 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'textarea';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Maximum length of the input string
      */
@@ -86,6 +94,10 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'richtext';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Whether to allow toolbar customization
      */
@@ -150,6 +162,10 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'markdown';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to display markdown as rich text
      */
     rich_markdown?: boolean;
@@ -181,6 +197,10 @@ export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'number';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Minimum value allowed
      */
     min_value?: number;
@@ -204,6 +224,10 @@ export type DatetimeFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'datetime';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to disable time selection (date-only mode)
      */
     disable_time?: boolean;
@@ -215,6 +239,10 @@ export type BooleanFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'boolean';
     /**
+     * Default value for the field
+     */
+    default_value?: boolean;
+    /**
      * Whether to display the label next to the toggle
      */
     inline_label?: boolean;
@@ -225,6 +253,10 @@ export type OptionFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'option';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Array of selectable options
      */
@@ -293,6 +325,12 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'options';
     /**
+     * Default value for the field: either a space-separated list of option
+     * values or the array of values itself.
+     *
+     */
+    default_value?: string | Array<string>;
+    /**
      * Array of selectable options
      */
     options?: Array<{
@@ -356,6 +394,10 @@ export type AssetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'asset';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Allowed file types (images, videos, audios, texts)
      */
     filetypes?: Array<string>;
@@ -390,6 +432,10 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'multiasset';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Allowed file types (images, videos, audios, texts)
      */
@@ -434,6 +480,10 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'multilink';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to restrict linkable content types
      */
     restrict_content_types?: boolean;
@@ -476,6 +526,14 @@ export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'bloks';
+    /**
+     * Default value for the field: either a JSON-encoded array of blocks or
+     * the array itself.
+     *
+     */
+    default_value?: string | Array<{
+        [key: string]: unknown;
+    }>;
     /**
      * Restriction type for component selection (groups, tags, or empty for specific blocks)
      */
@@ -531,6 +589,10 @@ export type TableFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'table';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
 };
 
 export type SectionFieldRoot = BaseFieldRoot & {
@@ -581,6 +643,10 @@ export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'custom';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Technical name of the field plugin
      */
@@ -840,6 +906,11 @@ export type BaseFieldRoot = {
  * Properties shared by content-bearing fields (i.e. fields that hold a value).
  * Layout-only field types like `section` and `tab` do not include these.
  *
+ * `default_value` is deliberately NOT here: its type depends on the field type
+ * (boolean fields hold a real boolean, bloks/options also accept an array), and
+ * these properties are merged via `allOf`, so a per-field-type override would
+ * intersect into `never` instead of replacing. Each field type declares its own.
+ *
  */
 export type ValueFieldRoot = {
     /**
@@ -850,10 +921,6 @@ export type ValueFieldRoot = {
      * Regular expression for validation
      */
     regex?: string;
-    /**
-     * Default value for the field (can be escaped JSON)
-     */
-    default_value?: string;
     /**
      * Whether the field is translatable
      */

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -25,6 +25,10 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'text';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Maximum length of the input string
      */
     max_length?: number;
@@ -51,6 +55,10 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'textarea';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Maximum length of the input string
      */
@@ -86,6 +94,10 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'richtext';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Whether to allow toolbar customization
      */
@@ -150,6 +162,10 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'markdown';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to display markdown as rich text
      */
     rich_markdown?: boolean;
@@ -181,6 +197,10 @@ export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'number';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Minimum value allowed
      */
     min_value?: number;
@@ -204,6 +224,10 @@ export type DatetimeFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'datetime';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to disable time selection (date-only mode)
      */
     disable_time?: boolean;
@@ -215,6 +239,10 @@ export type BooleanFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'boolean';
     /**
+     * Default value for the field
+     */
+    default_value?: boolean;
+    /**
      * Whether to display the label next to the toggle
      */
     inline_label?: boolean;
@@ -225,6 +253,10 @@ export type OptionFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'option';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Array of selectable options
      */
@@ -293,6 +325,12 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'options';
     /**
+     * Default value for the field: either a space-separated list of option
+     * values or the array of values itself.
+     *
+     */
+    default_value?: string | Array<string>;
+    /**
      * Array of selectable options
      */
     options?: Array<{
@@ -356,6 +394,10 @@ export type AssetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'asset';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Allowed file types (images, videos, audios, texts)
      */
     filetypes?: Array<string>;
@@ -390,6 +432,10 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'multiasset';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Allowed file types (images, videos, audios, texts)
      */
@@ -434,6 +480,10 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'multilink';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to restrict linkable content types
      */
     restrict_content_types?: boolean;
@@ -476,6 +526,14 @@ export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'bloks';
+    /**
+     * Default value for the field: either a JSON-encoded array of blocks or
+     * the array itself.
+     *
+     */
+    default_value?: string | Array<{
+        [key: string]: unknown;
+    }>;
     /**
      * Restriction type for component selection (groups, tags, or empty for specific blocks)
      */
@@ -531,6 +589,10 @@ export type TableFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'table';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
 };
 
 export type SectionFieldRoot = BaseFieldRoot & {
@@ -581,6 +643,10 @@ export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'custom';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Technical name of the field plugin
      */
@@ -840,6 +906,11 @@ export type BaseFieldRoot = {
  * Properties shared by content-bearing fields (i.e. fields that hold a value).
  * Layout-only field types like `section` and `tab` do not include these.
  *
+ * `default_value` is deliberately NOT here: its type depends on the field type
+ * (boolean fields hold a real boolean, bloks/options also accept an array), and
+ * these properties are merged via `allOf`, so a per-field-type override would
+ * intersect into `never` instead of replacing. Each field type declares its own.
+ *
  */
 export type ValueFieldRoot = {
     /**
@@ -850,10 +921,6 @@ export type ValueFieldRoot = {
      * Regular expression for validation
      */
     regex?: string;
-    /**
-     * Default value for the field (can be escaped JSON)
-     */
-    default_value?: string;
     /**
      * Whether the field is translatable
      */

--- a/packages/schema/playground/astro/src/schema/blocks/article.ts
+++ b/packages/schema/playground/astro/src/schema/blocks/article.ts
@@ -33,7 +33,7 @@ export const articleBlock = defineBlock({
     defineField('featured', {
       type: 'boolean',
       inline_label: true,
-      default_value: 'false',
+      default_value: false,
     }),
     defineField('slug_override', {
       type: 'text',

--- a/packages/schema/playground/astro/src/schema/blocks/gallery.ts
+++ b/packages/schema/playground/astro/src/schema/blocks/gallery.ts
@@ -25,7 +25,7 @@ export const galleryBlock = defineBlock({
     defineField('show_captions', {
       type: 'boolean',
       inline_label: true,
-      default_value: 'true',
+      default_value: true,
     }),
   ],
 });

--- a/packages/schema/playground/vanilla/base/blocks/kitchen-sink.ts
+++ b/packages/schema/playground/vanilla/base/blocks/kitchen-sink.ts
@@ -19,7 +19,7 @@ export const kitchenSinkBlock = defineBlock({
       toolbar: ['bold', 'italic', 'code'],
     }),
     defineField('number_field', { type: 'number', min_value: 0, max_value: 9999, decimals: 2, steps: 0.01 }),
-    defineField('boolean_field', { type: 'boolean', inline_label: true, default_value: 'false' }),
+    defineField('boolean_field', { type: 'boolean', inline_label: true, default_value: false }),
     defineField('datetime_field', { type: 'datetime' }),
     defineField('asset_field', { type: 'asset', filetypes: ['images'] }),
     defineField('multiasset_field', { type: 'multiasset', filetypes: ['images', 'videos'] }),

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -25,6 +25,10 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'text';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Maximum length of the input string
      */
     max_length?: number;
@@ -51,6 +55,10 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'textarea';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Maximum length of the input string
      */
@@ -86,6 +94,10 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'richtext';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Whether to allow toolbar customization
      */
@@ -150,6 +162,10 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'markdown';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to display markdown as rich text
      */
     rich_markdown?: boolean;
@@ -181,6 +197,10 @@ export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'number';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Minimum value allowed
      */
     min_value?: number;
@@ -204,6 +224,10 @@ export type DatetimeFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'datetime';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to disable time selection (date-only mode)
      */
     disable_time?: boolean;
@@ -215,6 +239,10 @@ export type BooleanFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'boolean';
     /**
+     * Default value for the field
+     */
+    default_value?: boolean;
+    /**
      * Whether to display the label next to the toggle
      */
     inline_label?: boolean;
@@ -225,6 +253,10 @@ export type OptionFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'option';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Array of selectable options
      */
@@ -293,6 +325,12 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'options';
     /**
+     * Default value for the field: either a space-separated list of option
+     * values or the array of values itself.
+     *
+     */
+    default_value?: string | Array<string>;
+    /**
      * Array of selectable options
      */
     options?: Array<{
@@ -356,6 +394,10 @@ export type AssetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'asset';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Allowed file types (images, videos, audios, texts)
      */
     filetypes?: Array<string>;
@@ -390,6 +432,10 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'multiasset';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Allowed file types (images, videos, audios, texts)
      */
@@ -434,6 +480,10 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     type: 'multilink';
     /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
      * Whether to restrict linkable content types
      */
     restrict_content_types?: boolean;
@@ -476,6 +526,14 @@ export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'bloks';
+    /**
+     * Default value for the field: either a JSON-encoded array of blocks or
+     * the array itself.
+     *
+     */
+    default_value?: string | Array<{
+        [key: string]: unknown;
+    }>;
     /**
      * Restriction type for component selection (groups, tags, or empty for specific blocks)
      */
@@ -531,6 +589,10 @@ export type TableFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'table';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
 };
 
 export type SectionFieldRoot = BaseFieldRoot & {
@@ -581,6 +643,10 @@ export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Field type discriminant
      */
     type: 'custom';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
     /**
      * Technical name of the field plugin
      */
@@ -840,6 +906,11 @@ export type BaseFieldRoot = {
  * Properties shared by content-bearing fields (i.e. fields that hold a value).
  * Layout-only field types like `section` and `tab` do not include these.
  *
+ * `default_value` is deliberately NOT here: its type depends on the field type
+ * (boolean fields hold a real boolean, bloks/options also accept an array), and
+ * these properties are merged via `allOf`, so a per-field-type override would
+ * intersect into `never` instead of replacing. Each field type declares its own.
+ *
  */
 export type ValueFieldRoot = {
     /**
@@ -850,10 +921,6 @@ export type ValueFieldRoot = {
      * Regular expression for validation
      */
     regex?: string;
-    /**
-     * Default value for the field (can be escaped JSON)
-     */
-    default_value?: string;
     /**
      * Whether the field is translatable
      */

--- a/packages/schema/src/generated/overlay/zod.gen.ts
+++ b/packages/schema/src/generated/overlay/zod.gen.ts
@@ -38,11 +38,15 @@ export const zTabFieldRoot = zBaseFieldRoot.and(z.object({
  * Properties shared by content-bearing fields (i.e. fields that hold a value).
  * Layout-only field types like `section` and `tab` do not include these.
  *
+ * `default_value` is deliberately NOT here: its type depends on the field type
+ * (boolean fields hold a real boolean, bloks/options also accept an array), and
+ * these properties are merged via `allOf`, so a per-field-type override would
+ * intersect into `never` instead of replacing. Each field type declares its own.
+ *
  */
 export const zValueFieldRoot = z.object({
     required: z.optional(z.boolean()),
     regex: z.optional(z.string()),
-    default_value: z.optional(z.string()),
     translatable: z.optional(z.boolean()),
     no_translate: z.optional(z.boolean()),
     exclude_from_ai_translation: z.optional(z.boolean()),
@@ -53,6 +57,7 @@ export const zValueFieldRoot = z.object({
 
 export const zAssetFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['asset']),
+    default_value: z.optional(z.string()),
     filetypes: z.optional(z.array(z.string())),
     asset_folder_id: z.optional(z.int()),
     allow_external_url: z.optional(z.boolean()),
@@ -64,6 +69,10 @@ export const zAssetFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object(
 
 export const zBloksFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['bloks']),
+    default_value: z.optional(z.union([
+        z.string(),
+        z.array(z.record(z.string(), z.unknown()))
+    ])),
     restrict_type: z.optional(z.string()),
     restrict_components: z.optional(z.boolean()),
     component_whitelist: z.optional(z.array(z.string())),
@@ -80,11 +89,13 @@ export const zBloksFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object(
 
 export const zBooleanFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['boolean']),
+    default_value: z.optional(z.boolean()),
     inline_label: z.optional(z.boolean())
 }));
 
 export const zCustomFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['custom']),
+    default_value: z.optional(z.string()),
     field_type: z.optional(z.string()),
     options: z.optional(z.array(z.object({
         name: z.optional(z.string()),
@@ -98,11 +109,13 @@ export const zCustomFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object
 
 export const zDatetimeFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['datetime']),
+    default_value: z.optional(z.string()),
     disable_time: z.optional(z.boolean())
 }));
 
 export const zMarkdownFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['markdown']),
+    default_value: z.optional(z.string()),
     rich_markdown: z.optional(z.boolean()),
     rtl: z.optional(z.boolean()),
     customize_toolbar: z.optional(z.boolean()),
@@ -136,6 +149,7 @@ export const zMarkdownFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.obje
 
 export const zMultiassetFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['multiasset']),
+    default_value: z.optional(z.string()),
     filetypes: z.optional(z.array(z.string())),
     asset_folder_id: z.optional(z.int()),
     allow_external_url: z.optional(z.boolean()),
@@ -149,6 +163,7 @@ export const zMultiassetFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.ob
 
 export const zMultilinkFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['multilink']),
+    default_value: z.optional(z.string()),
     restrict_content_types: z.optional(z.boolean()),
     component_whitelist: z.optional(z.array(z.string())),
     allow_target_blank: z.optional(z.boolean()),
@@ -162,6 +177,7 @@ export const zMultilinkFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.obj
 
 export const zNumberFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['number']),
+    default_value: z.optional(z.string()),
     min_value: z.optional(z.number()),
     max_value: z.optional(z.number()),
     decimals: z.optional(z.int()),
@@ -170,6 +186,7 @@ export const zNumberFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object
 
 export const zOptionFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['option']),
+    default_value: z.optional(z.string()),
     options: z.optional(z.array(z.object({
         _uid: z.optional(z.string()),
         name: z.optional(z.string()),
@@ -192,6 +209,10 @@ export const zOptionFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object
 
 export const zOptionsFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['options']),
+    default_value: z.optional(z.union([
+        z.string(),
+        z.array(z.string())
+    ])),
     options: z.optional(z.array(z.object({
         _uid: z.optional(z.string()),
         name: z.optional(z.string()),
@@ -213,6 +234,7 @@ export const zOptionsFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.objec
 
 export const zRichtextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['richtext']),
+    default_value: z.optional(z.string()),
     customize_toolbar: z.optional(z.boolean()),
     toolbar: z.optional(z.array(z.enum([
         'ai-complete',
@@ -286,11 +308,13 @@ export const zRichtextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.obje
 }));
 
 export const zTableFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
-    type: z.enum(['table'])
+    type: z.enum(['table']),
+    default_value: z.optional(z.string())
 }));
 
 export const zTextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['text']),
+    default_value: z.optional(z.string()),
     max_length: z.optional(z.int()),
     maxlength: z.optional(z.int()),
     minlength: z.optional(z.int()),
@@ -300,6 +324,7 @@ export const zTextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
 
 export const zTextareaFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['textarea']),
+    default_value: z.optional(z.string()),
     max_length: z.optional(z.int()),
     maxlength: z.optional(z.int()),
     minlength: z.optional(z.int()),

--- a/packages/schema/src/helpers/define-field.test-d.ts
+++ b/packages/schema/src/helpers/define-field.test-d.ts
@@ -90,6 +90,31 @@ describe('defineField type inference', () => {
     expectTypeOf<Body[number]['component']>().toEqualTypeOf<'post'>();
   });
 
+  it('should type `default_value` per field type', () => {
+    const bool = defineField('default_open', { type: 'boolean', default_value: false });
+    expectTypeOf(bool.default_value).toEqualTypeOf<false>();
+
+    const text = defineField('title', { type: 'text', default_value: 'Hello' });
+    expectTypeOf(text.default_value).toEqualTypeOf<'Hello'>();
+
+    // Numbers are stored as strings, matching what the editor writes.
+    const num = defineField('count', { type: 'number', default_value: '42' });
+    expectTypeOf(num.default_value).toEqualTypeOf<'42'>();
+
+    // Bloks and options accept either the JSON-encoded value or the array.
+    const bloks = defineField('body', { type: 'bloks', default_value: [{ component: 'hero' }] });
+    expectTypeOf(bloks.default_value[0].component).toEqualTypeOf<'hero'>();
+    const options = defineField('tags', { type: 'options', default_value: 'a b' });
+    expectTypeOf(options.default_value).toEqualTypeOf<'a b'>();
+  });
+
+  it('should reject `default_value` values that do not match the field type', () => {
+    // @ts-expect-error boolean fields take a boolean, not a string
+    void defineField('default_open', { type: 'boolean', default_value: 'false' });
+    // @ts-expect-error text fields take a string, not a boolean
+    void defineField('title', { type: 'text', default_value: false });
+  });
+
   it('should not include `allow` when not provided on a bloks field', () => {
     const f = defineField('body', { type: 'bloks' });
     expectTypeOf(f.type).toEqualTypeOf<'bloks'>();

--- a/tools/openapi-codegen/specs/mapi/components/field-types/asset-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/asset-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [asset]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       filetypes:
         type: array
         description: Allowed file types (images, videos, audios, texts)

--- a/tools/openapi-codegen/specs/mapi/components/field-types/bloks-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/bloks-field.yaml
@@ -10,6 +10,16 @@ allOf:
         type: string
         enum: [bloks]
         description: Field type discriminant
+      default_value:
+        description: |
+          Default value for the field: either a JSON-encoded array of blocks or
+          the array itself.
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: object
+              additionalProperties: true
       restrict_type:
         type: string
         description: Restriction type for component selection (groups, tags, or empty for specific blocks)

--- a/tools/openapi-codegen/specs/mapi/components/field-types/boolean-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/boolean-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [boolean]
         description: Field type discriminant
+      default_value:
+        type: boolean
+        description: Default value for the field
       inline_label:
         type: boolean
         description: Whether to display the label next to the toggle

--- a/tools/openapi-codegen/specs/mapi/components/field-types/custom-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/custom-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [custom]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       field_type:
         type: string
         description: Technical name of the field plugin

--- a/tools/openapi-codegen/specs/mapi/components/field-types/datetime-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/datetime-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [datetime]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       disable_time:
         type: boolean
         description: Whether to disable time selection (date-only mode)

--- a/tools/openapi-codegen/specs/mapi/components/field-types/markdown-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/markdown-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [markdown]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       rich_markdown:
         type: boolean
         description: Whether to display markdown as rich text

--- a/tools/openapi-codegen/specs/mapi/components/field-types/multiasset-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/multiasset-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [multiasset]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       filetypes:
         type: array
         description: Allowed file types (images, videos, audios, texts)

--- a/tools/openapi-codegen/specs/mapi/components/field-types/multilink-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/multilink-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [multilink]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       restrict_content_types:
         type: boolean
         description: Whether to restrict linkable content types

--- a/tools/openapi-codegen/specs/mapi/components/field-types/number-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/number-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [number]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       min_value:
         type: number
         description: Minimum value allowed

--- a/tools/openapi-codegen/specs/mapi/components/field-types/option-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/option-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [option]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       options:
         type: array
         description: Array of selectable options

--- a/tools/openapi-codegen/specs/mapi/components/field-types/options-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/options-field.yaml
@@ -10,6 +10,15 @@ allOf:
         type: string
         enum: [options]
         description: Field type discriminant
+      default_value:
+        description: |
+          Default value for the field: either a space-separated list of option
+          values or the array of values itself.
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
       options:
         type: array
         description: Array of selectable options

--- a/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [richtext]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       customize_toolbar:
         type: boolean
         description: Whether to allow toolbar customization

--- a/tools/openapi-codegen/specs/mapi/components/field-types/table-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/table-field.yaml
@@ -10,3 +10,6 @@ allOf:
         type: string
         enum: [table]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field

--- a/tools/openapi-codegen/specs/mapi/components/field-types/text-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/text-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [text]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       max_length:
         type: integer
         description: Maximum length of the input string

--- a/tools/openapi-codegen/specs/mapi/components/field-types/textarea-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/textarea-field.yaml
@@ -10,6 +10,9 @@ allOf:
         type: string
         enum: [textarea]
         description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
       max_length:
         type: integer
         description: Maximum length of the input string

--- a/tools/openapi-codegen/specs/mapi/components/field-types/value-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/value-field.yaml
@@ -2,6 +2,11 @@ type: object
 description: |
   Properties shared by content-bearing fields (i.e. fields that hold a value).
   Layout-only field types like `section` and `tab` do not include these.
+
+  `default_value` is deliberately NOT here: its type depends on the field type
+  (boolean fields hold a real boolean, bloks/options also accept an array), and
+  these properties are merged via `allOf`, so a per-field-type override would
+  intersect into `never` instead of replacing. Each field type declares its own.
 properties:
   required:
     type: boolean
@@ -9,9 +14,6 @@ properties:
   regex:
     type: string
     description: Regular expression for validation
-  default_value:
-    type: string
-    description: Default value for the field (can be escaped JSON)
   translatable:
     type: boolean
     description: Whether the field is translatable


### PR DESCRIPTION
`default_value` was declared once on the shared `value-field` spec fragment as `string`, so every field type inherited a `string`-only default. Reported by @diegoscholz:

```ts
defineField('default_open', {
  type: 'boolean',
  default_value: false, // Type 'boolean' is not assignable to type 'string'. ts(2322)
})
```

This also breaks code that `storyblok schema init` itself scaffolds — the serializer emits booleans unquoted, so bootstrapping a space with a boolean field that has a default produces code that doesn't compile.

## What the real type is

Verified against MAPI and the app:

- **Backend** (`storyrails`): the component `schema` is a free-form JSON blob. No validation, no coercion — `false`, `true` and `"true"` all round-trip verbatim (confirmed against a live space).
- **App** (`storyfront`): the boolean schema editor is a toggle emitting a real boolean, and default application does a strict identity check — `if (schema.default_value === true)`. So `default_value: "true"` silently behaves as `false`; a string is actively wrong for booleans.
- `bloks` / `options` accept either the encoded string (JSON for bloks, space-separated for options) or the array itself.
- Everything else is a string, including `number` (the editor writes a text field; `FieldTypeNumber` parses it).

## Change

Moves `default_value` off `value-field.yaml` onto each field type:

| Field type | `default_value` |
| --- | --- |
| `boolean` | `boolean` |
| `bloks` | `string \| Array<object>` |
| `options` | `string \| Array<string>` |
| all other value fields | `string` |

An override left in place on the field type wouldn't work: the fragments merge via `allOf`, so `string` + `boolean` intersects to `never`. The removal is documented in `value-field.yaml` so it doesn't get re-added.

Regenerated the four consumers (`@storyblok/schema`, `@storyblok/api-client`, `@storyblok/management-api-client`, `@storyblok/live-preview`).

Fixes DX-527