### PR TITLE
feat(cli): add support for .vtt files when using assets push

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -131,11 +131,12 @@ export const SUPPORTED_ASSET_EXTENSIONS = new Set([
   '.wma',
   '.m4a',
   '.opus',
-  // Documents: application/msword, text/plain, application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document
+  // Documents: application/msword, text/plain, application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/vtt
   '.pdf',
   '.doc',
   '.docx',
   '.txt',
+  '.vtt',
 ]);
 
 export const directories = {


### PR DESCRIPTION
The Storyblok CLI `storyblok assets push` command only picks up assets with extensions in the [`SUPPORTED_ASSET_EXTENSIONS`](https://github.com/storyblok/monoblok/blob/66547b6af129dd31e53e3d5140d70f421a01bd27/packages/cli/src/constants.ts) array. Among others, this causes the command to ignore `.vtt` subtitles files.

This PR expands the `SUPPORTED_ASSET_EXTENSIONS` with the `.vtt` extension

Fixes #731 