### PR TITLE
chore(repo): hide mechanical commits from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,17 @@
+# Commits to skip in `git blame`.
+#
+# Only ever add commits that are purely mechanical, such as a formatter run or
+# a mass rename, with no behavior change. Blame skips them entirely, so
+# anything real hidden in such a commit becomes very hard to find later.
+#
+# GitHub reads this file automatically. For local `git blame`, run:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# `pnpm install` does this for you via the root `prepare` script.
+
+# chore: reformat repo with oxfmt (1111 files)
+5f5fcbe7a6bbaf7539b861542165fb99a2214e62
+
+# chore(js-client): apply pending formatting fixes (#745)
+c1600ab4514f1e707ba3db5e70839cf98794a8c4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "scripts": {
     "monoblok": "node tools/monoblok/dist/index.mjs",
-    "prepare": "husky",
+    "prepare": "husky && (git config blame.ignoreRevsFile .git-blame-ignore-revs || true)",
     "release": "node tools/release.mjs",
     "build": "pnpm nx run-many --target=build",
     "lint": "oxlint --disable-nested-config && nx run-many --target=lint",


### PR DESCRIPTION
The recent repo-wide oxfmt run touched 1111 files, so `git blame` now attributes most lines in the repo to a formatting commit rather than to the change that actually introduced them.

Measured on `packages/cli/src/utils/error/api-error.ts`, first 40 lines:

| | owning commits |
|---|---|
| before | **38** lines `chore: reformat repo with oxfmt`, 2 lines `feat: add-storyblok-cli` |
| after | the 6 feature and fix commits that actually wrote them |

## What this does

`.git-blame-ignore-revs` lists the commits blame should skip. GitHub reads that filename automatically, so the web blame view needs no configuration.

For local `git blame`, git needs to be pointed at the file. The root `prepare` script now does that, so it works without extra flags after `pnpm install`:

```json
"prepare": "husky && (git config blame.ignoreRevsFile .git-blame-ignore-revs || true)"
```

The `git config` call is wrapped so a failure cannot break install (it runs wherever install runs, including environments without a writable git config). The parentheses matter: `husky && git config ... || true` would also swallow husky's own failure. Verified both ways, that husky's exit status still propagates and that a plain `git blame` picks up the file after `prepare`.

## Which commits are listed

Blame skips these wholesale, so anything real hidden inside becomes very hard to find. Both entries were checked rather than taken at face value:

- `5f5fcbe7` `chore: reformat repo with oxfmt` (1111 files)
- `c1600ab4` `chore(js-client): apply pending formatting fixes (#745)` (2 files)

Neither adds, deletes or renames a file (every path is a modification), and both are limited to quote style, brace style, line wrapping and `package.json` key order.

Note that `git show -w` is **not** a sufficient check here: oxfmt rewrites quotes and trailing commas, which are not whitespace, so ignoring whitespace still leaves a large diff. The verification above is per-file-status plus reading the changes.

Deliberately **not** included: `chore(repo): format code after oxlint autofixes in pre-commit hook`, which changes the hook itself alongside the formatting, and `Update nx configuration and improve code formatting`, which mixes config changes in. Only pure formatter output belongs here.