### PR TITLE
feat(experiments): keep serverless runtimes alive until event delivery settles

### DIFF
--- a/packages/experiments/src/create-experiments.test.ts
+++ b/packages/experiments/src/create-experiments.test.ts
@@ -88,4 +88,95 @@ describe('createExperiments', () => {
 
     expect(() => exp.resolveExperiment({ slug: 'home', visitorId: 'visitor-1' })).not.toThrow();
   });
+
+  it('hands each pending async delivery to waitUntil', async () => {
+    const waitUntil = vi.fn();
+    let delivered = false;
+    let resolveDelivery: () => void;
+    const delivery = new Promise<void>((resolve) => {
+      resolveDelivery = resolve;
+    });
+    const exp = createExperiments({
+      experiments: [homepageExperiment],
+      adapters: [() => delivery.then(() => { delivered = true; })],
+      waitUntil,
+    });
+
+    exp.resolveExperiment({ slug: 'home', visitorId: 'visitor-1' });
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    resolveDelivery!();
+    await waitUntil.mock.calls[0][0];
+    expect(delivered).toBe(true);
+  });
+
+  it('does not call waitUntil for a synchronous adapter', () => {
+    const waitUntil = vi.fn();
+    const exp = createExperiments({
+      experiments: [homepageExperiment],
+      adapters: [() => {}],
+      waitUntil,
+    });
+
+    exp.resolveExperiment({ slug: 'home', visitorId: 'visitor-1' });
+
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it('gives waitUntil a promise that resolves even when the adapter rejects', async () => {
+    const waitUntil = vi.fn();
+    const onError = vi.fn();
+    const boom = new Error('network');
+    const exp = createExperiments({
+      experiments: [homepageExperiment],
+      adapters: [() => Promise.reject(boom)],
+      onError,
+      waitUntil,
+    });
+
+    exp.resolveExperiment({ slug: 'home', visitorId: 'visitor-1' });
+
+    await expect(waitUntil.mock.calls[0][0]).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(boom, expect.objectContaining({ type: 'exposure' }));
+  });
+
+  it('flush resolves after pending async deliveries settle', async () => {
+    let delivered = false;
+    let resolveDelivery: () => void;
+    const delivery = new Promise<void>((resolve) => {
+      resolveDelivery = resolve;
+    });
+    const exp = createExperiments({
+      experiments: [homepageExperiment],
+      adapters: [() => delivery.then(() => { delivered = true; })],
+    });
+
+    exp.resolveExperiment({ slug: 'home', visitorId: 'visitor-1' });
+    const flushed = exp.flush();
+
+    resolveDelivery!();
+    await flushed;
+    expect(delivered).toBe(true);
+  });
+
+  it('flush does not reject when a pending delivery fails', async () => {
+    const onError = vi.fn();
+    const boom = new Error('network');
+    const exp = createExperiments({
+      experiments: [homepageExperiment],
+      adapters: [() => Promise.reject(boom)],
+      onError,
+    });
+
+    exp.resolveExperiment({ slug: 'home', visitorId: 'visitor-1' });
+
+    await expect(exp.flush()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(boom, expect.objectContaining({ type: 'exposure' }));
+  });
+
+  it('flush resolves immediately when nothing is pending', async () => {
+    const exp = createExperiments({ experiments: [homepageExperiment] });
+
+    await expect(exp.flush()).resolves.toBeUndefined();
+  });
 });

--- a/packages/experiments/src/create-experiments.ts
+++ b/packages/experiments/src/create-experiments.ts
@@ -11,6 +11,15 @@ export interface CreateExperimentsOptions {
    * the request. Defaults to a no-op.
    */
   onError?: (error: unknown, event: ExperimentEvent) => void;
+  /**
+   * Receives every pending async delivery so the host platform keeps the
+   * process alive until it settles. Without this, serverless runtimes
+   * (Vercel, Netlify, Cloudflare) may freeze the process as soon as the
+   * response is sent and silently drop in-flight events. Pass the platform's
+   * `waitUntil` (or Next.js `after`). The promise never rejects; failures
+   * still go to `onError`.
+   */
+  waitUntil?: (promise: Promise<unknown>) => void;
 }
 
 export interface FactoryResolveOptions {
@@ -32,6 +41,16 @@ export interface Experiments {
   resolveExperiment: (options: FactoryResolveOptions) => FactoryResolvedExperiment;
   /** Fires a conversion event for every experiment this visitor was assigned to. */
   track: (name: string, props?: Record<string, unknown>) => void;
+  /**
+   * Resolves once every pending async delivery has settled. Never rejects;
+   * failures go to `onError`. Await it before returning a response on
+   * platforms without a `waitUntil` hook.
+   */
+  flush: () => Promise<void>;
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === 'object' && value !== null && 'then' in value && typeof value.then === 'function';
 }
 
 /**
@@ -39,18 +58,33 @@ export interface Experiments {
  * per-request use. The bare `resolveExperiment` / `assignVariant` functions
  * stay available for full control.
  */
-export function createExperiments({ experiments, adapters = [], onError }: CreateExperimentsOptions): Experiments {
+export function createExperiments({ experiments, adapters = [], onError, waitUntil }: CreateExperimentsOptions): Experiments {
   // Per-instance (per-request) state: assignments made during resolveExperiment,
   // keyed by experiment id, so track() can attribute without re-passing context.
   const assignments = new Map<number, Assignment>();
 
-  // Fire-and-forget: an adapter that throws synchronously or rejects
-  // asynchronously must never surface as an unhandled rejection or break the
-  // request. Route failures to `onError` (default: swallow).
+  // Async deliveries still in flight, so flush() can await them.
+  const pending = new Set<Promise<void>>();
+
+  // An adapter that throws synchronously or rejects asynchronously must never
+  // surface as an unhandled rejection or break the request. Route failures to
+  // `onError` (default: swallow). Adapters are invoked synchronously so the
+  // request (e.g. a fetch) is initiated before the handler returns; async
+  // deliveries are tracked for flush() and handed to waitUntil so serverless
+  // runtimes do not freeze the process while they are in flight.
   const emit = (event: ExperimentEvent): void => {
     for (const adapter of adapters) {
       try {
-        Promise.resolve(adapter(event)).catch(error => onError?.(error, event));
+        const result = adapter(event);
+        if (isThenable(result)) {
+          const settled = Promise.resolve(result).then(
+            () => undefined,
+            (error) => { onError?.(error, event); },
+          );
+          pending.add(settled);
+          settled.then(() => pending.delete(settled));
+          waitUntil?.(settled);
+        }
       }
       catch (error) {
         onError?.(error, event);
@@ -95,6 +129,14 @@ export function createExperiments({ experiments, adapters = [], onError }: Creat
           name,
           props,
         });
+      }
+    },
+
+    async flush() {
+      // Deliveries can enqueue further deliveries (e.g. an adapter emitting
+      // through another instance), so drain until the set is empty.
+      while (pending.size > 0) {
+        await Promise.all(pending);
       }
     },
   };

--- a/packages/experiments/src/types.ts
+++ b/packages/experiments/src/types.ts
@@ -39,8 +39,8 @@ export interface ExperimentEvent {
 export type Exposure = ExperimentEvent & { type: 'exposure' };
 
 /**
- * A sink for experiment events. Bring your own, or use `fetchAdapter`. The
- * return value is ignored, so adapters can be sync or async (return a promise
- * to let callers await delivery).
+ * A sink for experiment events. Bring your own, or use `fetchAdapter`.
+ * Adapters can be sync or async: return a promise so callers, and the
+ * factory's `flush` and `waitUntil`, can await delivery.
  */
 export type Adapter = (event: ExperimentEvent) => unknown;


### PR DESCRIPTION
The `createExperiments` factory fires adapter events without awaiting them. On serverless platforms (Vercel, Netlify, Cloudflare) the process is frozen as soon as the response goes out, so in-flight deliveries are silently dropped: they never reject, so `onError` never fires. Conversions are hit harder than exposures because `track` typically runs right before the response, which biases measured conversion rates.

This PR hardens delivery without changing existing behavior:

- New `waitUntil` factory option: every pending async delivery is handed to the host platform's `waitUntil` (Vercel `@vercel/functions`, Next.js `after`, Netlify `context.waitUntil`, Cloudflare `ctx.waitUntil`, Nitro `event.waitUntil` all share the `(promise) => void` shape). The handed promise never rejects; failures still route to `onError`.
- New `flush()` method: resolves once every pending delivery has settled, for platforms without a `waitUntil` hook or when delivery must complete before the response. Non-rejecting, so a downed analytics sink still cannot break a request.
- Adapters are still invoked synchronously so the fetch is initiated before the handler returns, and `resolveExperiment` stays sync on the render path. Sync adapters no longer allocate a throwaway microtask.
- Fixed the `Adapter` doc comment that promised awaitable delivery the factory previously made impossible.

Docs PR with Vercel/Cloudflare guidance: storyblok/storyblok-docs-platform#603

Fixes DX-539