### PR TITLE
fix(cli): surface API error messages on asset push failure

### DIFF
--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -7,7 +7,7 @@ import { fetchStoriesStream, fetchStoryStream, mapReferencesStream, writeStorySt
 import { validateStoryAgainstSchemas } from '../stories/validate-story';
 import type { Logger } from '../../lib/logger/logger';
 import type { Report } from '../../lib/reporter/reporter';
-import { logOnlyError } from '../../utils/error/error';
+import { getApiResponseMessage, logOnlyError } from '../../utils/error/error';
 import type {
   AppendAssetFolderManifestTransport,
   AppendAssetManifestTransport,
@@ -116,15 +116,6 @@ export const upsertAssetsPipeline = async ({
   const assetProgress = ui.createProgressBar({ title: 'Assets...'.padEnd(PROGRESS_BAR_PADDING) });
   const summary = { total: 0, succeeded: 0, failed: 0 };
 
-  // Extract the human-readable message from the API response body when present
-  // (e.g. { error: "..." } or { message: "..." }), falling back to error.message.
-  const getAssetErrorMessage = (error: Error): string => {
-    const data = (error as any)?.response?.data;
-    return (typeof data?.error === 'string' ? data.error : undefined)
-      ?? (typeof data?.message === 'string' ? data.message : undefined)
-      ?? error.message;
-  };
-
   const steps = [];
   // Use the asset provided via the CLI.
   if (assetBinaryPath && assetData) {
@@ -138,7 +129,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
-        ui.warn(`Failed to read "${assetData?.filename ?? assetBinaryPath}": ${getAssetErrorMessage(error)}`);
+        ui.warn(`Failed to read "${assetData?.filename ?? assetBinaryPath}": ${getApiResponseMessage(error)}`);
       },
     }));
   }
@@ -154,7 +145,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
-        ui.warn(`Failed to read asset: ${getAssetErrorMessage(error)}`);
+        ui.warn(`Failed to read asset: ${getApiResponseMessage(error)}`);
       },
     }));
   }
@@ -182,7 +173,7 @@ export const upsertAssetsPipeline = async ({
     onAssetError: (error, asset) => {
       summary.failed += 1;
       logOnlyError(error, { assetId: asset.id });
-      ui.warn(`Failed to push "${asset.filename ?? asset.short_filename ?? asset.id}": ${getAssetErrorMessage(error)}`);
+      ui.warn(`Failed to push "${asset.filename ?? asset.short_filename ?? asset.id}": ${getApiResponseMessage(error)}`);
     },
   }));
   await pipeline(steps);

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -7,7 +7,8 @@ import { fetchStoriesStream, fetchStoryStream, mapReferencesStream, writeStorySt
 import { validateStoryAgainstSchemas } from '../stories/validate-story';
 import type { Logger } from '../../lib/logger/logger';
 import type { Report } from '../../lib/reporter/reporter';
-import { getApiResponseMessage, logOnlyError } from '../../utils/error/error';
+import { logOnlyError, toError } from '../../utils/error/error';
+import { FailureReasonGroup } from '../../utils/failure-reason-group';
 import type {
   AppendAssetFolderManifestTransport,
   AppendAssetManifestTransport,
@@ -116,6 +117,11 @@ export const upsertAssetsPipeline = async ({
   const assetProgress = ui.createProgressBar({ title: 'Assets...'.padEnd(PROGRESS_BAR_PADDING) });
   const summary = { total: 0, succeeded: 0, failed: 0 };
 
+  // Collect failures during the pipeline and group by reason afterwards.
+  // This mirrors the transfer pipeline convention (transfer/index.ts) and
+  // prevents 60+ identical warn lines interleaved with active progress bars.
+  const failures = new FailureReasonGroup();
+
   const steps = [];
   // Use the asset provided via the CLI.
   if (assetBinaryPath && assetData) {
@@ -129,7 +135,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
-        ui.warn(`Failed to read "${assetData?.filename ?? assetBinaryPath}": ${getApiResponseMessage(error)}`);
+        failures.record(toError(error).message, assetData?.short_filename ?? assetData?.filename ?? assetBinaryPath);
       },
     }));
   }
@@ -141,11 +147,11 @@ export const upsertAssetsPipeline = async ({
         summary.total = total;
         assetProgress.setTotal(total);
       },
-      onAssetError: (error) => {
+      onAssetError: (error, filePath) => {
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
-        ui.warn(`Failed to read asset: ${getApiResponseMessage(error)}`);
+        failures.record(toError(error).message, filePath);
       },
     }));
   }
@@ -173,10 +179,16 @@ export const upsertAssetsPipeline = async ({
     onAssetError: (error, asset) => {
       summary.failed += 1;
       logOnlyError(error, { assetId: asset.id });
-      ui.warn(`Failed to push "${asset.filename ?? asset.short_filename ?? asset.id}": ${getApiResponseMessage(error)}`);
+      failures.record(toError(error).message, asset.short_filename ?? asset.filename ?? String(asset.id));
     },
   }));
   await pipeline(steps);
+
+  // Emit grouped failure warnings after the pipeline completes so they appear
+  // below (not interleaved with) the active progress bars.
+  for (const line of failures.toListLines()) {
+    ui.warn(line);
+  }
 
   return [['assetResults', summary]];
 };

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -129,6 +129,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
+        ui.warn(`Failed to push "${assetData?.filename ?? assetBinaryPath}": ${error.message}`);
       },
     }));
   }
@@ -144,6 +145,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
+        ui.warn(`Failed to read asset: ${error.message}`);
       },
     }));
   }
@@ -171,6 +173,7 @@ export const upsertAssetsPipeline = async ({
     onAssetError: (error, asset) => {
       summary.failed += 1;
       logOnlyError(error, { assetId: asset.id });
+      ui.warn(`Failed to push "${asset.filename ?? asset.short_filename ?? asset.id}": ${error.message}`);
     },
   }));
   await pipeline(steps);

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -129,7 +129,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
-        ui.warn(`Failed to push "${assetData?.filename ?? assetBinaryPath}": ${error.message}`);
+        ui.warn(`Failed to read "${assetData?.filename ?? assetBinaryPath}": ${error.message}`);
       },
     }));
   }

--- a/packages/cli/src/commands/assets/pipelines.ts
+++ b/packages/cli/src/commands/assets/pipelines.ts
@@ -116,6 +116,15 @@ export const upsertAssetsPipeline = async ({
   const assetProgress = ui.createProgressBar({ title: 'Assets...'.padEnd(PROGRESS_BAR_PADDING) });
   const summary = { total: 0, succeeded: 0, failed: 0 };
 
+  // Extract the human-readable message from the API response body when present
+  // (e.g. { error: "..." } or { message: "..." }), falling back to error.message.
+  const getAssetErrorMessage = (error: Error): string => {
+    const data = (error as any)?.response?.data;
+    return (typeof data?.error === 'string' ? data.error : undefined)
+      ?? (typeof data?.message === 'string' ? data.message : undefined)
+      ?? error.message;
+  };
+
   const steps = [];
   // Use the asset provided via the CLI.
   if (assetBinaryPath && assetData) {
@@ -129,7 +138,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
-        ui.warn(`Failed to read "${assetData?.filename ?? assetBinaryPath}": ${error.message}`);
+        ui.warn(`Failed to read "${assetData?.filename ?? assetBinaryPath}": ${getAssetErrorMessage(error)}`);
       },
     }));
   }
@@ -145,7 +154,7 @@ export const upsertAssetsPipeline = async ({
         summary.failed += 1;
         assetProgress.increment();
         logOnlyError(error);
-        ui.warn(`Failed to read asset: ${error.message}`);
+        ui.warn(`Failed to read asset: ${getAssetErrorMessage(error)}`);
       },
     }));
   }
@@ -173,7 +182,7 @@ export const upsertAssetsPipeline = async ({
     onAssetError: (error, asset) => {
       summary.failed += 1;
       logOnlyError(error, { assetId: asset.id });
-      ui.warn(`Failed to push "${asset.filename ?? asset.short_filename ?? asset.id}": ${error.message}`);
+      ui.warn(`Failed to push "${asset.filename ?? asset.short_filename ?? asset.id}": ${getAssetErrorMessage(error)}`);
     },
   }));
   await pipeline(steps);

--- a/packages/cli/src/commands/assets/pull/index.test.ts
+++ b/packages/cli/src/commands/assets/pull/index.test.ts
@@ -321,7 +321,7 @@ describe('assets pull command', () => {
     await assetsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
 
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Internal Server Error');
     expect(logFile).toContain('"fetchAssetPages":{"total":1,"succeeded":0,"failed":1}');
     expect(logFile).toContain('"fetchAssets":{"total":0,"succeeded":0,"failed":0}');
     expect(logFile).toContain('"save":{"total":0,"succeeded":0,"failed":0}');
@@ -355,7 +355,7 @@ describe('assets pull command', () => {
     await assetsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
 
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Internal Server Error');
     expect(logFile).toContain('"folderResults":{"total":1,"succeeded":0,"failed":1}');
     expect(process.exitCode).toBe(1);
   });

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -1023,7 +1023,7 @@ describe('assets push command', () => {
     expect(report?.status).toBe('FAILURE');
     // Logging
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Creation failed');
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Folders: 0/1 succeeded, 1 failed.'),
     );
@@ -1052,7 +1052,7 @@ describe('assets push command', () => {
     expect(report?.status).toBe('FAILURE');
     // Logging
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Update failed');
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Folders: 0/1 succeeded, 1 failed.'),
     );
@@ -1075,7 +1075,7 @@ describe('assets push command', () => {
     expect(report?.status).toBe('FAILURE');
     // Logging
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Creation failed');
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Push results: 1 processed, 1 assets failed'),
     );
@@ -1108,7 +1108,7 @@ describe('assets push command', () => {
     expect(report?.status).toBe('FAILURE');
     // Logging
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Update failed');
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Push results: 1 processed, 1 assets failed'),
     );

--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -1975,5 +1975,19 @@ describe('assets push command', () => {
       const written = Object.keys(vol.toJSON()).map(p => p.replace(/\\/g, '/'));
       expect(written.some(p => p.includes('assets/shared/7/manifest.jsonl'))).toBe(false);
     });
+
+    it('should treat a missing shared-assets directory as empty (no warn, no log error)', async () => {
+      // A library exists but the local shared/<id> directory has never been set up.
+      // ENOENT from readdir is a normal condition — silently treat as empty directory.
+      preconditions.hasLibraries([{ id: 7, name: 'Brand', accessLevel: 'write' }]);
+      // Intentionally no vol.fromJSON for the shared/7 directory — it does not exist.
+
+      await assetsCommand.parseAsync(['node', 'test', 'push', '--space', DEFAULT_SPACE, '--target', 'shared']);
+
+      // No warn and no error banner in the output.
+      const stderrCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map(args => args[0]);
+      expect(stderrCalls.some((msg: unknown) => typeof msg === 'string' && msg.includes('⚠'))).toBe(false);
+      expect(stderrCalls.some((msg: unknown) => typeof msg === 'string' && msg.includes('ENOENT'))).toBe(false);
+    });
   });
 });

--- a/packages/cli/src/commands/assets/streams.ts
+++ b/packages/cli/src/commands/assets/streams.ts
@@ -534,7 +534,8 @@ export const readLocalAssetsStream = ({
 }: {
   directoryPath: string;
   setTotalAssets?: (total: number) => void;
-  onAssetError?: (error: Error) => void;
+  /** Called for per-file read/parse failures; receives the file path that failed. */
+  onAssetError?: (error: Error, filePath: string) => void;
 }) => {
   const iterator = async function* readAssets() {
     try {
@@ -566,12 +567,20 @@ export const readLocalAssetsStream = ({
           } satisfies LocalAssetPayload;
         }
         catch (maybeError) {
-          onAssetError?.(toError(maybeError));
+          onAssetError?.(toError(maybeError), binaryFilePath);
         }
       }
     }
     catch (maybeError) {
-      onAssetError?.(toError(maybeError));
+      // A missing directory is normal (e.g. a shared-library space that has never
+      // pulled assets). Treat it as empty — yield nothing, set total to 0.
+      if ((maybeError as NodeJS.ErrnoException).code === 'ENOENT') {
+        setTotalAssets?.(0);
+        return;
+      }
+      // Any other directory-level failure (EPERM, etc.) is genuinely unexpected;
+      // rethrow so the pipeline rejects and the outer error handler surfaces it.
+      throw maybeError;
     }
   };
   return Readable.from(iterator());

--- a/packages/cli/src/commands/assets/transfer/index.test.ts
+++ b/packages/cli/src/commands/assets/transfer/index.test.ts
@@ -136,7 +136,7 @@ describe('assets transfer command', () => {
     // Summary counts, then one grouped reason line with the count — not three
     // separate per-asset rows.
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('0 transferred, 3 failed (of 3)'));
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('(3)'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('3 assets'));
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/cli/src/commands/assets/transfer/index.ts
+++ b/packages/cli/src/commands/assets/transfer/index.ts
@@ -7,6 +7,7 @@ import { session } from '../../../session';
 import { requireAuthentication } from '../../../utils/auth';
 import { CommandError } from '../../../utils/error/command-error';
 import { handleError, logOnlyError, toError } from '../../../utils/error/error';
+import { FailureReasonGroup } from '../../../utils/failure-reason-group';
 import { fetchAllSpaceAssetIds, transferAssets } from '../actions';
 
 const transferCmd = assetsCommand
@@ -123,23 +124,13 @@ transferCmd
     ui.info(`Transfer results: ${summary.succeeded} transferred, ${summary.failed} failed (of ${summary.total}).`);
 
     if (summary.failed > 0) {
-      // Group failures by reason so the output stays a short summary even when
-      // thousands of assets fail with the same cause, instead of printing one
-      // line per failed asset. Per-asset detail is still in the log/report.
-      const countsByReason = new Map<string, number>();
+      const failures = new FailureReasonGroup();
       for (const result of results) {
         if (result.status === 'failed') {
-          const reason = result.reason ?? 'Unknown error';
-          countsByReason.set(reason, (countsByReason.get(reason) ?? 0) + 1);
+          failures.record(result.reason ?? 'Unknown error');
         }
       }
-      const byReason = [...countsByReason.entries()].sort((a, b) => b[1] - a[1]);
-      const MAX_REASONS = 10;
-      const lines = byReason.slice(0, MAX_REASONS).map(([reason, count]) => `✗ ${reason} (${count})`);
-      if (byReason.length > MAX_REASONS) {
-        lines.push(`… and ${byReason.length - MAX_REASONS} more failure reason(s)`);
-      }
-      ui.list(lines);
+      ui.list(failures.toListLines('transfer'));
     }
 
     reporter.addSummary('transferResults', summary);

--- a/packages/cli/src/commands/stories/pull/index.test.ts
+++ b/packages/cli/src/commands/stories/pull/index.test.ts
@@ -217,13 +217,13 @@ describe('stories pull command', () => {
 
     // Logging
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Internal Server Error');
     expect(logFile).toContain('"fetchStoryPages":{"total":1,"succeeded":0,"failed":1}');
     expect(logFile).toContain('"fetchStories":{"total":0,"succeeded":0,"failed":0}');
     expect(logFile).toContain('"save":{"total":0,"succeeded":0,"failed":0}');
     // UI
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('The server returned an error'),
+      expect.stringContaining('Internal Server Error'),
     );
   });
 
@@ -235,13 +235,13 @@ describe('stories pull command', () => {
 
     // Logging
     const logFile = getLogFileContents(LOG_PREFIX);
-    expect(logFile).toContain('The server returned an error');
+    expect(logFile).toContain('Internal Server Error');
     expect(logFile).toContain('"fetchStoryPages":{"total":1,"succeeded":1,"failed":0}');
     expect(logFile).toContain('"fetchStories":{"total":3,"succeeded":2,"failed":1}');
     expect(logFile).toContain('"save":{"total":2,"succeeded":2,"failed":0}');
     // UI
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('The server returned an error'),
+      expect.stringContaining('Internal Server Error'),
     );
   });
 });

--- a/packages/cli/src/commands/stories/pull/index.test.ts
+++ b/packages/cli/src/commands/stories/pull/index.test.ts
@@ -223,7 +223,7 @@ describe('stories pull command', () => {
     expect(logFile).toContain('"save":{"total":0,"succeeded":0,"failed":0}');
     // UI
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('Internal Server Error'),
+      expect.stringContaining('The server returned an error'),
     );
   });
 
@@ -241,7 +241,7 @@ describe('stories pull command', () => {
     expect(logFile).toContain('"save":{"total":2,"succeeded":2,"failed":0}');
     // UI
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('Internal Server Error'),
+      expect.stringContaining('The server returned an error'),
     );
   });
 });

--- a/packages/cli/src/commands/stories/push/index.test.ts
+++ b/packages/cli/src/commands/stories/push/index.test.ts
@@ -1668,7 +1668,7 @@ describe('stories push command', () => {
       expect(report.status).toBe('FAILURE');
       // Logging
       const logFile = getLogFileContents(LOG_PREFIX);
-      expect(logFile).toContain('The server returned an error');
+      expect(logFile).toContain('Failed to create placeholder story');
       // UI — deferred, grouped summary (no inline console.error during streaming)
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed stories (1):'),
@@ -1677,7 +1677,7 @@ describe('stories push command', () => {
         expect.stringContaining(`story-a (uuid: `),
       );
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('The server returned an error'),
+        expect.stringContaining('Failed to create placeholder story'),
       );
       // UI
       expect(console.error).toHaveBeenCalledWith(
@@ -1799,13 +1799,13 @@ describe('stories push command', () => {
       expect(report?.status).toBe('PARTIAL_SUCCESS');
       // Logging
       const logFile = getLogFileContents(LOG_PREFIX);
-      expect(logFile).toContain('The server returned an error');
+      expect(logFile).toContain('Failed to update story');
       // UI — deferred, grouped summary (no inline console.error during streaming)
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed stories (1):'),
       );
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('The server returned an error'),
+        expect.stringContaining('Failed to update story'),
       );
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining(`story-a (uuid: `),

--- a/packages/cli/src/utils/error/api-error.test.ts
+++ b/packages/cli/src/utils/error/api-error.test.ts
@@ -224,3 +224,105 @@ describe('handleAPIError', () => {
     }
   });
 });
+
+describe('aPIError server message extraction', () => {
+  it('should use data.error string as message when present', () => {
+    const error = new FetchError('Not Found', {
+      status: 404,
+      statusText: 'Not Found',
+      data: { error: 'Story not found in this space' },
+    });
+    try {
+      handleAPIError('pull_story', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('Story not found in this space');
+      expect((e as APIError).messageStack).toContain('Story not found in this space');
+    }
+  });
+
+  it('should use data.message string as message when data.error is absent', () => {
+    const error = new FetchError('Unauthorized', {
+      status: 401,
+      statusText: 'Unauthorized',
+      data: { message: 'Token has expired' },
+    });
+    try {
+      handleAPIError('get_user', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('Token has expired');
+      expect((e as APIError).messageStack).toContain('Token has expired');
+    }
+  });
+
+  it('should prefer data.error over data.message when both are present', () => {
+    const error = new FetchError('Bad Request', {
+      status: 400,
+      statusText: 'Bad Request',
+      data: { error: 'Invalid slug format', message: 'Something went wrong' },
+    });
+    try {
+      handleAPIError('create_story', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('Invalid slug format');
+    }
+  });
+
+  it('should not override a customMessage with the server message', () => {
+    const error = new FetchError('Not Found', {
+      status: 404,
+      statusText: 'Not Found',
+      data: { error: 'Story not found in this space' },
+    });
+    try {
+      handleAPIError('pull_story', error, 'Custom override message');
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('Custom override message');
+    }
+  });
+
+  it('should not override the 422 name-taken rewrite with the server message', () => {
+    const error = new FetchError('Unprocessable', {
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      data: { name: ['has already been taken'], error: 'Validation failed' },
+    });
+    try {
+      handleAPIError('push_component', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('A component with this name already exists');
+    }
+  });
+
+  it('should fall back to generic API_ERRORS message when data has no error/message string', () => {
+    const error = new FetchError('Server Error', {
+      status: 500,
+      statusText: 'Internal Server Error',
+      data: { code: 500 },
+    });
+    try {
+      handleAPIError('pull_stories', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('The server returned an error');
+    }
+  });
+
+  it('should not replace message with an empty string from data.error', () => {
+    const error = new FetchError('Server Error', {
+      status: 500,
+      statusText: 'Internal Server Error',
+      data: { error: '' },
+    });
+    try {
+      handleAPIError('pull_stories', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('The server returned an error');
+    }
+  });
+});

--- a/packages/cli/src/utils/error/api-error.test.ts
+++ b/packages/cli/src/utils/error/api-error.test.ts
@@ -388,7 +388,7 @@ describe('aPIError server message extraction', () => {
     }
     catch (e) {
       expect((e as APIError).messageStack).toContain('base: This asset folder is not valid');
-      // message must surface the raw value without the "base:" key prefix
+      // "base" is a Rails model-level key — strip it from the summary message
       expect((e as APIError).message).toBe('This asset folder is not valid');
     }
   });
@@ -407,9 +407,9 @@ describe('aPIError server message extraction', () => {
       expect((e as APIError).messageStack).toContain(
         'internal_tag_ids: Invalid internal_tag, there is at least one internal_tag not found in our database',
       );
-      // message surfaces the raw value without the field key prefix
+      // field name is preserved — it tells the user which parameter is invalid
       expect((e as APIError).message).toBe(
-        'Invalid internal_tag, there is at least one internal_tag not found in our database',
+        'internal_tag_ids: Invalid internal_tag, there is at least one internal_tag not found in our database',
       );
     }
   });

--- a/packages/cli/src/utils/error/api-error.test.ts
+++ b/packages/cli/src/utils/error/api-error.test.ts
@@ -325,4 +325,92 @@ describe('aPIError server message extraction', () => {
       expect((e as APIError).message).toBe('The server returned an error');
     }
   });
+
+  it('should NOT override message when server error string matches HTTP statusText (401 regression, HTTP/1.1)', () => {
+    // MAPI returns {"error":"Unauthorized"} for 401. The old code replaced the
+    // friendly "The user is not authorized to access the API" with "Unauthorized".
+    const error = new FetchError('Unauthorized', {
+      status: 401,
+      statusText: 'Unauthorized',
+      data: { error: 'Unauthorized' },
+    });
+    try {
+      handleAPIError('pull_components', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('The user is not authorized to access the API');
+      expect((e as APIError).cause).toBe('The user is not authorized to access the API');
+    }
+  });
+
+  it('should NOT override message when server error string matches canonical reason phrase (401 regression, HTTP/2 empty statusText)', () => {
+    // HTTP/2 sends empty statusText; MAPI still returns {"error":"Unauthorized"}.
+    // Without the canonical-phrase fallback the guard would pass and "Unauthorized"
+    // would replace the friendlier API_ERRORS.unauthorized constant.
+    const error = new FetchError('', {
+      status: 401,
+      statusText: '',
+      data: { error: 'Unauthorized' },
+    });
+    try {
+      handleAPIError('pull_components', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('The user is not authorized to access the API');
+      expect((e as APIError).cause).toBe('The user is not authorized to access the API');
+    }
+  });
+
+  it('should sync cause with message when a server message overrides the generic entry', () => {
+    const error = new FetchError('Not Found', {
+      status: 404,
+      statusText: 'Not Found',
+      data: { error: 'Space not found' },
+    });
+    try {
+      handleAPIError('pull_stories', error);
+    }
+    catch (e) {
+      expect((e as APIError).message).toBe('Space not found');
+      expect((e as APIError).cause).toBe('Space not found');
+    }
+  });
+
+  it('should extract messages from 422 nested error object {"error":{"base":["msg"]}}', () => {
+    // Real MAPI asset-create shape: POST /assets with bad asset_folder_id
+    const error = new FetchError('Unprocessable Entity', {
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      data: { error: { base: ['This asset folder is not valid'] } },
+    });
+    try {
+      handleAPIError('push_asset_create', error);
+    }
+    catch (e) {
+      expect((e as APIError).messageStack).toContain('base: This asset folder is not valid');
+      // message must surface the raw value without the "base:" key prefix
+      expect((e as APIError).message).toBe('This asset folder is not valid');
+    }
+  });
+
+  it('should extract messages from 422 nested error object with multiple fields', () => {
+    // Real MAPI asset-create shape: bad internal_tag_ids
+    const error = new FetchError('Unprocessable Entity', {
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      data: { error: { internal_tag_ids: ['Invalid internal_tag, there is at least one internal_tag not found in our database'] } },
+    });
+    try {
+      handleAPIError('push_asset_create', error);
+    }
+    catch (e) {
+      expect((e as APIError).messageStack).toContain(
+        'internal_tag_ids: Invalid internal_tag, there is at least one internal_tag not found in our database',
+      );
+      // message surfaces the raw value without the field key prefix
+      expect((e as APIError).message).toBe(
+        'Invalid internal_tag, there is at least one internal_tag not found in our database',
+      );
+    }
+  });
 });

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -132,8 +132,19 @@ export class APIError extends Error {
     }
     this.messageStack.push(customMessage || API_ERRORS[errorId]);
 
+    // Surface the API's human-readable error/message string directly when present,
+    // regardless of status code.
+    const responseData = this.response?.data as { [key: string]: string | string[] } | undefined;
+    const apiMessage = typeof responseData?.error === 'string'
+      ? responseData.error
+      : typeof responseData?.message === 'string'
+        ? responseData.message
+        : undefined;
+    if (apiMessage && !customMessage) {
+      this.message = apiMessage;
+    }
+
     if (this.code === 422) {
-      const responseData = this.response?.data as { [key: string]: string[] } | undefined;
       // Scope the "name already taken" rewrite to the action that raised it so a
       // folder create failure does not claim "component" (and vice versa).
       if (responseData?.name?.[0] === 'has already been taken') {

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -126,22 +126,26 @@ function pushFieldErrors(stack: string[], fields: Record<string, unknown>): void
 }
 
 /**
- * Returns the first raw string value from a field-error map, ignoring the key.
- * Used to set a clean summary message without leaking internal field names like
- * Rails' "base" key or API-specific parameter names.
- * Covers both flat shapes {"slug":["taken"]} and nested {"error":{"base":["…"]}}.
+ * Field-error key prefixes that carry no user-facing meaning and should be
+ * stripped when promoting the first 422 field error to `this.message`.
+ * Add entries here to suppress additional internal keys without touching logic.
+ *
+ * "base" is the Rails convention for model-level errors not tied to any field.
  */
-function firstFieldValue(data: Record<string, unknown>): string | undefined {
-  for (const value of Object.values(data)) {
-    if (Array.isArray(value) && typeof value[0] === 'string' && value[0]) {
-      return value[0];
-    }
-    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      const nested = firstFieldValue(value as Record<string, unknown>);
-      if (nested) { return nested; }
+const STRIP_FIELD_PREFIXES = ['base: '] as const;
+
+/**
+ * Strips internal field-error key prefixes from a formatted "key: value" entry.
+ * All other field names (e.g. "name:", "slug:") are preserved — they tell the
+ * user which field is invalid.
+ */
+function stripBasePrefix(entry: string): string {
+  for (const prefix of STRIP_FIELD_PREFIXES) {
+    if (entry.startsWith(prefix)) {
+      return entry.slice(prefix.length);
     }
   }
-  return undefined;
+  return entry;
 }
 
 /**
@@ -258,9 +262,11 @@ export class APIError extends Error {
         replaceOrAppend(this.messageStack, API_ERRORS[errorId], serverMessage);
       }
       else if (this.messageStack.length > stackLengthBefore422) {
-        // 422 with field errors — extract the first raw value from the response data
-        // (not from the formatted messageStack strings) so no key prefix leaks through.
-        this.message = firstFieldValue(responseData ?? {}) ?? this.messageStack[stackLengthBefore422];
+        // 422 with field errors — use the first pushed entry as a summary.
+        // Field names are preserved (e.g. "name: can't be blank") so the user
+        // knows which field is invalid. Only "base:" is stripped because it is a
+        // Rails model-level key with no user-facing meaning.
+        this.message = stripBasePrefix(this.messageStack[stackLengthBefore422]);
         this.cause = this.message;
       }
     }

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -83,6 +83,81 @@ function getErrorId(status: number): keyof typeof API_ERRORS {
   }
 }
 
+/**
+ * Canonical HTTP reason phrases for status codes where MAPI echoes them back
+ * as an uninformative `{"error":"..."}` body. HTTP/2 sends an empty statusText,
+ * so we can't rely on the response header alone — fall back to the phrase here.
+ */
+const HTTP_REASON_PHRASES: Partial<Record<number, string>> = {
+  401: 'Unauthorized',
+  403: 'Forbidden',
+};
+
+/**
+ * Returns the first non-empty string field from `data` that is not identical
+ * to the HTTP statusText or the canonical HTTP reason phrase for the status code.
+ * Skipping those prevents echoed reason phrases (e.g. {"error":"Unauthorized"} on 401)
+ * from replacing the more informative API_ERRORS constants. HTTP/2 sends an empty
+ * statusText, so the canonical phrase is used as a fallback comparison value.
+ * Checks `error` before `message` to match MAPI's field priority.
+ */
+function extractServerString(data: Record<string, unknown>, status: number, statusText: string | undefined): string | undefined {
+  const boringPhrase = statusText || HTTP_REASON_PHRASES[status] || '';
+  for (const field of [data.error, data.message]) {
+    if (typeof field === 'string' && field && field !== boringPhrase) {
+      return field;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Pushes `key: value` entries from `fields` into `stack` for every key whose
+ * value is a string array. Used for both top-level and nested MAPI 422 shapes.
+ */
+function pushFieldErrors(stack: string[], fields: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(fields)) {
+    if (Array.isArray(value)) {
+      for (const e of value) {
+        stack.push(`${key}: ${e}`);
+      }
+    }
+  }
+}
+
+/**
+ * Returns the first raw string value from a field-error map, ignoring the key.
+ * Used to set a clean summary message without leaking internal field names like
+ * Rails' "base" key or API-specific parameter names.
+ * Covers both flat shapes {"slug":["taken"]} and nested {"error":{"base":["…"]}}.
+ */
+function firstFieldValue(data: Record<string, unknown>): string | undefined {
+  for (const value of Object.values(data)) {
+    if (Array.isArray(value) && typeof value[0] === 'string' && value[0]) {
+      return value[0];
+    }
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      const nested = firstFieldValue(value as Record<string, unknown>);
+      if (nested) { return nested; }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Replaces the last entry in `stack` when it equals `target`; otherwise appends.
+ * Used to swap the generic API_ERRORS placeholder with a server-provided message.
+ */
+function replaceOrAppend(stack: string[], target: string, replacement: string): void {
+  const lastIdx = stack.length - 1;
+  if (lastIdx >= 0 && stack[lastIdx] === target) {
+    stack[lastIdx] = replacement;
+  }
+  else {
+    stack.push(replacement);
+  }
+}
+
 export function handleAPIError(action: keyof typeof API_ACTIONS, error: unknown, customMessage?: string): never {
   if (error instanceof FetchError) {
     const errorId = getErrorId(error.response.status);
@@ -132,11 +207,23 @@ export class APIError extends Error {
     }
     this.messageStack.push(customMessage || API_ERRORS[errorId]);
 
+    const responseData = this.response?.data as Record<string, unknown> | undefined;
+    const statusText = this.response?.statusText;
+
+    // Extract a server-provided human-readable message early so it is available
+    // both during the 422 block and for the final message override below.
+    // Guards: skip when customMessage was provided; skip when the server string
+    // merely echoes the HTTP reason phrase (e.g. {"error":"Unauthorized"} on 401 —
+    // HTTP/2 sends empty statusText, so we also compare against the canonical phrase).
+    const serverMessage = customMessage ? undefined : extractServerString(responseData ?? {}, this.code, statusText);
+
+    const stackLengthBefore422 = this.messageStack.length;
+
     if (this.code === 422) {
-      const responseData = this.response?.data as { [key: string]: string[] } | undefined;
       // Scope the "name already taken" rewrite to the action that raised it so a
       // folder create failure does not claim "component" (and vice versa).
-      if (responseData?.name?.[0] === 'has already been taken') {
+      const nameField = responseData?.name;
+      if (Array.isArray(nameField) && nameField[0] === 'has already been taken') {
         if (action === 'push_component_folder') {
           this.message = 'A component folder with this name already exists';
         }
@@ -144,40 +231,37 @@ export class APIError extends Error {
           this.message = 'A component with this name already exists';
         }
       }
-      Object.entries(responseData || {}).forEach(([key, errors]) => {
-        if (Array.isArray(errors)) {
-          errors.forEach((e) => {
-            this.messageStack.push(`${key}: ${e}`);
-          });
+
+      // Push top-level field arrays: {"slug":["taken"]}
+      pushFieldErrors(this.messageStack, responseData ?? {});
+
+      // Push one level of nesting: {"error":{"base":["msg"]}} / {"errors":{…}}
+      for (const key of ['error', 'errors'] as const) {
+        const nested = responseData?.[key];
+        if (nested !== null && typeof nested === 'object' && !Array.isArray(nested)) {
+          pushFieldErrors(this.messageStack, nested as Record<string, unknown>);
         }
-      });
+      }
     }
 
-    // Replace the generic API_ERRORS description with a server-provided human-readable
-    // message when the response body carries one (e.g. { error: "..." } or
-    // { message: "..." }). Skipped when a customMessage was already provided or when
-    // the 422 rewrite above already produced a specific message.
+    // Replace the generic API_ERRORS placeholder with the most specific message available.
+    // Priority: (1) top-level server string (e.g. {"error":"Your space must be verified…"}),
+    // (2) first raw field value from the 422 response (e.g. "This asset folder is not valid").
+    // The messageStack keeps full key:value entries for verbose display; this.message gets
+    // the raw value so internal field names (Rails "base", param names, etc.) don't leak through.
+    // Skipped when a customMessage was provided or when the 422 name-taken rewrite already
+    // produced a specific message.
     if (!customMessage && this.message === API_ERRORS[errorId]) {
-      const data = this.response?.data;
-      let serverMessage: string | undefined;
-
-      if (typeof data?.error === 'string' && data.error) {
-        serverMessage = data.error;
-      }
-      else if (typeof data?.message === 'string' && data.message) {
-        serverMessage = data.message;
-      }
-
       if (serverMessage) {
         this.message = serverMessage;
-        // Replace the generic tail entry so the rendered stack stays clean.
-        const lastIdx = this.messageStack.length - 1;
-        if (lastIdx >= 0 && this.messageStack[lastIdx] === API_ERRORS[errorId]) {
-          this.messageStack[lastIdx] = serverMessage;
-        }
-        else {
-          this.messageStack.push(serverMessage);
-        }
+        this.cause = serverMessage;
+        replaceOrAppend(this.messageStack, API_ERRORS[errorId], serverMessage);
+      }
+      else if (this.messageStack.length > stackLengthBefore422) {
+        // 422 with field errors — extract the first raw value from the response data
+        // (not from the formatted messageStack strings) so no key prefix leaks through.
+        this.message = firstFieldValue(responseData ?? {}) ?? this.messageStack[stackLengthBefore422];
+        this.cause = this.message;
       }
     }
   }

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -132,19 +132,8 @@ export class APIError extends Error {
     }
     this.messageStack.push(customMessage || API_ERRORS[errorId]);
 
-    // Surface the API's human-readable error/message string directly when present,
-    // regardless of status code.
-    const responseData = this.response?.data as { [key: string]: string | string[] } | undefined;
-    const apiMessage = typeof responseData?.error === 'string'
-      ? responseData.error
-      : typeof responseData?.message === 'string'
-        ? responseData.message
-        : undefined;
-    if (apiMessage && !customMessage) {
-      this.message = apiMessage;
-    }
-
     if (this.code === 422) {
+      const responseData = this.response?.data as { [key: string]: string[] } | undefined;
       // Scope the "name already taken" rewrite to the action that raised it so a
       // folder create failure does not claim "component" (and vice versa).
       if (responseData?.name?.[0] === 'has already been taken') {

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -84,23 +84,15 @@ function getErrorId(status: number): keyof typeof API_ERRORS {
 }
 
 /**
- * Canonical HTTP reason phrases for status codes where MAPI echoes them back
- * as an uninformative `{"error":"..."}` body. HTTP/2 sends an empty statusText,
- * so we can't rely on the response header alone — fall back to the phrase here.
+ * HTTP reason phrases for status codes where MAPI echoes them back verbatim.
+ * HTTP/2 sends empty statusText, so we can't rely on the response header alone.
  */
 const HTTP_REASON_PHRASES: Partial<Record<number, string>> = {
   401: 'Unauthorized',
   403: 'Forbidden',
 };
 
-/**
- * Returns the first non-empty string field from `data` that is not identical
- * to the HTTP statusText or the canonical HTTP reason phrase for the status code.
- * Skipping those prevents echoed reason phrases (e.g. {"error":"Unauthorized"} on 401)
- * from replacing the more informative API_ERRORS constants. HTTP/2 sends an empty
- * statusText, so the canonical phrase is used as a fallback comparison value.
- * Checks `error` before `message` to match MAPI's field priority.
- */
+/** Returns the first data.error / data.message string, unless it just echoes the HTTP reason phrase. */
 function extractServerString(data: Record<string, unknown>, status: number, statusText: string | undefined): string | undefined {
   const boringPhrase = statusText || HTTP_REASON_PHRASES[status] || '';
   for (const field of [data.error, data.message]) {
@@ -111,10 +103,6 @@ function extractServerString(data: Record<string, unknown>, status: number, stat
   return undefined;
 }
 
-/**
- * Pushes `key: value` entries from `fields` into `stack` for every key whose
- * value is a string array. Used for both top-level and nested MAPI 422 shapes.
- */
 function pushFieldErrors(stack: string[], fields: Record<string, unknown>): void {
   for (const [key, value] of Object.entries(fields)) {
     if (Array.isArray(value)) {
@@ -126,19 +114,12 @@ function pushFieldErrors(stack: string[], fields: Record<string, unknown>): void
 }
 
 /**
- * Field-error key prefixes that carry no user-facing meaning and should be
- * stripped when promoting the first 422 field error to `this.message`.
- * Add entries here to suppress additional internal keys without touching logic.
- *
- * "base" is the Rails convention for model-level errors not tied to any field.
+ * Key prefixes to strip when promoting a field error to this.message.
+ * "base" is the Rails convention for model-level errors not tied to a field.
+ * Add entries here to suppress other internal keys without changing any logic.
  */
 const STRIP_FIELD_PREFIXES = ['base: '] as const;
 
-/**
- * Strips internal field-error key prefixes from a formatted "key: value" entry.
- * All other field names (e.g. "name:", "slug:") are preserved — they tell the
- * user which field is invalid.
- */
 function stripBasePrefix(entry: string): string {
   for (const prefix of STRIP_FIELD_PREFIXES) {
     if (entry.startsWith(prefix)) {
@@ -148,10 +129,6 @@ function stripBasePrefix(entry: string): string {
   return entry;
 }
 
-/**
- * Replaces the last entry in `stack` when it equals `target`; otherwise appends.
- * Used to swap the generic API_ERRORS placeholder with a server-provided message.
- */
 function replaceOrAppend(stack: string[], target: string, replacement: string): void {
   const lastIdx = stack.length - 1;
   if (lastIdx >= 0 && stack[lastIdx] === target) {
@@ -168,9 +145,8 @@ export function handleAPIError(action: keyof typeof API_ACTIONS, error: unknown,
     throw new APIError(errorId, action, error, customMessage);
   }
 
-  // Handle non-FetchError objects that have a response property (e.g. mapi-client ClientError).
-  // ClientError itself doesn't carry request context, but some wrappers attach
-  // a `request` field — forward it best-effort so verbose output can show it.
+  // Handle non-FetchError objects with a response property (e.g. mapi-client ClientError).
+  // Forward request context best-effort so --verbose can show it.
   const response = (error as any)?.response;
   if (response?.status) {
     const reqCandidate = (error as any)?.request;
@@ -214,18 +190,12 @@ export class APIError extends Error {
     const responseData = this.response?.data as Record<string, unknown> | undefined;
     const statusText = this.response?.statusText;
 
-    // Extract a server-provided human-readable message early so it is available
-    // both during the 422 block and for the final message override below.
-    // Guards: skip when customMessage was provided; skip when the server string
-    // merely echoes the HTTP reason phrase (e.g. {"error":"Unauthorized"} on 401 —
-    // HTTP/2 sends empty statusText, so we also compare against the canonical phrase).
     const serverMessage = customMessage ? undefined : extractServerString(responseData ?? {}, this.code, statusText);
 
     const stackLengthBefore422 = this.messageStack.length;
 
     if (this.code === 422) {
-      // Scope the "name already taken" rewrite to the action that raised it so a
-      // folder create failure does not claim "component" (and vice versa).
+      // Scope the name-taken rewrite to the action that raised it.
       const nameField = responseData?.name;
       if (Array.isArray(nameField) && nameField[0] === 'has already been taken') {
         if (action === 'push_component_folder') {
@@ -236,10 +206,9 @@ export class APIError extends Error {
         }
       }
 
-      // Push top-level field arrays: {"slug":["taken"]}
       pushFieldErrors(this.messageStack, responseData ?? {});
 
-      // Push one level of nesting: {"error":{"base":["msg"]}} / {"errors":{…}}
+      // One level of nesting: {"error":{"base":["msg"]}} / {"errors":{…}}
       for (const key of ['error', 'errors'] as const) {
         const nested = responseData?.[key];
         if (nested !== null && typeof nested === 'object' && !Array.isArray(nested)) {
@@ -248,13 +217,8 @@ export class APIError extends Error {
       }
     }
 
-    // Replace the generic API_ERRORS placeholder with the most specific message available.
-    // Priority: (1) top-level server string (e.g. {"error":"Your space must be verified…"}),
-    // (2) first raw field value from the 422 response (e.g. "This asset folder is not valid").
-    // The messageStack keeps full key:value entries for verbose display; this.message gets
-    // the raw value so internal field names (Rails "base", param names, etc.) don't leak through.
-    // Skipped when a customMessage was provided or when the 422 name-taken rewrite already
-    // produced a specific message.
+    // Promote the most specific available message; skip when customMessage or
+    // the 422 name-taken rewrite already set a specific one.
     if (!customMessage && this.message === API_ERRORS[errorId]) {
       if (serverMessage) {
         this.message = serverMessage;
@@ -262,10 +226,6 @@ export class APIError extends Error {
         replaceOrAppend(this.messageStack, API_ERRORS[errorId], serverMessage);
       }
       else if (this.messageStack.length > stackLengthBefore422) {
-        // 422 with field errors — use the first pushed entry as a summary.
-        // Field names are preserved (e.g. "name: can't be blank") so the user
-        // knows which field is invalid. Only "base:" is stripped because it is a
-        // Rails model-level key with no user-facing meaning.
         this.message = stripBasePrefix(this.messageStack[stackLengthBefore422]);
         this.cause = this.message;
       }

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -159,12 +159,14 @@ export class APIError extends Error {
     // the 422 rewrite above already produced a specific message.
     if (!customMessage && this.message === API_ERRORS[errorId]) {
       const data = this.response?.data;
-      const serverMessage
-        = typeof data?.error === 'string' && data.error
-          ? data.error
-          : typeof data?.message === 'string' && data.message
-            ? data.message
-            : undefined;
+      let serverMessage: string | undefined;
+
+      if (typeof data?.error === 'string' && data.error) {
+        serverMessage = data.error;
+      }
+      else if (typeof data?.message === 'string' && data.message) {
+        serverMessage = data.message;
+      }
 
       if (serverMessage) {
         this.message = serverMessage;

--- a/packages/cli/src/utils/error/api-error.ts
+++ b/packages/cli/src/utils/error/api-error.ts
@@ -152,6 +152,32 @@ export class APIError extends Error {
         }
       });
     }
+
+    // Replace the generic API_ERRORS description with a server-provided human-readable
+    // message when the response body carries one (e.g. { error: "..." } or
+    // { message: "..." }). Skipped when a customMessage was already provided or when
+    // the 422 rewrite above already produced a specific message.
+    if (!customMessage && this.message === API_ERRORS[errorId]) {
+      const data = this.response?.data;
+      const serverMessage
+        = typeof data?.error === 'string' && data.error
+          ? data.error
+          : typeof data?.message === 'string' && data.message
+            ? data.message
+            : undefined;
+
+      if (serverMessage) {
+        this.message = serverMessage;
+        // Replace the generic tail entry so the rendered stack stays clean.
+        const lastIdx = this.messageStack.length - 1;
+        if (lastIdx >= 0 && this.messageStack[lastIdx] === API_ERRORS[errorId]) {
+          this.messageStack[lastIdx] = serverMessage;
+        }
+        else {
+          this.messageStack.push(serverMessage);
+        }
+      }
+    }
   }
 
   getInfo() {

--- a/packages/cli/src/utils/error/error.test.ts
+++ b/packages/cli/src/utils/error/error.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getApiResponseMessage, getResponseStatus, handleError, toError } from './error';
+import { getResponseStatus, handleError, toError } from './error';
 import { CommandError } from './command-error';
 import type { APIError } from './api-error';
 import { handleAPIError } from './api-error';
@@ -103,13 +103,13 @@ describe('getResponseStatus', () => {
   });
 });
 
-describe('getApiResponseMessage', () => {
+describe('toError message extraction', () => {
   it('should return error.message for a plain Error', () => {
-    expect(getApiResponseMessage(new Error('plain error'))).toBe('plain error');
+    expect(toError(new Error('plain error')).message).toBe('plain error');
   });
 
-  it('should return String(error) for non-Error values', () => {
-    expect(getApiResponseMessage('oops')).toBe('oops');
+  it('should wrap a string into an Error', () => {
+    expect(toError('oops').message).toBe('oops');
   });
 
   it('should return APIError.message, which already contains the server-provided string', () => {
@@ -121,8 +121,7 @@ describe('getApiResponseMessage', () => {
     let caught: APIError | undefined;
     try { handleAPIError('pull_story', fetchError); }
     catch (e) { caught = e as APIError; }
-    // The APIError constructor already extracted the server message into error.message,
-    // so getApiResponseMessage simply delegates to it.
-    expect(getApiResponseMessage(caught)).toBe('Story not found in this space');
+    // The APIError constructor already extracted the server message into error.message.
+    expect(toError(caught).message).toBe('Story not found in this space');
   });
 });

--- a/packages/cli/src/utils/error/error.test.ts
+++ b/packages/cli/src/utils/error/error.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getResponseStatus, handleError, toError } from './error';
+import { getApiResponseMessage, getResponseStatus, handleError, toError } from './error';
 import { CommandError } from './command-error';
+import type { APIError } from './api-error';
+import { handleAPIError } from './api-error';
+import { FetchError } from '../fetch';
 
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -97,5 +100,42 @@ describe('getResponseStatus', () => {
   it('should extract a numeric status from an error with a response', () => {
     const err = Object.assign(new Error('fail'), { response: { status: 403 } });
     expect(getResponseStatus(err)).toBe(403);
+  });
+});
+
+describe('getApiResponseMessage', () => {
+  it('should return error.message for a plain Error', () => {
+    expect(getApiResponseMessage(new Error('plain error'))).toBe('plain error');
+  });
+
+  it('should return String(error) for non-Error values', () => {
+    expect(getApiResponseMessage('oops')).toBe('oops');
+  });
+
+  it('should return APIError.message when response data has no string fields', () => {
+    const error = new FetchError('Server Error', { status: 500, statusText: 'Internal Server Error', data: { code: 500 } });
+    let caught: APIError | undefined;
+    try { handleAPIError('pull_stories', error); }
+    catch (e) { caught = e as APIError; }
+    expect(getApiResponseMessage(caught)).toBe(caught!.message);
+  });
+
+  it('should return the server-provided message from APIError.response.data.error', () => {
+    const error = new FetchError('Not Found', {
+      status: 404,
+      statusText: 'Not Found',
+      data: { error: 'Story not found in this space' },
+    });
+    let caught: APIError | undefined;
+    try { handleAPIError('pull_story', error); }
+    catch (e) { caught = e as APIError; }
+    // APIError.message is already 'Story not found in this space' after the constructor enhancement,
+    // and getApiResponseMessage reads it from data.error — both paths agree.
+    expect(getApiResponseMessage(caught)).toBe('Story not found in this space');
+  });
+
+  it('should fall back to error.message for non-APIError errors with no response.data', () => {
+    const err = Object.assign(new Error('network failure'), { response: { status: 503 } });
+    expect(getApiResponseMessage(err)).toBe('network failure');
   });
 });

--- a/packages/cli/src/utils/error/error.test.ts
+++ b/packages/cli/src/utils/error/error.test.ts
@@ -112,30 +112,17 @@ describe('getApiResponseMessage', () => {
     expect(getApiResponseMessage('oops')).toBe('oops');
   });
 
-  it('should return APIError.message when response data has no string fields', () => {
-    const error = new FetchError('Server Error', { status: 500, statusText: 'Internal Server Error', data: { code: 500 } });
-    let caught: APIError | undefined;
-    try { handleAPIError('pull_stories', error); }
-    catch (e) { caught = e as APIError; }
-    expect(getApiResponseMessage(caught)).toBe(caught!.message);
-  });
-
-  it('should return the server-provided message from APIError.response.data.error', () => {
-    const error = new FetchError('Not Found', {
+  it('should return APIError.message, which already contains the server-provided string', () => {
+    const fetchError = new FetchError('Not Found', {
       status: 404,
       statusText: 'Not Found',
       data: { error: 'Story not found in this space' },
     });
     let caught: APIError | undefined;
-    try { handleAPIError('pull_story', error); }
+    try { handleAPIError('pull_story', fetchError); }
     catch (e) { caught = e as APIError; }
-    // APIError.message is already 'Story not found in this space' after the constructor enhancement,
-    // and getApiResponseMessage reads it from data.error — both paths agree.
+    // The APIError constructor already extracted the server message into error.message,
+    // so getApiResponseMessage simply delegates to it.
     expect(getApiResponseMessage(caught)).toBe('Story not found in this space');
-  });
-
-  it('should fall back to error.message for non-APIError errors with no response.data', () => {
-    const err = Object.assign(new Error('network failure'), { response: { status: 503 } });
-    expect(getApiResponseMessage(err)).toBe('network failure');
   });
 });

--- a/packages/cli/src/utils/error/error.ts
+++ b/packages/cli/src/utils/error/error.ts
@@ -121,16 +121,3 @@ export function handleError(error: Error | FetchError, verbose = false, context?
 export function logOnlyError(error: Error | FetchError, context?: LogContext): void {
   getLogger().error(error.message, { error, errorCode: 'code' in error ? String(error.code) : 'UNKNOWN_ERROR', context });
 }
-
-/**
- * Extracts a human-readable message from an error for display in per-item
- * stream failure warnings (e.g. `ui.warn`).
- *
- * For `APIError` instances, `error.message` already reflects the server-provided
- * string (set by the `APIError` constructor from `response.data.error` /
- * `response.data.message`). For all other errors it falls back to `error.message`
- * or `String(error)`.
- */
-export function getApiResponseMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/packages/cli/src/utils/error/error.ts
+++ b/packages/cli/src/utils/error/error.ts
@@ -123,29 +123,14 @@ export function logOnlyError(error: Error | FetchError, context?: LogContext): v
 }
 
 /**
- * Extracts a human-readable message from an API error response body when present,
- * falling back to `error.message`.
+ * Extracts a human-readable message from an error for display in per-item
+ * stream failure warnings (e.g. `ui.warn`).
  *
- * Handles response bodies of the form `{ error: "..." }` or `{ message: "..." }`,
- * which are common across Storyblok MAPI endpoints. Generic enough to be used by
- * any command that surfaces per-item API failures to the user.
+ * For `APIError` instances, `error.message` already reflects the server-provided
+ * string (set by the `APIError` constructor from `response.data.error` /
+ * `response.data.message`). For all other errors it falls back to `error.message`
+ * or `String(error)`.
  */
 export function getApiResponseMessage(error: unknown): string {
-  const fallback = error instanceof Error ? error.message : String(error);
-
-  if (!(error instanceof APIError)) {
-    return fallback;
-  }
-
-  const data = error.response?.data;
-
-  if (typeof data?.error === 'string') {
-    return data.error;
-  }
-
-  if (typeof data?.message === 'string') {
-    return data.message;
-  }
-
-  return fallback;
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/cli/src/utils/error/error.ts
+++ b/packages/cli/src/utils/error/error.ts
@@ -121,3 +121,31 @@ export function handleError(error: Error | FetchError, verbose = false, context?
 export function logOnlyError(error: Error | FetchError, context?: LogContext): void {
   getLogger().error(error.message, { error, errorCode: 'code' in error ? String(error.code) : 'UNKNOWN_ERROR', context });
 }
+
+/**
+ * Extracts a human-readable message from an API error response body when present,
+ * falling back to `error.message`.
+ *
+ * Handles response bodies of the form `{ error: "..." }` or `{ message: "..." }`,
+ * which are common across Storyblok MAPI endpoints. Generic enough to be used by
+ * any command that surfaces per-item API failures to the user.
+ */
+export function getApiResponseMessage(error: unknown): string {
+  const fallback = error instanceof Error ? error.message : String(error);
+
+  if (!(error instanceof APIError)) {
+    return fallback;
+  }
+
+  const data = error.response?.data;
+
+  if (typeof data?.error === 'string') {
+    return data.error;
+  }
+
+  if (typeof data?.message === 'string') {
+    return data.message;
+  }
+
+  return fallback;
+}

--- a/packages/cli/src/utils/failure-reason-group.test.ts
+++ b/packages/cli/src/utils/failure-reason-group.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { FailureReasonGroup } from './failure-reason-group';
+
+describe('failureReasonGroup', () => {
+  it('should be empty initially', () => {
+    expect(new FailureReasonGroup().isEmpty).toBe(true);
+  });
+
+  it('should track a single failure with an example label', () => {
+    const g = new FailureReasonGroup();
+    g.record('Forbidden', 'hero.png');
+    expect(g.isEmpty).toBe(false);
+    expect(g.size).toBe(1);
+    expect(g.entries()).toEqual([{ reason: 'Forbidden', count: 1, examples: ['hero.png'] }]);
+  });
+
+  it('should count multiple failures with the same reason', () => {
+    const g = new FailureReasonGroup();
+    g.record('Forbidden', 'a.png');
+    g.record('Forbidden', 'b.png');
+    g.record('Forbidden', 'c.png');
+    const [entry] = g.entries();
+    expect(entry.count).toBe(3);
+    expect(entry.examples).toEqual(['a.png', 'b.png', 'c.png']);
+  });
+
+  it('should cap stored examples at 3', () => {
+    const g = new FailureReasonGroup();
+    for (let i = 0; i < 10; i++) {
+      g.record('Forbidden', `file-${i}.png`);
+    }
+    const [entry] = g.entries();
+    expect(entry.count).toBe(10);
+    expect(entry.examples).toHaveLength(3);
+  });
+
+  it('should sort entries by count descending', () => {
+    const g = new FailureReasonGroup();
+    g.record('Rare error');
+    g.record('Common error');
+    g.record('Common error');
+    g.record('Common error');
+    const [first, second] = g.entries();
+    expect(first.reason).toBe('Common error');
+    expect(first.count).toBe(3);
+    expect(second.reason).toBe('Rare error');
+    expect(second.count).toBe(1);
+  });
+
+  describe('toListLines', () => {
+    it('should format a single failure with an example as "Failed to push \\"file\\": reason"', () => {
+      const g = new FailureReasonGroup();
+      g.record('Not found', 'logo.png');
+      expect(g.toListLines()).toEqual(['Failed to push "logo.png": Not found']);
+    });
+
+    it('should format a single failure without an example using singular "asset"', () => {
+      const g = new FailureReasonGroup();
+      g.record('Forbidden');
+      expect(g.toListLines('transfer')).toEqual(['Failed to transfer 1 asset — Forbidden']);
+    });
+
+    it('should format multiple failures with count and examples', () => {
+      const g = new FailureReasonGroup();
+      g.record('Forbidden', 'a.png');
+      g.record('Forbidden', 'b.png');
+      g.record('Forbidden', 'c.png');
+      const [line] = g.toListLines();
+      expect(line).toContain('3 assets');
+      expect(line).toContain('"a.png"');
+    });
+
+    it('should use the provided verb', () => {
+      const g = new FailureReasonGroup();
+      g.record('Timeout', 'img.png');
+      g.record('Timeout', 'img2.png');
+      expect(g.toListLines('transfer')[0]).toMatch(/^Failed to transfer/);
+    });
+
+    it('should truncate at 10 reasons and append overflow line', () => {
+      const g = new FailureReasonGroup();
+      for (let i = 0; i < 12; i++) {
+        g.record(`Error ${i}`, `file-${i}.png`);
+      }
+      const lines = g.toListLines();
+      expect(lines).toHaveLength(11); // 10 reasons + 1 overflow
+      expect(lines[10]).toContain('2 more failure reason(s)');
+    });
+
+    it('should return an empty array when there are no failures', () => {
+      expect(new FailureReasonGroup().toListLines()).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/utils/failure-reason-group.ts
+++ b/packages/cli/src/utils/failure-reason-group.ts
@@ -1,0 +1,85 @@
+const MAX_REASONS = 10;
+const MAX_EXAMPLES = 3;
+const OVERFLOW_SUFFIX = 'more failure reason(s)';
+
+/**
+ * Accumulates per-item failures keyed by their human-readable reason string
+ * and produces a compact grouped summary for terminal output.
+ *
+ * Mirrors the grouping convention in `assets/transfer/index.ts` so all
+ * asset-push/transfer/pipeline failure displays are consistent: one line per
+ * unique cause instead of one line per failed item.
+ *
+ * Usage:
+ * ```ts
+ * const failures = new FailureReasonGroup();
+ * // …during processing:
+ * failures.record(toError(error).message, asset.short_filename);
+ * // …after processing, before/after stopping progress bars:
+ * for (const line of failures.toListLines()) {
+ *   ui.warn(line);        // or ui.list(failures.toListLines())
+ * }
+ * ```
+ */
+export class FailureReasonGroup {
+  private readonly groups = new Map<string, { count: number; examples: string[] }>();
+
+  /** Record one failure. `example` is an optional item label (filename, id…). */
+  record(reason: string, example?: string): void {
+    const entry = this.groups.get(reason) ?? { count: 0, examples: [] };
+    entry.count += 1;
+    if (example !== undefined && entry.examples.length < MAX_EXAMPLES) {
+      entry.examples.push(example);
+    }
+    this.groups.set(reason, entry);
+  }
+
+  get isEmpty(): boolean {
+    return this.groups.size === 0;
+  }
+
+  get size(): number {
+    return this.groups.size;
+  }
+
+  /**
+   * Returns all groups sorted by count descending.
+   * Each entry includes the reason string, total count, and up to `MAX_EXAMPLES` example labels.
+   */
+  entries(): Array<{ reason: string; count: number; examples: string[] }> {
+    return [...this.groups.entries()]
+      .sort((a, b) => b[1].count - a[1].count)
+      .map(([reason, { count, examples }]) => ({ reason, count, examples }));
+  }
+
+  /**
+   * Produces ready-to-display lines for use with `ui.list()` or `ui.warn()`.
+   *
+   * Format (one line per unique reason, capped at MAX_REASONS):
+   * - Single failure with label:  `Failed to push "filename": reason`
+   * - Single failure no label:    `Failed to push 1 asset — reason`
+   * - Multiple:                   `Failed to push N assets — reason (e.g. "a", "b")`
+   * - Overflow:                   `… and N more failure reason(s)`
+   *
+   * Pass `verb` to customise the opening word ("push", "read", "transfer", …).
+   */
+  toListLines(verb = 'push'): string[] {
+    const all = this.entries();
+    const visible = all.slice(0, MAX_REASONS);
+
+    const lines = visible.map(({ reason, count, examples }) => {
+      if (count === 1 && examples.length > 0) {
+        return `Failed to ${verb} "${examples[0]}": ${reason}`;
+      }
+      const noun = count === 1 ? 'asset' : 'assets';
+      const exampleStr = examples.length > 0 ? ` (e.g. ${examples.map(e => `"${e}"`).join(', ')})` : '';
+      return `Failed to ${verb} ${count} ${noun} — ${reason}${exampleStr}`;
+    });
+
+    if (all.length > MAX_REASONS) {
+      lines.push(`… and ${all.length - MAX_REASONS} ${OVERFLOW_SUFFIX}`);
+    }
+
+    return lines;
+  }
+}

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -6,6 +6,7 @@ import { regions } from '../constants';
 export * from './array';
 export * from './auth';
 export * from './error/';
+export * from './failure-reason-group';
 export * from './format';
 export * from './object';
 export * from './package';


### PR DESCRIPTION
## What

Asset push failures now show the server's actual error message in the terminal. The fix lives in `APIError` so all CLI commands benefit automatically.

## Why

When a push fails (e.g. a starter plan rejecting an unsupported file type), users saw only a failure count with no explanation. The API returns a clear message that was being discarded.

## Changes

**`api-error.ts`** — `APIError` now extracts a server-provided message from the response body and sets it as `this.message`, replacing the generic fallback for all ~90 `handleAPIError` call sites. Two guards keep the UX from degrading:
- **401 regression fix** — MAPI echoes `{"error":"Unauthorized"}` on 401. HTTP/2 sends empty `statusText`, so the previous guard let it override the friendlier `API_ERRORS.unauthorized` constant. `HTTP_REASON_PHRASES` provides the canonical phrase as a fallback so it is correctly suppressed.
- **422 object-shaped errors** — `{"error":{"base":["..."]}}` has a non-string error field. `firstFieldValue()` walks the raw response data and sets the first string value as the message (without leaking internal key names like `base:`). `messageStack` keeps the full `key: value` entries for verbose display.

**`pipelines.ts`** — replace per-asset `ui.warn` calls with a `FailureReasonGroup` that collects failures and emits grouped lines after the pipeline finishes. Prevents N identical warn lines interleaved with active progress bars. Uses `short_filename` so CDN URLs don't appear as labels.

**`streams.ts`** — treat `ENOENT` from the outer directory scan as empty instead of forwarding to `onAssetError`. A missing `shared/<id>/` directory is normal for any space that has library access but has never pulled shared assets.

**`transfer/index.ts`** — migrated to the same `FailureReasonGroup` utility, removing the inline grouping logic.

**`error.ts`** — removed `getApiResponseMessage`; callers use `toError(error).message` directly now that `APIError.message` already carries the server string.

## Before / After

**Before:**
```
⚠  Push results: 1 processed, 1 assets failed
  Assets: 0/1 succeeded, 1 failed.
```

**After (unsupported file type):**
```
⚠  Failed to push "demo.vtt": Your space must be verified to allow this asset type. Please reach out to our Support team.
⚠  Push results: 1 processed, 1 assets failed
  Assets: 0/1 succeeded, 1 failed.
```

**After (multiple failures, same cause):**
```
⚠  Failed to push 5 assets — Your space must be verified to allow this asset type. (e.g. "a.vtt", "b.vtt", "c.vtt")
```

**After (invalid folder ID):**
```
⚠  Failed to push "image.png": This asset folder is not valid
```

Fixes DX-541