### PR TITLE
fix(cli): remove conditional isVitest references

### DIFF
--- a/packages/cli/src/commands/create/index.test.ts
+++ b/packages/cli/src/commands/create/index.test.ts
@@ -43,7 +43,6 @@ vi.mock('../../utils', async (importOriginal) => {
     requireAuthentication: vi.fn(),
     handleError: vi.fn(),
     toHumanReadable: vi.fn(),
-    isVitest: true,
   };
 });
 

--- a/packages/cli/src/commands/login/index.test.ts
+++ b/packages/cli/src/commands/login/index.test.ts
@@ -21,14 +21,6 @@ vi.mock('../../creds', () => ({
   removeAllCredentials: vi.fn(),
 }));
 
-vi.mock('../../utils', async () => {
-  const actualUtils = await vi.importActual('../../utils');
-  return {
-    ...actualUtils,
-    isVitestRunning: true,
-  };
-});
-
 vi.mock('@inquirer/prompts', () => ({
   input: vi.fn(),
   password: vi.fn(),

--- a/packages/cli/src/commands/types/generate/index.test.ts
+++ b/packages/cli/src/commands/types/generate/index.test.ts
@@ -36,14 +36,6 @@ vi.mock('../../components/push/actions', () => ({
   readComponentsFiles: vi.fn(),
 }));
 
-vi.mock('../../../utils', async () => {
-  const actualUtils = await vi.importActual('../../../utils');
-  return {
-    ...actualUtils,
-    isVitestRunning: true,
-  };
-});
-
 describe('types generate', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/cli/src/lib/ui/ui.ts
+++ b/packages/cli/src/lib/ui/ui.ts
@@ -3,8 +3,8 @@ import { MultiBar, Presets } from 'cli-progress';
 import { Spinner } from '@topcli/spinner';
 import { colorPalette } from '../../constants';
 import { DEFAULT_GLOBAL_CONFIG } from '../config/defaults';
+import { getActiveConfig } from '../config/store';
 import { capitalize } from '../../utils/format';
-import { isVitest } from '../../utils';
 
 interface InfoOptions {
   header?: boolean;
@@ -182,7 +182,7 @@ export class UI {
 
   createSpinner(title: string): CLISpinner {
     if (!this.enabled) { return noopSpinner; }
-    const spinner = new Spinner({ verbose: !isVitest });
+    const spinner = new Spinner({ verbose: getActiveConfig().verbose });
     spinner.stream = process.stderr;
     return spinner.start(title);
   }

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -18,5 +18,3 @@ export const __dirname = dirname(__filename);
 export function isRegion(value: RegionCode): value is RegionCode {
   return Object.values(regions).includes(value);
 }
-
-export const isVitest = process.env.VITEST === 'true';


### PR DESCRIPTION
## What

Removes all `isVitest` / `isVitestRunning` references from the CLI package — an antipattern that coupled production code to test-environment detection.

## Why

Test-environment guards in production code are an antipattern. The spinner verbosity should be controlled by the existing `--verbose` global config option, not by sniffing `process.env.VITEST`.

## Changes

- **`src/lib/ui/ui.ts`** — replaced `verbose: !isVitest` with `verbose: getActiveConfig().verbose`; swapped the `isVitest` import for `getActiveConfig` from the config store
- **`src/utils/index.ts`** — deleted the `isVitest` export entirely
- **`src/commands/create/index.test.ts`** — removed dead `isVitest: true` entry from the utils mock (UI is already fully mocked via `vi.mock('../../lib/ui')`)
- **`src/commands/login/index.test.ts`** — removed entire `vi.mock('../../utils')` block; the only entry was a misnamed `isVitestRunning: true` key that had no effect
- **`src/commands/types/generate/index.test.ts`** — same as above

## Behaviour

Spinner `verbose` is now `false` by default (matching `GlobalConfig.verbose`), meaning spinner frames are silent unless the user passes `--verbose`. In tests the default config is unchanged (`verbose: false`), so no `isVitest` guard is needed.

Fixes DX-533