### PR TITLE
fix(experiments): rename adapter factories to create* names

### DIFF
--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -34,8 +34,8 @@
 - **Dependency-free**: The core ships with zero runtime dependencies
 - **Composable**: `assignVariant`, `resolveExperiment`, and `createConversion` are usable on their
   own, or bind them together with the `createExperiments` factory
-- **Pluggable adapters**: Deliver exposure and conversion events to any sink, or use the built-in
-  `fetchAdapter`
+- **Pluggable adapters**: Deliver exposure and conversion events to any sink, or build one with the
+  built-in `createFetchAdapter` factory
 
 ## Documentation
 

--- a/packages/experiments/src/adapters.test.ts
+++ b/packages/experiments/src/adapters.test.ts
@@ -2,7 +2,7 @@ import type { ExperimentEvent } from "./types";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { beaconAdapter, fetchAdapter } from "./adapters";
+import { createBeaconAdapter, createFetchAdapter } from "./adapters";
 
 const server = setupServer();
 
@@ -18,7 +18,7 @@ const event: ExperimentEvent = {
   name: "signup",
 };
 
-describe("fetchAdapter", () => {
+describe("createFetchAdapter", () => {
   it("sends the event as a JSON POST to the configured url", async () => {
     let captured: { body: unknown; contentType: string | null } | undefined;
     server.use(
@@ -28,7 +28,7 @@ describe("fetchAdapter", () => {
       }),
     );
 
-    await fetchAdapter("https://sink.example/events")(event);
+    await createFetchAdapter("https://sink.example/events")(event);
 
     expect(captured?.body).toEqual(event);
     expect(captured?.contentType).toContain("application/json");
@@ -43,7 +43,7 @@ describe("fetchAdapter", () => {
       }),
     );
 
-    await fetchAdapter("https://sink.example/events", {
+    await createFetchAdapter("https://sink.example/events", {
       headers: { authorization: "Bearer token" },
     })(event);
 
@@ -57,7 +57,7 @@ describe("fetchAdapter", () => {
       return new Response(null, { status: 204 });
     }) as typeof globalThis.fetch;
 
-    await fetchAdapter("https://sink.example/events", { fetch: fakeFetch })(event);
+    await createFetchAdapter("https://sink.example/events", { fetch: fakeFetch })(event);
 
     expect(calls).toEqual(["https://sink.example/events"]);
   });
@@ -67,23 +67,23 @@ describe("fetchAdapter", () => {
       http.post("https://sink.example/events", () => new HttpResponse(null, { status: 500 })),
     );
 
-    await expect(fetchAdapter("https://sink.example/events")(event)).rejects.toThrow(/500/);
+    await expect(createFetchAdapter("https://sink.example/events")(event)).rejects.toThrow(/500/);
   });
 
   it("throws at construction for a relative url with no base", () => {
     // Server-side `fetch` has no origin to resolve against, so a relative path
     // fails on every delivery — where `onError` swallows it. Fail loudly here.
-    expect(() => fetchAdapter("/api/experiments")).toThrow(/cannot resolve/i);
+    expect(() => createFetchAdapter("/api/experiments")).toThrow(/cannot resolve/i);
   });
 
   it("names the offending url and the way out when it cannot resolve", () => {
-    expect(() => fetchAdapter("/api/experiments")).toThrow(/\/api\/experiments/);
-    expect(() => fetchAdapter("/api/experiments")).toThrow(/baseUrl/);
+    expect(() => createFetchAdapter("/api/experiments")).toThrow(/\/api\/experiments/);
+    expect(() => createFetchAdapter("/api/experiments")).toThrow(/baseUrl/);
   });
 
   it("accepts any absolute url", () => {
-    expect(() => fetchAdapter("https://sink.example/events")).not.toThrow();
-    expect(() => fetchAdapter("http://localhost:3000/api/experiments")).not.toThrow();
+    expect(() => createFetchAdapter("https://sink.example/events")).not.toThrow();
+    expect(() => createFetchAdapter("http://localhost:3000/api/experiments")).not.toThrow();
   });
 
   it("resolves a relative url against baseUrl", async () => {
@@ -95,7 +95,9 @@ describe("fetchAdapter", () => {
       }),
     );
 
-    await fetchAdapter("/api/experiments", { baseUrl: "https://sink.example/pages/home" })(event);
+    await createFetchAdapter("/api/experiments", { baseUrl: "https://sink.example/pages/home" })(
+      event,
+    );
 
     expect(captured).toBe("hit");
   });
@@ -107,7 +109,7 @@ describe("fetchAdapter", () => {
       return new Response(null, { status: 204 });
     }) as typeof globalThis.fetch;
 
-    await fetchAdapter("https://sink.example/events", {
+    await createFetchAdapter("https://sink.example/events", {
       baseUrl: "https://other.example",
       fetch: fakeFetch,
     })(event);
@@ -126,7 +128,7 @@ describe("fetchAdapter", () => {
     }) as typeof globalThis.fetch;
 
     try {
-      await fetchAdapter("/api/experiments", { fetch: fakeFetch })(event);
+      await createFetchAdapter("/api/experiments", { fetch: fakeFetch })(event);
     } finally {
       vi.unstubAllGlobals();
     }
@@ -135,11 +137,11 @@ describe("fetchAdapter", () => {
   });
 });
 
-describe("beaconAdapter", () => {
+describe("createBeaconAdapter", () => {
   it("posts the serialized event to the url", async () => {
     const sendBeacon = vi.fn<(url: string, body: Blob) => boolean>(() => true);
 
-    beaconAdapter("/api/experiments", { sendBeacon })(event);
+    createBeaconAdapter("/api/experiments", { sendBeacon })(event);
 
     const [target, body] = sendBeacon.mock.calls[0];
     expect(target).toBe("/api/experiments");
@@ -149,7 +151,7 @@ describe("beaconAdapter", () => {
   it("sends the payload as application/json so a JSON endpoint accepts it", () => {
     const sendBeacon = vi.fn<(url: string, body: Blob) => boolean>(() => true);
 
-    beaconAdapter("/api/experiments", { sendBeacon })(event);
+    createBeaconAdapter("/api/experiments", { sendBeacon })(event);
 
     expect(sendBeacon.mock.calls[0][1].type).toBe("application/json");
   });
@@ -157,7 +159,7 @@ describe("beaconAdapter", () => {
   it("honors a contentType override, for a cross-origin sink avoiding a preflight", () => {
     const sendBeacon = vi.fn<(url: string, body: Blob) => boolean>(() => true);
 
-    beaconAdapter("/api/experiments", { sendBeacon, contentType: "text/plain" })(event);
+    createBeaconAdapter("/api/experiments", { sendBeacon, contentType: "text/plain" })(event);
 
     expect(sendBeacon.mock.calls[0][1].type).toBe("text/plain");
   });
@@ -165,17 +167,17 @@ describe("beaconAdapter", () => {
   it("accepts a relative url", () => {
     const sendBeacon = vi.fn<(url: string, body: Blob) => boolean>(() => true);
 
-    expect(() => beaconAdapter("/api/experiments", { sendBeacon })(event)).not.toThrow();
+    expect(() => createBeaconAdapter("/api/experiments", { sendBeacon })(event)).not.toThrow();
   });
 
   it("throws when the browser refuses to queue the payload", () => {
     const sendBeacon = vi.fn<(url: string, body: Blob) => boolean>(() => false);
 
-    expect(() => beaconAdapter("/api/experiments", { sendBeacon })(event)).toThrow(/queue/i);
+    expect(() => createBeaconAdapter("/api/experiments", { sendBeacon })(event)).toThrow(/queue/i);
   });
 
   it("throws a clear error when sendBeacon is unavailable", () => {
-    expect(() => beaconAdapter("/api/experiments", { sendBeacon: undefined })(event)).toThrow(
+    expect(() => createBeaconAdapter("/api/experiments", { sendBeacon: undefined })(event)).toThrow(
       /sendBeacon/,
     );
   });
@@ -183,6 +185,15 @@ describe("beaconAdapter", () => {
   it("returns nothing so the factory treats delivery as synchronous", () => {
     const sendBeacon = vi.fn<(url: string, body: Blob) => boolean>(() => true);
 
-    expect(beaconAdapter("/api/experiments", { sendBeacon })(event)).toBeUndefined();
+    expect(createBeaconAdapter("/api/experiments", { sendBeacon })(event)).toBeUndefined();
+  });
+});
+
+describe("deprecated aliases", () => {
+  it("keeps fetchAdapter and beaconAdapter pointing at the renamed factories", async () => {
+    const { beaconAdapter, fetchAdapter } = await import("./adapters");
+
+    expect(fetchAdapter).toBe(createFetchAdapter);
+    expect(beaconAdapter).toBe(createBeaconAdapter);
   });
 });

--- a/packages/experiments/src/adapters.ts
+++ b/packages/experiments/src/adapters.ts
@@ -2,7 +2,7 @@ import type { Adapter, ExperimentEvent } from "./types";
 
 export type { Adapter } from "./types";
 
-export interface FetchAdapterOptions {
+export interface CreateFetchAdapterOptions {
   /** Override the `fetch` implementation (e.g. for testing or a custom client). */
   fetch?: typeof globalThis.fetch;
   /** Extra headers merged onto the request. */
@@ -14,12 +14,12 @@ export interface FetchAdapterOptions {
   baseUrl?: string;
 }
 
-export interface BeaconAdapterOptions {
+export interface CreateBeaconAdapterOptions {
   /** Override `navigator.sendBeacon` (e.g. for testing). */
   sendBeacon?: (url: string, body: Blob) => boolean;
   /**
    * Content type the beacon is sent with. Defaults to `application/json`, which
-   * matches `fetchAdapter` so one endpoint can parse both.
+   * matches `createFetchAdapter` so one endpoint can parse both.
    *
    * `application/json` is not a CORS-safelisted content type, so a cross-origin
    * beacon is preflighted — and a preflight fired during page unload often does
@@ -43,15 +43,15 @@ function resolveTarget(url: string, baseUrl?: string): string {
     return new URL(url, base).toString();
   } catch {
     throw new Error(
-      `fetchAdapter: cannot resolve "${url}". Server-side fetch has no origin to resolve a relative path against — pass an absolute url, or set \`baseUrl\` to the incoming request url.`,
+      `createFetchAdapter: cannot resolve "${url}". Server-side fetch has no origin to resolve a relative path against — pass an absolute url, or set \`baseUrl\` to the incoming request url.`,
     );
   }
 }
 
 /**
- * An adapter that POSTs each event as JSON to `url`. This is the generic sink
- * for any HTTP endpoint. For other destinations, pass your own `Adapter`
- * function instead.
+ * Creates an `Adapter` that POSTs each event as JSON to `url`. This is the
+ * generic sink for any HTTP endpoint. For other destinations, pass your own
+ * `Adapter` function instead.
  *
  * `fetch` only rejects on a network failure, so a non-2xx response is turned
  * into a thrown error to make delivery failures observable (surfaced through
@@ -67,11 +67,11 @@ function resolveTarget(url: string, baseUrl?: string): string {
  * url on the server constructed fine and then failed on every delivery into
  * `onError`. Two consequences worth knowing:
  *
- * - A module-scope `fetchAdapter('/api/events')` in a module that both server and
- *   client code import now throws on the server, even when only the browser ever
- *   delivers through it. Pass `baseUrl`, use an absolute url, or build the
- *   adapter where it is used. On the client, prefer `beaconAdapter`, which takes
- *   a relative url and survives page unload.
+ * - A module-scope `createFetchAdapter('/api/events')` in a module that both
+ *   server and client code import now throws on the server, even when only the
+ *   browser ever delivers through it. Pass `baseUrl`, use an absolute url, or
+ *   build the adapter where it is used. On the client, prefer
+ *   `createBeaconAdapter`, which takes a relative url and survives page unload.
  * - In a browser the url is resolved once, at construction, against the page that
  *   was current then. Root-relative paths (`/api/events`) are unaffected; a
  *   path-relative one (`api/events`) keeps resolving against that first page
@@ -80,7 +80,7 @@ function resolveTarget(url: string, baseUrl?: string): string {
  * Pointing this at your own deployment costs an extra invocation per event; for
  * a same-deployment sink, pass a plain function as the adapter instead.
  */
-export function fetchAdapter(url: string, options: FetchAdapterOptions = {}): Adapter {
+export function createFetchAdapter(url: string, options: CreateFetchAdapterOptions = {}): Adapter {
   const { fetch = globalThis.fetch, headers, baseUrl } = options;
   const target = resolveTarget(url, baseUrl);
   return async (event: ExperimentEvent) => {
@@ -91,7 +91,7 @@ export function fetchAdapter(url: string, options: FetchAdapterOptions = {}): Ad
     });
     if (!response.ok) {
       throw new Error(
-        `fetchAdapter: POST ${target} failed with ${response.status} ${response.statusText}`,
+        `createFetchAdapter: POST ${target} failed with ${response.status} ${response.statusText}`,
       );
     }
     return response;
@@ -99,32 +99,61 @@ export function fetchAdapter(url: string, options: FetchAdapterOptions = {}): Ad
 }
 
 /**
- * A browser adapter that queues each event with `navigator.sendBeacon`. The
- * beacon survives page unload, so it works on a link or a form submit as well
+ * Creates a browser `Adapter` that queues each event with
+ * `navigator.sendBeacon`. The beacon survives page unload, so it works on a link or a form submit as well
  * as a button, where a `fetch` would be cancelled by the navigation.
  *
  * Delivery is fire-and-forget: the browser reports only whether it accepted the
  * payload for sending, not whether it arrived.
  *
  * The event is sent as a `Blob` rather than a string so the request carries
- * `content-type: application/json`, the same as `fetchAdapter`. A bare string
+ * `content-type: application/json`, the same as `createFetchAdapter`. A bare string
  * would be sent as `text/plain`, which a JSON-only endpoint rejects. See
  * `contentType` for the cross-origin caveat that comes with it.
  */
-export function beaconAdapter(url: string, options: BeaconAdapterOptions = {}): Adapter {
+export function createBeaconAdapter(
+  url: string,
+  options: CreateBeaconAdapterOptions = {},
+): Adapter {
   const { contentType = "application/json" } = options;
   return (event: ExperimentEvent): void => {
     const sendBeacon =
       options.sendBeacon ?? globalThis.navigator?.sendBeacon?.bind(globalThis.navigator);
     if (!sendBeacon) {
       throw new Error(
-        "beaconAdapter: navigator.sendBeacon is unavailable. Use it in a browser, or pass `fetchAdapter` on the server.",
+        "createBeaconAdapter: navigator.sendBeacon is unavailable. Use it in a browser, or pass `createFetchAdapter` on the server.",
       );
     }
     if (!sendBeacon(url, new Blob([JSON.stringify(event)], { type: contentType }))) {
       throw new Error(
-        `beaconAdapter: the browser refused to queue the event for ${url}, most likely because the payload exceeds its beacon size limit.`,
+        `createBeaconAdapter: the browser refused to queue the event for ${url}, most likely because the payload exceeds its beacon size limit.`,
       );
     }
   };
 }
+
+/**
+ * @deprecated Renamed to `CreateFetchAdapterOptions`, matching the renamed
+ * factory. Kept for backward compatibility, removed in the next major.
+ */
+export type FetchAdapterOptions = CreateFetchAdapterOptions;
+
+/**
+ * @deprecated Renamed to `CreateBeaconAdapterOptions`, matching the renamed
+ * factory. Kept for backward compatibility, removed in the next major.
+ */
+export type BeaconAdapterOptions = CreateBeaconAdapterOptions;
+
+/**
+ * @deprecated Renamed to `createFetchAdapter`, which reflects that it builds an
+ * `Adapter` rather than being one. This alias is kept for backward
+ * compatibility and will be removed in the next major.
+ */
+export const fetchAdapter = createFetchAdapter;
+
+/**
+ * @deprecated Renamed to `createBeaconAdapter`, which reflects that it builds an
+ * `Adapter` rather than being one. This alias is kept for backward
+ * compatibility and will be removed in the next major.
+ */
+export const beaconAdapter = createBeaconAdapter;

--- a/packages/experiments/src/types.ts
+++ b/packages/experiments/src/types.ts
@@ -64,7 +64,9 @@ export type Exposure = ExperimentEvent & { type: "exposure" };
 export type Conversion = ExperimentEvent & { type: "conversion" };
 
 /**
- * A sink for experiment events. Bring your own, or use `fetchAdapter`.
+ * A sink for experiment events. Bring your own, or build one with an adapter
+ * factory such as `createFetchAdapter`.
+ *
  * Adapters can be sync or async: return a promise so callers, and the
  * factory's `flush` and `waitUntil`, can await delivery.
  */


### PR DESCRIPTION
The package uses "adapter" for two different things. An adapter is `(event) => unknown` (the `Adapter` type). The functions exported from `@storyblok/experiments/adapters` are `(config) => Adapter` — factories, not adapters. The names, the JSDoc ("An adapter that POSTs each event as JSON"), and the docs site all blurred the two, which is confusing when you follow a symbol to its definition.

## What

- `fetchAdapter` → `createFetchAdapter`, `beaconAdapter` → `createBeaconAdapter`. The `create*` prefix is what the package already uses for `createExperiments` and `createConversion`, so this makes the adapters entrypoint consistent with the rest of the API rather than introducing a new convention.
- `FetchAdapterOptions` → `CreateFetchAdapterOptions`, `BeaconAdapterOptions` → `CreateBeaconAdapterOptions`, matching the `<functionName>Options` pattern of `CreateExperimentsOptions` / `CreateConversionOptions`.
- JSDoc now says a factory *creates* an `Adapter`; the `Adapter` type doc states the two-term distinction explicitly.
- Error message prefixes follow the rename, so a message someone hits in production greps back to the exported symbol.

## Backward compatibility

All four old names remain exported as `@deprecated` aliases, so this is non-breaking and can ship in a minor. They are removed in the next major.

## Follow-up

The docs site uses the old names throughout and calls the factories "adapters". Terminology fix is going onto storyblok/storyblok-docs-platform#608; the rename itself needs a docs pass once this is released, with the version badge for whichever minor it lands in.

Fixes DX-546