### PR TITLE
feat(cli): add stories validate command

### DIFF
--- a/packages/cli/src/commands/stories/README.md
+++ b/packages/cli/src/commands/stories/README.md
@@ -6,6 +6,7 @@ The `stories` module provides tools to manage Storyblok stories and their conten
 
 - [`pull`](./pull/README.md): Download stories from your Storyblok space.
 - [`push`](./push/README.md): Upload stories to your Storyblok space.
+- `validate`: Check every story's content against a local code-defined schema.
 
 > See each subcommand for detailed usage, options, and examples.
 

--- a/packages/cli/src/commands/stories/constants.ts
+++ b/packages/cli/src/commands/stories/constants.ts
@@ -39,3 +39,13 @@ export interface StoryIndexEntry {
 }
 
 export const normalizeFullSlug = (slug: string): string => slug.replace(/\/$/, '');
+
+/**
+ * Normalizes a `--starts-with` prefix for the MAPI `starts_with` filter.
+ *
+ * A story's `full_slug` never starts with a slash, and MAPI matches the prefix
+ * literally, so `/en/blog/` matches nothing at all. Leading slashes are the way
+ * people write paths (and how the option was documented), so strip them rather
+ * than let the filter silently select an empty set.
+ */
+export const normalizeStartsWith = (prefix: string): string => prefix.replace(/^\/+/, '');

--- a/packages/cli/src/commands/stories/index.ts
+++ b/packages/cli/src/commands/stories/index.ts
@@ -1,6 +1,7 @@
 import './command';
 import './pull';
 import './push';
+import './validate';
 
 export * from './actions';
 export * from './constants';

--- a/packages/cli/src/commands/stories/pull/index.test.ts
+++ b/packages/cli/src/commands/stories/pull/index.test.ts
@@ -183,10 +183,22 @@ describe('stories pull command', () => {
     preconditions.canPullStories([stories], {
       // `--query` is parsed into the structured filter_query before the request.
       filter_query: { highlighted: { in: 'true' } },
-      starts_with: '/en/blog/',
+      starts_with: 'en/blog/',
     });
 
-    await storiesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345', '--query', '[highlighted][in]=true', '--starts-with', '/en/blog/']);
+    await storiesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345', '--query', '[highlighted][in]=true', '--starts-with', 'en/blog/']);
+
+    expect(stories.every(storyFileExists)).toBeTruthy();
+  });
+
+  // Regression: a `full_slug` never starts with a slash and MAPI matches the
+  // prefix literally, so the documented `--starts-with="/en/blog/"` form pulled
+  // nothing at all.
+  it('should strip a leading slash from --starts-with', async () => {
+    const stories = [makeMockStory(), makeMockStory()];
+    preconditions.canPullStories([stories], { starts_with: 'en/blog/' });
+
+    await storiesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345', '--starts-with', '/en/blog/']);
 
     expect(stories.every(storyFileExists)).toBeTruthy();
   });

--- a/packages/cli/src/commands/stories/pull/index.ts
+++ b/packages/cli/src/commands/stories/pull/index.ts
@@ -1,5 +1,6 @@
 import { pipeline } from 'node:stream/promises';
 import type { Story } from '../constants';
+import { normalizeStartsWith } from '../constants';
 import { colorPalette, commands, directories } from '../../../constants';
 import { session } from '../../../session';
 import { storiesCommand } from '../command';
@@ -18,7 +19,7 @@ const pullCmd = storiesCommand
   .option('-s, --space <space>', 'space ID')
   .option('-d, --dry-run', 'Preview changes without applying them to Storyblok')
   .option('-q, --query <query>', 'Filter stories by content attributes using Storyblok filter query syntax. Example: --query="[highlighted][in]=true"')
-  .option('--starts-with <path>', 'Filter stories by path. Example: --starts-with="/en/blog/"')
+  .option('--starts-with <path>', 'Filter stories by path. Example: --starts-with="en/blog/"')
   .description(`Download your space's stories as separate json files.`);
 
 pullCmd
@@ -60,7 +61,11 @@ pullCmd
           spaceId: space,
           params: {
             filter_query: options.query ? parseFilterQuery(options.query) : undefined,
-            starts_with: options.startsWith,
+            // A `full_slug` never starts with a slash and MAPI matches the prefix
+            // literally, so `/en/blog/` would pull nothing at all.
+            starts_with: options.startsWith === undefined
+              ? undefined
+              : normalizeStartsWith(options.startsWith) || undefined,
           },
           setTotalPages: (totalPages) => {
             summary.fetchStoryPages.total = totalPages;

--- a/packages/cli/src/commands/stories/validate/index.test.ts
+++ b/packages/cli/src/commands/stories/validate/index.test.ts
@@ -1,0 +1,452 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { vol } from 'memfs';
+
+import '../index';
+import { storiesCommand } from '../command';
+import { resetReporter } from '../../../lib/reporter/reporter';
+import { getUI } from '../../../lib/ui';
+import { session } from '../../../session';
+import { loggedOutSessionState } from '../../../../test/setup';
+import { makeMockStory } from '../__tests__/helpers';
+import type { MockStory } from '../__tests__/helpers';
+
+// Mock jiti so the loader classifies a controlled schema module.
+let schemaModule: Record<string, unknown> = {};
+vi.mock('jiti', () => ({
+  createJiti: () => ({
+    import: async () => schemaModule,
+  }),
+}));
+
+vi.spyOn(console, 'error');
+vi.spyOn(console, 'warn');
+vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+const server = setupServer();
+
+const preconditions = {
+  canListStories(stories: MockStory[], params: Record<string, string> = {}) {
+    server.use(
+      http.get('https://mapi.storyblok.com/v1/spaces/12345/stories', ({ request }) => {
+        const url = new URL(request.url);
+        const matches = Object.entries(params).every(([key, value]) => url.searchParams.get(key) === value);
+        const page = Number(url.searchParams.get('page') ?? 1);
+        return HttpResponse.json(
+          { stories: matches && page === 1 ? stories : [] },
+          { headers: { 'Total': String(stories.length), 'Per-Page': '100' } },
+        );
+      }),
+    );
+  },
+  canFetchStories(stories: MockStory[]) {
+    for (const story of stories) {
+      server.use(http.get(`https://mapi.storyblok.com/v1/spaces/12345/stories/${story.id}`, () =>
+        HttpResponse.json({ story })));
+    }
+  },
+  listEndpointFails() {
+    server.use(http.get('https://mapi.storyblok.com/v1/spaces/12345/stories', () =>
+      HttpResponse.json({ message: 'Internal Server Error' }, { status: 500 })));
+  },
+  storyFetchFails(id: MockStory['id']) {
+    server.use(http.get(`https://mapi.storyblok.com/v1/spaces/12345/stories/${id}`, () =>
+      HttpResponse.json({ message: 'Internal Server Error' }, { status: 500 })));
+  },
+};
+
+/** Everything the UI printed for humans (all UI output routes to stderr). */
+function loggedOutput(): string {
+  const spied = (method: typeof console.error) => (method as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+  return [...spied(console.error), ...spied(console.warn)].map(call => String(call[0])).join('\n');
+}
+
+/** Everything written to stdout via `UI.writeMachineOutput()` (i.e. `--format json`). */
+function machineOutput(): string {
+  return (process.stdout.write as unknown as { mock: { calls: unknown[][] } }).mock.calls.map(call => String(call[0])).join('');
+}
+
+async function runValidate(...args: string[]): Promise<void> {
+  await storiesCommand.parseAsync(['node', 'test', 'validate', '--space', '12345', '--schema', 'src/schema.ts', ...args]);
+}
+
+describe('stories validate command', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  beforeEach(() => {
+    // A `page` block with a required `headline` text field.
+    schemaModule = {
+      page: { name: 'page', fields: [{ name: 'headline', type: 'text', required: true }] },
+    };
+    // The loader checks the entry file exists before handing it to jiti, so it
+    // has to be present in the mocked filesystem even though jiti is stubbed.
+    vol.fromJSON({ 'src/schema.ts': 'export const page = {};' });
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+    vol.reset();
+    server.resetHandlers();
+    resetReporter();
+    process.exitCode = undefined;
+  });
+  afterAll(() => server.close());
+
+  it('should exit 0 when every story matches the schema', async () => {
+    const stories = [
+      makeMockStory({ full_slug: 'home', content: { component: 'page', headline: 'Hi' } }),
+      makeMockStory({ full_slug: 'about', content: { component: 'page', headline: 'About' } }),
+    ];
+    preconditions.canListStories(stories);
+    preconditions.canFetchStories(stories);
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(0);
+    expect(loggedOutput()).toContain('0 errors, 0 warnings across 0 of 2 stories');
+  });
+
+  it('should exit 1 and report missing required (error) and unknown field (warning)', async () => {
+    const story = makeMockStory({
+      id: 123456,
+      full_slug: 'app/home',
+      content: { component: 'page', legacy_cta: 'x' },
+    });
+    preconditions.canListStories([story]);
+    preconditions.canFetchStories([story]);
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(1);
+    const output = loggedOutput();
+    expect(output).toContain('app/home (story #123456)');
+    expect(output).toContain('missing_required_field');
+    expect(output).toContain('unknown_field');
+    expect(output).toContain('1 error, 1 warning across 1 of 1 story');
+  });
+
+  it('should skip folders and exclude them from the total', async () => {
+    const folder = makeMockStory({ full_slug: 'blog', is_folder: true });
+    const story = makeMockStory({ full_slug: 'home', content: { component: 'page', headline: 'Hi' } });
+    preconditions.canListStories([folder, story]);
+    // Only the non-folder story is registered for fetch; if the folder were
+    // fetched, msw's onUnhandledRequest:'error' would fail the test.
+    preconditions.canFetchStories([story]);
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(0);
+    expect(loggedOutput()).toContain('across 0 of 1 story');
+  });
+
+  it('should exit 1 and count per-story fetch failures', async () => {
+    const story = makeMockStory({ id: 999, full_slug: 'broken', content: { component: 'page', headline: 'Hi' } });
+    preconditions.canListStories([story]);
+    preconditions.storyFetchFails(story.id);
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should exit 2 when the list endpoint is down', async () => {
+    preconditions.listEndpointFails();
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(2);
+  });
+
+  // A failed listing used to fall through to the formatter, ending an exit-2 run
+  // with a green "0 errors, 0 warnings" line.
+  it('should not print a clean summary when the listing failed', async () => {
+    preconditions.listEndpointFails();
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(2);
+    expect(loggedOutput()).not.toContain('0 errors, 0 warnings');
+  });
+
+  it('should report ok:false in JSON when the listing failed', async () => {
+    preconditions.listEndpointFails();
+
+    await runValidate('--format', 'json');
+
+    expect(process.exitCode).toBe(2);
+    expect(JSON.parse(machineOutput())).toMatchObject({ ok: false, listFailed: true });
+  });
+
+  // Regression: handleError's "run with --verbose" hint used to go to stdout,
+  // which made the JSON document unparseable on any run that also reported an error.
+  it('should keep the verbose hint off stdout when emitting JSON', async () => {
+    preconditions.listEndpointFails();
+
+    await runValidate('--format', 'json');
+
+    expect(() => JSON.parse(machineOutput())).not.toThrow();
+    expect(machineOutput()).not.toContain('--verbose');
+  });
+
+  it('should still print the verbose hint for pretty output', async () => {
+    preconditions.listEndpointFails();
+
+    await runValidate();
+
+    expect(loggedOutput()).toContain('--verbose');
+  });
+
+  it('should report ok:false in JSON when a story could not be fetched', async () => {
+    const story = makeMockStory({ id: 999, full_slug: 'broken', content: { component: 'page', headline: 'Hi' } });
+    preconditions.canListStories([story]);
+    preconditions.storyFetchFails(story.id);
+
+    await runValidate('--format', 'json');
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(machineOutput())).toMatchObject({ ok: false, fetchFailures: 1, errors: 0 });
+  });
+
+  it('should emit pure, parseable JSON for --format json', async () => {
+    const story = makeMockStory({
+      id: 123456,
+      full_slug: 'app/home',
+      content: { component: 'page', legacy_cta: 'x' },
+    });
+    preconditions.canListStories([story]);
+    preconditions.canFetchStories([story]);
+
+    await runValidate('--format', 'json');
+
+    expect(process.exitCode).toBe(1);
+    const report = JSON.parse(machineOutput());
+    expect(report).toMatchObject({ ok: false, unit: 'stories', errors: 1, warnings: 1, unitsTotal: 1 });
+    expect(report.groups[0].header).toBe('app/home (story #123456)');
+    // Nothing decorative may land on stdout alongside the document.
+    expect(machineOutput().trimEnd()).toBe(JSON.stringify(report, null, 2));
+  });
+
+  it('should report ok:true in JSON for a clean run', async () => {
+    const story = makeMockStory({ full_slug: 'home', content: { component: 'page', headline: 'Hi' } });
+    preconditions.canListStories([story]);
+    preconditions.canFetchStories([story]);
+
+    await runValidate('--format', 'json');
+
+    expect(process.exitCode).toBe(0);
+    expect(JSON.parse(machineOutput())).toMatchObject({ ok: true, errors: 0, fetchFailures: 0, listFailed: false });
+  });
+
+  it('should exit 2 for an invalid --format value', async () => {
+    await runValidate('--format', 'yaml');
+
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('should exit 2 when --schema is omitted', async () => {
+    await storiesCommand.parseAsync(['node', 'test', 'validate', '--space', '12345']);
+
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('should exit 2 when the schema entry exports no definitions', async () => {
+    schemaModule = { helper: () => {} };
+    const story = makeMockStory({ content: { component: 'page' } });
+    preconditions.canListStories([story]);
+    preconditions.canFetchStories([story]);
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(2);
+  });
+
+  // Without blocks, every story would report `unknown_component` — a wall of
+  // issues pointing at the content instead of at the schema entry file.
+  it('should exit 2 when the schema entry defines datasources but no blocks', async () => {
+    schemaModule = { colors: { name: 'Colors', slug: 'colors' } };
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(2);
+    expect(loggedOutput()).toContain('No blocks found in the schema entry file');
+  });
+
+  it('should scope validation with --starts-with', async () => {
+    const story = makeMockStory({ full_slug: 'en/home', content: { component: 'page', headline: 'Hi' } });
+    preconditions.canListStories([story], { starts_with: 'en/' });
+    preconditions.canFetchStories([story]);
+
+    await runValidate('--starts-with', 'en/');
+
+    expect(process.exitCode).toBe(0);
+    expect(loggedOutput()).toContain('across 0 of 1 story');
+  });
+
+  // Regression: a `full_slug` never starts with a slash and MAPI matches the
+  // prefix literally, so the documented `--starts-with="/en/blog/"` form
+  // selected nothing and reported a green run over 0 stories.
+  it('should strip a leading slash from --starts-with', async () => {
+    const story = makeMockStory({ full_slug: 'en/home', content: { component: 'page', headline: 'Hi' } });
+    // The handler only answers when `starts_with` is exactly `en/`.
+    preconditions.canListStories([story], { starts_with: 'en/' });
+    preconditions.canFetchStories([story]);
+
+    await runValidate('--starts-with', '/en/');
+
+    expect(process.exitCode).toBe(0);
+    expect(loggedOutput()).toContain('across 0 of 1 story');
+  });
+
+  it('should warn when --starts-with matched no stories', async () => {
+    preconditions.canListStories([]);
+
+    await runValidate('--starts-with', 'nope/');
+
+    expect(process.exitCode).toBe(0);
+    expect(loggedOutput()).toContain('No stories matched --starts-with "nope/"');
+  });
+
+  // The bar is created lazily so a run with nothing to count leaves no bar
+  // behind. A zero-match filter used to draw `0% | 0/1 processed` above the
+  // warning saying nothing was validated.
+  it('should create no progress bar when there is nothing to count', async () => {
+    const createProgressBar = vi.spyOn(getUI(), 'createProgressBar');
+    preconditions.canListStories([]);
+
+    await runValidate('--starts-with', 'nope/');
+
+    expect(createProgressBar).not.toHaveBeenCalled();
+  });
+
+  it('should create a progress bar once there are stories to count', async () => {
+    const createProgressBar = vi.spyOn(getUI(), 'createProgressBar');
+    const stories = [makeMockStory({ content: { component: 'page', headline: 'Hi' } })];
+    preconditions.canListStories(stories);
+    preconditions.canFetchStories(stories);
+
+    await runValidate();
+
+    expect(createProgressBar).toHaveBeenCalled();
+  });
+
+  it('should not warn about an empty space when no filter was given', async () => {
+    preconditions.canListStories([]);
+
+    await runValidate();
+
+    expect(loggedOutput()).not.toContain('No stories matched');
+  });
+
+  // The pretty run warns; a `--format json` consumer sees no stderr, so without
+  // this the document is indistinguishable from a clean run over real content.
+  it('should surface a filter that matched no stories in the JSON document', async () => {
+    preconditions.canListStories([]);
+
+    await runValidate('--starts-with', 'nope/', '--format', 'json');
+
+    expect(JSON.parse(machineOutput())).toMatchObject({
+      ok: true,
+      unitsTotal: 0,
+      noMatches: true,
+      filter: { option: '--starts-with', value: 'nope/' },
+    });
+  });
+
+  it('should echo the normalized filter, not the raw argument', async () => {
+    const story = makeMockStory({ full_slug: 'en/home', content: { component: 'page', headline: 'Hi' } });
+    preconditions.canListStories([story], { starts_with: 'en/' });
+    preconditions.canFetchStories([story]);
+
+    await runValidate('--starts-with', '/en/', '--format', 'json');
+
+    const report = JSON.parse(machineOutput());
+    expect(report.filter).toEqual({ option: '--starts-with', value: 'en/' });
+    expect(report).not.toHaveProperty('noMatches');
+  });
+
+  // Stories are fetched concurrently, so arrival order varies between runs;
+  // unsorted output is not diffable in CI.
+  it('should order groups by path, not by arrival', async () => {
+    const stories = [
+      makeMockStory({ id: 2, full_slug: 'zebra', content: { component: 'page' } }),
+      makeMockStory({ id: 1, full_slug: 'alpha', content: { component: 'page' } }),
+    ];
+    preconditions.canListStories(stories);
+    preconditions.canFetchStories(stories);
+
+    await runValidate('--format', 'json');
+
+    const report = JSON.parse(machineOutput());
+    expect(report.groups.map((group: { ref: { slug: string } }) => group.ref.slug)).toEqual(['alpha', 'zebra']);
+  });
+
+  // Regression: ordering with `localeCompare` depends on the runtime's default
+  // locale and ICU build. `älpha` sorts before `zebra` under `en`/`de` but after
+  // it under `sv`, so two CI runners with a different `LANG` produced different
+  // output for identical content — the opposite of the diffable ordering the sort
+  // exists for. Plain string comparison is locale-independent, which puts the
+  // non-ASCII slug last here.
+  it('should order groups independently of the runtime locale', async () => {
+    const stories = [
+      makeMockStory({ id: 1, full_slug: 'älpha', content: { component: 'page' } }),
+      makeMockStory({ id: 2, full_slug: 'zebra', content: { component: 'page' } }),
+    ];
+    preconditions.canListStories(stories);
+    preconditions.canFetchStories(stories);
+
+    await runValidate('--format', 'json');
+
+    const slugs = JSON.parse(machineOutput()).groups.map((group: { ref: { slug: string } }) => group.ref.slug);
+    expect(slugs).toEqual(['zebra', 'älpha']);
+  });
+
+  it('should carry each story\'s identity in the JSON groups', async () => {
+    const story = makeMockStory({
+      id: 123456,
+      name: 'Home',
+      full_slug: 'app/home',
+      content: { component: 'page' },
+    });
+    preconditions.canListStories([story]);
+    preconditions.canFetchStories([story]);
+
+    await runValidate('--format', 'json');
+
+    expect(JSON.parse(machineOutput()).groups[0].ref).toEqual({
+      kind: 'story',
+      id: 123456,
+      slug: 'app/home',
+      name: 'Home',
+    });
+  });
+
+  it('should carry the reason a failed listing aborted the run in JSON', async () => {
+    preconditions.listEndpointFails();
+
+    await runValidate('--format', 'json');
+
+    expect(JSON.parse(machineOutput()).listError).toBeTruthy();
+  });
+
+  it('should carry the reason a story could not be fetched in JSON', async () => {
+    const story = makeMockStory({ id: 999, full_slug: 'broken', content: { component: 'page', headline: 'Hi' } });
+    preconditions.canListStories([story]);
+    preconditions.storyFetchFails(story.id);
+
+    await runValidate('--format', 'json');
+
+    const [failure] = JSON.parse(machineOutput()).fetchErrors;
+    expect(failure).toMatchObject({ id: 999, slug: 'broken' });
+    expect(failure.message).toBeTruthy();
+  });
+
+  it('should exit 2 when not logged in', async () => {
+    // `preAction` calls `initializeSession`; make that one call land logged out.
+    vi.mocked(session().initializeSession).mockImplementationOnce(async () => {
+      session().state = loggedOutSessionState();
+    });
+
+    await runValidate();
+
+    expect(process.exitCode).toBe(2);
+  });
+});

--- a/packages/cli/src/commands/stories/validate/index.test.ts
+++ b/packages/cli/src/commands/stories/validate/index.test.ts
@@ -148,22 +148,24 @@ describe('stories validate command', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('should exit 2 when the list endpoint is down', async () => {
+  // A listing failure is an API failure, not a bad invocation, so it exits 1 like
+  // every other runtime error: `handleError` owns the mapping.
+  it('should exit 1 when the list endpoint is down', async () => {
     preconditions.listEndpointFails();
 
     await runValidate();
 
-    expect(process.exitCode).toBe(2);
+    expect(process.exitCode).toBe(1);
   });
 
-  // A failed listing used to fall through to the formatter, ending an exit-2 run
+  // A failed listing used to fall through to the formatter, ending a failed run
   // with a green "0 errors, 0 warnings" line.
   it('should not print a clean summary when the listing failed', async () => {
     preconditions.listEndpointFails();
 
     await runValidate();
 
-    expect(process.exitCode).toBe(2);
+    expect(process.exitCode).toBe(1);
     expect(loggedOutput()).not.toContain('0 errors, 0 warnings');
   });
 
@@ -172,7 +174,7 @@ describe('stories validate command', () => {
 
     await runValidate('--format', 'json');
 
-    expect(process.exitCode).toBe(2);
+    expect(process.exitCode).toBe(1);
     expect(JSON.parse(machineOutput())).toMatchObject({ ok: false, listFailed: true });
   });
 

--- a/packages/cli/src/commands/stories/validate/index.ts
+++ b/packages/cli/src/commands/stories/validate/index.ts
@@ -72,8 +72,8 @@ storiesCommand
     const failFatal = (message: string): void => {
       // Record a failure so the report reflects the aborted run, not SUCCESS.
       reporter.addSummary('validation', { total: 1, succeeded: 0, failed: 1 });
+      // `handleError` owns the exit code: a CommandError already exits 2.
       handleError(new CommandError(message), verbose);
-      process.exitCode = 2;
     };
 
     try {
@@ -93,8 +93,9 @@ storiesCommand
       logger.info('Stories validate started', { space, schemaEntry, startsWith, level, format });
 
       if (!requireAuthentication(state, verbose)) {
+        // `requireAuthentication` has already reported through `handleError`,
+        // which owns the exit code.
         reporter.addSummary('validation', { total: 1, succeeded: 0, failed: 1 });
-        process.exitCode = 2;
         return;
       }
       if (!space) {
@@ -298,7 +299,9 @@ storiesCommand
         if (!isJson) {
           ui.error('Listing stories failed; the space was not fully validated.');
         }
-        process.exitCode = 2;
+        // `onPageError` already reported the API failure through `handleError`,
+        // which owns the exit code. Returning here is what keeps the clean
+        // summary from printing over an incomplete run.
         return;
       }
 

--- a/packages/cli/src/commands/stories/validate/index.ts
+++ b/packages/cli/src/commands/stories/validate/index.ts
@@ -1,0 +1,324 @@
+import { Transform, Writable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import type { Story } from '../constants';
+import { normalizeStartsWith } from '../constants';
+import { colorPalette, commands } from '../../../constants';
+import { session } from '../../../session';
+import { storiesCommand } from '../command';
+import type { ProgressBar } from '../../../lib/ui';
+import { getUI } from '../../../lib/ui';
+import { getLogger } from '../../../lib/logger/logger';
+import { getReporter } from '../../../lib/reporter/reporter';
+import { fetchStoriesStream, fetchStoryStream } from '../streams';
+import { requireAuthentication } from '../../../utils/auth';
+import { handleError, toError } from '../../../utils/error/error';
+import { CommandError } from '../../../utils/error/command-error';
+import type { FormatOption, LevelOption, SchemaLike, ValidationGroup, ValidationGroupRef, ValidationRunResult } from '../../../lib/validation';
+import {
+  countIssues,
+  formatJson,
+  formatPretty,
+  loadSchemaEntry,
+  parseFormat,
+  parseLevel,
+  validateStory,
+  writeValidationReport,
+} from '../../../lib/validation';
+
+interface StoriesValidateOptions {
+  schema?: string;
+  startsWith?: string;
+  level: string;
+  format: string;
+}
+
+/** Human-readable heading for a story group, e.g. `app/home (story #123456)`. */
+function storyHeader(story: Story): string {
+  const slug = story.full_slug ?? story.slug ?? String(story.id);
+  return `${slug} (story #${story.id})`;
+}
+
+/** Machine-readable identity for a story group, so a consumer never parses the header. */
+function storyRef(story: Story): ValidationGroupRef {
+  return {
+    kind: 'story',
+    id: story.id,
+    ...(story.full_slug ? { slug: story.full_slug } : {}),
+    ...(story.name ? { name: story.name } : {}),
+  };
+}
+
+storiesCommand
+  .command('validate')
+  .description('Validate every story\'s draft content in a space against a local code-defined schema.')
+  .option('-s, --space <space>', 'space ID')
+  .option('--schema <entry-file>', 'Path to the TypeScript schema entry file')
+  .option('--starts-with <path>', 'Only validate stories whose path starts with this prefix. Example: --starts-with="en/blog/"')
+  .option('--level <level>', 'Display threshold: error|warning', 'warning')
+  .option('--format <format>', 'Output format: pretty|json', 'pretty')
+  .action(async (options: StoriesValidateOptions, command) => {
+    const { schema: schemaEntry } = options;
+    // A leading slash would make `starts_with` match nothing; `/` alone leaves no
+    // prefix at all, which is the same as not filtering.
+    const startsWith = options.startsWith === undefined
+      ? undefined
+      : normalizeStartsWith(options.startsWith) || undefined;
+    const ui = getUI();
+    const logger = getLogger();
+    const reporter = getReporter();
+    const { space, verbose } = command.optsWithGlobals();
+    const { state } = session();
+
+    const failFatal = (message: string): void => {
+      // Record a failure so the report reflects the aborted run, not SUCCESS.
+      reporter.addSummary('validation', { total: 1, succeeded: 0, failed: 1 });
+      handleError(new CommandError(message), verbose);
+      process.exitCode = 2;
+    };
+
+    try {
+      // 1. Preconditions (fatal — exit 2).
+      let level: LevelOption;
+      let format: FormatOption;
+      try {
+        level = parseLevel(options.level);
+        format = parseFormat(options.format);
+      }
+      catch (maybeError) {
+        failFatal(toError(maybeError).message);
+        return;
+      }
+
+      const isJson = format === 'json';
+      logger.info('Stories validate started', { space, schemaEntry, startsWith, level, format });
+
+      if (!requireAuthentication(state, verbose)) {
+        reporter.addSummary('validation', { total: 1, succeeded: 0, failed: 1 });
+        process.exitCode = 2;
+        return;
+      }
+      if (!space) {
+        failFatal('Please provide the space as argument --space YOUR_SPACE_ID.');
+        return;
+      }
+      if (!schemaEntry) {
+        failFatal('Please provide the schema entry file with --schema <entry-file>.');
+        return;
+      }
+
+      // 2. Load the schema (fatal on bad/empty/unresolvable entry file — exit 2).
+      let schema: SchemaLike;
+      try {
+        // Story content cannot be validated without block definitions, so an
+        // entry file with none is a bad invocation rather than a clean run.
+        ({ schema } = await loadSchemaEntry(schemaEntry, { requireBlocks: true }));
+      }
+      catch (maybeError) {
+        failFatal(toError(maybeError).message);
+        return;
+      }
+
+      // 3. Fetch every non-folder story and validate its content.
+      const groups: ValidationGroup[] = [];
+      let totalStories = 0;
+      const fetchErrors: NonNullable<ValidationRunResult['fetchErrors']> = [];
+      let listFailed = false;
+      let listError: string | undefined;
+
+      // The progress bar draws on stdout: skip it for JSON so the document stays
+      // pure, and create it only once there is something to count so a run that
+      // never lists a story does not leave an empty bar behind its error output.
+      let progress: ProgressBar | undefined;
+      let listedTotal = 0;
+      let foldersSkipped = 0;
+      const startProgress = (): ProgressBar | undefined => {
+        if (isJson) {
+          return undefined;
+        }
+        progress ??= ui.createProgressBar({ title: 'Validating Stories...'.padEnd(23) });
+        return progress;
+      };
+      // The list `Total` header counts folders too, and is re-reported on every
+      // page, so the bar's total is recomputed from both numbers rather than
+      // adjusted in place. Keeps the bar counting the same population the summary
+      // reports instead of finishing one short per folder.
+      const syncProgressTotal = () => {
+        const total = Math.max(listedTotal - foldersSkipped, 0);
+        // Nothing to count yet, so do not bring a bar into existence: a filter
+        // that matched nothing would otherwise leave an empty `0/1` bar sitting
+        // above the warning that says nothing was validated.
+        if (total === 0 && progress === undefined) {
+          return;
+        }
+        startProgress()?.setTotal(total);
+      };
+      const stopProgress = () => {
+        progress?.stop();
+        ui.stopAllProgressBars();
+      };
+
+      if (!isJson) {
+        ui.title(`${commands.STORIES}`, colorPalette.STORIES, 'Validating stories...');
+      }
+
+      try {
+        await pipeline(
+          fetchStoriesStream({
+            spaceId: space,
+            params: { starts_with: startsWith },
+            setTotalStories: (total) => {
+              listedTotal = total;
+              syncProgressTotal();
+            },
+            onPageError: (error, page, total) => {
+              // A failure listing stories is fatal — we cannot validate a partial space.
+              listFailed = true;
+              listError = error.message;
+              // Leave no live bar redrawing itself underneath the error output.
+              stopProgress();
+              logger.error('Failed to list stories', { error: error.message, page, total });
+              handleError(error, verbose, { page, total });
+            },
+          }),
+          // Skip folders: they carry no content to validate, and are not part of
+          // the population the summary counts.
+          new Transform({
+            objectMode: true,
+            transform(story: Story, _encoding, callback) {
+              if (story.is_folder) {
+                foldersSkipped += 1;
+                syncProgressTotal();
+                callback();
+                return;
+              }
+              totalStories += 1;
+              this.push(story);
+              callback();
+            },
+          }),
+          fetchStoryStream({
+            spaceId: space,
+            onStoryError: (error, story) => {
+              fetchErrors.push({
+                id: story.id,
+                ...(story.full_slug ? { slug: story.full_slug } : {}),
+                message: error.message,
+              });
+              progress?.increment();
+              logger.error('Failed to fetch story', { error: error.message, storyId: story.id });
+              handleError(error, verbose, { storyId: story.id });
+            },
+          }),
+          new Writable({
+            objectMode: true,
+            async write(story: Story, _encoding, callback) {
+              try {
+                const { issues } = await validateStory(story, schema);
+                if (issues.length > 0) {
+                  groups.push({ header: storyHeader(story), ref: storyRef(story), issues });
+                }
+                progress?.increment();
+                callback();
+              }
+              catch (maybeError) {
+                // Validation is not expected to throw; treat it as fatal rather
+                // than letting the stream hang on a missing callback.
+                callback(toError(maybeError));
+              }
+            },
+          }),
+        );
+      }
+      catch (maybeError) {
+        // An unexpected pipeline failure (e.g. the network is down) is fatal.
+        stopProgress();
+        failFatal(toError(maybeError).message);
+        return;
+      }
+
+      stopProgress();
+
+      // Stories arrive in completion order, not list order, so identical content
+      // would print in a different order on every run. Sort by path to keep the
+      // output diffable in CI. Compared as plain strings rather than with
+      // `localeCompare`, whose result depends on the runtime's default locale and
+      // ICU build: two CI runners with a different `LANG` would order the same
+      // slugs differently, which is the opposite of diffable. These are slugs,
+      // not display names, so there is no human collation worth preserving.
+      groups.sort((a, b) => {
+        const left = a.ref.slug ?? a.header;
+        const right = b.ref.slug ?? b.header;
+        if (left !== right) {
+          return left < right ? -1 : 1;
+        }
+        return (a.ref.id ?? 0) - (b.ref.id ?? 0);
+      });
+
+      // 4. Build the result. The run-level failures travel with it so neither
+      //    formatter can present an incomplete run as a clean one.
+      const fetchFailures = fetchErrors.length;
+      const result: ValidationRunResult = {
+        unitNoun: 'stories',
+        unitNounSingular: 'story',
+        unitsTotal: totalStories,
+        groups,
+        // Travels with the result so both formatters can say the population was
+        // narrowed, rather than only the pretty one knowing.
+        ...(startsWith === undefined ? {} : { filter: { option: '--starts-with', value: startsWith } }),
+        fetchFailures,
+        fetchErrors,
+        listFailed,
+        listError,
+      };
+
+      // 5. Report. The artifact carries the run-level fetch/list failures so an
+      //    incomplete run is never recorded as success.
+      writeValidationReport(reporter, result);
+      reporter.addSummary('fetch', {
+        total: totalStories,
+        succeeded: totalStories - fetchFailures,
+        failed: fetchFailures,
+      });
+      if (listFailed) {
+        // Mark the run failed in the report even when no story had issues.
+        reporter.addSummary('list', { total: 1, succeeded: 0, failed: 1 });
+      }
+
+      const { errors, warnings } = countIssues(result);
+      logger.info('Stories validate finished', { errors, warnings, stories: totalStories, fetchFailures, listFailed });
+
+      // 6. Render and set the exit code. A failed listing means the run never
+      //    had a population to validate, so it reports as fatal rather than
+      //    printing a clean summary over an incomplete run.
+      if (isJson) {
+        ui.writeMachineOutput(formatJson(result, level));
+      }
+
+      if (listFailed) {
+        if (!isJson) {
+          ui.error('Listing stories failed; the space was not fully validated.');
+        }
+        process.exitCode = 2;
+        return;
+      }
+
+      if (!isJson) {
+        ui.log(formatPretty(result, level));
+        // A prefix that selects nothing produces the same green summary as a
+        // clean space. Say so, or the run reads as a pass over content it never
+        // looked at.
+        if (result.filter && totalStories === 0) {
+          ui.warn(`No stories matched ${result.filter.option} "${result.filter.value}"; nothing was validated.`);
+        }
+        if (fetchFailures > 0) {
+          ui.warn(`${fetchFailures} story(s) could not be fetched and were not validated.`);
+        }
+      }
+
+      process.exitCode = errors > 0 || fetchFailures > 0 ? 1 : 0;
+    }
+    finally {
+      // Always write the report artifact, including on every fatal early return.
+      reporter.finalize();
+    }
+  });

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -808,8 +808,8 @@ export type TableFieldValueRoot = {
      * Table header cells
      */
     thead: Array<{
-        _uid: string;
-        component: '_table_head';
+        _uid?: string;
+        component?: '_table_head';
         /**
          * Header cell content
          */
@@ -819,14 +819,14 @@ export type TableFieldValueRoot = {
      * Table body rows
      */
     tbody: Array<{
-        _uid: string;
-        component: '_table_row';
+        _uid?: string;
+        component?: '_table_row';
         /**
          * Cells in this row
          */
         body?: Array<{
-            _uid: string;
-            component: '_table_col';
+            _uid?: string;
+            component?: '_table_col';
             /**
              * Cell content
              */
@@ -924,7 +924,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
     /**
      * Anchor/fragment identifier for the story link
      */
-    anchor?: string;
+    anchor?: string | null;
     /**
      * Link relationship attribute
      */
@@ -934,7 +934,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
      */
     title?: string;
 } & {
-    [key: string]: string;
+    [key: string]: string | null;
 };
 
 /**

--- a/packages/schema/src/generated/overlay/zod.gen.ts
+++ b/packages/schema/src/generated/overlay/zod.gen.ts
@@ -423,10 +423,16 @@ export const zMultilinkFieldValueEmailLink = zMultilinkFieldValueSharedLink.and(
  */
 export const zMultilinkFieldValueStoryLink = zMultilinkFieldValueSharedLink.and(z.object({
     linktype: z.enum(['story']),
-    anchor: z.optional(z.string()),
+    anchor: z.optional(z.union([
+        z.string(),
+        z.null()
+    ])),
     rel: z.optional(z.string()),
     title: z.optional(z.string())
-})).and(z.record(z.string(), z.string()));
+})).and(z.record(z.string(), z.union([
+    z.string(),
+    z.null()
+])));
 
 /**
  * Link to an external URL.
@@ -667,16 +673,16 @@ export const zRichTextFieldValueTextNode = z.object({
  */
 export const zTableFieldValueRoot = z.object({
     thead: z.array(z.object({
-        _uid: z.string(),
-        component: z.enum(['_table_head']),
+        _uid: z.optional(z.string()),
+        component: z.optional(z.enum(['_table_head'])),
         value: z.optional(z.string())
     })),
     tbody: z.array(z.object({
-        _uid: z.string(),
-        component: z.enum(['_table_row']),
+        _uid: z.optional(z.string()),
+        component: z.optional(z.enum(['_table_row'])),
         body: z.optional(z.array(z.object({
-            _uid: z.string(),
-            component: z.enum(['_table_col']),
+            _uid: z.optional(z.string()),
+            component: z.optional(z.enum(['_table_col'])),
             value: z.optional(z.string())
         })))
     }))

--- a/packages/schema/src/multilink-field-value.test-d.ts
+++ b/packages/schema/src/multilink-field-value.test-d.ts
@@ -12,10 +12,11 @@ describe('MultilinkFieldValue', () => {
   it('narrows variant properties by linktype', () => {
     const assertNarrowing = (link: MultilinkFieldValue) => {
       if (link.linktype === 'story') {
-        expectTypeOf(link.anchor).toEqualTypeOf<string | undefined>();
+        // Nullable: the editor stores `anchor: null` once an existing anchor is cleared.
+        expectTypeOf(link.anchor).toEqualTypeOf<string | null | undefined>();
         expectTypeOf(link.rel).toEqualTypeOf<string | undefined>();
         // Storyfront permits arbitrary string-valued custom attributes.
-        expectTypeOf(link.email).toEqualTypeOf<string>();
+        expectTypeOf(link.email).toEqualTypeOf<string | null>();
       }
       else if (link.linktype === 'email') {
         expectTypeOf(link.email).toEqualTypeOf<string | undefined>();
@@ -48,13 +49,16 @@ describe('MultilinkFieldValue', () => {
     expectTypeOf(url.linktype).toEqualTypeOf<'url'>();
   });
 
-  it('rejects nullable target and story anchor values', () => {
-    // @ts-expect-error Storyfront only accepts a non-null target when present.
+  it('rejects a nullable target', () => {
+    // @ts-expect-error Storyfront only writes '_self' or '_blank', never null.
     const _invalidTarget: MultilinkFieldValue = { ...shared, linktype: 'asset', target: null };
-    // @ts-expect-error Storyfront only accepts a non-null story anchor when present.
-    const _invalidAnchor: MultilinkFieldValue = { ...shared, linktype: 'story', anchor: null };
 
     void _invalidTarget;
-    void _invalidAnchor;
+  });
+
+  it('accepts a story anchor cleared to null', () => {
+    const cleared = { ...shared, linktype: 'story', anchor: null } satisfies MultilinkFieldValue;
+
+    expectTypeOf(cleared.anchor).toEqualTypeOf<null>();
   });
 });

--- a/packages/schema/src/validators/shapes.ts
+++ b/packages/schema/src/validators/shapes.ts
@@ -21,6 +21,15 @@ export interface SchemaFieldLike {
   allow?: readonly (string | { folder: string })[];
   /** Normalized datasource slug for option/options fields. */
   datasource?: string;
+  /** `option`/`options`: the self-sourced selectable options. */
+  options?: readonly { name?: string; value?: string }[];
+  /**
+   * `option`/`options`: where the selectable options come from. Undefined (or
+   * empty) means self — the `options` array above. Any other value
+   * (`internal`, `external`, `internal_stories`, `internal_languages`) resolves
+   * in the space, so the accepted values are not knowable from the schema.
+   */
+  source?: string;
   // Value constraints enforced by `validateStory` (all optional).
   /** `text`/`textarea`/`markdown`: maximum string length. */
   max_length?: number;

--- a/packages/schema/src/validators/validate-story.test.ts
+++ b/packages/schema/src/validators/validate-story.test.ts
@@ -273,7 +273,6 @@ describe('validateStory — multilink values', () => {
 
   it.each([
     ['nullable target', { ...multilinkBase, linktype: 'asset', target: null }],
-    ['nullable story anchor', { ...multilinkBase, linktype: 'story', anchor: null }],
     ['non-string URL attribute', { ...multilinkBase, linktype: 'url', rel: 42 }],
     ['non-string custom story attribute', { ...multilinkBase, linktype: 'story', analytics: 42 }],
   ])('rejects %s', (_label, value) => {
@@ -281,6 +280,16 @@ describe('validateStory — multilink values', () => {
 
     expect(result.ok).toBe(false);
     expect(codesFor(result)).toContain('invalid_value');
+  });
+
+  // This case used to be asserted as a rejection, but the editor produces it:
+  // the anchor modal emits `anchor.value || null`, so clearing an existing
+  // anchor stores `anchor: null`. Rejecting it flagged ordinary edited content.
+  it('accepts a story anchor cleared to null', () => {
+    const result = validateMultilink({ ...multilinkBase, linktype: 'story', anchor: null });
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
   });
 });
 
@@ -379,6 +388,16 @@ describe('validateStory — constraints', () => {
     expect(disallowed).toBeDefined();
     expect(disallowed?.path).toEqual(['content', 'items', 0, 'component']);
   });
+
+  // A component missing from the schema is one mistake, not two: reporting both
+  // `unknown_component` and `disallowed_component` double-counted it and buried
+  // the real cause.
+  it('reports only unknown_component for a component the schema does not define', () => {
+    const result = validate({ items: [{ component: 'nope' }] });
+    const codes = result.issues.map(issue => issue.code);
+    expect(codes).toContain('unknown_component');
+    expect(codes).not.toContain('disallowed_component');
+  });
 });
 
 describe('validateStory — number wire format', () => {
@@ -401,6 +420,14 @@ describe('validateStory — number wire format', () => {
 
   it('rejects a JSON number, which the API refuses to store', () => {
     expect(check(7).issues.some(i => i.code === 'invalid_value')).toBe(true);
+  });
+
+  // `Expected string, received number.` reads like a validator bug on a field
+  // that looks numeric; the message has to name the wire format.
+  it('explains that the wire form of a number field is a string', () => {
+    expect(check(7).issues[0].message).toBe(
+      'Expected a numeric string (number fields are stored as strings), received number.',
+    );
   });
 
   it('rejects strings that are not numeric', () => {
@@ -521,5 +548,386 @@ describe('validateStory — richtext allow entries', () => {
     expect(disallowed?.message).toBe(
       'Component "teaser" is not allowed in field "body"; allowed: folder:Layout.',
     );
+  });
+});
+
+// Removing or renaming an option in the schema is exactly the change that
+// orphans existing content, so a stored value outside the declared list must be
+// reported rather than passing as "some string".
+describe('validateStory — declared options', () => {
+  const article = defineBlock({
+    name: 'article',
+    is_root: true,
+    fields: [
+      defineField('tier', { type: 'option', options: [{ name: 'Gold', value: 'gold' }, { name: 'Silver', value: 'silver' }] }),
+      defineField('tags', { type: 'options', options: [{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }] }),
+    ],
+  });
+  const s = { blocks: { article } };
+  const check = (content: Record<string, unknown>) =>
+    validateStory({ content: { component: 'article', ...content } }, s);
+
+  it('accepts a declared option value', () => {
+    expect(check({ tier: 'gold', tags: ['a', 'b'] }).ok).toBe(true);
+  });
+
+  it('rejects an option value that is not declared', () => {
+    const issue = check({ tier: 'bronze' }).issues.find(i => i.code === 'unknown_option');
+    expect(issue?.path).toEqual(['content', 'tier']);
+    expect(issue?.message).toBe('Value "bronze" is not one of the options declared for field "tier": "gold", "silver".');
+  });
+
+  it('rejects an undeclared entry of a multi-option value and points at its index', () => {
+    const issue = check({ tags: ['a', 'zz'] }).issues.find(i => i.code === 'unknown_option');
+    expect(issue?.path).toEqual(['content', 'tags', 1]);
+  });
+
+  it('accepts an empty string, which is how an unset option field is stored', () => {
+    expect(check({ tier: '' }).ok).toBe(true);
+  });
+
+  it('skips fields whose options are resolved in the space', () => {
+    // A datasource-backed field carries no entries in the schema (entries are
+    // content), so its accepted values are not knowable offline.
+    const themed = defineBlock({
+      name: 'themed',
+      is_root: true,
+      fields: [defineField('theme', { type: 'option', source: 'internal', datasource: 'colors' })],
+    });
+    const result = validateStory({ content: { component: 'themed', theme: 'anything' } }, { blocks: { themed } });
+    expect(result.ok).toBe(true);
+  });
+
+  it('skips a field that declares no options', () => {
+    const free = defineBlock({
+      name: 'free',
+      is_root: true,
+      fields: [defineField('tier', { type: 'option' })],
+    });
+    expect(validateStory({ content: { component: 'free', tier: 'whatever' } }, { blocks: { free } }).ok).toBe(true);
+  });
+});
+
+// Zod reports a bare `Invalid input` for a failed union, which told the user
+// nothing about what a valid multilink/asset/richtext value looks like.
+describe('validateStory — value messages', () => {
+  const linked = defineBlock({
+    name: 'linked',
+    is_root: true,
+    fields: [
+      defineField('link', { type: 'multilink' }),
+      defineField('cover', { type: 'asset' }),
+      defineField('body', { type: 'richtext' }),
+    ],
+  });
+  const s = { blocks: { linked } };
+  const messageFor = (content: Record<string, unknown>) =>
+    validateStory({ content: { component: 'linked', ...content } }, s).issues[0]?.message;
+
+  it('describes the accepted shape when a multilink union fails', () => {
+    expect(messageFor({ link: { linktype: 'nonsense' } })).toBe(
+      'Expected a link object: { fieldtype: "multilink", linktype: "story" | "url" | "email" | "asset", id, url, cached_url }.',
+    );
+  });
+
+  it('describes the accepted shape when an asset value is not an object', () => {
+    expect(messageFor({ cover: 'https://a.storyblok.com/f/1/x.png' })).toBe(
+      'Expected an asset object: { fieldtype: "asset", id, alt, filename }.',
+    );
+  });
+
+  it('describes the accepted shape when a richtext value is not a document', () => {
+    expect(messageFor({ body: 'plain text' })).toBe(
+      'Expected a richtext document: { type: "doc", content: [...] }.',
+    );
+  });
+
+  it('keeps the validator message for a failure inside the value, which names the key', () => {
+    const message = messageFor({ cover: { fieldtype: 'asset', id: 1, alt: null } });
+    expect(message).toContain('expected string');
+    expect(message?.endsWith('.')).toBe(true);
+  });
+});
+
+// Regression: table content authored before `_uid`/`component` were introduced
+// carries only `value`, and the API still serves it. Requiring those keys made
+// every legacy table report three errors naming keys the author never wrote.
+describe('validateStory — legacy table content', () => {
+  const spec = defineBlock({
+    name: 'spec',
+    is_root: true,
+    fields: [defineField('data', { type: 'table' })],
+  });
+  const s = { blocks: { spec } };
+  const validate = (data: unknown) => validateStory({ content: { component: 'spec', data } }, s);
+
+  it('accepts a table whose cells carry only a value', () => {
+    const result = validate({
+      thead: [{ value: 'Header' }],
+      tbody: [{ body: [{ value: 'Cell' }] }],
+    });
+    expect(result.issues).toEqual([]);
+  });
+
+  it('accepts a table carrying the component keys', () => {
+    const result = validate({
+      fieldtype: 'table',
+      thead: [{ _uid: 'a', component: '_table_head', value: 'Header' }],
+      tbody: [{ _uid: 'b', component: '_table_row', body: [{ _uid: 'c', component: '_table_col', value: 'Cell' }] }],
+    });
+    expect(result.issues).toEqual([]);
+  });
+
+  it('still rejects a component key naming the wrong type', () => {
+    const result = validate({
+      thead: [{ component: '_table_row', value: 'Header' }],
+      tbody: [],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('still rejects a table missing thead or tbody', () => {
+    expect(validate({ thead: [] }).ok).toBe(false);
+  });
+});
+
+// Field-level translations are stored as `<field>__i18n__<locale>` siblings of
+// the default value. Treating them as separate keys made every translated field
+// warn as unknown *and* left its value unchecked, so a wrong type in any locale
+// but the default passed silently.
+describe('validateStory — field-level translations', () => {
+  const page = defineBlock({
+    name: 'page',
+    is_root: true,
+    fields: [
+      defineField('headline', { type: 'text', required: true }),
+      defineField('cover', { type: 'asset' }),
+      defineField('body', { type: 'bloks', allow: [teaser] }),
+    ],
+  });
+  const s = { blocks: { page, teaser } };
+
+  it('accepts a translated value without reporting it as an unknown field', () => {
+    const result = validateStory({
+      content: { component: 'page', headline: 'Hello', headline__i18n__de: 'Hallo' },
+    }, s);
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it('validates a translated value against its field definition', () => {
+    const result = validateStory({
+      content: { component: 'page', headline: 'Hello', headline__i18n__de: 12345 },
+    }, s);
+    expect(result.ok).toBe(false);
+    const issue = result.issues.find(i => i.code === 'invalid_value');
+    expect(issue?.path).toEqual(['content', 'headline__i18n__de']);
+    expect(issue?.message).toBe('Expected string, received number.');
+  });
+
+  it('recurses into bloks nested under a translated field', () => {
+    const result = validateStory({
+      content: {
+        component: 'page',
+        headline: 'Hello',
+        body__i18n__de: [{ _uid: 'uid-1', component: 'ghost' }],
+      },
+    }, s);
+    expect(codesFor(result)).toContain('unknown_component');
+    expect(result.issues[0]?.path).toEqual(['content', 'body__i18n__de', 0, 'component']);
+  });
+
+  it('reports every locale of a field independently', () => {
+    const result = validateStory({
+      content: {
+        component: 'page',
+        headline: 'Hello',
+        headline__i18n__de: 1,
+        headline__i18n__fr: 2,
+      },
+    }, s);
+    expect(result.issues.map(i => i.path)).toEqual([
+      ['content', 'headline__i18n__de'],
+      ['content', 'headline__i18n__fr'],
+    ]);
+  });
+
+  it('keeps required scoped to the default value, so an untranslated locale is not a missing value', () => {
+    // Only `de` is translated. `fr` being absent is normal content, not drift.
+    const result = validateStory({
+      content: { component: 'page', headline: 'Hello', headline__i18n__de: 'Hallo' },
+    }, s);
+    expect(codesFor(result)).not.toContain('missing_required_field');
+  });
+
+  it('still reports a required field left unset even when a locale carries a value', () => {
+    const result = validateStory({
+      content: { component: 'page', headline: '', headline__i18n__de: 'Hallo' },
+    }, s);
+    expect(codesFor(result)).toContain('missing_required_field');
+  });
+
+  it('warns on a translated key whose base field the block does not define', () => {
+    const result = validateStory({
+      content: { component: 'page', headline: 'Hello', ghost__i18n__de: 'x' },
+    }, s);
+    const issue = result.issues.find(i => i.code === 'unknown_field');
+    expect(issue?.severity).toBe('warning');
+    expect(issue?.message).toBe('Unknown field "ghost__i18n__de" on component "page".');
+  });
+});
+
+// A validator that fails on a union deep inside a value reports a bare
+// `Invalid input`, which names nothing. When a more specific issue already
+// covers the same value, the vague one is noise.
+// One representation of "no value" should read the same on every field type.
+// `''` used to pass for `number` and `datetime`, whose unset wire form it is, and
+// fail as a type error for `boolean`, `asset`, and `multilink`.
+describe('validateStory — the empty string counts as unset', () => {
+  const every = defineBlock({
+    name: 'every',
+    is_root: true,
+    fields: [
+      defineField('num', { type: 'number' }),
+      defineField('when', { type: 'datetime' }),
+      defineField('flag', { type: 'boolean' }),
+      defineField('cover', { type: 'asset' }),
+      defineField('link', { type: 'multilink' }),
+      defineField('body', { type: 'richtext' }),
+    ],
+  });
+  const s = { blocks: { every } };
+
+  it.each(['num', 'when', 'flag', 'cover', 'link', 'body'])('accepts an optional %s left as ""', (name) => {
+    const result = validateStory({ content: { component: 'every', [name]: '' } }, s);
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it('still reports a required field left as ""', () => {
+    const required = defineBlock({
+      name: 'required',
+      is_root: true,
+      fields: [defineField('cover', { type: 'asset', required: true })],
+    });
+    const result = validateStory({ content: { component: 'required', cover: '' } }, { blocks: { required } });
+    expect(codesFor(result)).toEqual(['missing_required_field']);
+  });
+
+  it('still validates a non-empty value of the same field', () => {
+    const result = validateStory({ content: { component: 'every', flag: 'yes' } }, s);
+    expect(codesFor(result)).toEqual(['invalid_value']);
+  });
+});
+
+// A number field stores its value as a string, so a JSON number is drift worth
+// surfacing. It is not a broken value, though: the backend neither coerces nor
+// rejects it, so API-authored and migrated content carries it and still reads.
+describe('validateStory — a JSON number in a number field', () => {
+  const counted = defineBlock({
+    name: 'counted',
+    is_root: true,
+    fields: [defineField('count', { type: 'number' })],
+  });
+  const s = { blocks: { counted } };
+
+  it('warns rather than errors, and keeps the run ok', () => {
+    const result = validateStory({ content: { component: 'counted', count: 42 } }, s);
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toMatchObject({ severity: 'warning', code: 'invalid_value' });
+    expect(result.issues[0]?.message).toBe(
+      'Expected a numeric string (number fields are stored as strings), received number.',
+    );
+  });
+
+  it('still errors on a string that is not numeric', () => {
+    const result = validateStory({ content: { component: 'counted', count: 'abc' } }, s);
+    expect(result.ok).toBe(false);
+  });
+});
+
+// An empty object fails several keys of one value at once, and the keys that
+// carry no message of their own are pure noise next to the ones that do.
+describe('validateStory — an empty object in an object-shaped field', () => {
+  const shaped = defineBlock({
+    name: 'shaped',
+    is_root: true,
+    fields: [defineField('cover', { type: 'asset' })],
+  });
+  const s = { blocks: { shaped } };
+
+  it('reports only the keys that name what is wrong', () => {
+    const result = validateStory({ content: { component: 'shaped', cover: {} } }, s);
+
+    expect(result.ok).toBe(false);
+    for (const issue of result.issues) {
+      expect(issue.message).not.toBe('Invalid input.');
+      expect(issue.message).not.toBe('Value does not match any shape this field accepts.');
+    }
+    expect(result.issues.map(i => i.path)).toEqual([
+      ['content', 'cover', 'fieldtype'],
+      ['content', 'cover', 'filename'],
+    ]);
+  });
+});
+
+describe('validateStory — subsumed issues', () => {
+  const page = defineBlock({
+    name: 'page',
+    is_root: true,
+    fields: [defineField('body', { type: 'richtext' })],
+  });
+  const s = { blocks: { page, teaser } };
+
+  it('drops the bare union message when a deeper issue explains the same node', () => {
+    // `attrs.id` is missing, so the node fails the richtext union; the blok walk
+    // separately finds the unknown component underneath it.
+    const result = validateStory({
+      content: {
+        component: 'page',
+        body: { type: 'doc', content: [{ type: 'blok', attrs: { body: [{ _uid: 'u', component: 'ghost' }] } }] },
+      },
+    }, s);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]?.code).toBe('unknown_component');
+    expect(result.issues[0]?.path).toEqual(['content', 'body', 'content', 0, 'attrs', 'body', 0, 'component']);
+  });
+
+  it('keeps the vague message when nothing deeper explains it', () => {
+    // Same malformed node, but the embedded blok itself is valid, so the vague
+    // issue is the only signal the node is wrong. It says so in words a reader can
+    // act on rather than passing Zod's bare `Invalid input` through, and it stays
+    // at the node's own path: the field's expected shape describes a whole
+    // richtext document, not one node inside it.
+    const result = validateStory({
+      content: {
+        component: 'page',
+        body: { type: 'doc', content: [{ type: 'blok', attrs: { body: [{ _uid: 'u', component: 'teaser', text: 'hi' }] } }] },
+      },
+    }, s);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]?.message).toBe('Value does not match any shape this field accepts.');
+    expect(result.issues[0]?.path).toEqual(['content', 'body', 'content', 0]);
+  });
+
+  it('does not let an issue on a sibling path suppress an unrelated vague issue', () => {
+    const twoFields = defineBlock({
+      name: 'two',
+      is_root: true,
+      fields: [defineField('a', { type: 'richtext' }), defineField('b', { type: 'text' })],
+    });
+    const result = validateStory({
+      content: {
+        component: 'two',
+        a: { type: 'doc', content: [{ type: 'blok', attrs: { body: [{ _uid: 'u', component: 'teaser', text: 'hi' }] } }] },
+        b: 42,
+      },
+    }, { blocks: { two: twoFields, teaser } });
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues.map(i => i.path)).toEqual([
+      ['content', 'a', 'content', 0],
+      ['content', 'b'],
+    ]);
   });
 });

--- a/packages/schema/src/validators/validate-story.test.ts
+++ b/packages/schema/src/validators/validate-story.test.ts
@@ -911,7 +911,29 @@ describe('validateStory — subsumed issues', () => {
     expect(result.issues[0]?.path).toEqual(['content', 'body', 'content', 0]);
   });
 
-  it('does not let an issue on a sibling path suppress an unrelated vague issue', () => {
+  it('does not let an issue on a sibling node suppress an unrelated vague issue', () => {
+    // Two malformed nodes in one richtext field. The second names its problem;
+    // the first has only the vague union failure to go on. Suppressing the first
+    // because the second is explained would hide a whole broken node, so both
+    // are reported.
+    const result = validateStory({
+      content: {
+        component: 'page',
+        body: { type: 'doc', content: [
+          { type: 'blok', attrs: { body: [{ _uid: 'u1', component: 'teaser', text: 'hi' }] } },
+          { type: 'blok', attrs: { body: [{ _uid: 'u2', component: 'ghost' }] } },
+        ] },
+      },
+    }, s);
+    expect(result.issues.map(i => i.path)).toEqual([
+      ['content', 'body', 'content', 0],
+      ['content', 'body', 'content', 1, 'attrs', 'body', 0, 'component'],
+    ]);
+    expect(result.issues[0]?.message).toBe('Value does not match any shape this field accepts.');
+    expect(result.issues[1]?.code).toBe('unknown_component');
+  });
+
+  it('does not let an issue on a sibling field suppress an unrelated vague issue', () => {
     const twoFields = defineBlock({
       name: 'two',
       is_root: true,

--- a/packages/schema/src/validators/validate-story.ts
+++ b/packages/schema/src/validators/validate-story.ts
@@ -77,11 +77,15 @@ const UNINFORMATIVE_MESSAGES = new Set(['Invalid input.']);
 const VAGUE_MESSAGE = 'Value does not match any shape this field accepts.';
 
 /**
- * Maps a vague issue to the path of the field value it came from, so
- * {@link dropSubsumedIssues} can tell whether anything else in that same value
- * explains it. Keyed weakly: every issue object is created once, for one call.
+ * Maps a vague issue to where it sits, so {@link dropSubsumedIssues} can tell
+ * whether anything else explains it. `path` is the issue's own path; `valueDepth`
+ * is the depth of the field value it came from, which the scoping must never
+ * reach above. Keyed weakly: every issue object is created once, for one call.
  */
-const vagueIssueValuePaths = new WeakMap<ValidationIssue, string>();
+const vagueIssueScopes = new WeakMap<ValidationIssue, {
+  path: (string | number)[];
+  valueDepth: number;
+}>();
 
 /**
  * Rewrites a validator's own message into the style the hand-written messages use.
@@ -129,21 +133,38 @@ function pathKey(path: (string | number)[]): string {
  * likewise reports one vague issue per key that carries no message of its own,
  * alongside the keys that do name what is wrong.
  *
- * Scoped to the value the vague issue came from, so an issue on an unrelated
- * field never suppresses it, and a vague issue that nothing else explains is
- * always kept: a value is never rejected silently.
+ * Scoped to the vague issue's own path, so a clear issue somewhere else never
+ * suppresses it. Widened by one segment when the vague issue sits on an object
+ * key, because a key carrying no message of its own says nothing next to a named
+ * problem on the same object — the two describe one broken value. An array index
+ * is never widened: elements are independent, so a malformed richtext node must
+ * not be silenced by an unrelated node beside it. The widening also never reaches
+ * above the field value itself, so a vague issue on one field survives a clear
+ * issue on another.
+ *
+ * A vague issue that nothing else explains is always kept: a value is never
+ * rejected silently.
  */
 function dropSubsumedIssues(issues: ValidationIssue[]): ValidationIssue[] {
   const explanatoryPaths = issues
-    .filter(issue => !vagueIssueValuePaths.has(issue))
+    .filter(issue => !vagueIssueScopes.has(issue))
     .map(issue => pathKey(issue.path));
+  const hasIssueUnder = (path: (string | number)[]): boolean => {
+    const prefix = `${pathKey(path)}\u0000`;
+    return explanatoryPaths.some(candidate => candidate.startsWith(prefix));
+  };
+
   return issues.filter((issue) => {
-    const valuePath = vagueIssueValuePaths.get(issue);
-    if (valuePath === undefined) {
+    const scope = vagueIssueScopes.get(issue);
+    if (scope === undefined) {
       return true;
     }
-    const prefix = `${valuePath}\u0000`;
-    return !explanatoryPaths.some(candidate => candidate.startsWith(prefix));
+    if (hasIssueUnder(scope.path)) {
+      return false;
+    }
+    const key = scope.path.at(-1);
+    const widens = typeof key === 'string' && scope.path.length > scope.valueDepth;
+    return widens ? !hasIssueUnder(scope.path.slice(0, -1)) : true;
   });
 }
 
@@ -193,7 +214,7 @@ function checkValue(
         message,
       };
       if (vague) {
-        vagueIssueValuePaths.set(issue, pathKey(path));
+        vagueIssueScopes.set(issue, { path: issue.path, valueDepth: path.length });
       }
       issues.push(issue);
     }

--- a/packages/schema/src/validators/validate-story.ts
+++ b/packages/schema/src/validators/validate-story.ts
@@ -14,6 +14,33 @@ import { slugifyFolderPath } from '../utils/slugify-folder-path';
 /** Field-content keys that are not user-defined fields. */
 const RESERVED_KEYS = new Set(['_uid', 'component', '_editable']);
 
+/** Separator the CMS puts between a field name and a locale for field-level translations. */
+const I18N_SEPARATOR = '__i18n__';
+
+/**
+ * Strips the field-level translation suffix from a content key, e.g.
+ * `headline__i18n__de` → `headline`. Field-level translations are stored as
+ * siblings of the default value and belong to the same field definition, so the
+ * suffix has to come off before the key is looked up in the block's fields.
+ */
+function baseFieldName(key: string): string {
+  const index = key.indexOf(I18N_SEPARATOR);
+  return index === -1 ? key : key.slice(0, index);
+}
+
+/**
+ * Human descriptions of the accepted wire shape per field type, used when the
+ * underlying validator can only report that the value as a whole is wrong (see
+ * {@link formatValidatorMessage}).
+ */
+const EXPECTED_SHAPE = {
+  asset: 'expected an asset object: { fieldtype: "asset", id, alt, filename }',
+  multilink: 'expected a link object: { fieldtype: "multilink", linktype: "story" | "url" | "email" | "asset", id, url, cached_url }',
+  richtext: 'expected a richtext document: { type: "doc", content: [...] }',
+  table: 'expected a table object: { fieldtype: "table", thead: [...], tbody: [...] }',
+  plugin: 'expected a field plugin object carrying a "plugin" key',
+} as const;
+
 /**
  * Relaxed plugin envelope used by the `custom` case. Mirrors the generated
  * `zPluginFieldValue` but relaxes `_uid` from a UUID to a plain string, matching
@@ -22,13 +49,116 @@ const RESERVED_KEYS = new Set(['_uid', 'component', '_editable']);
  */
 const zPluginEnvelope = z.object({ plugin: z.string(), _uid: z.optional(z.string()) });
 
-/** Maps a Standard Schema validator to a {@link ValidationIssue} reporter at `path`. */
+/**
+ * Whether a content value counts as "no value". Mirrors the backend's required
+ * check, which is `field_value.blank?`, and `''.blank?` is true. Applied
+ * uniformly so one representation of unset cannot read as a type error on one
+ * field type and as unset on another.
+ */
+function isUnset(value: unknown): boolean {
+  return value === undefined || value === null || value === '';
+}
+
+/** Capitalizes and gives the text exactly one trailing period. */
+function asSentence(text: string): string {
+  const capitalized = text.charAt(0).toUpperCase() + text.slice(1);
+  return /[.!?]$/.test(capitalized) ? capitalized : `${capitalized}.`;
+}
+
+/** Validator messages that name nothing at all, and so are worth rewording. */
+const UNINFORMATIVE_MESSAGES = new Set(['Invalid input.']);
+
+/**
+ * Said in place of a validator message that names nothing. Deliberately does not
+ * borrow the field's expected shape: at a nested path that shape describes the
+ * wrong thing (a richtext *node* is not a richtext *document*), so it would trade
+ * a vague message for a misleading one.
+ */
+const VAGUE_MESSAGE = 'Value does not match any shape this field accepts.';
+
+/**
+ * Maps a vague issue to the path of the field value it came from, so
+ * {@link dropSubsumedIssues} can tell whether anything else in that same value
+ * explains it. Keyed weakly: every issue object is created once, for one call.
+ */
+const vagueIssueValuePaths = new WeakMap<ValidationIssue, string>();
+
+/**
+ * Rewrites a validator's own message into the style the hand-written messages use.
+ *
+ * A validator says the least when the value as a whole fails (`atRoot`): Zod
+ * reports a bare `Invalid input` for a failed union, every member having
+ * mismatched so it can name none of them, which tells the reader nothing about
+ * what a multilink or richtext value should look like. `expected` describes the
+ * accepted shape and stands in for those.
+ *
+ * Deeper down, a message that names a key is kept verbatim, but one that names
+ * nothing is reworded: `Invalid input.` gives a reader nothing to act on.
+ */
+function formatValidatorMessage(
+  message: string,
+  expected: string | undefined,
+  atRoot: boolean,
+): { message: string; vague: boolean } {
+  const formatted = asSentence(message.trim());
+  if (expected !== undefined && atRoot) {
+    return { message: asSentence(expected), vague: false };
+  }
+  if (UNINFORMATIVE_MESSAGES.has(formatted)) {
+    return { message: VAGUE_MESSAGE, vague: true };
+  }
+  return { message: formatted, vague: false };
+}
+
+/**
+ * Joins a path into a comparable string. The separator is a NUL byte, which no
+ * content key can contain, so a prefix match can only ever land on a whole
+ * segment boundary.
+ */
+function pathKey(path: (string | number)[]): string {
+  return path.join('\u0000');
+}
+
+/**
+ * Drops vague issues that something else in the same field value already
+ * explains.
+ *
+ * A malformed richtext blok reports twice: once as the vague failure the node's
+ * union produces, once as the `unknown_component` the blok walk finds underneath
+ * it, and only the second tells the reader what to fix. An empty asset object
+ * likewise reports one vague issue per key that carries no message of its own,
+ * alongside the keys that do name what is wrong.
+ *
+ * Scoped to the value the vague issue came from, so an issue on an unrelated
+ * field never suppresses it, and a vague issue that nothing else explains is
+ * always kept: a value is never rejected silently.
+ */
+function dropSubsumedIssues(issues: ValidationIssue[]): ValidationIssue[] {
+  const explanatoryPaths = issues
+    .filter(issue => !vagueIssueValuePaths.has(issue))
+    .map(issue => pathKey(issue.path));
+  return issues.filter((issue) => {
+    const valuePath = vagueIssueValuePaths.get(issue);
+    if (valuePath === undefined) {
+      return true;
+    }
+    const prefix = `${valuePath}\u0000`;
+    return !explanatoryPaths.some(candidate => candidate.startsWith(prefix));
+  });
+}
+
+/**
+ * Maps a Standard Schema validator to a {@link ValidationIssue} reporter at `path`.
+ * `expected` describes the accepted shape and is used when the validator's own
+ * message carries no information (see {@link formatValidatorMessage}).
+ */
 function checkValue(
   schema: StandardSchemaV1,
   value: unknown,
   path: (string | number)[],
   entity: string,
   issues: ValidationIssue[],
+  expected?: string,
 ): void {
   const result = schema['~standard'].validate(value);
   // `validateStory` is synchronous. The internal Zod schemas never return a
@@ -46,17 +176,26 @@ function checkValue(
     return;
   }
   if (result.issues) {
-    for (const issue of result.issues) {
-      const issuePath = (issue.path ?? []).map(segment =>
+    for (const rawIssue of result.issues) {
+      const issuePath = (rawIssue.path ?? []).map(segment =>
         (typeof segment === 'object' && segment !== null ? String(segment.key) : (segment as string | number)),
       );
-      issues.push({
+      const { message, vague } = formatValidatorMessage(
+        rawIssue.message,
+        expected,
+        issuePath.length === 0,
+      );
+      const issue: ValidationIssue = {
         severity: 'error',
         code: 'invalid_value',
         path: [...path, ...issuePath],
         entity,
-        message: issue.message,
-      });
+        message,
+      };
+      if (vague) {
+        vagueIssueValuePaths.set(issue, pathKey(path));
+      }
+      issues.push(issue);
     }
   }
 }
@@ -72,28 +211,28 @@ function validateFieldValue(
 ): void {
   switch (field.type) {
     case 'asset':
-      checkValue(zAssetFieldValue, value, path, entity, issues);
+      checkValue(zAssetFieldValue, value, path, entity, issues, EXPECTED_SHAPE.asset);
       break;
     case 'multiasset':
       if (!Array.isArray(value)) {
         pushTypeIssue(value, 'array', path, entity, issues);
         break;
       }
-      value.forEach((item, index) => checkValue(zAssetFieldValue, item, [...path, index], entity, issues));
+      value.forEach((item, index) => checkValue(zAssetFieldValue, item, [...path, index], entity, issues, EXPECTED_SHAPE.asset));
       checkCount(value.length, field.minimum_entries, field.maximum_entries, 'asset(s)', path, entity, issues);
       break;
     case 'multilink':
-      checkValue(zMultilinkFieldValue, value, path, entity, issues);
+      checkValue(zMultilinkFieldValue, value, path, entity, issues, EXPECTED_SHAPE.multilink);
       break;
     case 'table':
-      checkValue(zTableFieldValue, value, path, entity, issues);
+      checkValue(zTableFieldValue, value, path, entity, issues, EXPECTED_SHAPE.table);
       break;
     case 'richtext':
-      checkValue(zRichTextFieldValue, value, path, entity, issues);
+      checkValue(zRichTextFieldValue, value, path, entity, issues, EXPECTED_SHAPE.richtext);
       validateRichtextBloks(value, field, blocksByName, fieldPluginsByType, path, entity, issues);
       break;
     case 'custom': {
-      checkValue(zPluginEnvelope, value, path, entity, issues);
+      checkValue(zPluginEnvelope, value, path, entity, issues, EXPECTED_SHAPE.plugin);
       const validator = field.field_type ? fieldPluginsByType.get(field.field_type) : undefined;
       if (validator && isRecord(value)) {
         // Envelope keys sit alongside the plugin's own keys; strip them so the
@@ -125,6 +264,12 @@ function validateFieldValue(
       checkStringLength(field, value, path, entity, issues);
       break;
     case 'option':
+      if (typeof value !== 'string') {
+        pushTypeIssue(value, 'string', path, entity, issues);
+        break;
+      }
+      checkDeclaredOption(field, value, path, entity, issues);
+      break;
     case 'datetime':
       if (typeof value !== 'string') {
         pushTypeIssue(value, 'string', path, entity, issues);
@@ -132,7 +277,18 @@ function validateFieldValue(
       break;
     case 'number': {
       if (typeof value !== 'string') {
-        pushTypeIssue(value, 'string', path, entity, issues);
+        // The wire form of a number field is a string, so a JSON number is not
+        // what the editor writes. Reported as a warning rather than an error: the
+        // backend neither coerces nor rejects it, so API-authored and migrated
+        // content carries it and still reads fine. It is drift worth surfacing,
+        // not a broken value worth failing a build over.
+        issues.push({
+          severity: 'warning',
+          code: 'invalid_value',
+          path,
+          entity,
+          message: `Expected a numeric string (number fields are stored as strings), received ${describeType(value)}.`,
+        });
         break;
       }
       // Mirrors the backend's `\A-?\d*\.?\d*\z`: an optional leading `-`, digits
@@ -178,6 +334,7 @@ function validateFieldValue(
         break;
       }
       checkCount(value.length, toCount(field.min_options), toCount(field.max_options), 'option(s)', path, entity, issues);
+      value.forEach((item: string, index) => checkDeclaredOption(field, item, [...path, index], entity, issues));
       break;
     case 'section':
     case 'tab':
@@ -216,6 +373,12 @@ function checkComponentAllowed(
   if (allowEntries.length === 0 || !isRecord(item) || typeof item.component !== 'string') {
     return;
   }
+  // A component the schema does not define at all is reported once as
+  // `unknown_component` by validateBlokContent. Adding `disallowed_component`
+  // for the same node would double-count one mistake and bury the real cause.
+  if (!blocksByName.has(item.component)) {
+    return;
+  }
   const blockNamesAllowed = allowEntries.filter((entry): entry is string => typeof entry === 'string');
   const folderPathsAllowed = allowEntries.filter(
     (entry): entry is { folder: string } =>
@@ -242,6 +405,45 @@ function checkComponentAllowed(
       message: `Component "${item.component}" is not allowed in field "${field.name}"; allowed: ${allowedList}.`,
     });
   }
+}
+
+/**
+ * Reports a value that is not among a field's declared options — the drift left
+ * behind when an option is renamed or removed from the schema while stories
+ * still carry the old value.
+ *
+ * Only self-sourced fields can be checked. Every other `source` resolves its
+ * options inside the space (`internal` from a datasource, `internal_stories`
+ * from the story tree, `internal_languages` from the space languages, `external`
+ * from a remote JSON URL), and a datasource definition deliberately carries no
+ * entries — entries are content, not schema — so the accepted values are not
+ * knowable here. An empty string is the unset form of an option field, not a
+ * value, and a field declaring no options constrains nothing.
+ */
+function checkDeclaredOption(
+  field: SchemaFieldLike,
+  value: string,
+  path: (string | number)[],
+  entity: string,
+  issues: ValidationIssue[],
+): void {
+  if (value === '' || (field.source !== undefined && field.source !== '')) {
+    return;
+  }
+  const declared = (field.options ?? [])
+    .map(option => option.value)
+    .filter((optionValue): optionValue is string => typeof optionValue === 'string' && optionValue !== '');
+  if (declared.length === 0 || declared.includes(value)) {
+    return;
+  }
+  issues.push({
+    severity: 'error',
+    code: 'unknown_option',
+    path,
+    entity,
+    message: `Value "${value}" is not one of the options declared for field "${field.name}": `
+      + `${declared.map(optionValue => `"${optionValue}"`).join(', ')}.`,
+  });
 }
 
 /** Reports a constraint (bound/length/count) violation as an error issue. */
@@ -315,6 +517,21 @@ function toCount(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+/** Names a received value's type for a message (`null` is reported as itself). */
+function describeType(value: unknown): string {
+  return value === null ? 'null' : typeof value;
+}
+
+/** Reports an invalid field value with a caller-provided message. */
+function pushInvalidValue(
+  message: string,
+  path: (string | number)[],
+  entity: string,
+  issues: ValidationIssue[],
+): void {
+  issues.push({ severity: 'error', code: 'invalid_value', path, entity, message });
+}
+
 function pushTypeIssue(
   value: unknown,
   expected: string,
@@ -322,13 +539,7 @@ function pushTypeIssue(
   entity: string,
   issues: ValidationIssue[],
 ): void {
-  issues.push({
-    severity: 'error',
-    code: 'invalid_value',
-    path,
-    entity,
-    message: `Expected ${expected}, received ${value === null ? 'null' : typeof value}.`,
-  });
+  pushInvalidValue(`Expected ${expected}, received ${describeType(value)}.`, path, entity, issues);
 }
 
 /**
@@ -403,8 +614,16 @@ function validateBlokContent(
   const fields = block.fields ?? [];
   const fieldsByName = new Map(fields.map(field => [field.name, field]));
 
+  // Translated keys are grouped under the field they belong to so the value loop
+  // below can check each locale against the same field definition.
+  const translatedKeysByField = new Map<string, string[]>();
+
   for (const key of Object.keys(content)) {
-    if (!RESERVED_KEYS.has(key) && !fieldsByName.has(key)) {
+    if (RESERVED_KEYS.has(key)) {
+      continue;
+    }
+    const fieldName = baseFieldName(key);
+    if (!fieldsByName.has(fieldName)) {
       issues.push({
         severity: 'warning',
         code: 'unknown_field',
@@ -412,6 +631,16 @@ function validateBlokContent(
         entity,
         message: `Unknown field "${key}" on component "${block.name}".`,
       });
+      continue;
+    }
+    if (key !== fieldName) {
+      const translated = translatedKeysByField.get(fieldName);
+      if (translated) {
+        translated.push(key);
+      }
+      else {
+        translatedKeysByField.set(fieldName, [key]);
+      }
     }
   }
 
@@ -421,7 +650,7 @@ function validateBlokContent(
     // true, so an empty string is unset rather than a value. That matters most
     // for `number`, whose unset wire form *is* `''` — the value branch below
     // legitimately skips it, leaving the required check as the only diagnostic.
-    if (field.required && (value === undefined || value === null || value === '')) {
+    if (field.required && isUnset(value)) {
       issues.push({
         severity: 'error',
         code: 'missing_required_field',
@@ -429,22 +658,39 @@ function validateBlokContent(
         entity,
         message: `Missing required field "${field.name}" on component "${block.name}".`,
       });
-      continue;
     }
-    // An empty string on an optional field still goes through value validation:
-    // it is a legal value for the string-ish types but not, say, for `asset`.
-    if (value === undefined || value === null) {
-      continue;
+    // `''` counts as unset for every field type, matching the required check
+    // above. Validating it as a value instead made the same content both unset
+    // and wrongly typed depending on the field: `''` passed for `number` and
+    // `datetime`, whose unset wire form it is, and failed for `boolean`, `asset`,
+    // and `multilink`. Nothing is lost by skipping it, since an empty string
+    // carries no value to be wrong about.
+    else if (!isUnset(value)) {
+      validateFieldValue(field, value, blocksByName, fieldPluginsByType, [...path, field.name], entity, issues);
     }
-    validateFieldValue(field, value, blocksByName, fieldPluginsByType, [...path, field.name], entity, issues);
+
+    // A translated value is the same field in another locale, so it is held to
+    // the same value rules. `required` stays scoped to the default value: a
+    // locale nobody has translated yet is normal, not a missing value.
+    for (const key of translatedKeysByField.get(field.name) ?? []) {
+      const translatedValue = content[key];
+      if (isUnset(translatedValue)) {
+        continue;
+      }
+      validateFieldValue(field, translatedValue, blocksByName, fieldPluginsByType, [...path, key], entity, issues);
+    }
   }
 }
 
 /**
  * Validates a story's content against a schema without throwing. Reports unknown
  * components (error), unknown fields (warning), missing required fields (error),
- * and invalid field-value shapes (error), recursing into nested `bloks` and
- * richtext-embedded bloks.
+ * invalid field-value shapes (error), and values outside a field's declared
+ * options (error), recursing into nested `bloks` and richtext-embedded bloks.
+ *
+ * Field-level translations (`headline__i18n__de`) are validated against the
+ * field they belong to, so a translated value is held to the same rules as the
+ * default one and is not mistaken for an unknown field.
  *
  * @example
  * const result = validateStory(story, { blocks: { page, hero } });
@@ -457,5 +703,9 @@ export function validateStory(story: unknown, schema: SchemaLike): ValidationRes
   );
   const content = isRecord(story) ? story.content : undefined;
   validateBlokContent(content, blocksByName, fieldPluginsByType, ['content'], issues);
-  return { ok: issues.every(issue => issue.severity !== 'error'), issues };
+  // One mistake should read as one issue. Suppression happens here, over the
+  // whole story, because the specific issue often comes from a different walk
+  // than the vague one it explains.
+  const reported = dropSubsumedIssues(issues);
+  return { ok: reported.every(issue => issue.severity !== 'error'), issues: reported };
 }

--- a/tools/openapi-codegen/specs/shared/stories/field-types/multilink-field-value.yaml
+++ b/tools/openapi-codegen/specs/shared/stories/field-types/multilink-field-value.yaml
@@ -48,7 +48,7 @@ $defs:
             type: string
             enum: [story]
           anchor:
-            type: string
+            type: [string, 'null']
             description: Anchor/fragment identifier for the story link
           rel:
             type: string
@@ -56,9 +56,14 @@ $defs:
           title:
             type: string
             description: Link title attribute
+      # Custom link attributes are string-valued by construction in the editor,
+      # but null has to pass: the anchor modal emits `null` when an existing
+      # anchor is cleared (storyfront MultiLinkAnchor.vue, `anchor.value || null`),
+      # so any link whose anchor was removed is stored with `anchor: null`. This
+      # branch carries no `properties`, so it applies to every key.
       - type: object
         additionalProperties:
-          type: string
+          type: [string, 'null']
 
   UrlLink:
     description: Link to an external URL.

--- a/tools/openapi-codegen/specs/shared/stories/field-types/table-field-value.yaml
+++ b/tools/openapi-codegen/specs/shared/stories/field-types/table-field-value.yaml
@@ -1,6 +1,8 @@
 # See: https://www.storyblok.com/docs/api/management/components/possible-field-types
 # Note: Table fields do NOT have a 'fieldtype' property in API responses
 # They are identified by the presence of 'thead' and 'tbody' properties
+# Note: `_uid` and `component` are not required. Table content authored before
+# they were introduced carries only `value`, and the API still serves it.
 type: object
 description: Table field type - structured table data
 required:
@@ -12,9 +14,6 @@ properties:
     description: Table header cells
     items:
       type: object
-      required:
-        - _uid
-        - component
       properties:
         _uid:
           type: string
@@ -29,9 +28,6 @@ properties:
     description: Table body rows
     items:
       type: object
-      required:
-        - _uid
-        - component
       properties:
         _uid:
           type: string
@@ -43,9 +39,6 @@ properties:
           description: Cells in this row
           items:
             type: object
-            required:
-              - _uid
-              - component
             properties:
               _uid:
                 type: string


### PR DESCRIPTION
> This targets `feat/WDX-452-schema-validate` (#736), not `main`. Review #736 first, and rebase or retarget this branch once #736 merges.

Adds `storyblok stories validate`, which streams every story in a space and checks its draft content against a local code-defined schema, so a schema change that strands existing content surfaces before it reaches production.

`--starts-with` narrows the run to a subtree, and `--level` and `--format` behave as they do in `schema validate`.

## Content validation

Validation in `@storyblok/schema` grows to cover what the platform actually accepts:

- Field-level translations are validated, and issues subsumed by a broader issue on the same value are dropped.
- Values that no longer fit a field's declared `options` are reported. `SchemaFieldLike` gains `options` and `source` so a self-sourced option field can be checked while a space-sourced one is left alone, since its accepted values are not knowable from the schema.
- The link and table shapes the specs were rejecting are now accepted, with the corresponding spec and generated overlay updates.

## Drive-by fix

`stories pull --starts-with` now strips a leading slash from the prefix. A `full_slug` never starts with one and MAPI matches the prefix literally, so the documented `/en/blog/` form silently selected nothing.

## Related PRs

| PR | What it covers |
| --- | --- |
| #736 | `schema validate` and the shared validation layer, the base of this branch |
| **#737 (this one)** | `stories validate` and the content-validation work in `@storyblok/schema` |
| storyblok/storyblok-docs-platform#606 | Reference docs for both commands |
| #669 | The original combined PR, superseded by this split |

Fixes DX-452
