### PR TITLE
feat(schema,cli): redact plugin option secrets in schema commands

### DIFF
--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -34,6 +34,9 @@ npm install storyblok@<version>
 | [`migrations generate`](./commands/migrations/generate/README.md) | ✅ | Replaces previous generate-migrations |
 | [`migrations run`](./commands/migrations/run/README.md) | ✅ | Replaces previous run-migrations |
 | [`migrations rollback`](./commands/migrations/rollback/README.md) | ✅ | Replaces previous rollback-migrations |
+| [`schema init`](./commands/schema/README.md) | ✅ | Bootstrap local code-driven schema from a space. Redacts plugin option secrets to `secret()` |
+| [`schema push`](./commands/schema/README.md#secret-handling) | ✅ | Apply local schema changes to a space. Restores redacted secrets from the space or `process.env` |
+| [`schema rollback`](./commands/schema/README.md#secret-handling) | ✅ | Revert a previous `schema push` |
 | [`types generate`](./commands/types/generate/README.md) | ✅ | Replaces previous generate-typescript-typedefs |
 | [`signup`](./commands/signup/README.md) | ✅ | Opens the Storyblok signup page in your browser |
 | `sync` | ⚠️ | Pending new API endpoint implementation for improved performance and reliability (Check below for more details) |

--- a/packages/cli/src/commands/schema/README.md
+++ b/packages/cli/src/commands/schema/README.md
@@ -1,113 +1,29 @@
 # Schema Command
 
-The `schema` command lets you manage a space's content model as versioned code. `storyblok schema init` bootstraps local TypeScript definitions from an existing space, `storyblok schema push` applies your local changes back to the space, and `storyblok schema rollback` reverts a previous push.
+Manage a space's content model as versioned code.
 
-## Secret handling
+## Subcommands
 
-Some custom field plugins, for example the Shopware integration, store credentials inside a field's `options` array as `{ name, value }` pairs. To keep those values out of your Git repository, `schema init` redacts them and `schema push` restores them at push time. A secret is identified only by the option `name`, never by the plugin's `field_type` (which the plugin developer chooses freely).
+- `schema init` — bootstrap local TypeScript definitions from an existing space.
+- `schema push` — apply local schema and datasource definitions to a space.
+- `schema rollback` — revert a previous `schema push`.
 
-### Default secret names
-
-By default, init redacts the `value` of any plugin option whose `name` matches one of the following, case-insensitively:
-
-- `accessKey`
-- `apiKey`
-- `apiToken`
-- `token`
-- `secret`
-- `clientSecret`
-- `password`
-- `privateKey`
-
-### How init redacts
-
-Each matching value is replaced with a `secret()` placeholder imported from `@storyblok/schema`, so the real value never reaches the generated file. Given a Shopware field, `storyblok schema init --space 12345` produces:
-
-```ts
-// .storyblok/schema/blocks/product.ts
-import { defineBlock, defineField, secret } from '@storyblok/schema';
-
-export const productBlock = defineBlock({
-  name: 'product',
-  fields: [
-    defineField('products', {
-      type: 'custom',
-      field_type: 'shopware-integration',
-      datasource: 'shopware',
-      required: true,
-      options: [
-        { name: 'baseUrl', value: 'https://shop.example' },
-        { name: 'clientId', value: secret() },
-        { name: 'clientSecret', value: secret() },
-      ],
-    }),
-  ],
-});
-```
-
-You can commit this file safely: no credentials are stored in it.
-
-### How push restores
-
-`schema push` excludes secrets from the diff, so a redacted value never shows up as a change and never triggers a secret-only update. Just before the Management API call, each `secret()` is resolved in this order:
-
-1. `process.env[ENV_VAR]` when the placeholder is written as `secret('ENV_VAR')` and that variable is set and non-empty. Use this to manage or rotate a secret from your environment or CI.
-2. Otherwise, the value already stored on the space. The existing secret is preserved, never cleared.
-3. Otherwise, the value is left empty and a warning is printed. This only happens when creating a brand-new component on a fresh space, where there is no stored value to preserve. Use `secret('ENV_VAR')` to provision it.
-
-A placeholder never reaches the Management API. The same restore logic applies to `schema rollback`, and the changeset and local component JSON files written to disk store placeholders rather than real values.
-
-A preserve-remote `secret()` is excluded from the diff entirely, so it never shows as a change on its own. An env-managed `secret('ENV_VAR')` participates in the diff: when the environment value differs from the value on the space, push reports an update and rotates the secret. The diff shows a non-revealing fingerprint, never the secret value itself.
-
-To manage a value from the environment, point the placeholder at a variable name:
-
-```ts
-defineField('products', {
-  type: 'custom',
-  options: [
-    { name: 'clientSecret', value: secret('SHOPWARE_CLIENT_SECRET') },
-  ],
-});
-```
-
-```bash
-SHOPWARE_CLIENT_SECRET=whsec_live_xxx storyblok schema push .storyblok/schema/schema.ts --space 12345
-```
-
-### Custom secret names
-
-Pass `--secret-names` to `schema init` to redact additional plugin option names on top of the defaults. The value is a comma-separated list and is added to, not a replacement for, the default set:
-
-```bash
-storyblok schema init --space 12345 --secret-names apiSecret,privateToken
-```
-
-To disable redaction entirely and write sensitive option values verbatim, pass `--no-redact-secrets`:
-
-```bash
-storyblok schema init --space 12345 --no-redact-secrets
-```
-
-### Secret options
+## `schema init` options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--secret-names <names>` | Comma-separated plugin option names to redact as `secret()`, added to the defaults | Default secret names above |
-| `--no-redact-secrets` | Write sensitive option values verbatim instead of redacting them | Redaction enabled |
+| `-s, --space <space>` | (Required) Space ID | - |
+| `--out-dir <dir>` | Output directory for generated bootstrap files | `.storyblok/schema` |
+| `--secret-names <names>` | Comma-separated custom-plugin option names to redact as `secret()`, added to the defaults (`accessKey`, `apiKey`, `apiToken`, `token`, `secret`, `clientSecret`, `password`, `privateKey`) | defaults |
+| `--no-redact-secrets` | Write sensitive plugin option values verbatim instead of redacting them | redaction on |
 
-### End-to-end example
+## `schema push` options
 
-```bash
-# 1. Bootstrap local definitions from the space. Secrets are redacted to secret().
-storyblok schema init --space 12345
-
-# 2. Commit the generated files. No credentials are stored in them.
-git add .storyblok/schema && git commit -m "Add code-driven schema"
-
-# 3. Push local changes. Redacted secrets are restored from the space,
-#    so unrelated changes never clear an existing clientSecret.
-storyblok schema push .storyblok/schema/schema.ts --space 12345
-
-# 4. Optionally manage a secret from the environment during push.
-SHOPWARE_CLIENT_SECRET=whsec_live_xxx storyblok schema push .storyblok/schema/schema.ts --space 12345
-```
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-s, --space <space>` | (Required) Space ID | - |
+| `-p, --path <path>` | Path for file storage | - |
+| `--dry-run` | Show diffs without applying changes | `false` |
+| `--delete` | Delete remote entities not present in local schema | `false` |
+| `--migrations` / `--no-migrations` | Generate scaffold migrations for breaking changes | `true` |
+| `--write-components` / `--no-write-components` | Write component schemas as local JSON after push | `true` |

--- a/packages/cli/src/commands/schema/README.md
+++ b/packages/cli/src/commands/schema/README.md
@@ -57,12 +57,17 @@ You can commit this file safely: no credentials are stored in it.
 
 A placeholder never reaches the Management API. The same restore logic applies to `schema rollback`, and the changeset and local component JSON files written to disk store placeholders rather than real values.
 
+A preserve-remote `secret()` is excluded from the diff entirely, so it never shows as a change on its own. An env-managed `secret('ENV_VAR')` participates in the diff: when the environment value differs from the value on the space, push reports an update and rotates the secret. The diff shows a non-revealing fingerprint, never the secret value itself.
+
 To manage a value from the environment, point the placeholder at a variable name:
 
 ```ts
-options: [
-  { name: 'clientSecret', value: secret('SHOPWARE_CLIENT_SECRET') },
-],
+defineField('products', {
+  type: 'custom',
+  options: [
+    { name: 'clientSecret', value: secret('SHOPWARE_CLIENT_SECRET') },
+  ],
+});
 ```
 
 ```bash

--- a/packages/cli/src/commands/schema/README.md
+++ b/packages/cli/src/commands/schema/README.md
@@ -1,0 +1,108 @@
+# Schema Command
+
+The `schema` command lets you manage a space's content model as versioned code. `storyblok schema init` bootstraps local TypeScript definitions from an existing space, `storyblok schema push` applies your local changes back to the space, and `storyblok schema rollback` reverts a previous push.
+
+## Secret handling
+
+Some custom field plugins, for example the Shopware integration, store credentials inside a field's `options` array as `{ name, value }` pairs. To keep those values out of your Git repository, `schema init` redacts them and `schema push` restores them at push time. A secret is identified only by the option `name`, never by the plugin's `field_type` (which the plugin developer chooses freely).
+
+### Default secret names
+
+By default, init redacts the `value` of any plugin option whose `name` matches one of the following, case-insensitively:
+
+- `accessKey`
+- `apiKey`
+- `apiToken`
+- `token`
+- `secret`
+- `clientSecret`
+- `password`
+- `privateKey`
+
+### How init redacts
+
+Each matching value is replaced with a `secret()` placeholder imported from `@storyblok/schema`, so the real value never reaches the generated file. Given a Shopware field, `storyblok schema init --space 12345` produces:
+
+```ts
+// .storyblok/schema/blocks/product.ts
+import { defineBlock, defineField, secret } from '@storyblok/schema';
+
+export const productBlock = defineBlock({
+  name: 'product',
+  fields: [
+    defineField('products', {
+      type: 'custom',
+      field_type: 'shopware-integration',
+      datasource: 'shopware',
+      required: true,
+      options: [
+        { name: 'baseUrl', value: 'https://shop.example' },
+        { name: 'clientId', value: secret() },
+        { name: 'clientSecret', value: secret() },
+      ],
+    }),
+  ],
+});
+```
+
+You can commit this file safely: no credentials are stored in it.
+
+### How push restores
+
+`schema push` excludes secrets from the diff, so a redacted value never shows up as a change and never triggers a secret-only update. Just before the Management API call, each `secret()` is resolved in this order:
+
+1. `process.env[ENV_VAR]` when the placeholder is written as `secret('ENV_VAR')` and that variable is set and non-empty. Use this to manage or rotate a secret from your environment or CI.
+2. Otherwise, the value already stored on the space. The existing secret is preserved, never cleared.
+3. Otherwise, the value is left empty and a warning is printed. This only happens when creating a brand-new component on a fresh space, where there is no stored value to preserve. Use `secret('ENV_VAR')` to provision it.
+
+A placeholder never reaches the Management API. The same restore logic applies to `schema rollback`, and the changeset and local component JSON files written to disk store placeholders rather than real values.
+
+To manage a value from the environment, point the placeholder at a variable name:
+
+```ts
+options: [
+  { name: 'clientSecret', value: secret('SHOPWARE_CLIENT_SECRET') },
+],
+```
+
+```bash
+SHOPWARE_CLIENT_SECRET=whsec_live_xxx storyblok schema push .storyblok/schema/schema.ts --space 12345
+```
+
+### Custom secret names
+
+Pass `--secret-names` to `schema init` to redact additional plugin option names on top of the defaults. The value is a comma-separated list and is added to, not a replacement for, the default set:
+
+```bash
+storyblok schema init --space 12345 --secret-names apiSecret,privateToken
+```
+
+To disable redaction entirely and write sensitive option values verbatim, pass `--no-redact-secrets`:
+
+```bash
+storyblok schema init --space 12345 --no-redact-secrets
+```
+
+### Secret options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--secret-names <names>` | Comma-separated plugin option names to redact as `secret()`, added to the defaults | Default secret names above |
+| `--no-redact-secrets` | Write sensitive option values verbatim instead of redacting them | Redaction enabled |
+
+### End-to-end example
+
+```bash
+# 1. Bootstrap local definitions from the space. Secrets are redacted to secret().
+storyblok schema init --space 12345
+
+# 2. Commit the generated files. No credentials are stored in them.
+git add .storyblok/schema && git commit -m "Add code-driven schema"
+
+# 3. Push local changes. Redacted secrets are restored from the space,
+#    so unrelated changes never clear an existing clientSecret.
+storyblok schema push .storyblok/schema/schema.ts --space 12345
+
+# 4. Optionally manage a secret from the environment during push.
+SHOPWARE_CLIENT_SECRET=whsec_live_xxx storyblok schema push .storyblok/schema/schema.ts --space 12345
+```

--- a/packages/cli/src/commands/schema/init/actions.ts
+++ b/packages/cli/src/commands/schema/init/actions.ts
@@ -36,6 +36,7 @@ export async function writeSchemaFiles(
   components: Component[],
   componentFolders: ComponentFolder[],
   datasources: Datasource[],
+  secretNameMatcher?: (name: string) => boolean,
 ): Promise<string[]> {
   const writtenFiles: string[] = [];
   const groupPathByUuid = buildGroupPathByUuid(componentFolders);
@@ -63,7 +64,7 @@ export async function writeSchemaFiles(
     const filePath = join(targetPath, 'blocks', ...segments, `${fileName}.ts`);
     const folder = component.component_group_uuid ? folderByUuid.get(component.component_group_uuid) : undefined;
     const folderRef = folder && { varName: folder.varName, segments };
-    await writeFileWithDirs(filePath, generateComponentFile(component, varName, folderRef, folderVarByUuid));
+    await writeFileWithDirs(filePath, generateComponentFile(component, varName, folderRef, folderVarByUuid, secretNameMatcher));
     writtenFiles.push(filePath);
   }
 

--- a/packages/cli/src/commands/schema/init/constants.ts
+++ b/packages/cli/src/commands/schema/init/constants.ts
@@ -1,3 +1,7 @@
 export interface SchemaInitOptions {
   outDir: string;
+  /** Extra plugin option names to treat as secrets, on top of the defaults. */
+  secretNames?: string[];
+  /** Whether sensitive plugin option values are replaced with `secret()` placeholders. */
+  redactSecrets: boolean;
 }

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -53,6 +53,53 @@ describe('generateComponentFile', () => {
     expect(result).not.toContain('created_at');
   });
 
+  it('should redact secret plugin option values as secret() placeholders', () => {
+    const isSecretName = (name: string) => ['clientid', 'clientsecret'].includes(name.toLowerCase());
+    const component = {
+      id: 1,
+      name: 'shop',
+      created_at: '',
+      updated_at: '',
+      schema: {
+        products: {
+          type: 'custom',
+          pos: 0,
+          field_type: 'shopware-integration',
+          options: [
+            { _uid: 'a', name: 'baseUrl', value: 'https://shop.example' },
+            { _uid: 'b', name: 'clientSecret', value: 'WXpZbzltM1kx' },
+          ],
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any, undefined, undefined, undefined, isSecretName);
+
+    // The secret import is added and the option value is replaced with secret().
+    expect(result).toContain('  secret,');
+    expect(result).toContain('value: secret(),');
+    expect(result).not.toContain('WXpZbzltM1kx');
+    // Non-secret option values and the plugin name are untouched.
+    expect(result).toContain('value: \'https://shop.example\',');
+    expect(result).toContain('field_type: \'shopware-integration\',');
+  });
+
+  it('should not add the secret import when no option value is redacted', () => {
+    const isSecretName = (name: string) => name.toLowerCase() === 'clientsecret';
+    const component = {
+      id: 1,
+      name: 'page',
+      created_at: '',
+      updated_at: '',
+      schema: { title: { type: 'text', pos: 0 } },
+    };
+
+    const result = generateComponentFile(component as any, undefined, undefined, undefined, isSecretName);
+
+    expect(result).not.toContain('secret,');
+    expect(result).not.toContain('secret()');
+  });
+
   it('should escape backslashes and newlines in field values so the output round-trips', () => {
     const component = {
       id: 1,

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -84,6 +84,34 @@ describe('generateComponentFile', () => {
     expect(result).toContain('field_type: \'shopware-integration\',');
   });
 
+  it('should not redact choices of a built-in option/options select field', () => {
+    // Select fields use the same `{ name, value }` shape for their choices; a
+    // choice named like a secret must NOT be redacted (only `type: 'custom'`).
+    const isSecretName = (name: string) => name.toLowerCase() === 'token';
+    const component = {
+      id: 1,
+      name: 'page',
+      created_at: '',
+      updated_at: '',
+      schema: {
+        kind: {
+          type: 'option',
+          pos: 0,
+          options: [
+            { _uid: 'a', name: 'token', value: 'ring' },
+            { _uid: 'b', name: 'coin', value: 'gold' },
+          ],
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any, undefined, undefined, undefined, isSecretName);
+
+    expect(result).not.toContain('secret,');
+    expect(result).not.toContain('secret()');
+    expect(result).toContain('value: \'ring\',');
+  });
+
   it('should not add the secret import when no option value is redacted', () => {
     const isSecretName = (name: string) => name.toLowerCase() === 'clientsecret';
     const component = {

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -271,14 +271,12 @@ function omitEmptyArrays(obj: Record<string, unknown>): Record<string, unknown> 
  * Generates a `defineField('name', {...})` code string for a single schema field.
  * Position is implicit in the array index, so `pos` is stripped from the config.
  *
- * When `secretNameMatcher` is given, the `value` of any plugin option
- * (`options: [{ name, value }]`) whose `name` is a secret is replaced with a
- * `secret()` placeholder so it never reaches the versioned file. Redaction is
- * scoped to custom plugin fields (`type: 'custom'`): the built-in `option`/
- * `options` select fields use the same `{ name, value }` shape for their choices,
- * which must never be redacted. Redaction runs on the raw wire field, before
- * `toDslField` introduces `RawCode` folder refs — `redactSecretValues` only ever
- * walks plain data.
+ * When `secretNameMatcher` is given, the `value` of a custom plugin field's
+ * option (`options: [{ name, value }]`) whose `name` is a secret is replaced with
+ * a `secret()` placeholder so it never reaches the versioned file.
+ * `redactSecretValues` self-scopes to `type: 'custom'` fields, so select-field
+ * choices are left intact. Redaction runs on the raw wire field, before
+ * `toDslField` introduces `RawCode` folder refs — it only ever walks plain data.
  */
 function generateFieldCode(
   fieldName: string,
@@ -287,7 +285,7 @@ function generateFieldCode(
   folderVarByUuid?: Map<string, string>,
   secretNameMatcher?: (name: string) => boolean,
 ): string {
-  const input = secretNameMatcher && fieldData.type === 'custom'
+  const input = secretNameMatcher
     ? redactSecretValues(fieldData, secretNameMatcher, () => new RawCode('secret()')) as Record<string, unknown>
     : fieldData;
   const clean = omitEmptyArrays(toDslField(stripKeys(input, FIELD_STRIP_KEYS), folderVarByUuid));
@@ -362,11 +360,9 @@ export function generateComponentFile(
   const lines: string[] = [];
 
   // Emit a `secret` import only when this block actually redacts a value, so
-  // files without secrets keep a minimal import. Scoped to custom plugin fields,
-  // matching `generateFieldCode` — select-field choices are never redacted.
-  const usesSecret = !!secretNameMatcher && Object.values(
-    isRecord(component.schema) ? component.schema : {},
-  ).some(field => isRecord(field) && field.type === 'custom' && hasSecretOption(field, secretNameMatcher));
+  // files without secrets keep a minimal import. `hasSecretOption` self-scopes to
+  // custom plugin fields — select-field choices are never counted.
+  const usesSecret = !!secretNameMatcher && hasSecretOption(component.schema, secretNameMatcher);
 
   lines.push('import {');
   lines.push('  defineBlock,');

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -11,6 +11,7 @@ import {
   RawCode,
   stripKeys,
 } from '../utils';
+import { hasSecretOption, redactSecretValues } from '../secrets';
 
 /** Fields to strip from individual schema field entries (`pos` is implicit in array order). */
 const FIELD_STRIP_KEYS = new Set(['id', 'pos']);
@@ -269,14 +270,24 @@ function omitEmptyArrays(obj: Record<string, unknown>): Record<string, unknown> 
 /**
  * Generates a `defineField('name', {...})` code string for a single schema field.
  * Position is implicit in the array index, so `pos` is stripped from the config.
+ *
+ * When `secretNameMatcher` is given, the `value` of any plugin option
+ * (`options: [{ name, value }]`) whose `name` is a secret is replaced with a
+ * `secret()` placeholder so it never reaches the versioned file. Redaction runs
+ * on the raw wire field, before `toDslField` introduces `RawCode` folder refs —
+ * `redactSecretValues` only ever walks plain data.
  */
 function generateFieldCode(
   fieldName: string,
   fieldData: Record<string, unknown>,
   depth: number,
   folderVarByUuid?: Map<string, string>,
+  secretNameMatcher?: (name: string) => boolean,
 ): string {
-  const clean = omitEmptyArrays(toDslField(stripKeys(fieldData, FIELD_STRIP_KEYS), folderVarByUuid));
+  const input = secretNameMatcher
+    ? redactSecretValues(fieldData, secretNameMatcher, () => new RawCode('secret()')) as Record<string, unknown>
+    : fieldData;
+  const clean = omitEmptyArrays(toDslField(stripKeys(input, FIELD_STRIP_KEYS), folderVarByUuid));
   return `defineField(${quoteString(fieldName)}, ${formatValue(clean, depth)})`;
 }
 
@@ -343,12 +354,18 @@ export function generateComponentFile(
   varName?: string,
   folderRef?: { varName: string; segments: string[] },
   folderVarByUuid?: Map<string, string>,
+  secretNameMatcher?: (name: string) => boolean,
 ): string {
   const lines: string[] = [];
+
+  // Emit a `secret` import only when this block actually redacts a value, so
+  // files without secrets keep a minimal import.
+  const usesSecret = !!secretNameMatcher && hasSecretOption(component.schema, secretNameMatcher);
 
   lines.push('import {');
   lines.push('  defineBlock,');
   lines.push('  defineField,');
+  if (usesSecret) { lines.push('  secret,'); }
   lines.push('} from \'@storyblok/schema\';');
   lines.push('');
 
@@ -412,7 +429,7 @@ export function generateComponentFile(
     if (sortedFields.length > 0) {
       lines.push(`${INDENT}fields: [`);
       for (const [fieldName, fieldData] of sortedFields) {
-        const fieldCode = generateFieldCode(fieldName, fieldData, 2, folderVarByUuid);
+        const fieldCode = generateFieldCode(fieldName, fieldData, 2, folderVarByUuid, secretNameMatcher);
         lines.push(`${INDENT}${INDENT}${fieldCode},`);
       }
       lines.push(`${INDENT}],`);

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -273,9 +273,12 @@ function omitEmptyArrays(obj: Record<string, unknown>): Record<string, unknown> 
  *
  * When `secretNameMatcher` is given, the `value` of any plugin option
  * (`options: [{ name, value }]`) whose `name` is a secret is replaced with a
- * `secret()` placeholder so it never reaches the versioned file. Redaction runs
- * on the raw wire field, before `toDslField` introduces `RawCode` folder refs —
- * `redactSecretValues` only ever walks plain data.
+ * `secret()` placeholder so it never reaches the versioned file. Redaction is
+ * scoped to custom plugin fields (`type: 'custom'`): the built-in `option`/
+ * `options` select fields use the same `{ name, value }` shape for their choices,
+ * which must never be redacted. Redaction runs on the raw wire field, before
+ * `toDslField` introduces `RawCode` folder refs — `redactSecretValues` only ever
+ * walks plain data.
  */
 function generateFieldCode(
   fieldName: string,
@@ -284,7 +287,7 @@ function generateFieldCode(
   folderVarByUuid?: Map<string, string>,
   secretNameMatcher?: (name: string) => boolean,
 ): string {
-  const input = secretNameMatcher
+  const input = secretNameMatcher && fieldData.type === 'custom'
     ? redactSecretValues(fieldData, secretNameMatcher, () => new RawCode('secret()')) as Record<string, unknown>
     : fieldData;
   const clean = omitEmptyArrays(toDslField(stripKeys(input, FIELD_STRIP_KEYS), folderVarByUuid));
@@ -359,8 +362,11 @@ export function generateComponentFile(
   const lines: string[] = [];
 
   // Emit a `secret` import only when this block actually redacts a value, so
-  // files without secrets keep a minimal import.
-  const usesSecret = !!secretNameMatcher && hasSecretOption(component.schema, secretNameMatcher);
+  // files without secrets keep a minimal import. Scoped to custom plugin fields,
+  // matching `generateFieldCode` — select-field choices are never redacted.
+  const usesSecret = !!secretNameMatcher && Object.values(
+    isRecord(component.schema) ? component.schema : {},
+  ).some(field => isRecord(field) && field.type === 'custom' && hasSecretOption(field, secretNameMatcher));
 
   lines.push('import {');
   lines.push('  defineBlock,');

--- a/packages/cli/src/commands/schema/init/index.ts
+++ b/packages/cli/src/commands/schema/init/index.ts
@@ -1,4 +1,5 @@
 import { readdir } from 'node:fs/promises';
+import { Option } from 'commander';
 import { resolve } from 'pathe';
 
 import { colorPalette, commands } from '../../../constants';
@@ -9,9 +10,15 @@ import { getUI } from '../../../utils/ui';
 import { session } from '../../../session';
 import { schemaCommand } from '../command';
 import { displayPath } from '../utils';
+import { createSecretNameMatcher, DEFAULT_SECRET_NAMES } from '../secrets';
 import type { SchemaInitOptions } from './constants';
 import { fetchRemoteSchema } from '../actions';
 import { writeSchemaFiles } from './actions';
+
+/** Parses a comma-separated `--secret-names` value into a trimmed, non-empty list. */
+function parseSecretNames(value: string): string[] {
+  return value.split(',').map(name => name.trim()).filter(Boolean);
+}
 
 async function isTargetEmpty(targetPath: string): Promise<boolean> {
   try {
@@ -30,6 +37,12 @@ schemaCommand
   .description('Initialize a local code-driven schema workspace from an existing Storyblok space (one-time bootstrap)')
   .option('-s, --space <space>', 'space ID')
   .option('--out-dir <dir>', 'Output directory for generated bootstrap files', '.storyblok/schema')
+  .option(
+    '--secret-names <names>',
+    `Comma-separated plugin option names to redact as \`secret()\` (added to the defaults: ${DEFAULT_SECRET_NAMES.join(', ')})`,
+    parseSecretNames,
+  )
+  .addOption(new Option('--no-redact-secrets', 'Do not redact sensitive plugin option values (write them verbatim)'))
   .action(async (options: SchemaInitOptions, command) => {
     const ui = getUI();
     const logger = getLogger();
@@ -75,9 +88,14 @@ schemaCommand
       const { rawComponents, rawComponentFolders, rawDatasources } = fetchResult;
       fetchSpinner.succeed(`Found: ${rawComponents.length} components, ${rawComponentFolders.length} component folders, ${rawDatasources.length} datasources`);
 
-      // 2. Generate and write files
+      // 2. Generate and write files. Sensitive field-config values are redacted
+      //    to `secret()` placeholders unless `--no-redact-secrets` is set.
+      const secretNameMatcher = options.redactSecrets
+        ? createSecretNameMatcher([...DEFAULT_SECRET_NAMES, ...(options.secretNames ?? [])])
+        : undefined;
+
       const writeSpinner = ui.createSpinner(`Generating TypeScript files to ${targetDisplayPath}...`);
-      const writtenFiles = await writeSchemaFiles(targetPath, rawComponents, rawComponentFolders, rawDatasources);
+      const writtenFiles = await writeSchemaFiles(targetPath, rawComponents, rawComponentFolders, rawDatasources, secretNameMatcher);
 
       summary.total = writtenFiles.length;
       summary.succeeded = writtenFiles.length;
@@ -85,6 +103,12 @@ schemaCommand
       writeSpinner.succeed(`Generated ${writtenFiles.length} files`);
       ui.list(writtenFiles.map(file => displayPath(file, options.outDir)));
       ui.warn('`schema init` is a one-time bootstrap step for adopting an existing space. Review generated files before continuing.');
+      if (secretNameMatcher) {
+        ui.info('Sensitive plugin option values were replaced with `secret()` placeholders. `schema push` restores them from the space (or from `secret(\'ENV_VAR\')`). Review before committing.');
+      }
+      else {
+        ui.warn('Secret redaction is disabled (`--no-redact-secrets`): generated files may contain sensitive values. Review before committing.');
+      }
       ui.info('After bootstrapping, keep your local schema as the source of truth and use `schema push` for ongoing changes.');
       ui.info('Make sure `@storyblok/schema` is installed in the project that imports these files (e.g. `pnpm add @storyblok/schema`).');
     }

--- a/packages/cli/src/commands/schema/push/actions.test.ts
+++ b/packages/cli/src/commands/schema/push/actions.test.ts
@@ -709,7 +709,7 @@ describe('executePush - folders', () => {
     const local: SchemaData = {
       components: [{
         name: 'shop',
-        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: { [SECRET_MARKER]: true } }] } },
+        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: SECRET_MARKER }] } },
       } as unknown as Component],
       folders: [],
       datasources: [],
@@ -746,7 +746,7 @@ describe('executePush - folders', () => {
     const local: SchemaData = {
       components: [{
         name: 'shop',
-        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: { [SECRET_MARKER]: true, env: 'TEST_SHOPWARE_KEY' } }] } },
+        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: `${SECRET_MARKER}:TEST_SHOPWARE_KEY` }] } },
       } as unknown as Component],
       folders: [],
       datasources: [],

--- a/packages/cli/src/commands/schema/push/actions.test.ts
+++ b/packages/cli/src/commands/schema/push/actions.test.ts
@@ -7,6 +7,7 @@ import type { DiffResult, RemoteSchemaData, SchemaData } from '../types';
 import { getMapiClient } from '../../../api';
 import { buildChangesetEntries, executePush, formatDiffOutput } from './actions';
 import { toComponentCreate, toDatasourceCreate, toDatasourceUpdate } from '../transform';
+import { SECRET_MARKER } from '../secrets';
 
 describe('toComponentCreate', () => {
   it('should strip API-assigned fields from a component', () => {
@@ -693,6 +694,86 @@ describe('executePush - folders', () => {
 
     expect(capturedComponent).toBeDefined();
     expect(capturedComponent).toHaveProperty('component_group_uuid', null);
+  });
+
+  it('preserves the existing remote secret when the local option value is a secret() placeholder', async () => {
+    let capturedComponent: Record<string, unknown> | undefined;
+    server.use(
+      http.put('https://mapi.storyblok.com/v1/spaces/12345/components/50', async ({ request }) => {
+        const body = await request.json() as { component: Record<string, unknown> };
+        capturedComponent = body.component;
+        return HttpResponse.json({ component: { id: 50, name: 'shop' } });
+      }),
+    );
+
+    const local: SchemaData = {
+      components: [{
+        name: 'shop',
+        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: { [SECRET_MARKER]: true } }] } },
+      } as unknown as Component],
+      folders: [],
+      datasources: [],
+    };
+    const remote: RemoteSchemaData = {
+      components: new Map([['shop', {
+        id: 50,
+        name: 'shop',
+        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: 'live-secret' }] } },
+      } as unknown as Component]]),
+      componentFolders: new Map(),
+      datasources: new Map(),
+    };
+    const diffResult = makeDiffResult([
+      { type: 'component', name: 'shop', action: 'update', diff: null, local: null, remote: null },
+    ]);
+
+    await executePush('12345', local, remote, diffResult, { delete: false });
+
+    const schema = capturedComponent!.schema as Record<string, { options: Array<{ value: unknown }> }>;
+    expect(schema.products.options[0].value).toBe('live-secret');
+  });
+
+  it('sources a secret from the environment when the placeholder names a set variable', async () => {
+    let capturedComponent: Record<string, unknown> | undefined;
+    server.use(
+      http.put('https://mapi.storyblok.com/v1/spaces/12345/components/50', async ({ request }) => {
+        const body = await request.json() as { component: Record<string, unknown> };
+        capturedComponent = body.component;
+        return HttpResponse.json({ component: { id: 50, name: 'shop' } });
+      }),
+    );
+
+    const local: SchemaData = {
+      components: [{
+        name: 'shop',
+        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: { [SECRET_MARKER]: true, env: 'TEST_SHOPWARE_KEY' } }] } },
+      } as unknown as Component],
+      folders: [],
+      datasources: [],
+    };
+    const remote: RemoteSchemaData = {
+      components: new Map([['shop', {
+        id: 50,
+        name: 'shop',
+        schema: { products: { type: 'custom', field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: 'live-secret' }] } },
+      } as unknown as Component]]),
+      componentFolders: new Map(),
+      datasources: new Map(),
+    };
+    const diffResult = makeDiffResult([
+      { type: 'component', name: 'shop', action: 'update', diff: null, local: null, remote: null },
+    ]);
+
+    process.env.TEST_SHOPWARE_KEY = 'env-secret';
+    try {
+      await executePush('12345', local, remote, diffResult, { delete: false });
+    }
+    finally {
+      delete process.env.TEST_SHOPWARE_KEY;
+    }
+
+    const schema = capturedComponent!.schema as Record<string, { options: Array<{ value: unknown }> }>;
+    expect(schema.products.options[0].value).toBe('env-secret');
   });
 
   it('deletes stale folders children-first with --delete', async () => {

--- a/packages/cli/src/commands/schema/push/actions.ts
+++ b/packages/cli/src/commands/schema/push/actions.ts
@@ -7,6 +7,7 @@ import { CommandError, handleAPIError } from '../../../utils';
 import { toComponentCreate, toComponentUpdate, toDatasourceCreate, toDatasourceUpdate } from '../transform';
 import { buildGroupPathByUuid } from '../folders';
 import { isRecord } from '../utils';
+import { hydrateSecretValues, maskSecretsToPlaceholder, type SecretResolution } from '../secrets';
 
 /** A resolved component group reference: its numeric id and server uuid. */
 interface GroupRef { id: number; uuid: string }
@@ -144,12 +145,13 @@ export async function executePush(
   remote: RemoteSchemaData,
   diffResult: DiffResult,
   options: { delete: boolean },
-): Promise<{ created: number; updated: number; deleted: number }> {
+): Promise<{ created: number; updated: number; deleted: number; secretWarnings: string[] }> {
   const client = getMapiClient();
   const spaceIdNum = Number(spaceId);
   let created = 0;
   let updated = 0;
   let deleted = 0;
+  const secretWarnings: string[] = [];
 
   // 1. Create missing folders (component groups) parent-first, building a
   //    `slug path → { id, uuid }` map from the remote groups plus the ones we
@@ -202,7 +204,25 @@ export async function executePush(
   for (const diff of componentDiffs) {
     if (diff.action !== 'create' && diff.action !== 'update') { continue; }
     const localComp = local.components.find(c => c.name === diff.name);
-    if (localComp) { resolvedComponents.set(diff.name, resolveGroupRefs(localComp, groupByPath)); }
+    if (!localComp) { continue; }
+    const resolved = resolveGroupRefs(localComp, groupByPath);
+
+    // Substitute `secret()` placeholders with their real value just before the
+    // payload is built — from `process.env` when the placeholder names a set
+    // variable, otherwise from the value already on the space (so an existing
+    // secret is preserved, never cleared). A placeholder never reaches the API.
+    const remoteComp = remote.components.get(diff.name) as unknown as Record<string, unknown> | undefined;
+    const resolutions: SecretResolution[] = [];
+    const hydrated = hydrateSecretValues(resolved, remoteComp, process.env, resolutions) as Component;
+    for (const r of resolutions) {
+      if (r.source === 'missing') {
+        secretWarnings.push(
+          `Secret '${r.key}' on component '${diff.name}' has no value`
+          + `${r.env ? ` (env '${r.env}' is unset)` : ''} and no existing value on the space; it was left empty.`,
+        );
+      }
+    }
+    resolvedComponents.set(diff.name, hydrated);
   }
   const componentResults = await Promise.allSettled(
     componentDiffs.map(async (diff) => {
@@ -375,7 +395,7 @@ export async function executePush(
     }
   }
 
-  return { created, updated, deleted };
+  return { created, updated, deleted, secretWarnings };
 }
 
 /** Builds changeset entries from diff results for storage. */
@@ -423,7 +443,12 @@ export function buildChangesetEntries(
       type: diff.type,
       name: diff.name,
       action,
-      ...(remoteSrc && { before: { ...remoteSrc } }),
+      // Mask secret values (identified by the local schema's `secret()`
+      // placeholders) in the pre-push remote snapshot, so real secrets are never
+      // written to the changeset yet `schema rollback` can still recognize the
+      // field and hydrate it from the live space. `after` (local) only ever
+      // holds redacted placeholders.
+      ...(remoteSrc && { before: maskSecretsToPlaceholder(remoteSrc, localSrc) as Record<string, unknown> }),
       ...(localSrc && { after: { ...localSrc } }),
     });
   }

--- a/packages/cli/src/commands/schema/push/diff-schema.test.ts
+++ b/packages/cli/src/commands/schema/push/diff-schema.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import type { RemoteSchemaData, SchemaData } from '../types';
 import { diffSchema } from './diff-schema';
+import { SECRET_MARKER } from '../secrets';
 
 function makeComponent(name: string, schema: Record<string, unknown>) {
   return { id: 1, name, created_at: '', updated_at: '', schema } as any;
 }
+
+const secretPlaceholder = { [SECRET_MARKER]: true } as const;
 
 function makeDatasource(name: string, slug: string) {
   return { id: 1, name, slug, created_at: '', updated_at: '' } as any;
@@ -48,6 +51,56 @@ describe('diffSchema', () => {
 
     expect(result.unchanged).toBe(1);
     expect(result.diffs[0].action).toBe('unchanged');
+  });
+
+  it('should not diff a secret placeholder against the real remote value', () => {
+    // Local carries a `secret()` placeholder (in an option pair); remote holds
+    // the real value. The secret must be excluded from both sides — no diff.
+    const localComp = makeComponent('shop', {
+      products: { type: 'custom', pos: 0, field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: secretPlaceholder }] },
+    });
+    const remoteComp = makeComponent('shop', {
+      products: { type: 'custom', pos: 0, field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: 'real-live-secret' }] },
+    });
+
+    const local: SchemaData = { components: [localComp], folders: [], datasources: [] };
+    const remote: RemoteSchemaData = {
+      components: new Map([['shop', { ...remoteComp, id: 99 }]]),
+      componentFolders: new Map(),
+      datasources: new Map(),
+    };
+
+    const result = diffSchema(local, remote);
+
+    expect(result.unchanged).toBe(1);
+    expect(result.updates).toBe(0);
+    expect(result.diffs[0].action).toBe('unchanged');
+  });
+
+  it('should still diff a non-secret change on a component that also has a secret', () => {
+    const localComp = makeComponent('shop', {
+      products: { type: 'custom', pos: 0, field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: secretPlaceholder }] },
+      label: { type: 'text', pos: 1, max_length: 50 },
+    });
+    const remoteComp = makeComponent('shop', {
+      products: { type: 'custom', pos: 0, field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: 'real-live-secret' }] },
+      label: { type: 'text', pos: 1, max_length: 20 },
+    });
+
+    const local: SchemaData = { components: [localComp], folders: [], datasources: [] };
+    const remote: RemoteSchemaData = {
+      components: new Map([['shop', { ...remoteComp, id: 99 }]]),
+      componentFolders: new Map(),
+      datasources: new Map(),
+    };
+
+    const result = diffSchema(local, remote);
+
+    expect(result.updates).toBe(1);
+    expect(result.diffs[0].action).toBe('update');
+    // The diff shows the label change but never the secret value.
+    expect(result.diffs[0].diff).not.toContain('real-live-secret');
+    expect(result.diffs[0].diff).toContain('max_length');
   });
 
   it('should detect updated entities with diff string', () => {

--- a/packages/cli/src/commands/schema/push/diff-schema.test.ts
+++ b/packages/cli/src/commands/schema/push/diff-schema.test.ts
@@ -8,7 +8,7 @@ function makeComponent(name: string, schema: Record<string, unknown>) {
   return { id: 1, name, created_at: '', updated_at: '', schema } as any;
 }
 
-const secretPlaceholder = { [SECRET_MARKER]: true } as const;
+const secretPlaceholder = SECRET_MARKER; // the `secret()` sentinel string
 
 function makeDatasource(name: string, slug: string) {
   return { id: 1, name, slug, created_at: '', updated_at: '' } as any;
@@ -101,6 +101,37 @@ describe('diffSchema', () => {
     // The diff shows the label change but never the secret value.
     expect(result.diffs[0].diff).not.toContain('real-live-secret');
     expect(result.diffs[0].diff).toContain('max_length');
+  });
+
+  it('should detect an env-managed secret rotation as an update without revealing the value', () => {
+    const localComp = makeComponent('shop', {
+      products: { type: 'custom', pos: 0, field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: `${SECRET_MARKER}:SW_ROTATE` }] },
+    });
+    const remoteComp = makeComponent('shop', {
+      products: { type: 'custom', pos: 0, field_type: 'shopware-integration', options: [{ _uid: 'a', name: 'clientSecret', value: 'old-remote-secret' }] },
+    });
+
+    const local: SchemaData = { components: [localComp], folders: [], datasources: [] };
+    const remote: RemoteSchemaData = {
+      components: new Map([['shop', { ...remoteComp, id: 99 }]]),
+      componentFolders: new Map(),
+      datasources: new Map(),
+    };
+
+    process.env.SW_ROTATE = 'new-rotated-secret';
+    let result;
+    try {
+      result = diffSchema(local, remote);
+    }
+    finally {
+      delete process.env.SW_ROTATE;
+    }
+
+    expect(result.updates).toBe(1);
+    expect(result.diffs[0].action).toBe('update');
+    // Neither the env value nor the remote value appears in the printed diff.
+    expect(result.diffs[0].diff).not.toContain('new-rotated-secret');
+    expect(result.diffs[0].diff).not.toContain('old-remote-secret');
   });
 
   it('should detect updated entities with diff string', () => {

--- a/packages/cli/src/commands/schema/push/diff-schema.ts
+++ b/packages/cli/src/commands/schema/push/diff-schema.ts
@@ -4,6 +4,7 @@ import type { DiffResult, EntityDiff, RemoteSchemaData, SchemaData } from '../ty
 import { applyDefaults, COMPONENT_DEFAULTS, DATASOURCE_DEFAULTS, isRecord } from '../utils';
 import { serializeComponent, serializeDatasource } from '../serialize';
 import { buildGroupPathByUuid } from '../folders';
+import { stripSecretKeys } from '../secrets';
 
 type EntityType = 'component' | 'datasource';
 
@@ -128,6 +129,16 @@ export function diffSchema(local: SchemaData, remote: RemoteSchemaData): DiffRes
     if (remoteForDiff) {
       remoteForDiff.schema = translateGroupWhitelist(remoteForDiff.schema, uuidToPath);
     }
+
+    // Drop secret-placeholder keys from both sides so a redacted secret never
+    // shows as a diff (and never triggers an update on its own). The local
+    // schema — which still carries the `secret()` placeholders — is the
+    // reference for what to strip on both sides.
+    const secretRef = localForDiff.schema;
+    if (remoteForDiff) {
+      remoteForDiff.schema = stripSecretKeys(remoteForDiff.schema, secretRef);
+    }
+    localForDiff.schema = stripSecretKeys(localForDiff.schema, secretRef);
 
     const localSerialized = serializeComponent(applyDefaults(localForDiff, COMPONENT_DEFAULTS), { includeGroupUuid });
     const remoteSerialized = remoteForDiff

--- a/packages/cli/src/commands/schema/push/diff-schema.ts
+++ b/packages/cli/src/commands/schema/push/diff-schema.ts
@@ -4,7 +4,7 @@ import type { DiffResult, EntityDiff, RemoteSchemaData, SchemaData } from '../ty
 import { applyDefaults, COMPONENT_DEFAULTS, DATASOURCE_DEFAULTS, isRecord } from '../utils';
 import { serializeComponent, serializeDatasource } from '../serialize';
 import { buildGroupPathByUuid } from '../folders';
-import { stripSecretKeys } from '../secrets';
+import { markLocalSecretsForDiff, markRemoteSecretsForDiff } from '../secrets';
 
 type EntityType = 'component' | 'datasource';
 
@@ -130,15 +130,16 @@ export function diffSchema(local: SchemaData, remote: RemoteSchemaData): DiffRes
       remoteForDiff.schema = translateGroupWhitelist(remoteForDiff.schema, uuidToPath);
     }
 
-    // Drop secret-placeholder keys from both sides so a redacted secret never
-    // shows as a diff (and never triggers an update on its own). The local
-    // schema — which still carries the `secret()` placeholders — is the
-    // reference for what to strip on both sides.
+    // Represent secrets in the diff. Preserve-remote secrets (`secret()`) are
+    // dropped from both sides so they never diff; env-managed secrets
+    // (`secret('ENV')` with the variable set) become a non-revealing fingerprint
+    // on both sides, so rotating the env value shows as an update. The local
+    // schema — which still carries the placeholders — is the reference.
     const secretRef = localForDiff.schema;
     if (remoteForDiff) {
-      remoteForDiff.schema = stripSecretKeys(remoteForDiff.schema, secretRef);
+      remoteForDiff.schema = markRemoteSecretsForDiff(remoteForDiff.schema, secretRef);
     }
-    localForDiff.schema = stripSecretKeys(localForDiff.schema, secretRef);
+    localForDiff.schema = markLocalSecretsForDiff(secretRef);
 
     const localSerialized = serializeComponent(applyDefaults(localForDiff, COMPONENT_DEFAULTS), { includeGroupUuid });
     const remoteSerialized = remoteForDiff

--- a/packages/cli/src/commands/schema/push/index.ts
+++ b/packages/cli/src/commands/schema/push/index.ts
@@ -18,6 +18,7 @@ import { fetchRemoteSchema } from '../actions';
 import { buildGroupPathByUuid } from '../folders';
 import { buildChangesetEntries, executePush, formatDiffOutput } from './actions';
 import { saveChangeset } from '../changeset';
+import { maskSecretsToPlaceholder } from '../secrets';
 import { analyzeBreakingChanges } from './migrations/analyze';
 import { renderMigrationCode, writeMigrationFile } from './migrations/generate';
 import { writeLocalComponents } from './write-local-components';
@@ -218,10 +219,18 @@ schemaCommand
       const resolvedPath = resolvePath(basePath, '');
       const timestamp = new Date().toISOString();
 
+      // Mask secret values in the pre-push remote snapshot before it is written
+      // to disk. Each local component (keyed by name) carries the `secret()`
+      // placeholders that mark which field-config keys to mask; rollback later
+      // hydrates them from the live space.
+      const localByName = new Map(local.components.map(c => [c.name, c]));
+      const redactedRemoteComponents = rawComponents.map(rc =>
+        maskSecretsToPlaceholder(rc, localByName.get(rc.name)) as typeof rc);
+
       const changesetPath = await saveChangeset(resolvedPath, {
         timestamp,
         spaceId: Number(space),
-        remote: { components: rawComponents, componentFolders: rawComponentFolders, datasources: rawDatasources },
+        remote: { components: redactedRemoteComponents, componentFolders: rawComponentFolders, datasources: rawDatasources },
         changes: buildChangesetEntries(diffResult, local, remote, { delete: options.delete }),
       });
       logger.info('Changeset saved', { path: displayPath(changesetPath, basePath) });
@@ -247,6 +256,10 @@ schemaCommand
         summary.succeeded = summary.total;
 
         pushSpinner.succeed(`Pushed ${result.created} creations, ${result.updated} updates${result.deleted > 0 ? `, ${result.deleted} deletions` : ''}.`);
+
+        for (const warning of result.secretWarnings) {
+          ui.warn(warning);
+        }
       }
 
       // 10. Write local component files (keeps disk in sync with intended schema state,

--- a/packages/cli/src/commands/schema/rollback/actions.ts
+++ b/packages/cli/src/commands/schema/rollback/actions.ts
@@ -11,6 +11,7 @@ import { handleAPIError } from '../../../utils';
 import { fileExists, readDirectory } from '../../../utils/filesystem';
 import { toComponentCreate, toComponentUpdate, toDatasourceCreate, toDatasourceUpdate } from '../transform';
 import { buildGroupPathByUuid } from '../folders';
+import { hydrateSecretValues } from '../secrets';
 
 /** API-assigned fields stripped before sending a rollback create payload to MAPI. */
 const API_ASSIGNED_FIELDS = [
@@ -322,10 +323,14 @@ export async function executeRollback(
     }
   }
 
-  // 2. Component creates/updates
+  // 2. Component creates/updates. A restored snapshot may carry `secret()`
+  //    placeholders (secrets are never stored in the changeset); hydrate them
+  //    from the live space (or `process.env`) so the rollback neither writes a
+  //    placeholder to the API nor clears an existing secret.
   for (const op of componentOps.filter(o => o.action !== 'delete')) {
     if (op.action === 'create') {
-      const payload = toComponentCreate(remapGroupUuids(stripApiFields(op.payload), groupUuidMap));
+      const hydrated = hydrateSecretValues(op.payload, undefined, process.env, []) as Record<string, unknown>;
+      const payload = toComponentCreate(remapGroupUuids(stripApiFields(hydrated), groupUuidMap));
       try {
         await client.components.create({
           path: { space_id: spaceIdNum },
@@ -341,7 +346,13 @@ export async function executeRollback(
     else if (op.action === 'update') {
       const existing = remote.components.get(op.name);
       if (existing?.id) {
-        const payload = toComponentUpdate(remapGroupUuids(stripApiFields(op.payload), groupUuidMap));
+        const hydrated = hydrateSecretValues(
+          op.payload,
+          existing as unknown as Record<string, unknown>,
+          process.env,
+          [],
+        ) as Record<string, unknown>;
+        const payload = toComponentUpdate(remapGroupUuids(stripApiFields(hydrated), groupUuidMap));
         try {
           await client.components.update(existing.id, {
             path: { space_id: spaceIdNum },

--- a/packages/cli/src/commands/schema/secrets.test.ts
+++ b/packages/cli/src/commands/schema/secrets.test.ts
@@ -75,6 +75,13 @@ describe('redactSecretValues', () => {
     const out = redactSecretValues({ clientSecret: 'not-an-option' }, isSecretName, make) as Record<string, any>;
     expect(out.clientSecret).toBe('not-an-option');
   });
+
+  it('should not redact select-field choices (only custom plugin fields)', () => {
+    // A built-in `option` field reuses the { name, value } shape for choices.
+    const select = { type: 'option', options: [{ name: 'clientSecret', value: 'a-legit-choice' }] };
+    const out = redactSecretValues(select, isSecretName, make) as Record<string, any>;
+    expect(out.options[0].value).toBe('a-legit-choice');
+  });
 });
 
 describe('hasSecretOption', () => {
@@ -86,7 +93,12 @@ describe('hasSecretOption', () => {
   });
 
   it('should return false when no option name is a secret', () => {
-    const schema = { products: { options: [{ name: 'baseUrl', value: 'x' }] } };
+    const schema = { products: { type: 'custom', options: [{ name: 'baseUrl', value: 'x' }] } };
+    expect(hasSecretOption(schema, isSecretName)).toBe(false);
+  });
+
+  it('should not count a select field whose choice name matches a secret', () => {
+    const schema = { kind: { type: 'option', options: [{ name: 'clientSecret', value: 'x' }] } };
     expect(hasSecretOption(schema, isSecretName)).toBe(false);
   });
 });

--- a/packages/cli/src/commands/schema/secrets.test.ts
+++ b/packages/cli/src/commands/schema/secrets.test.ts
@@ -7,21 +7,28 @@ import {
   hasSecretPlaceholder,
   hydrateSecretValues,
   isSecretPlaceholder,
+  markLocalSecretsForDiff,
+  markRemoteSecretsForDiff,
+  maskSecretsToPlaceholder,
   redactSecretValues,
   SECRET_MARKER,
+  secretEnvOf,
   type SecretResolution,
-  stripSecretKeys,
 } from './secrets';
 
-const placeholder = (env?: string) =>
-  (env === undefined ? { [SECRET_MARKER]: true } : { [SECRET_MARKER]: true, env });
+/** Builds a sentinel-string placeholder like `secret()` / `secret('ENV')`. */
+const ph = (env?: string) => (env === undefined ? SECRET_MARKER : `${SECRET_MARKER}:${env}`);
 
-describe('isSecretPlaceholder', () => {
-  it('should detect the marker structurally', () => {
-    expect(isSecretPlaceholder(placeholder())).toBe(true);
-    expect(isSecretPlaceholder(placeholder('X'))).toBe(true);
-    expect(isSecretPlaceholder({ accessKey: 'real' })).toBe(false);
+describe('isSecretPlaceholder / secretEnvOf', () => {
+  it('should detect the sentinel string and parse its env', () => {
+    expect(isSecretPlaceholder(ph())).toBe(true);
+    expect(isSecretPlaceholder(ph('X'))).toBe(true);
+    expect(isSecretPlaceholder('accessKey')).toBe(false);
     expect(isSecretPlaceholder(null)).toBe(false);
+    expect(isSecretPlaceholder({ [SECRET_MARKER]: true })).toBe(false);
+
+    expect(secretEnvOf(ph())).toBeUndefined();
+    expect(secretEnvOf(ph('SHOPWARE_KEY'))).toBe('SHOPWARE_KEY');
   });
 });
 
@@ -30,7 +37,6 @@ describe('createSecretNameMatcher', () => {
     const matches = createSecretNameMatcher(['clientSecret', 'token']);
     expect(matches('clientSecret')).toBe(true);
     expect(matches('CLIENTSECRET')).toBe(true);
-    expect(matches('Token')).toBe(true);
     expect(matches('baseUrl')).toBe(false);
   });
 
@@ -44,48 +50,30 @@ describe('createSecretNameMatcher', () => {
 
 describe('redactSecretValues', () => {
   const isSecretName = createSecretNameMatcher(['clientSecret', 'clientId']);
-  const make = (name: string) => placeholder(name === 'never' ? 'X' : undefined);
+  const make = () => ph();
 
-  it('should redact the `value` of option pairs by name (Shopware integration form)', () => {
-    // Mirrors a real Storyblok custom field: secrets live in `options`, keyed by
-    // the entry `name`; `field_type` is a developer-chosen plugin name and is
-    // never used to identify secrets.
+  it('should redact the `value` of option pairs by name (Shopware form)', () => {
     const input = {
       type: 'custom',
       field_type: 'shopware-integration',
-      datasource: 'shopware',
-      required: true,
       options: [
         { _uid: 'a', name: 'baseUrl', value: 'https://shop.example' },
         { _uid: 'b', name: 'clientId', value: 'SWIACMHZRUTCVEPWSGLQRVJXZW' },
         { _uid: 'c', name: 'clientSecret', value: 'WXpZbzltM1kx' },
-        { _uid: 'd', name: 'limit', value: '1' },
       ],
     };
     const out = redactSecretValues(input, isSecretName, make) as Record<string, any>;
 
     expect(out.options[0].value).toBe('https://shop.example');
-    expect(out.options[1].value).toEqual(placeholder());
-    expect(out.options[2].value).toEqual(placeholder());
-    expect(out.options[3].value).toBe('1');
-    // `name`/`_uid` and other keys are preserved.
-    expect(out.options[2]).toEqual({ _uid: 'c', name: 'clientSecret', value: placeholder() });
+    expect(out.options[1].value).toBe(ph());
+    expect(out.options[2]).toEqual({ _uid: 'c', name: 'clientSecret', value: ph() });
     expect(out.field_type).toBe('shopware-integration');
-    // Source untouched.
-    expect(input.options[2].value).toBe('WXpZbzltM1kx');
-  });
-
-  it('should not touch option pairs whose name is not a secret', () => {
-    const input = { options: [{ name: 'baseUrl', value: 'https://x' }] };
-    const out = redactSecretValues(input, isSecretName, make) as Record<string, any>;
-    expect(out.options[0].value).toBe('https://x');
+    expect(input.options[2].value).toBe('WXpZbzltM1kx'); // source untouched
   });
 
   it('should not treat a top-level key as a secret (only option pairs)', () => {
-    // `clientSecret` as a bare key is NOT redacted — secrets only ever live in options.
-    const input = { clientSecret: 'not-an-option-pair' };
-    const out = redactSecretValues(input, isSecretName, make) as Record<string, any>;
-    expect(out.clientSecret).toBe('not-an-option-pair');
+    const out = redactSecretValues({ clientSecret: 'not-an-option' }, isSecretName, make) as Record<string, any>;
+    expect(out.clientSecret).toBe('not-an-option');
   });
 });
 
@@ -93,44 +81,59 @@ describe('hasSecretOption', () => {
   const isSecretName = createSecretNameMatcher(['clientSecret']);
 
   it('should find a secret option nested in a component schema', () => {
-    const schema = {
-      products: { type: 'custom', options: [{ name: 'clientSecret', value: 'x' }] },
-    };
+    const schema = { products: { type: 'custom', options: [{ name: 'clientSecret', value: 'x' }] } };
     expect(hasSecretOption(schema, isSecretName)).toBe(true);
   });
 
   it('should return false when no option name is a secret', () => {
-    const schema = { title: { type: 'text' }, products: { options: [{ name: 'baseUrl', value: 'x' }] } };
+    const schema = { products: { options: [{ name: 'baseUrl', value: 'x' }] } };
     expect(hasSecretOption(schema, isSecretName)).toBe(false);
   });
 });
 
-describe('stripSecretKeys', () => {
-  it('should drop keys that are placeholders in the reference, from both sides', () => {
-    const local = { type: 'custom', accessKey: placeholder(), label: 'a' };
-    const remote = { type: 'custom', accessKey: 'real-secret', label: 'a' };
+describe('markLocalSecretsForDiff / markRemoteSecretsForDiff', () => {
+  const local = { options: [{ name: 'clientSecret', value: ph('SW_SECRET') }, { name: 'apiKey', value: ph() }] };
 
-    const localStripped = stripSecretKeys(local, local) as Record<string, unknown>;
-    const remoteStripped = stripSecretKeys(remote, local) as Record<string, unknown>;
+  it('should drop preserve-remote secrets and env-managed secrets whose var is unset', () => {
+    const localOut = markLocalSecretsForDiff(local, {}) as any;
+    const remote = { options: [{ name: 'clientSecret', value: 'real' }, { name: 'apiKey', value: 'real2' }] };
+    const remoteOut = markRemoteSecretsForDiff(remote, local, {}) as any;
 
-    expect('accessKey' in localStripped).toBe(false);
-    expect('accessKey' in remoteStripped).toBe(false);
-    expect(localStripped).toEqual(remoteStripped);
+    // Both the preserve secret (apiKey) and the env secret with unset var are dropped on both sides.
+    expect('value' in localOut.options[0]).toBe(false);
+    expect('value' in localOut.options[1]).toBe(false);
+    expect('value' in remoteOut.options[0]).toBe(false);
+    expect('value' in remoteOut.options[1]).toBe(false);
   });
 
-  it('should not mutate its inputs', () => {
-    const local = { accessKey: placeholder() };
-    const remote = { accessKey: 'real' };
-    stripSecretKeys(remote, local);
-    expect(remote.accessKey).toBe('real');
-    expect(local.accessKey).toEqual(placeholder());
+  it('should produce equal tokens when the env value matches the remote value', () => {
+    const env = { SW_SECRET: 'same-value' };
+    const localOut = markLocalSecretsForDiff(local, env) as any;
+    const remote = { options: [{ name: 'clientSecret', value: 'same-value' }, { name: 'apiKey', value: 'x' }] };
+    const remoteOut = markRemoteSecretsForDiff(remote, local, env) as any;
+
+    expect(localOut.options[0].value).toBe(remoteOut.options[0].value);
   });
 
-  it('should leave non-secret keys intact when reference lacks a placeholder', () => {
-    const remote = { accessKey: 'real', label: 'x' };
-    const local = { label: 'x' };
-    const out = stripSecretKeys(remote, local) as Record<string, unknown>;
-    expect(out).toEqual({ accessKey: 'real', label: 'x' });
+  it('should produce different, non-revealing tokens when the env value differs from remote', () => {
+    const env = { SW_SECRET: 'rotated-value' };
+    const localOut = markLocalSecretsForDiff(local, env) as any;
+    const remote = { options: [{ name: 'clientSecret', value: 'old-value' }, { name: 'apiKey', value: 'x' }] };
+    const remoteOut = markRemoteSecretsForDiff(remote, local, env) as any;
+
+    expect(localOut.options[0].value).not.toBe(remoteOut.options[0].value);
+    // The raw secret values never appear in the tokens.
+    expect(localOut.options[0].value).not.toContain('rotated-value');
+    expect(remoteOut.options[0].value).not.toContain('old-value');
+  });
+});
+
+describe('maskSecretsToPlaceholder', () => {
+  it('should mask a real remote value to the local placeholder string', () => {
+    const local = { options: [{ name: 'clientSecret', value: ph('SW') }] };
+    const remote = { options: [{ name: 'clientSecret', value: 'real-live-secret' }] };
+    const out = maskSecretsToPlaceholder(remote, local) as any;
+    expect(out.options[0].value).toBe(ph('SW'));
   });
 });
 
@@ -138,92 +141,59 @@ describe('hydrateSecretValues', () => {
   it('should preserve the remote value when no env is given', () => {
     const resolutions: SecretResolution[] = [];
     const out = hydrateSecretValues(
-      { accessKey: placeholder() },
-      { accessKey: 'remote-secret' },
+      { options: [{ name: 'clientSecret', value: ph() }] },
+      { options: [{ name: 'clientSecret', value: 'remote-secret' }] },
       {},
       resolutions,
-    ) as Record<string, unknown>;
+    ) as any;
 
-    expect(out.accessKey).toBe('remote-secret');
-    expect(resolutions).toEqual([{ key: 'accessKey', source: 'remote' }]);
+    expect(out.options[0].value).toBe('remote-secret');
+    expect(resolutions).toEqual([{ key: 'clientSecret', source: 'remote' }]);
   });
 
   it('should read from the environment when the placeholder names a set variable', () => {
     const resolutions: SecretResolution[] = [];
     const out = hydrateSecretValues(
-      { accessKey: placeholder('SHOPWARE_KEY') },
-      { accessKey: 'remote-secret' },
-      { SHOPWARE_KEY: 'from-env' },
+      { options: [{ name: 'clientSecret', value: ph('SW_KEY') }] },
+      { options: [{ name: 'clientSecret', value: 'remote-secret' }] },
+      { SW_KEY: 'from-env' },
       resolutions,
-    ) as Record<string, unknown>;
+    ) as any;
 
-    expect(out.accessKey).toBe('from-env');
-    expect(resolutions).toEqual([{ key: 'accessKey', source: 'env', env: 'SHOPWARE_KEY' }]);
-  });
-
-  it('should fall back to remote when the named env var is empty or unset', () => {
-    const resolutions: SecretResolution[] = [];
-    const out = hydrateSecretValues(
-      { accessKey: placeholder('SHOPWARE_KEY') },
-      { accessKey: 'remote-secret' },
-      { SHOPWARE_KEY: '' },
-      resolutions,
-    ) as Record<string, unknown>;
-
-    expect(out.accessKey).toBe('remote-secret');
-    expect(resolutions).toEqual([{ key: 'accessKey', source: 'remote' }]);
-  });
-
-  it('should drop the key and record missing when no source exists (e.g. on create)', () => {
-    const resolutions: SecretResolution[] = [];
-    const out = hydrateSecretValues(
-      { accessKey: placeholder('SHOPWARE_KEY'), label: 'keep' },
-      undefined,
-      {},
-      resolutions,
-    ) as Record<string, unknown>;
-
-    expect('accessKey' in out).toBe(false);
-    expect(out.label).toBe('keep');
-    expect(resolutions).toEqual([{ key: 'accessKey', source: 'missing', env: 'SHOPWARE_KEY' }]);
+    expect(out.options[0].value).toBe('from-env');
+    expect(resolutions).toEqual([{ key: 'clientSecret', source: 'env', env: 'SW_KEY' }]);
   });
 
   it('should hydrate option-pair secrets by name even when remote options are reordered', () => {
-    // Local (from the generated file) and remote (live) option arrays can be in
-    // different orders; matching by `name` must still pull the right value.
-    const local = {
-      options: [
-        { name: 'clientId', value: placeholder() },
-        { name: 'clientSecret', value: placeholder() },
-      ],
-    };
-    const remote = {
-      options: [
-        { name: 'clientSecret', value: 'the-secret' },
-        { name: 'clientId', value: 'the-id' },
-      ],
-    };
+    const localSchema = { options: [{ name: 'clientId', value: ph() }, { name: 'clientSecret', value: ph() }] };
+    const remoteSchema = { options: [{ name: 'clientSecret', value: 'the-secret' }, { name: 'clientId', value: 'the-id' }] };
 
-    const out = hydrateSecretValues(local, remote, {}, []) as any;
+    const out = hydrateSecretValues(localSchema, remoteSchema, {}, []) as any;
 
     expect(out.options[0]).toEqual({ name: 'clientId', value: 'the-id' });
     expect(out.options[1]).toEqual({ name: 'clientSecret', value: 'the-secret' });
   });
 
+  it('should drop the key and record missing when no source exists (e.g. on create)', () => {
+    const resolutions: SecretResolution[] = [];
+    const out = hydrateSecretValues(
+      { options: [{ name: 'clientSecret', value: ph('SW_KEY') }] },
+      undefined,
+      {},
+      resolutions,
+    ) as any;
+
+    expect('value' in out.options[0]).toBe(false);
+    expect(resolutions).toEqual([{ key: 'clientSecret', source: 'missing', env: 'SW_KEY' }]);
+  });
+
   it('should never leave a placeholder in the output', () => {
     const out = hydrateSecretValues(
-      { schema: { field: { accessKey: placeholder() } } },
-      { schema: { field: { accessKey: 'real' } } },
+      { options: [{ name: 'clientSecret', value: ph() }] },
+      { options: [{ name: 'clientSecret', value: 'real' }] },
       {},
       [],
     );
     expect(hasSecretPlaceholder(out)).toBe(false);
-  });
-});
-
-describe('hasSecretPlaceholder', () => {
-  it('should find placeholders nested anywhere', () => {
-    expect(hasSecretPlaceholder({ a: { b: [placeholder()] } })).toBe(true);
-    expect(hasSecretPlaceholder({ a: { b: ['plain'] } })).toBe(false);
   });
 });

--- a/packages/cli/src/commands/schema/secrets.test.ts
+++ b/packages/cli/src/commands/schema/secrets.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createSecretNameMatcher,
+  DEFAULT_SECRET_NAMES,
+  hasSecretOption,
+  hasSecretPlaceholder,
+  hydrateSecretValues,
+  isSecretPlaceholder,
+  redactSecretValues,
+  SECRET_MARKER,
+  type SecretResolution,
+  stripSecretKeys,
+} from './secrets';
+
+const placeholder = (env?: string) =>
+  (env === undefined ? { [SECRET_MARKER]: true } : { [SECRET_MARKER]: true, env });
+
+describe('isSecretPlaceholder', () => {
+  it('should detect the marker structurally', () => {
+    expect(isSecretPlaceholder(placeholder())).toBe(true);
+    expect(isSecretPlaceholder(placeholder('X'))).toBe(true);
+    expect(isSecretPlaceholder({ accessKey: 'real' })).toBe(false);
+    expect(isSecretPlaceholder(null)).toBe(false);
+  });
+});
+
+describe('createSecretNameMatcher', () => {
+  it('should match case-insensitively', () => {
+    const matches = createSecretNameMatcher(['clientSecret', 'token']);
+    expect(matches('clientSecret')).toBe(true);
+    expect(matches('CLIENTSECRET')).toBe(true);
+    expect(matches('Token')).toBe(true);
+    expect(matches('baseUrl')).toBe(false);
+  });
+
+  it('should ship sensible defaults', () => {
+    const matches = createSecretNameMatcher(DEFAULT_SECRET_NAMES);
+    expect(matches('clientSecret')).toBe(true);
+    expect(matches('apiToken')).toBe(true);
+    expect(matches('password')).toBe(true);
+  });
+});
+
+describe('redactSecretValues', () => {
+  const isSecretName = createSecretNameMatcher(['clientSecret', 'clientId']);
+  const make = (name: string) => placeholder(name === 'never' ? 'X' : undefined);
+
+  it('should redact the `value` of option pairs by name (Shopware integration form)', () => {
+    // Mirrors a real Storyblok custom field: secrets live in `options`, keyed by
+    // the entry `name`; `field_type` is a developer-chosen plugin name and is
+    // never used to identify secrets.
+    const input = {
+      type: 'custom',
+      field_type: 'shopware-integration',
+      datasource: 'shopware',
+      required: true,
+      options: [
+        { _uid: 'a', name: 'baseUrl', value: 'https://shop.example' },
+        { _uid: 'b', name: 'clientId', value: 'SWIACMHZRUTCVEPWSGLQRVJXZW' },
+        { _uid: 'c', name: 'clientSecret', value: 'WXpZbzltM1kx' },
+        { _uid: 'd', name: 'limit', value: '1' },
+      ],
+    };
+    const out = redactSecretValues(input, isSecretName, make) as Record<string, any>;
+
+    expect(out.options[0].value).toBe('https://shop.example');
+    expect(out.options[1].value).toEqual(placeholder());
+    expect(out.options[2].value).toEqual(placeholder());
+    expect(out.options[3].value).toBe('1');
+    // `name`/`_uid` and other keys are preserved.
+    expect(out.options[2]).toEqual({ _uid: 'c', name: 'clientSecret', value: placeholder() });
+    expect(out.field_type).toBe('shopware-integration');
+    // Source untouched.
+    expect(input.options[2].value).toBe('WXpZbzltM1kx');
+  });
+
+  it('should not touch option pairs whose name is not a secret', () => {
+    const input = { options: [{ name: 'baseUrl', value: 'https://x' }] };
+    const out = redactSecretValues(input, isSecretName, make) as Record<string, any>;
+    expect(out.options[0].value).toBe('https://x');
+  });
+
+  it('should not treat a top-level key as a secret (only option pairs)', () => {
+    // `clientSecret` as a bare key is NOT redacted — secrets only ever live in options.
+    const input = { clientSecret: 'not-an-option-pair' };
+    const out = redactSecretValues(input, isSecretName, make) as Record<string, any>;
+    expect(out.clientSecret).toBe('not-an-option-pair');
+  });
+});
+
+describe('hasSecretOption', () => {
+  const isSecretName = createSecretNameMatcher(['clientSecret']);
+
+  it('should find a secret option nested in a component schema', () => {
+    const schema = {
+      products: { type: 'custom', options: [{ name: 'clientSecret', value: 'x' }] },
+    };
+    expect(hasSecretOption(schema, isSecretName)).toBe(true);
+  });
+
+  it('should return false when no option name is a secret', () => {
+    const schema = { title: { type: 'text' }, products: { options: [{ name: 'baseUrl', value: 'x' }] } };
+    expect(hasSecretOption(schema, isSecretName)).toBe(false);
+  });
+});
+
+describe('stripSecretKeys', () => {
+  it('should drop keys that are placeholders in the reference, from both sides', () => {
+    const local = { type: 'custom', accessKey: placeholder(), label: 'a' };
+    const remote = { type: 'custom', accessKey: 'real-secret', label: 'a' };
+
+    const localStripped = stripSecretKeys(local, local) as Record<string, unknown>;
+    const remoteStripped = stripSecretKeys(remote, local) as Record<string, unknown>;
+
+    expect('accessKey' in localStripped).toBe(false);
+    expect('accessKey' in remoteStripped).toBe(false);
+    expect(localStripped).toEqual(remoteStripped);
+  });
+
+  it('should not mutate its inputs', () => {
+    const local = { accessKey: placeholder() };
+    const remote = { accessKey: 'real' };
+    stripSecretKeys(remote, local);
+    expect(remote.accessKey).toBe('real');
+    expect(local.accessKey).toEqual(placeholder());
+  });
+
+  it('should leave non-secret keys intact when reference lacks a placeholder', () => {
+    const remote = { accessKey: 'real', label: 'x' };
+    const local = { label: 'x' };
+    const out = stripSecretKeys(remote, local) as Record<string, unknown>;
+    expect(out).toEqual({ accessKey: 'real', label: 'x' });
+  });
+});
+
+describe('hydrateSecretValues', () => {
+  it('should preserve the remote value when no env is given', () => {
+    const resolutions: SecretResolution[] = [];
+    const out = hydrateSecretValues(
+      { accessKey: placeholder() },
+      { accessKey: 'remote-secret' },
+      {},
+      resolutions,
+    ) as Record<string, unknown>;
+
+    expect(out.accessKey).toBe('remote-secret');
+    expect(resolutions).toEqual([{ key: 'accessKey', source: 'remote' }]);
+  });
+
+  it('should read from the environment when the placeholder names a set variable', () => {
+    const resolutions: SecretResolution[] = [];
+    const out = hydrateSecretValues(
+      { accessKey: placeholder('SHOPWARE_KEY') },
+      { accessKey: 'remote-secret' },
+      { SHOPWARE_KEY: 'from-env' },
+      resolutions,
+    ) as Record<string, unknown>;
+
+    expect(out.accessKey).toBe('from-env');
+    expect(resolutions).toEqual([{ key: 'accessKey', source: 'env', env: 'SHOPWARE_KEY' }]);
+  });
+
+  it('should fall back to remote when the named env var is empty or unset', () => {
+    const resolutions: SecretResolution[] = [];
+    const out = hydrateSecretValues(
+      { accessKey: placeholder('SHOPWARE_KEY') },
+      { accessKey: 'remote-secret' },
+      { SHOPWARE_KEY: '' },
+      resolutions,
+    ) as Record<string, unknown>;
+
+    expect(out.accessKey).toBe('remote-secret');
+    expect(resolutions).toEqual([{ key: 'accessKey', source: 'remote' }]);
+  });
+
+  it('should drop the key and record missing when no source exists (e.g. on create)', () => {
+    const resolutions: SecretResolution[] = [];
+    const out = hydrateSecretValues(
+      { accessKey: placeholder('SHOPWARE_KEY'), label: 'keep' },
+      undefined,
+      {},
+      resolutions,
+    ) as Record<string, unknown>;
+
+    expect('accessKey' in out).toBe(false);
+    expect(out.label).toBe('keep');
+    expect(resolutions).toEqual([{ key: 'accessKey', source: 'missing', env: 'SHOPWARE_KEY' }]);
+  });
+
+  it('should hydrate option-pair secrets by name even when remote options are reordered', () => {
+    // Local (from the generated file) and remote (live) option arrays can be in
+    // different orders; matching by `name` must still pull the right value.
+    const local = {
+      options: [
+        { name: 'clientId', value: placeholder() },
+        { name: 'clientSecret', value: placeholder() },
+      ],
+    };
+    const remote = {
+      options: [
+        { name: 'clientSecret', value: 'the-secret' },
+        { name: 'clientId', value: 'the-id' },
+      ],
+    };
+
+    const out = hydrateSecretValues(local, remote, {}, []) as any;
+
+    expect(out.options[0]).toEqual({ name: 'clientId', value: 'the-id' });
+    expect(out.options[1]).toEqual({ name: 'clientSecret', value: 'the-secret' });
+  });
+
+  it('should never leave a placeholder in the output', () => {
+    const out = hydrateSecretValues(
+      { schema: { field: { accessKey: placeholder() } } },
+      { schema: { field: { accessKey: 'real' } } },
+      {},
+      [],
+    );
+    expect(hasSecretPlaceholder(out)).toBe(false);
+  });
+});
+
+describe('hasSecretPlaceholder', () => {
+  it('should find placeholders nested anywhere', () => {
+    expect(hasSecretPlaceholder({ a: { b: [placeholder()] } })).toBe(true);
+    expect(hasSecretPlaceholder({ a: { b: ['plain'] } })).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/schema/secrets.ts
+++ b/packages/cli/src/commands/schema/secrets.ts
@@ -1,34 +1,40 @@
+import { createHash, randomBytes } from 'node:crypto';
+
 import { isRecord } from './utils';
 
 /**
- * Secret handling for the `schema` command. Sensitive field-config values (e.g.
- * an integration `accessKey`) must never be written to the versioned schema, and
- * must never be cleared on the remote space by a push that carries a redacted
- * local value.
+ * Secret handling for the `schema` command. Sensitive plugin option values (e.g.
+ * an integration `clientSecret`) must never be written to the versioned schema,
+ * and must never be cleared on the space by a push that carries a redacted local
+ * value.
  *
- * The mechanism is a placeholder object marked with {@link SECRET_MARKER},
- * produced by `@storyblok/schema`'s `secret()` helper. This module owns the CLI
- * side: introducing placeholders on `init` (redaction), excluding them from
- * diffing, and substituting the real value on `push` (hydration).
+ * The mechanism is a placeholder produced by `@storyblok/schema`'s `secret()`
+ * helper. It is a sentinel **string** (not an object) so it slots into a plugin
+ * option's string `value`. This module owns the CLI side: introducing
+ * placeholders on `init` (redaction), representing them in the diff, and
+ * substituting the real value on `push` (hydration).
  *
- * Detection is structural (by the marker string), not by object identity, so a
- * placeholder produced by any installed version of `@storyblok/schema` is
- * recognized — the value reaching the CLI comes from the user's project, not
- * from this package.
+ * Detection is structural (by the marker prefix), so a placeholder produced by
+ * any installed version of `@storyblok/schema` is recognized — the value
+ * reaching the CLI comes from the user's project, not from this package.
  */
 
 /** Must match `SECRET_MARKER` exported by `@storyblok/schema`. */
-export const SECRET_MARKER = '__storyblokSecret';
+export const SECRET_MARKER = '__storyblokSecret__';
 
-export interface SecretPlaceholder {
-  [SECRET_MARKER]: true;
-  /** Environment variable the real value is read from on push, when present. */
-  env?: string;
-}
+/** A redacted secret placeholder: `SECRET_MARKER`, optionally `` `${SECRET_MARKER}:ENV` ``. */
+export type SecretPlaceholder = string;
 
 /** Returns true if `value` is a secret placeholder produced by `secret()`. */
 export function isSecretPlaceholder(value: unknown): value is SecretPlaceholder {
-  return isRecord(value) && value[SECRET_MARKER] === true;
+  return typeof value === 'string'
+    && (value === SECRET_MARKER || value.startsWith(`${SECRET_MARKER}:`));
+}
+
+/** Returns the env var name a placeholder is bound to, or `undefined` for a preserve-remote secret. */
+export function secretEnvOf(placeholder: string): string | undefined {
+  const prefix = `${SECRET_MARKER}:`;
+  return placeholder.startsWith(prefix) ? placeholder.slice(prefix.length) : undefined;
 }
 
 /**
@@ -110,23 +116,80 @@ export function redactSecretValues(
   return value;
 }
 
+// Per-process salt so a secret's diff fingerprint reveals nothing and cannot be
+// correlated across runs; equality within a single diff (local vs remote) still
+// holds because both sides use the same salt.
+const FINGERPRINT_SALT = randomBytes(16);
+
+/** Short, non-reversible fingerprint of a value, for change detection in diffs without revealing it. */
+function fingerprint(value: unknown): string {
+  return createHash('sha256').update(FINGERPRINT_SALT).update(String(value)).digest('hex').slice(0, 10);
+}
+
+/** A stable, non-revealing diff token for an env-managed secret. Equal tokens ⇒ equal values. */
+function secretDiffToken(envName: string, fp: string): string {
+  return `<secret env:${envName} #${fp}>`;
+}
+
 /**
- * Deep-copies `value`, dropping every key whose value in `reference` (at the
- * same path) is a secret placeholder. Symmetric by design: pass the local schema
- * as `reference` for both the local copy (secret keys drop out) and the remote
- * copy (the same keys drop out), so a redacted secret produces no diff. Also used
- * to redact a remote snapshot for the changeset. Neither argument is mutated.
+ * Deep-copies the **local** schema for diffing: an env-managed secret
+ * (`secret('ENV')` with the variable set and non-empty) becomes a non-revealing
+ * fingerprint token of the env value, so rotating it shows as a diff; a
+ * preserve-remote secret (`secret()`, or its env var unset) is dropped so it
+ * never diffs. The source is never mutated.
  */
-export function stripSecretKeys(value: unknown, reference: unknown): unknown {
+export function markLocalSecretsForDiff(value: unknown, env: Record<string, string | undefined> = process.env): unknown {
   if (Array.isArray(value)) {
-    return value.map((item, i) => stripSecretKeys(item, referenceFor(item, i, reference)));
+    return value.map(item => markLocalSecretsForDiff(item, env));
   }
   if (isRecord(value)) {
     const out: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      const ref = isRecord(reference) ? reference[key] : undefined;
-      if (isSecretPlaceholder(ref)) { continue; }
-      out[key] = stripSecretKeys(val, ref);
+      if (isSecretPlaceholder(val)) {
+        const envName = secretEnvOf(val);
+        const envVal = envName ? env[envName] : undefined;
+        if (envName && envVal !== undefined && envVal !== '') {
+          out[key] = secretDiffToken(envName, fingerprint(envVal));
+        }
+        // else preserve-remote: drop so it never diffs.
+        continue;
+      }
+      out[key] = markLocalSecretsForDiff(val, env);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Deep-copies the **remote** schema for diffing, using the local schema as the
+ * reference for which values are secret. Symmetric with
+ * {@link markLocalSecretsForDiff}: an env-managed secret becomes a fingerprint
+ * token of the **remote** value; a preserve-remote secret is dropped. The
+ * arguments are never mutated.
+ */
+export function markRemoteSecretsForDiff(
+  value: unknown,
+  referenceLocal: unknown,
+  env: Record<string, string | undefined> = process.env,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, i) => markRemoteSecretsForDiff(item, referenceFor(item, i, referenceLocal), env));
+  }
+  if (isRecord(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const ref = isRecord(referenceLocal) ? referenceLocal[key] : undefined;
+      if (isSecretPlaceholder(ref)) {
+        const envName = secretEnvOf(ref);
+        const envVal = envName ? env[envName] : undefined;
+        if (envName && envVal !== undefined && envVal !== '') {
+          out[key] = secretDiffToken(envName, fingerprint(val));
+        }
+        // else preserve-remote: drop so it never diffs.
+        continue;
+      }
+      out[key] = markRemoteSecretsForDiff(val, ref, env);
     }
     return out;
   }
@@ -135,11 +198,11 @@ export function stripSecretKeys(value: unknown, reference: unknown): unknown {
 
 /**
  * Deep-copies `value`, replacing each value whose counterpart in `reference` (at
- * the same path) is a secret placeholder with a copy of that placeholder. Unlike
- * {@link stripSecretKeys} (which drops the key), this keeps the key present as a
- * placeholder — used for the changeset's remote snapshot so a real secret is
- * never written to disk, yet `schema rollback` can still recognize the field as
- * secret and hydrate it from the live space. Neither argument is mutated.
+ * the same path) is a secret placeholder with that placeholder string. Keeps the
+ * key present (unlike a plain strip) — used for the changeset's remote snapshot
+ * so a real secret is never written to disk, yet `schema rollback` can still
+ * recognize the field as secret and hydrate it from the live space. Neither
+ * argument is mutated.
  */
 export function maskSecretsToPlaceholder(value: unknown, reference: unknown): unknown {
   if (Array.isArray(value)) {
@@ -150,7 +213,7 @@ export function maskSecretsToPlaceholder(value: unknown, reference: unknown): un
     for (const [key, val] of Object.entries(value)) {
       const ref = isRecord(reference) ? reference[key] : undefined;
       out[key] = isSecretPlaceholder(ref)
-        ? { ...ref }
+        ? ref
         : maskSecretsToPlaceholder(val, ref);
     }
     return out;
@@ -160,7 +223,7 @@ export function maskSecretsToPlaceholder(value: unknown, reference: unknown): un
 
 /** How a single secret placeholder was resolved during {@link hydrateSecretValues}. */
 export interface SecretResolution {
-  /** The config key that held the placeholder (for user-facing messages). */
+  /** The secret's option name (or object key) for user-facing messages. */
   key: string;
   /** `env`: read from `process.env`; `remote`: kept from the space; `missing`: no source. */
   source: 'env' | 'remote' | 'missing';
@@ -195,22 +258,25 @@ export function hydrateSecretValues(
   }
   if (isRecord(value)) {
     const out: Record<string, unknown> = {};
+    // Report an option secret by its `name` rather than the `value` key it sits under.
+    const label = typeof value.name === 'string' ? value.name : undefined;
     for (const [key, val] of Object.entries(value)) {
       const remoteVal = isRecord(remote) ? remote[key] : undefined;
       if (isSecretPlaceholder(val)) {
-        const envName = val.env;
+        const reportKey = key === 'value' && label ? label : key;
+        const envName = secretEnvOf(val);
         const envVal = envName ? env[envName] : undefined;
         if (envName && envVal !== undefined && envVal !== '') {
           out[key] = envVal;
-          resolutions.push({ key, source: 'env', env: envName });
+          resolutions.push({ key: reportKey, source: 'env', env: envName });
         }
         else if (remoteVal !== undefined) {
           out[key] = remoteVal;
-          resolutions.push({ key, source: 'remote' });
+          resolutions.push({ key: reportKey, source: 'remote' });
         }
         else {
           // No source: drop the key so a placeholder never reaches the API.
-          resolutions.push({ key, source: 'missing', ...(envName && { env: envName }) });
+          resolutions.push({ key: reportKey, source: 'missing', ...(envName && { env: envName }) });
         }
         continue;
       }

--- a/packages/cli/src/commands/schema/secrets.ts
+++ b/packages/cli/src/commands/schema/secrets.ts
@@ -1,0 +1,244 @@
+import { isRecord } from './utils';
+
+/**
+ * Secret handling for the `schema` command. Sensitive field-config values (e.g.
+ * an integration `accessKey`) must never be written to the versioned schema, and
+ * must never be cleared on the remote space by a push that carries a redacted
+ * local value.
+ *
+ * The mechanism is a placeholder object marked with {@link SECRET_MARKER},
+ * produced by `@storyblok/schema`'s `secret()` helper. This module owns the CLI
+ * side: introducing placeholders on `init` (redaction), excluding them from
+ * diffing, and substituting the real value on `push` (hydration).
+ *
+ * Detection is structural (by the marker string), not by object identity, so a
+ * placeholder produced by any installed version of `@storyblok/schema` is
+ * recognized — the value reaching the CLI comes from the user's project, not
+ * from this package.
+ */
+
+/** Must match `SECRET_MARKER` exported by `@storyblok/schema`. */
+export const SECRET_MARKER = '__storyblokSecret';
+
+export interface SecretPlaceholder {
+  [SECRET_MARKER]: true;
+  /** Environment variable the real value is read from on push, when present. */
+  env?: string;
+}
+
+/** Returns true if `value` is a secret placeholder produced by `secret()`. */
+export function isSecretPlaceholder(value: unknown): value is SecretPlaceholder {
+  return isRecord(value) && value[SECRET_MARKER] === true;
+}
+
+/**
+ * Storyblok plugin option `name`s that `schema init` redacts by default.
+ * Sensitive plugin data lives in an `options: [{ name, value }]` array (e.g. the
+ * Shopware integration keeps its credentials there), so a secret is identified
+ * by the option's `name`, not by a top-level config key. Matching is
+ * case-insensitive. Extend via `--secret-names`; disable via `--no-redact-secrets`.
+ */
+export const DEFAULT_SECRET_NAMES: readonly string[] = [
+  'accessKey',
+  'apiKey',
+  'apiToken',
+  'token',
+  'secret',
+  'clientSecret',
+  'password',
+  'privateKey',
+];
+
+/** Builds a case-insensitive matcher from a list of secret option names. */
+export function createSecretNameMatcher(names: Iterable<string>): (name: string) => boolean {
+  const set = new Set([...names].map(name => name.toLowerCase()));
+  return (name: string) => set.has(name.toLowerCase());
+}
+
+/**
+ * Storyblok stores plugin options as `{ name, value }` pairs inside an
+ * `options: [...]` array (e.g. the Shopware integration keeps `clientSecret`
+ * under `value`, discriminated by the sibling `name`). A secret is identified by
+ * the entry's `name`. Returns the matching `name` when `record` is such a pair,
+ * otherwise `undefined`.
+ */
+function secretOptionName(record: Record<string, unknown>, isSecretName: (name: string) => boolean): string | undefined {
+  return typeof record.name === 'string' && 'value' in record && isSecretName(record.name)
+    ? record.name
+    : undefined;
+}
+
+/**
+ * Finds the counterpart of an array element in `reference`. Option pairs carry a
+ * stable `name`, so elements with a string `name` are matched by name (robust to
+ * reordering); everything else falls back to positional index.
+ */
+function referenceFor(item: unknown, index: number, reference: unknown): unknown {
+  if (!Array.isArray(reference)) { return undefined; }
+  if (isRecord(item) && typeof item.name === 'string') {
+    const byName = reference.find(entry => isRecord(entry) && entry.name === item.name);
+    if (byName !== undefined) { return byName; }
+  }
+  return reference[index];
+}
+
+/**
+ * Deep-copies `value`, replacing the `value` of every Storyblok option pair
+ * `{ name, value }` whose `name` matches `isSecretName` with
+ * `makePlaceholder(name)` (the `name`/`_uid` are kept). Used by `init` before
+ * writing to disk. The replaced value is not recursed into; the source is never
+ * mutated.
+ */
+export function redactSecretValues(
+  value: unknown,
+  isSecretName: (name: string) => boolean,
+  makePlaceholder: (name: string) => unknown,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map(item => redactSecretValues(item, isSecretName, makePlaceholder));
+  }
+  if (isRecord(value)) {
+    const optionName = secretOptionName(value, isSecretName);
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = optionName && key === 'value'
+        ? makePlaceholder(optionName)
+        : redactSecretValues(val, isSecretName, makePlaceholder);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Deep-copies `value`, dropping every key whose value in `reference` (at the
+ * same path) is a secret placeholder. Symmetric by design: pass the local schema
+ * as `reference` for both the local copy (secret keys drop out) and the remote
+ * copy (the same keys drop out), so a redacted secret produces no diff. Also used
+ * to redact a remote snapshot for the changeset. Neither argument is mutated.
+ */
+export function stripSecretKeys(value: unknown, reference: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, i) => stripSecretKeys(item, referenceFor(item, i, reference)));
+  }
+  if (isRecord(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const ref = isRecord(reference) ? reference[key] : undefined;
+      if (isSecretPlaceholder(ref)) { continue; }
+      out[key] = stripSecretKeys(val, ref);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Deep-copies `value`, replacing each value whose counterpart in `reference` (at
+ * the same path) is a secret placeholder with a copy of that placeholder. Unlike
+ * {@link stripSecretKeys} (which drops the key), this keeps the key present as a
+ * placeholder — used for the changeset's remote snapshot so a real secret is
+ * never written to disk, yet `schema rollback` can still recognize the field as
+ * secret and hydrate it from the live space. Neither argument is mutated.
+ */
+export function maskSecretsToPlaceholder(value: unknown, reference: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, i) => maskSecretsToPlaceholder(item, referenceFor(item, i, reference)));
+  }
+  if (isRecord(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const ref = isRecord(reference) ? reference[key] : undefined;
+      out[key] = isSecretPlaceholder(ref)
+        ? { ...ref }
+        : maskSecretsToPlaceholder(val, ref);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** How a single secret placeholder was resolved during {@link hydrateSecretValues}. */
+export interface SecretResolution {
+  /** The config key that held the placeholder (for user-facing messages). */
+  key: string;
+  /** `env`: read from `process.env`; `remote`: kept from the space; `missing`: no source. */
+  source: 'env' | 'remote' | 'missing';
+  /** The environment variable consulted, when the placeholder specified one. */
+  env?: string;
+}
+
+/**
+ * Deep-copies `value`, replacing each secret placeholder with its resolved real
+ * value so nothing marked secret ever reaches the Management API as a
+ * placeholder. Resolution order per placeholder:
+ *
+ * 1. `process.env[env]` when the placeholder names an env var that is set and
+ *    non-empty (managed/rotatable secret, e.g. in CI);
+ * 2. otherwise the value already stored in the space at the same path (the
+ *    existing secret is preserved rather than cleared);
+ * 3. otherwise the key is omitted entirely and recorded as `missing` — on a
+ *    freshly created component there is no remote value to preserve.
+ *
+ * Each resolution is appended to `resolutions` so the caller can warn about
+ * `missing` ones. `remote` is the corresponding remote subtree (may be
+ * undefined, e.g. on create). Neither argument is mutated.
+ */
+export function hydrateSecretValues(
+  value: unknown,
+  remote: unknown,
+  env: Record<string, string | undefined>,
+  resolutions: SecretResolution[],
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, i) => hydrateSecretValues(item, referenceFor(item, i, remote), env, resolutions));
+  }
+  if (isRecord(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const remoteVal = isRecord(remote) ? remote[key] : undefined;
+      if (isSecretPlaceholder(val)) {
+        const envName = val.env;
+        const envVal = envName ? env[envName] : undefined;
+        if (envName && envVal !== undefined && envVal !== '') {
+          out[key] = envVal;
+          resolutions.push({ key, source: 'env', env: envName });
+        }
+        else if (remoteVal !== undefined) {
+          out[key] = remoteVal;
+          resolutions.push({ key, source: 'remote' });
+        }
+        else {
+          // No source: drop the key so a placeholder never reaches the API.
+          resolutions.push({ key, source: 'missing', ...(envName && { env: envName }) });
+        }
+        continue;
+      }
+      out[key] = hydrateSecretValues(val, remoteVal, env, resolutions);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Returns true if any secret placeholder exists anywhere within `value`. */
+export function hasSecretPlaceholder(value: unknown): boolean {
+  if (isSecretPlaceholder(value)) { return true; }
+  if (Array.isArray(value)) { return value.some(hasSecretPlaceholder); }
+  if (isRecord(value)) { return Object.values(value).some(hasSecretPlaceholder); }
+  return false;
+}
+
+/**
+ * Returns true if any Storyblok option pair anywhere within `value` has a `name`
+ * matching `isSecretName`. Used to decide whether an `init`-generated file needs
+ * a `secret` import.
+ */
+export function hasSecretOption(value: unknown, isSecretName: (name: string) => boolean): boolean {
+  if (Array.isArray(value)) { return value.some(item => hasSecretOption(item, isSecretName)); }
+  if (isRecord(value)) {
+    if (secretOptionName(value, isSecretName)) { return true; }
+    return Object.values(value).some(val => hasSecretOption(val, isSecretName));
+  }
+  return false;
+}

--- a/packages/cli/src/commands/schema/secrets.ts
+++ b/packages/cli/src/commands/schema/secrets.ts
@@ -94,6 +94,10 @@ function referenceFor(item: unknown, index: number, reference: unknown): unknown
  * `makePlaceholder(name)` (the `name`/`_uid` are kept). Used by `init` before
  * writing to disk. The replaced value is not recursed into; the source is never
  * mutated.
+ *
+ * The caller must scope this to custom plugin field configs (`type: 'custom'`):
+ * the built-in `option`/`options` select fields use the same `{ name, value }`
+ * shape for their choices, and those must never be redacted.
  */
 export function redactSecretValues(
   value: unknown,

--- a/packages/cli/src/commands/schema/secrets.ts
+++ b/packages/cli/src/commands/schema/secrets.ts
@@ -95,25 +95,29 @@ function referenceFor(item: unknown, index: number, reference: unknown): unknown
  * writing to disk. The replaced value is not recursed into; the source is never
  * mutated.
  *
- * The caller must scope this to custom plugin field configs (`type: 'custom'`):
- * the built-in `option`/`options` select fields use the same `{ name, value }`
- * shape for their choices, and those must never be redacted.
+ * Redaction is scoped to custom plugin fields: a pair is only eligible once the
+ * walk has entered a `type: 'custom'` record. The built-in `option`/`options`
+ * select fields reuse the same `{ name, value }` shape for their choices, which
+ * must never be redacted. `inCustomField` carries that context down the tree and
+ * defaults to `false` (callers pass a whole field/schema, not a bare option).
  */
 export function redactSecretValues(
   value: unknown,
   isSecretName: (name: string) => boolean,
   makePlaceholder: (name: string) => unknown,
+  inCustomField = false,
 ): unknown {
   if (Array.isArray(value)) {
-    return value.map(item => redactSecretValues(item, isSecretName, makePlaceholder));
+    return value.map(item => redactSecretValues(item, isSecretName, makePlaceholder, inCustomField));
   }
   if (isRecord(value)) {
-    const optionName = secretOptionName(value, isSecretName);
+    const custom = inCustomField || value.type === 'custom';
+    const optionName = custom ? secretOptionName(value, isSecretName) : undefined;
     const out: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
       out[key] = optionName && key === 'value'
         ? makePlaceholder(optionName)
-        : redactSecretValues(val, isSecretName, makePlaceholder);
+        : redactSecretValues(val, isSecretName, makePlaceholder, custom);
     }
     return out;
   }
@@ -300,15 +304,17 @@ export function hasSecretPlaceholder(value: unknown): boolean {
 }
 
 /**
- * Returns true if any Storyblok option pair anywhere within `value` has a `name`
- * matching `isSecretName`. Used to decide whether an `init`-generated file needs
- * a `secret` import.
+ * Returns true if any custom plugin field within `value` has an option pair
+ * whose `name` matches `isSecretName`. Scoped to `type: 'custom'` records the
+ * same way as {@link redactSecretValues}, so select-field choices never count.
+ * Used to decide whether an `init`-generated file needs a `secret` import.
  */
-export function hasSecretOption(value: unknown, isSecretName: (name: string) => boolean): boolean {
-  if (Array.isArray(value)) { return value.some(item => hasSecretOption(item, isSecretName)); }
+export function hasSecretOption(value: unknown, isSecretName: (name: string) => boolean, inCustomField = false): boolean {
+  if (Array.isArray(value)) { return value.some(item => hasSecretOption(item, isSecretName, inCustomField)); }
   if (isRecord(value)) {
-    if (secretOptionName(value, isSecretName)) { return true; }
-    return Object.values(value).some(val => hasSecretOption(val, isSecretName));
+    const custom = inCustomField || value.type === 'custom';
+    if (custom && secretOptionName(value, isSecretName)) { return true; }
+    return Object.values(value).some(val => hasSecretOption(val, isSecretName, custom));
   }
   return false;
 }

--- a/packages/schema/src/helpers/secret.test.ts
+++ b/packages/schema/src/helpers/secret.test.ts
@@ -3,19 +3,17 @@ import { describe, expect, it } from 'vitest';
 import { isSecretPlaceholder, secret, SECRET_MARKER } from './secret';
 
 describe('secret', () => {
-  it('should create a preserve-remote placeholder with no env', () => {
-    expect(secret()).toEqual({ [SECRET_MARKER]: true });
+  it('should create a preserve-remote placeholder string with no env', () => {
+    expect(secret()).toBe(SECRET_MARKER);
   });
 
-  it('should create an env-backed placeholder when a variable name is given', () => {
-    expect(secret('SHOPWARE_ACCESS_KEY')).toEqual({
-      [SECRET_MARKER]: true,
-      env: 'SHOPWARE_ACCESS_KEY',
-    });
+  it('should encode the env variable name when given', () => {
+    expect(secret('SHOPWARE_ACCESS_KEY')).toBe(`${SECRET_MARKER}:SHOPWARE_ACCESS_KEY`);
   });
 
-  it('should not carry an env key when none is provided', () => {
-    expect('env' in secret()).toBe(false);
+  it('should return a string so it fits a plugin option value', () => {
+    expect(typeof secret()).toBe('string');
+    expect(typeof secret('X')).toBe('string');
   });
 });
 
@@ -26,17 +24,17 @@ describe('isSecretPlaceholder', () => {
   });
 
   it('should recognize a structurally-equal placeholder from another package instance', () => {
-    // The CLI matches on the marker string, not object identity, so a plain
-    // object with the marker must be accepted.
-    expect(isSecretPlaceholder({ [SECRET_MARKER]: true })).toBe(true);
+    // The CLI matches on the marker string, so a bare sentinel must be accepted.
+    expect(isSecretPlaceholder(SECRET_MARKER)).toBe(true);
+    expect(isSecretPlaceholder(`${SECRET_MARKER}:MY_ENV`)).toBe(true);
   });
 
   it('should reject non-placeholder values', () => {
     expect(isSecretPlaceholder('accessKey')).toBe(false);
+    expect(isSecretPlaceholder('')).toBe(false);
     expect(isSecretPlaceholder(null)).toBe(false);
     expect(isSecretPlaceholder(undefined)).toBe(false);
-    expect(isSecretPlaceholder({ [SECRET_MARKER]: false })).toBe(false);
-    expect(isSecretPlaceholder({ accessKey: 'real' })).toBe(false);
-    expect(isSecretPlaceholder([SECRET_MARKER])).toBe(false);
+    expect(isSecretPlaceholder({ [SECRET_MARKER]: true })).toBe(false);
+    expect(isSecretPlaceholder(`prefixed ${SECRET_MARKER}`)).toBe(false);
   });
 });

--- a/packages/schema/src/helpers/secret.test.ts
+++ b/packages/schema/src/helpers/secret.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSecretPlaceholder, secret, SECRET_MARKER } from './secret';
+
+describe('secret', () => {
+  it('should create a preserve-remote placeholder with no env', () => {
+    expect(secret()).toEqual({ [SECRET_MARKER]: true });
+  });
+
+  it('should create an env-backed placeholder when a variable name is given', () => {
+    expect(secret('SHOPWARE_ACCESS_KEY')).toEqual({
+      [SECRET_MARKER]: true,
+      env: 'SHOPWARE_ACCESS_KEY',
+    });
+  });
+
+  it('should not carry an env key when none is provided', () => {
+    expect('env' in secret()).toBe(false);
+  });
+});
+
+describe('isSecretPlaceholder', () => {
+  it('should recognize placeholders produced by secret()', () => {
+    expect(isSecretPlaceholder(secret())).toBe(true);
+    expect(isSecretPlaceholder(secret('TOKEN'))).toBe(true);
+  });
+
+  it('should recognize a structurally-equal placeholder from another package instance', () => {
+    // The CLI matches on the marker string, not object identity, so a plain
+    // object with the marker must be accepted.
+    expect(isSecretPlaceholder({ [SECRET_MARKER]: true })).toBe(true);
+  });
+
+  it('should reject non-placeholder values', () => {
+    expect(isSecretPlaceholder('accessKey')).toBe(false);
+    expect(isSecretPlaceholder(null)).toBe(false);
+    expect(isSecretPlaceholder(undefined)).toBe(false);
+    expect(isSecretPlaceholder({ [SECRET_MARKER]: false })).toBe(false);
+    expect(isSecretPlaceholder({ accessKey: 'real' })).toBe(false);
+    expect(isSecretPlaceholder([SECRET_MARKER])).toBe(false);
+  });
+});

--- a/packages/schema/src/helpers/secret.ts
+++ b/packages/schema/src/helpers/secret.ts
@@ -1,51 +1,44 @@
-import { isRecord } from '../utils/is-record';
-
 /**
- * Property key that brands a value as a redacted secret placeholder. Chosen to be
- * unlikely to collide with a real field-config key. The Storyblok CLI recognizes
- * this exact string structurally (not by object identity), so a placeholder
- * produced by *any* installed version of `@storyblok/schema` round-trips through
- * `schema push` — keep the literal stable across releases.
+ * Marker prefix of a redacted secret placeholder. A placeholder is a plain
+ * string so it fits string-typed plugin option values (`options: [{ name, value }]`,
+ * where `value` is a `string`). The Storyblok CLI recognizes this exact prefix
+ * structurally, so a placeholder produced by any installed version of
+ * `@storyblok/schema` round-trips through `schema push` — keep the literal stable.
+ *
+ * - `secret()` produces exactly `SECRET_MARKER`.
+ * - `secret('ENV')` produces `` `${SECRET_MARKER}:ENV` ``.
  */
-export const SECRET_MARKER = '__storyblokSecret' as const;
+export const SECRET_MARKER = '__storyblokSecret__' as const;
+
+/** A redacted secret placeholder: a sentinel string, optionally carrying an env var name. */
+export type SecretPlaceholder = string;
 
 /**
- * Placeholder that stands in for a sensitive field-config value (e.g. an
- * integration `accessKey`) in a versioned schema. It carries no secret itself —
- * only, optionally, the name of the environment variable the real value should
- * be read from at push time.
- */
-export interface SecretPlaceholder {
-  readonly [SECRET_MARKER]: true;
-  /** Environment variable the CLI reads the real value from on `schema push`. */
-  readonly env?: string;
-}
-
-/**
- * Marks a field-config value as a secret so it is never written to the versioned
- * schema. `schema init` emits this in place of sensitive values; `schema push`
- * excludes it from diffing and, right before writing to the Management API,
- * substitutes the real value — from `process.env[env]` when an `env` name is
- * given and set, otherwise from the value already stored in the space (so an
- * existing secret is preserved, never cleared).
+ * Marks a plugin option value as a secret so it is never written to the
+ * versioned schema. `schema init` emits this in place of sensitive values;
+ * `schema push` excludes it from diffing and, right before writing to the
+ * Management API, substitutes the real value — from `process.env[env]` when an
+ * `env` name is given and set, otherwise from the value already stored in the
+ * space (so an existing secret is preserved, never cleared).
+ *
+ * Returns a sentinel string, so it slots into a plugin option's string `value`.
  *
  * @param env Optional environment variable to source the value from on push.
  *
  * @example
  * // Preserve whatever the space already has (secret never leaves Storyblok):
- * defineField('shopware', { type: 'custom', accessKey: secret() });
+ * defineField('shopware', { type: 'custom', options: [{ name: 'accessKey', value: secret() }] });
  *
  * @example
  * // Manage the value from an environment variable (e.g. in CI):
- * defineField('shopware', { type: 'custom', accessKey: secret('SHOPWARE_ACCESS_KEY') });
+ * defineField('shopware', { type: 'custom', options: [{ name: 'accessKey', value: secret('SHOPWARE_ACCESS_KEY') }] });
  */
 export function secret(env?: string): SecretPlaceholder {
-  return env === undefined
-    ? { [SECRET_MARKER]: true }
-    : { [SECRET_MARKER]: true, env };
+  return env === undefined ? SECRET_MARKER : `${SECRET_MARKER}:${env}`;
 }
 
 /** Returns true if `value` is a {@link SecretPlaceholder} produced by {@link secret}. */
 export function isSecretPlaceholder(value: unknown): value is SecretPlaceholder {
-  return isRecord(value) && value[SECRET_MARKER] === true;
+  return typeof value === 'string'
+    && (value === SECRET_MARKER || value.startsWith(`${SECRET_MARKER}:`));
 }

--- a/packages/schema/src/helpers/secret.ts
+++ b/packages/schema/src/helpers/secret.ts
@@ -1,0 +1,51 @@
+import { isRecord } from '../utils/is-record';
+
+/**
+ * Property key that brands a value as a redacted secret placeholder. Chosen to be
+ * unlikely to collide with a real field-config key. The Storyblok CLI recognizes
+ * this exact string structurally (not by object identity), so a placeholder
+ * produced by *any* installed version of `@storyblok/schema` round-trips through
+ * `schema push` — keep the literal stable across releases.
+ */
+export const SECRET_MARKER = '__storyblokSecret' as const;
+
+/**
+ * Placeholder that stands in for a sensitive field-config value (e.g. an
+ * integration `accessKey`) in a versioned schema. It carries no secret itself —
+ * only, optionally, the name of the environment variable the real value should
+ * be read from at push time.
+ */
+export interface SecretPlaceholder {
+  readonly [SECRET_MARKER]: true;
+  /** Environment variable the CLI reads the real value from on `schema push`. */
+  readonly env?: string;
+}
+
+/**
+ * Marks a field-config value as a secret so it is never written to the versioned
+ * schema. `schema init` emits this in place of sensitive values; `schema push`
+ * excludes it from diffing and, right before writing to the Management API,
+ * substitutes the real value — from `process.env[env]` when an `env` name is
+ * given and set, otherwise from the value already stored in the space (so an
+ * existing secret is preserved, never cleared).
+ *
+ * @param env Optional environment variable to source the value from on push.
+ *
+ * @example
+ * // Preserve whatever the space already has (secret never leaves Storyblok):
+ * defineField('shopware', { type: 'custom', accessKey: secret() });
+ *
+ * @example
+ * // Manage the value from an environment variable (e.g. in CI):
+ * defineField('shopware', { type: 'custom', accessKey: secret('SHOPWARE_ACCESS_KEY') });
+ */
+export function secret(env?: string): SecretPlaceholder {
+  return env === undefined
+    ? { [SECRET_MARKER]: true }
+    : { [SECRET_MARKER]: true, env };
+}
+
+/** Returns true if `value` is a {@link SecretPlaceholder} produced by {@link secret}. */
+export function isSecretPlaceholder(value: unknown): value is SecretPlaceholder {
+  return isRecord(value) && value[SECRET_MARKER] === true;
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -50,6 +50,10 @@ export type { BlockFolder } from './helpers/define-folder';
 export { defineSchema } from './helpers/define-schema';
 export type { Schema } from './helpers/schema-type';
 
+// Secret (redacted field-config placeholder)
+export { isSecretPlaceholder, secret, SECRET_MARKER } from './helpers/secret';
+export type { SecretPlaceholder } from './helpers/secret';
+
 // Validators (Zod-powered, non-throwing)
 export { createStoryValidator } from './validators/create-story-validator';
 export type { ValidationIssue, ValidationResult, ValidationSeverity } from './validators/types';


### PR DESCRIPTION
## Problem

Custom field plugins like the Shopware and Shopify integrations store credentials inside the field's `options: [{ name, value }]` array (e.g. `clientSecret`).

- `schema init` wrote those values verbatim into the generated, versioned files → secrets end up in Git.
- Deleting them by hand doesn't help: `schema push` then diffs the emptied local value against the remote and **clears the secret on the space**.

## Solution

A first-class `secret()` placeholder in `@storyblok/schema`, recognized by the schema command. Secrets are identified purely by the option `name` (the developer-chosen `field_type` is never used), covering the `{ name, value }` options form only.

`secret()` returns a sentinel **string** (`__storyblokSecret__`, or `__storyblokSecret__:ENV`), so it slots into a plugin option's string `value` and the generated files type-check.

- **`secret()`** — preserve-remote: push keeps whatever the space already has, and it is excluded from the diff entirely.
- **`secret('ENV_VAR')`** — read from `process.env` on push, and participates in the diff: when the environment value differs from the value on the space, push reports an update and rotates the secret. Falls back to preserve-remote when the variable is unset.

### Wiring

- **init** — redacts secret option values to `secret()`. Default names + `--secret-names <names>`; opt out via `--no-redact-secrets`.
- **push** — excludes preserve-remote secrets from the diff; env-managed secrets participate via a non-revealing per-run fingerprint (the diff never prints the value). Secrets are hydrated just before the API call (env → remote → omit + warn on create). A placeholder never reaches the Management API.
- **changeset + local component JSON** — real values are masked to placeholders on disk; **rollback** hydrates them from the live space the same way push does.

Name-based array alignment keeps hydration and rotation correct even if option order differs between the local file and the space.

## Tests

Unit tests for the redact / mark / mask / hydrate helpers, integration tests for init codegen, push diff (including env rotation), and `executePush` (preserve + env), plus a jiti round-trip. All green.

## Notes

- On **create** (fresh space) a preserve-remote `secret()` has no source, so the value is left empty with a warning — use `secret('ENV')` to provision it.
- Optional follow-up: surface `schema.secrets` in the config file (`defineConfig`) so the name list needn't be passed per-invocation.