### PR TITLE
fix(capi-client): support nested filter_query serialization

### DIFF
--- a/packages/capi-client/playground/integration-tests/test/specs/capi-round-trip.spec.e2e.ts
+++ b/packages/capi-client/playground/integration-tests/test/specs/capi-round-trip.spec.e2e.ts
@@ -59,6 +59,7 @@ const pageComponent = defineBlock({
     defineField('headline', { type: 'text', required: true }),
     defineField('rating', { type: 'number' }),
     defineField('is_featured', { type: 'boolean' }),
+    defineField('enddate', { type: 'text' }),
     defineField('body', {
       type: 'bloks',
       allow: [teaserComponent.name, sectionComponent.name],
@@ -144,8 +145,9 @@ describe('schema + capi-client CAPI round-trip', () => {
         headline: { type: 'text', required: true, pos: 0 },
         rating: { type: 'number', pos: 1 },
         is_featured: { type: 'boolean', pos: 2 },
-        body: { type: 'bloks', component_whitelist: [teaserComponent.name, sectionComponent.name], pos: 3 },
-        any_blocks: { type: 'bloks', pos: 4 },
+        enddate: { type: 'text', pos: 3 },
+        body: { type: 'bloks', component_whitelist: [teaserComponent.name, sectionComponent.name], pos: 4 },
+        any_blocks: { type: 'bloks', pos: 5 },
       },
       is_root: true,
     } } });
@@ -159,6 +161,7 @@ describe('schema + capi-client CAPI round-trip', () => {
         headline: 'Hello from CAPI e2e',
         rating: 42,
         is_featured: true,
+        enddate: '2020-06-15 12:00',
         body: [
           {
             component: teaserComponent.name,
@@ -341,6 +344,39 @@ describe('schema + capi-client CAPI round-trip', () => {
             expect(typeof nestedTeaser.title).toBe('string');
           }
         }
+      }
+    });
+
+    it('should filter stories by nested filter_query with lt_date operator', async () => {
+      const capiClient = createTypedCapiClient(previewToken);
+
+      // Use a date in the future so the story's enddate ('2020-06-15 12:00') passes the lt_date filter
+      const future = new Date();
+      future.setFullYear(future.getFullYear() + 5);
+      const year = future.getFullYear();
+      const month = String(future.getMonth() + 1).padStart(2, '0');
+      const day = String(future.getDate()).padStart(2, '0');
+      const hours = String(future.getHours()).padStart(2, '0');
+      const minutes = String(future.getMinutes()).padStart(2, '0');
+
+      const res = await capiClient.stories.list({
+        query: {
+          starts_with: STORY_SLUG_PREFIX,
+          filter_query: {
+            enddate: { lt_date: `${year}-${month}-${day} ${hours}:${minutes}` },
+          },
+        },
+      });
+
+      expect(res.data?.stories).toBeDefined();
+      expect(res.data!.stories!.length).toBeGreaterThan(0);
+
+      const story = res.data!.stories![0];
+      if (story.content.component === pageComponent.name) {
+        expect(story.content.enddate).toBe('2020-06-15 12:00');
+      }
+      else {
+        throw new Error(`Unexpected component discriminant: ${story.content.component}`);
       }
     });
   });

--- a/packages/capi-client/src/client.ts
+++ b/packages/capi-client/src/client.ts
@@ -5,6 +5,7 @@ import { ClientError } from './error';
 import type { RateLimitConfig, ThrottleManager } from './utils/rate-limit';
 import { createThrottleManager } from './utils/rate-limit';
 import { applyCvToQuery, extractCv } from './utils/cv';
+import { querySerializer } from './utils/query-serializer';
 import { createCacheKey, shouldUseCache } from './utils/request';
 import { getRegionBaseUrl, type Region } from '@storyblok/region-helper';
 import type { Block as Component } from './generated/types/block';
@@ -240,6 +241,9 @@ export const createApiClientBase = <
       auth: accessToken,
       baseUrl: baseUrl || getRegionBaseUrl(region),
       headers,
+      // Default serializer throws on nested objects; CAPI needs `filter_query`
+      // serialized as a nested hash (`filter_query[field][op]=value`).
+      querySerializer,
       throwOnError,
       kyOptions: {
         // Enable `throwHttpErrors` to make retry work, even if `throwOnError`

--- a/packages/capi-client/src/utils/query-serializer.ts
+++ b/packages/capi-client/src/utils/query-serializer.ts
@@ -1,0 +1,64 @@
+// NOTE: This file is intentionally identical to packages/mapi-client/src/utils/query-serializer.ts
+// except for the import paths (capi vs mapi generated core). Keep them in sync.
+
+import type { QuerySerializer } from '../generated/capi/core/bodySerializer.gen';
+import { serializeArrayParam, serializePrimitiveParam } from '../generated/capi/core/pathSerializer.gen';
+
+/**
+ * Query serializer for the Content Delivery API client.
+ *
+ * Behaves identically to the generated default for primitives, primitive
+ * arrays, and dates, but additionally serializes **nested objects** (and arrays
+ * of objects) into bracket notation — e.g. `filter_query[enddate][lt_date]=2031-01-01 00:00`.
+ *
+ * The generated default serializer throws on this nesting ("Deeply-nested
+ * arrays/objects aren't supported. Provide your own `querySerializer()`"), yet
+ * CAPI requires `filter_query` as a nested hash. This mirrors the bracket
+ * serialization used by `storyblok-js-client` and the MAPI client.
+ */
+function serialize(name: string, value: unknown, parts: string[]): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (value instanceof Date) {
+    parts.push(`${name}=${value.toISOString()}`);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    // Arrays containing objects need per-item bracket recursion.
+    if (value.some(item => item !== null && typeof item === 'object')) {
+      for (const item of value) {
+        serialize(`${name}[]`, item, parts);
+      }
+      return;
+    }
+    // Primitive arrays keep the generated default form (`name=a&name=b`).
+    const serialized = serializeArrayParam({ explode: true, name, style: 'form', value });
+    if (serialized) {
+      parts.push(serialized);
+    }
+    return;
+  }
+
+  if (typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      serialize(`${name}[${key}]`, child, parts);
+    }
+    return;
+  }
+
+  const serialized = serializePrimitiveParam({ name, value: value as string });
+  if (serialized) {
+    parts.push(serialized);
+  }
+}
+
+export const querySerializer: QuerySerializer = (query) => {
+  const parts: string[] = [];
+  for (const [name, value] of Object.entries(query)) {
+    serialize(name, value, parts);
+  }
+  return parts.join('&');
+};


### PR DESCRIPTION
## Problem

The CAPI client's generated query serializer throws when `filter_query` contains nested objects (e.g. `filter_query[enddate][lt_date]=...`):

> Deeply-nested arrays/objects aren't supported. Provide your own `querySerializer()` to handle these.

This means any call to `stories.list` with a nested `filter_query` operator (`lt_date`, `in`, `gt_int`, etc.) fails at runtime.

## Solution

Add a custom `querySerializer` to `@storyblok/api-client` that serializes nested objects into bracket notation — the same approach already used in `@storyblok/management-api-client`.

- Added `src/utils/query-serializer.ts` (mirrors `mapi-client` implementation)
- Wired it into `createConfig` in `src/client.ts`

## Verification

Added an e2e test in the capi-client playground covering `filter_query` with `lt_date`. All 6 playground e2e tests pass.

Fixes DX-531