### PR TITLE
chore(js-client): apply pending formatting fixes

### DIFF
--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -2110,10 +2110,10 @@ describe("storyblokClient", () => {
     }, 3000);
   });
 
-  describe('version param on non-CDN URLs', () => {
-    it('strips version from params when calling a Management API endpoint', async () => {
-      vi.doUnmock('../src/sbFetch');
-      const { default: RealSbFetch } = await import('./sbFetch');
+  describe("version param on non-CDN URLs", () => {
+    it("strips version from params when calling a Management API endpoint", async () => {
+      vi.doUnmock("../src/sbFetch");
+      const { default: RealSbFetch } = await import("./sbFetch");
 
       const capturedUrls: string[] = [];
       const mockFetch = vi.fn((url: string): Promise<Response> => {
@@ -2123,18 +2123,18 @@ describe("storyblokClient", () => {
         );
       });
 
-      const mapiClient = new StoryblokClient({ oauthToken: 'test-management-token' });
+      const mapiClient = new StoryblokClient({ oauthToken: "test-management-token" });
       (mapiClient as any).client = new RealSbFetch({
-        baseURL: 'https://mapi.storyblok.com/v1',
+        baseURL: "https://mapi.storyblok.com/v1",
         headers: new Headers(),
         fetch: mockFetch as any,
       });
 
-      await mapiClient.get('spaces/123/stories/456', { version: 'draft' } as any);
+      await mapiClient.get("spaces/123/stories/456", { version: "draft" } as any);
 
-      expect(capturedUrls[0]).not.toContain('version');
+      expect(capturedUrls[0]).not.toContain("version");
 
-      vi.doMock('../src/sbFetch');
+      vi.doMock("../src/sbFetch");
     });
   });
 });

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -239,8 +239,7 @@ export class Storyblok {
     // Only add/keep version parameter for CDN URLs — strip it from MAPI requests
     if (isCDNUrl(url)) {
       params.version = params.version || this.version;
-    }
-    else if (params.version) {
+    } else if (params.version) {
       delete params.version;
     }
 
@@ -590,7 +589,7 @@ export class Storyblok {
     links.forEach((story: ISbStoryData | any) => {
       this.links[resolveId][story.uuid] = {
         ...story,
-        ...{ _stopResolving: true },
+        _stopResolving: true,
       };
     });
   }
@@ -640,7 +639,7 @@ export class Storyblok {
       relations.forEach((story: ISbStoryData) => {
         this.relations[resolveId][story.uuid] = {
           ...story,
-          ...{ _stopResolving: true },
+          _stopResolving: true,
         };
       });
     }


### PR DESCRIPTION
## Summary

Applies the two pending formatting fixes in `storyblok-js-client` that were left uncommitted:

- **`src/index.ts`**: Normalize brace style — move `else if` to the same line as the closing brace
- **`src/index.test.ts`**: Normalize string quotes — single quotes → double quotes

No logic changes.