### PR TITLE
fix(richtext): use discriminated union for MultilinkFieldValueRoot types

### DIFF
--- a/packages/richtext/package.json
+++ b/packages/richtext/package.json
@@ -162,6 +162,7 @@
       "generate:openapi": {
         "inputs": [
           "{projectRoot}/scripts/generate.ts",
+          "{projectRoot}/package.json",
           "openapiCodegen"
         ],
         "outputs": [

--- a/packages/richtext/src/generated/overlay/types.gen.ts
+++ b/packages/richtext/src/generated/overlay/types.gen.ts
@@ -415,38 +415,9 @@ export interface AssetFieldValueRoot {
 }
 
 /**
- * Multilink field type - link to internal stories, external URLs, emails, etc.
+ * Multilink field type - link to internal stories, external URLs, emails, or assets.
  */
-export interface MultilinkFieldValueRoot {
-  /**
-   * Identifies this as a multilink field
-   */
-  fieldtype: 'multilink';
-  /**
-   * UUID of the linked story (for internal links)
-   */
-  id: string;
-  /**
-   * URL for external links or email addresses
-   */
-  url: string;
-  /**
-   * Type of link
-   */
-  linktype: 'story' | 'url' | 'email' | 'asset';
-  /**
-   * Cached URL path for the linked story
-   */
-  cached_url: string;
-  /**
-   * Anchor/fragment identifier for the link
-   */
-  anchor?: string | null;
-  /**
-   * Link target attribute
-   */
-  target?: '_self' | '_blank' | null;
-}
+export type MultilinkFieldValueRoot = MultilinkFieldValueStoryLink | MultilinkFieldValueUrlLink | MultilinkFieldValueEmailLink | MultilinkFieldValueAssetLink;
 
 /**
  * Table field type - structured table data
@@ -456,8 +427,8 @@ export interface TableFieldValueRoot {
    * Table header cells
    */
   thead: Array<{
-    _uid: string;
-    component: '_table_head';
+    _uid?: string;
+    component?: '_table_head';
     /**
      * Header cell content
      */
@@ -467,14 +438,14 @@ export interface TableFieldValueRoot {
    * Table body rows
    */
   tbody: Array<{
-    _uid: string;
-    component: '_table_row';
+    _uid?: string;
+    component?: '_table_row';
     /**
      * Cells in this row
      */
     body?: Array<{
-      _uid: string;
-      component: '_table_col';
+      _uid?: string;
+      component?: '_table_col';
       /**
        * Cell content
        */
@@ -496,4 +467,87 @@ export interface PluginFieldValueRoot {
    */
   _uid?: string;
   [key: string]: unknown | string | undefined;
+}
+
+/**
+ * Link to an internal Storyblok story.
+ */
+export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
+  linktype: 'story';
+  /**
+   * Anchor/fragment identifier for the story link
+   */
+  anchor?: string | null;
+  /**
+   * Link relationship attribute
+   */
+  rel?: string;
+  /**
+   * Link title attribute
+   */
+  title?: string;
+} & {
+  [key: string]: string | null;
+};
+
+/**
+ * Link to an external URL.
+ */
+export type MultilinkFieldValueUrlLink = MultilinkFieldValueSharedLink & {
+  linktype: 'url';
+  /**
+   * Link relationship attribute
+   */
+  rel?: string;
+  /**
+   * Link title attribute
+   */
+  title?: string;
+} & {
+  [key: string]: string;
+};
+
+/**
+ * Link to an email address.
+ */
+export type MultilinkFieldValueEmailLink = MultilinkFieldValueSharedLink & {
+  linktype: 'email';
+  /**
+   * Email address
+   */
+  email?: string;
+};
+
+/**
+ * Link to a Storyblok asset.
+ */
+export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
+  linktype: 'asset';
+};
+
+export interface MultilinkFieldValueSharedLink {
+  /**
+   * Identifies this as a multilink field
+   */
+  fieldtype: 'multilink';
+  /**
+   * Type of link
+   */
+  linktype: string;
+  /**
+   * UUID of the linked story for internal links
+   */
+  id: string;
+  /**
+   * URL for external links
+   */
+  url: string;
+  /**
+   * Cached URL path for the linked story
+   */
+  cached_url: string;
+  /**
+   * Link target attribute
+   */
+  target?: '_self' | '_blank';
 }


### PR DESCRIPTION
## Summary

Fixes incorrect type definition for `MultilinkFieldValueRoot` in the richtext package generated overlay types.

### Changes

**`packages/richtext/src/generated/overlay/types.gen.ts`**
- Replaced the flat `MultilinkFieldValueRoot` interface with a proper discriminated union: `MultilinkFieldValueStoryLink | MultilinkFieldValueUrlLink | MultilinkFieldValueEmailLink | MultilinkFieldValueAssetLink`
- Each link variant now has its own narrowed type with link-type-specific fields (e.g. `anchor`, `rel`, `title` for story/url links; `email` for email links)
- Shared fields extracted into `MultilinkFieldValueSharedLink` base type
- Updated the doc comment to mention asset links (`emails, or assets`)
- Made `_uid` and `component` fields optional on table `thead`, `tbody`, and `body` cell entries to match actual API responses

**`packages/richtext/package.json`**
- Added `{projectRoot}/package.json` to `generate:openapi` NX task inputs so the cache is correctly invalidated when the package version changes

### Type of change
- [x] Bug fix (type definitions were incorrect/too loose)