### PR TITLE
fix(js-client): strip version param from non-CDN requests

### DIFF
--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -2096,4 +2096,32 @@ describe('storyblokClient', () => {
       vi.doMock('../src/sbFetch');
     }, 3000);
   });
+
+  describe('version param on non-CDN URLs', () => {
+    it('strips version from params when calling a Management API endpoint', async () => {
+      vi.doUnmock('../src/sbFetch');
+      const { default: RealSbFetch } = await import('./sbFetch');
+
+      const capturedUrls: string[] = [];
+      const mockFetch = vi.fn((url: string): Promise<Response> => {
+        capturedUrls.push(url);
+        return Promise.resolve(
+          new Response(JSON.stringify({ story: { id: 123 } }), { status: 200 }),
+        );
+      });
+
+      const mapiClient = new StoryblokClient({ oauthToken: 'test-management-token' });
+      (mapiClient as any).client = new RealSbFetch({
+        baseURL: 'https://mapi.storyblok.com/v1',
+        headers: new Headers(),
+        fetch: mockFetch as any,
+      });
+
+      await mapiClient.get('spaces/123/stories/456', { version: 'draft' } as any);
+
+      expect(capturedUrls[0]).not.toContain('version');
+
+      vi.doMock('../src/sbFetch');
+    });
+  });
 });

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -241,9 +241,12 @@ export class Storyblok {
     }
     const url = `/${slug}`;
 
-    // Only add version parameter for CDN URLs
+    // Only add/keep version parameter for CDN URLs — strip it from MAPI requests
     if (isCDNUrl(url)) {
       params.version = params.version || this.version;
+    }
+    else if (params.version) {
+      delete params.version;
     }
 
     const query = this.factoryParamOptions(url, params);


### PR DESCRIPTION
## What

The `version` parameter is CDN-only. When passed to a Management API endpoint it was silently forwarded, causing the backend to return a confusing `404 This record could not be found` with no indication of why.

## How

In `get()`, when the URL is not a CDN URL and `params.version` is set, it is now deleted before the request is made.

## Test

Added a unit test that confirms `version` is stripped from the URL when calling a MAPI endpoint.

Fixes #433