### PR TITLE
fix(schema): model multilink as a discriminated union

### DIFF
--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -701,38 +701,9 @@ export type BlockContentInputRoot = {
 };
 
 /**
- * Multilink field type - link to internal stories, external URLs, emails, etc.
+ * Multilink field type - link to internal stories, external URLs, emails, or assets.
  */
-export type MultilinkFieldValueRoot = {
-    /**
-     * Identifies this as a multilink field
-     */
-    fieldtype: 'multilink';
-    /**
-     * UUID of the linked story (for internal links)
-     */
-    id: string;
-    /**
-     * URL for external links or email addresses
-     */
-    url: string;
-    /**
-     * Type of link
-     */
-    linktype: 'story' | 'url' | 'email' | 'asset';
-    /**
-     * Cached URL path for the linked story
-     */
-    cached_url: string;
-    /**
-     * Anchor/fragment identifier for the link
-     */
-    anchor?: string | null;
-    /**
-     * Link target attribute
-     */
-    target?: '_self' | '_blank' | null;
-};
+export type MultilinkFieldValueRoot = MultilinkFieldValueStoryLink | MultilinkFieldValueUrlLink | MultilinkFieldValueEmailLink | MultilinkFieldValueAssetLink;
 
 /**
  * Plugin/Custom field type - field plugin with custom structure
@@ -879,9 +850,92 @@ export type ValueFieldRoot = {
 };
 
 /**
+ * Link to an internal Storyblok story.
+ */
+export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
+    linktype: 'story';
+    /**
+     * Anchor/fragment identifier for the story link
+     */
+    anchor?: string;
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an external URL.
+ */
+export type MultilinkFieldValueUrlLink = MultilinkFieldValueSharedLink & {
+    linktype: 'url';
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an email address.
+ */
+export type MultilinkFieldValueEmailLink = MultilinkFieldValueSharedLink & {
+    linktype: 'email';
+    /**
+     * Email address
+     */
+    email?: string;
+};
+
+/**
+ * Link to a Storyblok asset.
+ */
+export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
+    linktype: 'asset';
+};
+
+/**
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+export type MultilinkFieldValueSharedLink = {
+    /**
+     * Identifies this as a multilink field
+     */
+    fieldtype: 'multilink';
+    /**
+     * Type of link
+     */
+    linktype: string;
+    /**
+     * UUID of the linked story for internal links
+     */
+    id: string;
+    /**
+     * URL for external links
+     */
+    url: string;
+    /**
+     * Cached URL path for the linked story
+     */
+    cached_url: string;
+    /**
+     * Link target attribute
+     */
+    target?: '_self' | '_blank';
+};
 
 export type RichTextFieldValueParagraphNode = {
     type: 'paragraph';

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -701,38 +701,9 @@ export type BlockContentInputRoot = {
 };
 
 /**
- * Multilink field type - link to internal stories, external URLs, emails, etc.
+ * Multilink field type - link to internal stories, external URLs, emails, or assets.
  */
-export type MultilinkFieldValueRoot = {
-    /**
-     * Identifies this as a multilink field
-     */
-    fieldtype: 'multilink';
-    /**
-     * UUID of the linked story (for internal links)
-     */
-    id: string;
-    /**
-     * URL for external links or email addresses
-     */
-    url: string;
-    /**
-     * Type of link
-     */
-    linktype: 'story' | 'url' | 'email' | 'asset';
-    /**
-     * Cached URL path for the linked story
-     */
-    cached_url: string;
-    /**
-     * Anchor/fragment identifier for the link
-     */
-    anchor?: string | null;
-    /**
-     * Link target attribute
-     */
-    target?: '_self' | '_blank' | null;
-};
+export type MultilinkFieldValueRoot = MultilinkFieldValueStoryLink | MultilinkFieldValueUrlLink | MultilinkFieldValueEmailLink | MultilinkFieldValueAssetLink;
 
 /**
  * Plugin/Custom field type - field plugin with custom structure
@@ -879,9 +850,92 @@ export type ValueFieldRoot = {
 };
 
 /**
+ * Link to an internal Storyblok story.
+ */
+export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
+    linktype: 'story';
+    /**
+     * Anchor/fragment identifier for the story link
+     */
+    anchor?: string;
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an external URL.
+ */
+export type MultilinkFieldValueUrlLink = MultilinkFieldValueSharedLink & {
+    linktype: 'url';
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an email address.
+ */
+export type MultilinkFieldValueEmailLink = MultilinkFieldValueSharedLink & {
+    linktype: 'email';
+    /**
+     * Email address
+     */
+    email?: string;
+};
+
+/**
+ * Link to a Storyblok asset.
+ */
+export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
+    linktype: 'asset';
+};
+
+/**
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+export type MultilinkFieldValueSharedLink = {
+    /**
+     * Identifies this as a multilink field
+     */
+    fieldtype: 'multilink';
+    /**
+     * Type of link
+     */
+    linktype: string;
+    /**
+     * UUID of the linked story for internal links
+     */
+    id: string;
+    /**
+     * URL for external links
+     */
+    url: string;
+    /**
+     * Cached URL path for the linked story
+     */
+    cached_url: string;
+    /**
+     * Link target attribute
+     */
+    target?: '_self' | '_blank';
+};
 
 export type RichTextFieldValueParagraphNode = {
     type: 'paragraph';

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -701,38 +701,9 @@ export type BlockContentInputRoot = {
 };
 
 /**
- * Multilink field type - link to internal stories, external URLs, emails, etc.
+ * Multilink field type - link to internal stories, external URLs, emails, or assets.
  */
-export type MultilinkFieldValueRoot = {
-    /**
-     * Identifies this as a multilink field
-     */
-    fieldtype: 'multilink';
-    /**
-     * UUID of the linked story (for internal links)
-     */
-    id: string;
-    /**
-     * URL for external links or email addresses
-     */
-    url: string;
-    /**
-     * Type of link
-     */
-    linktype: 'story' | 'url' | 'email' | 'asset';
-    /**
-     * Cached URL path for the linked story
-     */
-    cached_url: string;
-    /**
-     * Anchor/fragment identifier for the link
-     */
-    anchor?: string | null;
-    /**
-     * Link target attribute
-     */
-    target?: '_self' | '_blank' | null;
-};
+export type MultilinkFieldValueRoot = MultilinkFieldValueStoryLink | MultilinkFieldValueUrlLink | MultilinkFieldValueEmailLink | MultilinkFieldValueAssetLink;
 
 /**
  * Plugin/Custom field type - field plugin with custom structure
@@ -879,9 +850,92 @@ export type ValueFieldRoot = {
 };
 
 /**
+ * Link to an internal Storyblok story.
+ */
+export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
+    linktype: 'story';
+    /**
+     * Anchor/fragment identifier for the story link
+     */
+    anchor?: string;
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an external URL.
+ */
+export type MultilinkFieldValueUrlLink = MultilinkFieldValueSharedLink & {
+    linktype: 'url';
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an email address.
+ */
+export type MultilinkFieldValueEmailLink = MultilinkFieldValueSharedLink & {
+    linktype: 'email';
+    /**
+     * Email address
+     */
+    email?: string;
+};
+
+/**
+ * Link to a Storyblok asset.
+ */
+export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
+    linktype: 'asset';
+};
+
+/**
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+export type MultilinkFieldValueSharedLink = {
+    /**
+     * Identifies this as a multilink field
+     */
+    fieldtype: 'multilink';
+    /**
+     * Type of link
+     */
+    linktype: string;
+    /**
+     * UUID of the linked story for internal links
+     */
+    id: string;
+    /**
+     * URL for external links
+     */
+    url: string;
+    /**
+     * Cached URL path for the linked story
+     */
+    cached_url: string;
+    /**
+     * Link target attribute
+     */
+    target?: '_self' | '_blank';
+};
 
 export type RichTextFieldValueParagraphNode = {
     type: 'paragraph';

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -701,38 +701,9 @@ export type BlockContentInputRoot = {
 };
 
 /**
- * Multilink field type - link to internal stories, external URLs, emails, etc.
+ * Multilink field type - link to internal stories, external URLs, emails, or assets.
  */
-export type MultilinkFieldValueRoot = {
-    /**
-     * Identifies this as a multilink field
-     */
-    fieldtype: 'multilink';
-    /**
-     * UUID of the linked story (for internal links)
-     */
-    id: string;
-    /**
-     * URL for external links or email addresses
-     */
-    url: string;
-    /**
-     * Type of link
-     */
-    linktype: 'story' | 'url' | 'email' | 'asset';
-    /**
-     * Cached URL path for the linked story
-     */
-    cached_url: string;
-    /**
-     * Anchor/fragment identifier for the link
-     */
-    anchor?: string | null;
-    /**
-     * Link target attribute
-     */
-    target?: '_self' | '_blank' | null;
-};
+export type MultilinkFieldValueRoot = MultilinkFieldValueStoryLink | MultilinkFieldValueUrlLink | MultilinkFieldValueEmailLink | MultilinkFieldValueAssetLink;
 
 /**
  * Plugin/Custom field type - field plugin with custom structure
@@ -879,9 +850,92 @@ export type ValueFieldRoot = {
 };
 
 /**
+ * Link to an internal Storyblok story.
+ */
+export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
+    linktype: 'story';
+    /**
+     * Anchor/fragment identifier for the story link
+     */
+    anchor?: string;
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an external URL.
+ */
+export type MultilinkFieldValueUrlLink = MultilinkFieldValueSharedLink & {
+    linktype: 'url';
+    /**
+     * Link relationship attribute
+     */
+    rel?: string;
+    /**
+     * Link title attribute
+     */
+    title?: string;
+} & {
+    [key: string]: string;
+};
+
+/**
+ * Link to an email address.
+ */
+export type MultilinkFieldValueEmailLink = MultilinkFieldValueSharedLink & {
+    linktype: 'email';
+    /**
+     * Email address
+     */
+    email?: string;
+};
+
+/**
+ * Link to a Storyblok asset.
+ */
+export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
+    linktype: 'asset';
+};
+
+/**
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+export type MultilinkFieldValueSharedLink = {
+    /**
+     * Identifies this as a multilink field
+     */
+    fieldtype: 'multilink';
+    /**
+     * Type of link
+     */
+    linktype: string;
+    /**
+     * UUID of the linked story for internal links
+     */
+    id: string;
+    /**
+     * URL for external links
+     */
+    url: string;
+    /**
+     * Cached URL path for the linked story
+     */
+    cached_url: string;
+    /**
+     * Link target attribute
+     */
+    target?: '_self' | '_blank';
+};
 
 export type RichTextFieldValueParagraphNode = {
     type: 'paragraph';

--- a/packages/schema/src/generated/overlay/zod.gen.ts
+++ b/packages/schema/src/generated/overlay/zod.gen.ts
@@ -369,30 +369,58 @@ export const zAssetFieldValueRoot = z.object({
 
 export const zAssetFieldValue = zAssetFieldValueRoot;
 
-/**
- * Multilink field type - link to internal stories, external URLs, emails, etc.
- */
-export const zMultilinkFieldValueRoot = z.object({
+export const zMultilinkFieldValueSharedLink = z.object({
     fieldtype: z.enum(['multilink']),
+    linktype: z.string(),
     id: z.string(),
     url: z.string(),
-    linktype: z.enum([
-        'story',
-        'url',
-        'email',
-        'asset'
-    ]),
     cached_url: z.string(),
-    anchor: z.optional(z.union([
-        z.string(),
-        z.null()
-    ])),
-    target: z.optional(z.union([
-        z.literal('_self'),
-        z.literal('_blank'),
-        z.null()
-    ]))
+    target: z.optional(z.enum(['_self', '_blank']))
 });
+
+/**
+ * Link to a Storyblok asset.
+ */
+export const zMultilinkFieldValueAssetLink = zMultilinkFieldValueSharedLink.and(z.object({
+    linktype: z.enum(['asset'])
+}));
+
+/**
+ * Link to an email address.
+ */
+export const zMultilinkFieldValueEmailLink = zMultilinkFieldValueSharedLink.and(z.object({
+    linktype: z.enum(['email']),
+    email: z.optional(z.string())
+}));
+
+/**
+ * Link to an internal Storyblok story.
+ */
+export const zMultilinkFieldValueStoryLink = zMultilinkFieldValueSharedLink.and(z.object({
+    linktype: z.enum(['story']),
+    anchor: z.optional(z.string()),
+    rel: z.optional(z.string()),
+    title: z.optional(z.string())
+})).and(z.record(z.string(), z.string()));
+
+/**
+ * Link to an external URL.
+ */
+export const zMultilinkFieldValueUrlLink = zMultilinkFieldValueSharedLink.and(z.object({
+    linktype: z.enum(['url']),
+    rel: z.optional(z.string()),
+    title: z.optional(z.string())
+})).and(z.record(z.string(), z.string()));
+
+/**
+ * Multilink field type - link to internal stories, external URLs, emails, or assets.
+ */
+export const zMultilinkFieldValueRoot = z.union([
+    zMultilinkFieldValueStoryLink,
+    zMultilinkFieldValueUrlLink,
+    zMultilinkFieldValueEmailLink,
+    zMultilinkFieldValueAssetLink
+]);
 
 export const zMultilinkFieldValue = zMultilinkFieldValueRoot;
 

--- a/packages/schema/src/multilink-field-value.test-d.ts
+++ b/packages/schema/src/multilink-field-value.test-d.ts
@@ -1,0 +1,60 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { MultilinkFieldValue } from './generated/types/field';
+
+const shared = {
+  fieldtype: 'multilink',
+  id: '',
+  url: '',
+  cached_url: '',
+} as const;
+
+describe('MultilinkFieldValue', () => {
+  it('narrows variant properties by linktype', () => {
+    const assertNarrowing = (link: MultilinkFieldValue) => {
+      if (link.linktype === 'story') {
+        expectTypeOf(link.anchor).toEqualTypeOf<string | undefined>();
+        expectTypeOf(link.rel).toEqualTypeOf<string | undefined>();
+        // Storyfront permits arbitrary string-valued custom attributes.
+        expectTypeOf(link.email).toEqualTypeOf<string>();
+      }
+      else if (link.linktype === 'email') {
+        expectTypeOf(link.email).toEqualTypeOf<string | undefined>();
+        // @ts-expect-error Anchors are only declared by the story variant.
+        void link.anchor;
+      }
+      else if (link.linktype === 'asset') {
+        expectTypeOf(link.linktype).toEqualTypeOf<'asset'>();
+      }
+    };
+
+    expectTypeOf(assertNarrowing).parameter(0).toEqualTypeOf<MultilinkFieldValue>();
+  });
+
+  it('accepts string custom attributes on story and URL links', () => {
+    const story = {
+      ...shared,
+      linktype: 'story',
+      anchor: 'features',
+      analyticsLabel: 'hero-cta',
+    } satisfies MultilinkFieldValue;
+    const url = {
+      ...shared,
+      linktype: 'url',
+      rel: 'noopener',
+      dataTrackingId: 'external-cta',
+    } satisfies MultilinkFieldValue;
+
+    expectTypeOf(story.linktype).toEqualTypeOf<'story'>();
+    expectTypeOf(url.linktype).toEqualTypeOf<'url'>();
+  });
+
+  it('rejects nullable target and story anchor values', () => {
+    // @ts-expect-error Storyfront only accepts a non-null target when present.
+    const _invalidTarget: MultilinkFieldValue = { ...shared, linktype: 'asset', target: null };
+    // @ts-expect-error Storyfront only accepts a non-null story anchor when present.
+    const _invalidAnchor: MultilinkFieldValue = { ...shared, linktype: 'story', anchor: null };
+
+    void _invalidTarget;
+    void _invalidAnchor;
+  });
+});

--- a/packages/schema/src/validators/validate-story.test.ts
+++ b/packages/schema/src/validators/validate-story.test.ts
@@ -205,6 +205,49 @@ describe('validateStory', () => {
   });
 });
 
+const linkedPage = defineBlock({
+  name: 'linked-page',
+  is_root: true,
+  fields: [defineField('cta', { type: 'multilink' })],
+});
+const linkedSchema = { blocks: { linkedPage } };
+const multilinkBase = {
+  fieldtype: 'multilink',
+  id: '',
+  url: '',
+  cached_url: '',
+};
+const validateMultilink = (cta: unknown) => validateStory({
+  content: { component: 'linked-page', cta },
+}, linkedSchema);
+
+describe('validateStory — multilink values', () => {
+  it('accepts every raw Storyfront multilink variant', () => {
+    const variants = [
+      { ...multilinkBase, linktype: 'story', anchor: 'features', rel: 'bookmark' },
+      { ...multilinkBase, linktype: 'url', url: 'https://example.com', title: 'Example' },
+      { ...multilinkBase, linktype: 'email', email: 'hello@example.com' },
+      { ...multilinkBase, linktype: 'asset', id: 'asset-id' },
+    ];
+
+    for (const variant of variants) {
+      expect(validateMultilink(variant).ok).toBe(true);
+    }
+  });
+
+  it.each([
+    ['nullable target', { ...multilinkBase, linktype: 'asset', target: null }],
+    ['nullable story anchor', { ...multilinkBase, linktype: 'story', anchor: null }],
+    ['non-string URL attribute', { ...multilinkBase, linktype: 'url', rel: 42 }],
+    ['non-string custom story attribute', { ...multilinkBase, linktype: 'story', analytics: 42 }],
+  ])('rejects %s', (_label, value) => {
+    const result = validateMultilink(value);
+
+    expect(result.ok).toBe(false);
+    expect(codesFor(result)).toContain('invalid_value');
+  });
+});
+
 const asset = () => ({ fieldtype: 'asset' as const, id: null, alt: null, filename: '' });
 
 const constrained = defineBlock({

--- a/tools/openapi-codegen/specs/shared/stories/field-types/multilink-field-value.yaml
+++ b/tools/openapi-codegen/specs/shared/stories/field-types/multilink-field-value.yaml
@@ -1,38 +1,106 @@
 # See: https://www.storyblok.com/docs/api/management/components/possible-field-types
-type: object
-description: Multilink field type - link to internal stories, external URLs, emails, etc.
-required:
-  - fieldtype
-  - id
-  - url
-  - cached_url
-  - linktype
-properties:
-  fieldtype:
-    type: string
-    enum: [multilink]
-    description: Identifies this as a multilink field
-  id:
-    type: string
-    description: UUID of the linked story (for internal links)
-  url:
-    type: string
-    description: URL for external links or email addresses
-  linktype:
-    type: string
-    enum: [story, url, email, asset]
-    description: Type of link
-  cached_url:
-    type: string
-    description: Cached URL path for the linked story
-  anchor:
-    type:
-      - string
-      - 'null'
-    description: Anchor/fragment identifier for the link
-  target:
-    oneOf:
-      - type: string
+description: Multilink field type - link to internal stories, external URLs, emails, or assets.
+oneOf:
+  - $ref: '#/$defs/StoryLink'
+  - $ref: '#/$defs/UrlLink'
+  - $ref: '#/$defs/EmailLink'
+  - $ref: '#/$defs/AssetLink'
+
+$defs:
+  SharedLink:
+    type: object
+    required:
+      - fieldtype
+      - linktype
+      - id
+      - url
+      - cached_url
+    properties:
+      fieldtype:
+        type: string
+        enum: [multilink]
+        description: Identifies this as a multilink field
+      linktype:
+        type: string
+        description: Type of link
+      id:
+        type: string
+        description: UUID of the linked story for internal links
+      url:
+        type: string
+        description: URL for external links
+      cached_url:
+        type: string
+        description: Cached URL path for the linked story
+      target:
+        type: string
         enum: [_self, _blank]
-      - type: 'null'
-    description: Link target attribute
+        description: Link target attribute
+
+  StoryLink:
+    description: Link to an internal Storyblok story.
+    allOf:
+      - $ref: '#/$defs/SharedLink'
+      - type: object
+        required: [linktype]
+        properties:
+          linktype:
+            type: string
+            enum: [story]
+          anchor:
+            type: string
+            description: Anchor/fragment identifier for the story link
+          rel:
+            type: string
+            description: Link relationship attribute
+          title:
+            type: string
+            description: Link title attribute
+      - type: object
+        additionalProperties:
+          type: string
+
+  UrlLink:
+    description: Link to an external URL.
+    allOf:
+      - $ref: '#/$defs/SharedLink'
+      - type: object
+        required: [linktype]
+        properties:
+          linktype:
+            type: string
+            enum: [url]
+          rel:
+            type: string
+            description: Link relationship attribute
+          title:
+            type: string
+            description: Link title attribute
+      - type: object
+        additionalProperties:
+          type: string
+
+  EmailLink:
+    description: Link to an email address.
+    allOf:
+      - $ref: '#/$defs/SharedLink'
+      - type: object
+        required: [linktype]
+        properties:
+          linktype:
+            type: string
+            enum: [email]
+          email:
+            type: string
+            description: Email address
+
+  AssetLink:
+    description: Link to a Storyblok asset.
+    allOf:
+      - $ref: '#/$defs/SharedLink'
+      - type: object
+        required: [linktype]
+        properties:
+          linktype:
+            type: string
+            enum: [asset]


### PR DESCRIPTION
- model multilink values as a shared base plus story, URL, email, and asset variants
- make target and story anchor optional but non-null
- preserve Storyfront string-valued custom attributes for story and URL links
- regenerate schema, Content API, Management API, and live-preview overlay types
- add type-narrowing and runtime-validator regression coverage

## Scope

- no CLI multilink type changes
- no API-client runtime link/story normalization

Fixes DX-534