### PR TITLE
chore(tools): bring all OpenAPI consumers up to date and stop partial regeneration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,10 @@ These sibling repos may not be available; ignore them if absent.
 
 ## OpenAPI codegen
 
-`tools/openapi-codegen/` owns OpenAPI spec fetching and the shared generator. Consumer packages commit their `src/generated/` output so external contributors can build without spec access and so type-relevant spec changes surface as reviewable diffs. The commit-generated-code rule applies to OpenAPI codegen output specifically, not all generated code in the repo! Read `tools/openapi-codegen/README.md` when working with OpenAPI specs.
+`tools/openapi-codegen/` owns OpenAPI spec fetching, the committed overlay specs in `tools/openapi-codegen/specs/`, and the shared generator. Consumer packages commit their `src/generated/` output so external contributors can build without spec access and so type-relevant spec changes surface as reviewable diffs. The commit-generated-code rule applies to OpenAPI codegen output specifically, not all generated code in the repo! Read `tools/openapi-codegen/README.md` when working with OpenAPI specs.
+
+- **IMPORTANT:** After changing anything under `tools/openapi-codegen/`, including the committed specs in `specs/`, regenerate **every** consumer with `pnpm nx run-many -t generate:openapi` and commit the resulting `packages/*/src/generated/` diff. Never regenerate only the package you are working on: the consumers export the same public types, so a partial regeneration makes them disagree, and nothing in CI catches it.
+- Editing `specs/` does not move `spec.lock`, so there is no lock diff to hint that regeneration is due.
 
 ## Architecture Decision Records
 

--- a/packages/capi-client/package.json
+++ b/packages/capi-client/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "scripts": {
-    "generate": "tsx scripts/generate.ts",
+    "generate:openapi": "tsx scripts/generate.ts",
     "build": "tsdown",
     "test": "vitest run",
     "test:types": "tsc --noEmit --skipLibCheck",
@@ -56,14 +56,14 @@
   },
   "nx": {
     "targets": {
-      "generate": {
+      "generate:openapi": {
         "inputs": [
           "{projectRoot}/scripts/generate.ts",
           "{projectRoot}/package.json",
           "openapiCodegen"
         ],
         "outputs": [
-          "{projectRoot}/src/generated/**"
+          "{projectRoot}/src/generated"
         ],
         "cache": true,
         "dependsOn": [

--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -808,8 +808,8 @@ export type TableFieldValueRoot = {
      * Table header cells
      */
     thead: Array<{
-        _uid: string;
-        component: '_table_head';
+        _uid?: string;
+        component?: '_table_head';
         /**
          * Header cell content
          */
@@ -819,14 +819,14 @@ export type TableFieldValueRoot = {
      * Table body rows
      */
     tbody: Array<{
-        _uid: string;
-        component: '_table_row';
+        _uid?: string;
+        component?: '_table_row';
         /**
          * Cells in this row
          */
         body?: Array<{
-            _uid: string;
-            component: '_table_col';
+            _uid?: string;
+            component?: '_table_col';
             /**
              * Cell content
              */
@@ -924,7 +924,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
     /**
      * Anchor/fragment identifier for the story link
      */
-    anchor?: string;
+    anchor?: string | null;
     /**
      * Link relationship attribute
      */
@@ -934,7 +934,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
      */
     title?: string;
 } & {
-    [key: string]: string;
+    [key: string]: string | null;
 };
 
 /**

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "generate": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/generate.ts",
+    "generate:openapi": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/generate.ts",
     "test": "vitest run",
     "test:e2e": "vitest run -c vitest.config.e2e.ts",
     "lint": "eslint .",
@@ -61,9 +61,10 @@
   },
   "nx": {
     "targets": {
-      "generate": {
+      "generate:openapi": {
         "inputs": [
           "{projectRoot}/scripts/generate.ts",
+          "{projectRoot}/package.json",
           "openapiCodegen"
         ],
         "outputs": [

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "generate": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/generate.ts",
+    "generate:openapi": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/generate.ts",
     "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -47,9 +47,10 @@
   },
   "nx": {
     "targets": {
-      "generate": {
+      "generate:openapi": {
         "inputs": [
           "{projectRoot}/scripts/generate.ts",
+          "{projectRoot}/package.json",
           "openapiCodegen"
         ],
         "outputs": [

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -808,8 +808,8 @@ export type TableFieldValueRoot = {
      * Table header cells
      */
     thead: Array<{
-        _uid: string;
-        component: '_table_head';
+        _uid?: string;
+        component?: '_table_head';
         /**
          * Header cell content
          */
@@ -819,14 +819,14 @@ export type TableFieldValueRoot = {
      * Table body rows
      */
     tbody: Array<{
-        _uid: string;
-        component: '_table_row';
+        _uid?: string;
+        component?: '_table_row';
         /**
          * Cells in this row
          */
         body?: Array<{
-            _uid: string;
-            component: '_table_col';
+            _uid?: string;
+            component?: '_table_col';
             /**
              * Cell content
              */
@@ -924,7 +924,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
     /**
      * Anchor/fragment identifier for the story link
      */
-    anchor?: string;
+    anchor?: string | null;
     /**
      * Link relationship attribute
      */
@@ -934,7 +934,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
      */
     title?: string;
 } & {
-    [key: string]: string;
+    [key: string]: string | null;
 };
 
 /**

--- a/packages/mapi-client/package.json
+++ b/packages/mapi-client/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "scripts": {
-    "generate": "tsx scripts/generate.ts",
+    "generate:openapi": "tsx scripts/generate.ts",
     "build": "tsdown",
     "test": "vitest run",
     "test:types": "tsc --noEmit --skipLibCheck",
@@ -55,14 +55,14 @@
   },
   "nx": {
     "targets": {
-      "generate": {
+      "generate:openapi": {
         "inputs": [
           "{projectRoot}/scripts/generate.ts",
           "{projectRoot}/package.json",
           "openapiCodegen"
         ],
         "outputs": [
-          "{projectRoot}/src/generated/**"
+          "{projectRoot}/src/generated"
         ],
         "cache": true,
         "dependsOn": [

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -808,8 +808,8 @@ export type TableFieldValueRoot = {
      * Table header cells
      */
     thead: Array<{
-        _uid: string;
-        component: '_table_head';
+        _uid?: string;
+        component?: '_table_head';
         /**
          * Header cell content
          */
@@ -819,14 +819,14 @@ export type TableFieldValueRoot = {
      * Table body rows
      */
     tbody: Array<{
-        _uid: string;
-        component: '_table_row';
+        _uid?: string;
+        component?: '_table_row';
         /**
          * Cells in this row
          */
         body?: Array<{
-            _uid: string;
-            component: '_table_col';
+            _uid?: string;
+            component?: '_table_col';
             /**
              * Cell content
              */
@@ -924,7 +924,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
     /**
      * Anchor/fragment identifier for the story link
      */
-    anchor?: string;
+    anchor?: string | null;
     /**
      * Link relationship attribute
      */
@@ -934,7 +934,7 @@ export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
      */
     title?: string;
 } & {
-    [key: string]: string;
+    [key: string]: string | null;
 };
 
 /**

--- a/packages/richtext/package.json
+++ b/packages/richtext/package.json
@@ -162,6 +162,7 @@
       "generate:openapi": {
         "inputs": [
           "{projectRoot}/scripts/generate.ts",
+          "{projectRoot}/package.json",
           "openapiCodegen"
         ],
         "outputs": [

--- a/packages/richtext/src/generated/overlay/types.gen.ts
+++ b/packages/richtext/src/generated/overlay/types.gen.ts
@@ -415,38 +415,9 @@ export interface AssetFieldValueRoot {
 }
 
 /**
- * Multilink field type - link to internal stories, external URLs, emails, etc.
+ * Multilink field type - link to internal stories, external URLs, emails, or assets.
  */
-export interface MultilinkFieldValueRoot {
-  /**
-   * Identifies this as a multilink field
-   */
-  fieldtype: 'multilink';
-  /**
-   * UUID of the linked story (for internal links)
-   */
-  id: string;
-  /**
-   * URL for external links or email addresses
-   */
-  url: string;
-  /**
-   * Type of link
-   */
-  linktype: 'story' | 'url' | 'email' | 'asset';
-  /**
-   * Cached URL path for the linked story
-   */
-  cached_url: string;
-  /**
-   * Anchor/fragment identifier for the link
-   */
-  anchor?: string | null;
-  /**
-   * Link target attribute
-   */
-  target?: '_self' | '_blank' | null;
-}
+export type MultilinkFieldValueRoot = MultilinkFieldValueStoryLink | MultilinkFieldValueUrlLink | MultilinkFieldValueEmailLink | MultilinkFieldValueAssetLink;
 
 /**
  * Table field type - structured table data
@@ -456,8 +427,8 @@ export interface TableFieldValueRoot {
    * Table header cells
    */
   thead: Array<{
-    _uid: string;
-    component: '_table_head';
+    _uid?: string;
+    component?: '_table_head';
     /**
      * Header cell content
      */
@@ -467,14 +438,14 @@ export interface TableFieldValueRoot {
    * Table body rows
    */
   tbody: Array<{
-    _uid: string;
-    component: '_table_row';
+    _uid?: string;
+    component?: '_table_row';
     /**
      * Cells in this row
      */
     body?: Array<{
-      _uid: string;
-      component: '_table_col';
+      _uid?: string;
+      component?: '_table_col';
       /**
        * Cell content
        */
@@ -496,4 +467,87 @@ export interface PluginFieldValueRoot {
    */
   _uid?: string;
   [key: string]: unknown | string | undefined;
+}
+
+/**
+ * Link to an internal Storyblok story.
+ */
+export type MultilinkFieldValueStoryLink = MultilinkFieldValueSharedLink & {
+  linktype: 'story';
+  /**
+   * Anchor/fragment identifier for the story link
+   */
+  anchor?: string | null;
+  /**
+   * Link relationship attribute
+   */
+  rel?: string;
+  /**
+   * Link title attribute
+   */
+  title?: string;
+} & {
+  [key: string]: string | null;
+};
+
+/**
+ * Link to an external URL.
+ */
+export type MultilinkFieldValueUrlLink = MultilinkFieldValueSharedLink & {
+  linktype: 'url';
+  /**
+   * Link relationship attribute
+   */
+  rel?: string;
+  /**
+   * Link title attribute
+   */
+  title?: string;
+} & {
+  [key: string]: string;
+};
+
+/**
+ * Link to an email address.
+ */
+export type MultilinkFieldValueEmailLink = MultilinkFieldValueSharedLink & {
+  linktype: 'email';
+  /**
+   * Email address
+   */
+  email?: string;
+};
+
+/**
+ * Link to a Storyblok asset.
+ */
+export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
+  linktype: 'asset';
+};
+
+export interface MultilinkFieldValueSharedLink {
+  /**
+   * Identifies this as a multilink field
+   */
+  fieldtype: 'multilink';
+  /**
+   * Type of link
+   */
+  linktype: string;
+  /**
+   * UUID of the linked story for internal links
+   */
+  id: string;
+  /**
+   * URL for external links
+   */
+  url: string;
+  /**
+   * Cached URL path for the linked story
+   */
+  cached_url: string;
+  /**
+   * Link target attribute
+   */
+  target?: '_self' | '_blank';
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -41,7 +41,7 @@
     "dist"
   ],
   "scripts": {
-    "generate": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/generate.ts",
+    "generate:openapi": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/generate.ts",
     "build": "tsdown",
     "test": "vitest run",
     "test:types": "tsc --noEmit --skipLibCheck",
@@ -65,7 +65,7 @@
   },
   "nx": {
     "targets": {
-      "generate": {
+      "generate:openapi": {
         "inputs": [
           "{projectRoot}/scripts/generate.ts",
           "{projectRoot}/package.json",

--- a/tools/openapi-codegen/README.md
+++ b/tools/openapi-codegen/README.md
@@ -1,6 +1,17 @@
 # @storyblok/openapi-codegen
 
-Internal workspace package. It owns the OpenAPI spec cache and the shared `@hey-api/openapi-ts` generator invocation used by `@storyblok/api-client`, `@storyblok/management-api-client`, and `@storyblok/schema`. Not published.
+Internal workspace package. It owns the OpenAPI spec cache, the committed overlay specs, and the shared `@hey-api/openapi-ts` generator invocation. Not published.
+
+Every package with a `generate:openapi` target is a consumer. Today that is `@storyblok/api-client`, `@storyblok/management-api-client`, `@storyblok/schema`, `@storyblok/live-preview`, `@storyblok/experiments`, and `@storyblok/richtext`. Do not maintain that list by hand anywhere: `pnpm nx run-many -t generate:openapi` resolves it from the target name, so a new consumer is picked up automatically.
+
+## Two spec sources
+
+Generation reads from two places, and both of them can change the generated output:
+
+- `.openapi-cache/` holds the upstream specs fetched from the private `storyblok/openapi-wdx` repo. It is git-ignored, pinned by `spec.lock`, and populated by `pull`.
+- `specs/` holds this repo's own overlay specs, including `specs/overlay.openapi.yaml` and the shared field-type shapes under `specs/shared/`. It **is** committed, so anyone can edit it in a normal PR without spec access.
+
+The second source is the easier one to get wrong. Editing a file under `specs/` changes the generated types for every consumer even though `spec.lock` does not move, so there is no lock diff to remind you to regenerate.
 
 ## Workflow
 
@@ -19,26 +30,32 @@ Both `pull` commands require `gh auth status`. Specs live in the private `storyb
 
 `generate` verifies the cache content hash against `spec.lock` before running and fails fast on a mismatch, so a stale cache left over from a different SHA can never silently produce divergent output. Run `pull` to resync if it reports a mismatch.
 
-After a `pull:update`, regenerate consumers and commit the diff:
+## Regenerate consumers
+
+**Whenever you change anything the generator reads, regenerate every consumer in the same PR.** That means a `pull:update`, an edit under `specs/`, and a change to `src/` or `templates/`. Regenerating only the package you happen to be working on leaves the others behind, and because these packages export the same public types, the surface then disagrees across packages: a value `@storyblok/schema` accepts fails to compile against `@storyblok/management-api-client`.
 
 ```sh
-pnpm nx run-many -t generate --projects=@storyblok/api-client,@storyblok/management-api-client,@storyblok/schema
-git add tools/openapi-codegen/spec.lock packages/*/src/generated
+pnpm nx run-many -t generate:openapi
+git add tools/openapi-codegen packages/*/src/generated
 ```
 
-To regenerate a single consumer, run its `generate` target directly:
+Regenerating a consumer that needs no update is free, so always run the whole set rather than reasoning about which packages a spec change reaches.
+
+To regenerate a single consumer while iterating, run its target directly. Run the full set again before you commit:
 
 ```sh
-pnpm nx run @storyblok/live-preview:generate
+pnpm nx run @storyblok/live-preview:generate:openapi
 ```
 
-## Why specs are not committed
+Nx caches this target and restores its declared outputs, so a regeneration can be silently replaced by a cached copy of the previous output. Pass `--skip-nx-cache` if the diff looks empty when you expect one, and confirm the working tree before committing.
 
-The bundled OpenAPI specs are git-ignored (`.openapi-cache/` is local-only). The upstream repo is private, and checking specs into this repo would expose them. External contributors can still build the repo without spec access because each consumer commits its own `src/generated/` output.
+## Why the upstream cache is not committed
+
+The upstream repo is private, and checking its specs into this repo would expose them, so `.openapi-cache/` stays local-only. External contributors can still build the repo without spec access because each consumer commits its own `src/generated/` output. The overlay specs under `specs/` are ours, so they are committed and reviewable.
 
 ## Why generated code IS committed
 
-Two reasons. First, external contributor access: people without `storyblok/openapi-wdx` access can still run `pnpm install && pnpm build` without fetching specs. Second, diff visibility: a spec update produces a real diff in the consumer packages' `src/generated/` only when something type-relevant changed. A PR that touches `spec.lock` with no consumer diff signals irrelevant spec churn. A PR that touches `spec.lock` and produces a consumer diff signals a real surface-area change worth reviewing.
+Two reasons. First, external contributor access: people without `storyblok/openapi-wdx` access can still run `pnpm install && pnpm build` without fetching specs. Second, diff visibility: a spec update produces a real diff in the consumer packages' `src/generated/` only when something type-relevant changed. A PR that touches `spec.lock` or `specs/` with no consumer diff signals irrelevant churn. A PR that touches either and produces a consumer diff signals a real surface-area change worth reviewing.
 
 ## Version policy
 
@@ -46,7 +63,9 @@ Pinned at `0.0.1`. Updates here are chores, so consumers never get a dependency 
 
 ## CI contract
 
-CI never runs `pull`, `pull:update`, or any consumer `generate` target. CI builds from committed `src/generated/`. If `spec.lock` changes in a PR and the consumer generated code is stale, the resulting diff mismatch is reviewer-visible.
+CI never runs `pull`, `pull:update`, or any consumer `generate:openapi` target, because generation needs the private spec cache. CI builds from committed `src/generated/`.
+
+Nothing in CI can therefore prove that the committed output is current. A PR that edits `specs/` and regenerates only some consumers passes every check, and the packages left behind stay stale until someone regenerates them for an unrelated reason. Reviewers are the only guard: when a PR touches `spec.lock` or `specs/`, check that `packages/*/src/generated/` changed for every consumer the edit reaches, or that the author states why none of them do.
 
 ## spec.lock
 


### PR DESCRIPTION
`@storyblok/api-client`, `@storyblok/management-api-client`, `@storyblok/live-preview`, and `@storyblok/richtext` were serving stale OpenAPI output, so the same public types disagreed across packages: a multilink with `anchor: null`, or a table cell without `_uid`, validated fine through `@storyblok/schema` but failed to compile against `@storyblok/management-api-client`.

#737 widened those shapes in the committed overlay specs (`anchor` and custom link attributes accept `null`, `_uid` and `component` are optional on table cells) and regenerated one of six consumers. #741 caught the `@storyblok/richtext` half of the fallout; this PR closes the rest and removes the way the drift happened.

## Regenerated output

Output of `pnpm nx run-many -t generate:openapi` at the pinned spec, no hand edits. `@storyblok/schema` and `@storyblok/experiments` were already current, which confirms the stale set was exactly these four.

## Why it drifted, and what changes

Editing `tools/openapi-codegen/specs/` does not move `spec.lock`, and CI cannot regenerate without the private spec cache, so a partial regeneration passes every check and the packages left behind stay stale until something unrelated touches them. The instructions actively pointed the wrong way:

- The documented regenerate command hardcoded three of the six consumers, and `@storyblok/richtext`'s target was not even named `generate`, so the command could not reach it.
- Regeneration was framed as a step you take after a `pull:update`, not after editing `specs/`, which is what actually happened.
- A section titled "Why specs are not committed" was wrong. `tools/openapi-codegen/specs/` is committed; only the upstream `.openapi-cache/` is git-ignored. A reader would conclude spec edits need private access and cannot be what they are touching.

So:

- Every consumer's codegen target is now named `generate:openapi`, matching what `@storyblok/richtext` already called its OpenAPI generator and keeping it distinct from that package's separate static generator. `pnpm nx run-many -t generate:openapi` resolves the consumer set from the target name, so the command cannot miss a package and no list needs hand-maintaining. Nothing outside the README referenced the old target names.
- The six targets' `inputs` and `outputs` are normalized. Three were missing `{projectRoot}/package.json` and two declared `src/generated/**` against the others' `src/generated`.
- `AGENTS.md` gains the rule as an IMPORTANT bullet: after changing anything under `tools/openapi-codegen/`, regenerate every consumer and commit the diff. `CLAUDE.md` is a symlink to it.
- The README gets a "Two spec sources" section separating the private cache from the committed overlay, the corrected heading, the regenerate-everything rule with its reason, and a CI-contract section that says plainly that CI cannot prove the committed output is current, so reviewers are the only guard.
- The nx caching gotcha is documented too: this target's cached outputs get restored over a fresh regeneration, so an empty diff can be a lie. Use `--skip-nx-cache` and check the working tree before committing.

## Not included

No CI guard. Generation needs the private spec cache, so the only feasible check is a heuristic: fail when a PR touches `spec.lock` or `specs/` without any `packages/*/src/generated/` change. That false-positives on comment-only spec edits, so it is left as reviewer guidance in the README instead. Happy to add it if you want the tradeoff.
