### PR TITLE
fix(schema): translate `deny` to `component_denylist` on push

### DIFF
--- a/packages/capi-client/src/generated/types/field.ts
+++ b/packages/capi-client/src/generated/types/field.ts
@@ -227,21 +227,44 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
+/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
+type FolderOf<T> =
+  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+
 /**
- * Removes the registry blocks named in `deny`, the `Exclude` counterpart to
- * {@link ApplyAllow}. The wire `component_denylist` denies by block name only,
- * so folder refs are not accepted. A `deny` entry naming no known block is
- * inert: it removes nothing rather than collapsing the field.
+ * Removes the registry blocks in `TFolders` (or any nested folder), the
+ * {@link MatchesFolder} counterpart for `deny`. A `never` folder set removes
+ * nothing, so a block-name-only `deny` leaves the union untouched.
+ */
+type DenyFolders<TBlocks, TFolders extends string> = [TFolders] extends [never]
+  ? TBlocks
+  : TBlocks extends any
+    ? [MatchesFolder<TBlocks, TFolders>] extends [never]
+      ? TBlocks
+      : never
+    : never;
+
+/**
+ * Removes the registry blocks named in `deny`, or living in a folder it names,
+ * the `Exclude` counterpart to {@link ApplyAllow}. A `deny` entry naming no known
+ * block or folder is inert: it removes nothing rather than collapsing the field.
+ *
+ * `TDenied` is split with `Extract` rather than a `TDenied extends string`
+ * conditional, because that conditional would distribute over the deny union and
+ * union the per-entry `Exclude` results back together — re-admitting every denied
+ * block. Names and folders are therefore removed in one pass each.
  */
 type ApplyDeny<TField, TBlocks> = TField extends {
-  deny: ReadonlyArray<infer TDenied extends string>;
+  deny: ReadonlyArray<infer TDenied extends AllowEntry>;
 }
-  ? Exclude<TBlocks, { name: TDenied }>
+  ? DenyFolders<Exclude<TBlocks, { name: Extract<TDenied, string> }>, FolderOf<TDenied>>
   : TBlocks;
 
 /**
  * Resolves the block union a `bloks` field accepts: `allow` narrows the registry
- * first, then `deny` removes from what is left, so the two compose.
+ * first, then `deny` removes from what is left, so the two compose. The editor
+ * instead gives a non-empty `allow` precedence and ignores `deny` beside it, so on
+ * a field carrying both these types are the stricter of the two views.
  */
 type ApplyRestrictions<TField, TBlocks> = ApplyDeny<TField, ApplyAllow<TField, TBlocks>>;
 

--- a/packages/capi-client/src/generated/types/field.ts
+++ b/packages/capi-client/src/generated/types/field.ts
@@ -227,9 +227,16 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
-/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
-type FolderOf<T> =
-  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+/**
+ * The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union.
+ *
+ * Written as an indexed access rather than a conditional with `infer`: when the
+ * union names no folder at all, `Extract` yields `never`, and `never extends
+ * { folder: infer F extends string }` takes the *true* branch with no inference
+ * candidate for `F`, which then falls back to its `string` constraint. That turned
+ * a block-name-only `deny` into "deny every folder".
+ */
+type FolderOf<T> = Extract<T, { folder: string }>["folder"];
 
 /**
  * Removes the registry blocks in `TFolders` (or any nested folder), the

--- a/packages/cli/src/commands/components/push/graph-operations/dependency-graph.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/dependency-graph.ts
@@ -22,9 +22,19 @@ import { getLogger } from "../../../../lib/logger/logger";
 // =============================================================================
 
 /**
- * Field types that support component whitelists (group, tag, and component whitelists)
+ * Field types that support component restriction lists (group, tag, and
+ * component names, in both their allow and deny halves)
  */
 const fieldTypesWithDependencies = ["bloks", "richtext"] as const;
+
+/**
+ * The restriction lists whose entries identify an entity by something that is
+ * only valid within one space, and so have to be translated on a cross-space
+ * push. Both halves of each dimension: a denylist is as space-bound as its
+ * whitelist.
+ */
+const GROUP_LIST_KEYS = ["component_group_whitelist", "component_group_denylist"] as const;
+const TAG_LIST_KEYS = ["component_tag_whitelist", "component_tag_denylist"] as const;
 
 // =============================================================================
 // GRAPH BUILDING
@@ -204,17 +214,23 @@ export function collectWhitelistDependencies(schema: Record<string, any>): Schem
 
   function traverseField(field: Record<string, any>) {
     if (fieldTypesWithDependencies.includes(field.type)) {
-      // Collect group dependencies
-      if (field.component_group_whitelist && Array.isArray(field.component_group_whitelist)) {
-        field.component_group_whitelist.forEach((uuid: string) => groupUuids.add(uuid));
+      // Both halves of each dimension, not just the whitelist: a group uuid and a
+      // tag id differ per space, so a denylist left unresolved arrives in the
+      // target pointing at source-space entities and silently denies nothing.
+      for (const key of GROUP_LIST_KEYS) {
+        if (Array.isArray(field[key])) {
+          field[key].forEach((uuid: string) => groupUuids.add(uuid));
+        }
       }
 
-      // Collect tag dependencies
-      if (field.component_tag_whitelist && Array.isArray(field.component_tag_whitelist)) {
-        field.component_tag_whitelist.forEach((tagId: number) => tagIds.add(tagId));
+      for (const key of TAG_LIST_KEYS) {
+        if (Array.isArray(field[key])) {
+          field[key].forEach((tagId: number) => tagIds.add(tagId));
+        }
       }
 
-      // Collect component dependencies
+      // Component names are space-independent, so only the whitelist matters for
+      // ordering the push: a denied block need not exist in the target.
       if (field.component_whitelist && Array.isArray(field.component_whitelist)) {
         field.component_whitelist.forEach((name: string) => componentNames.add(name));
       }
@@ -734,37 +750,30 @@ export class ComponentNode extends GraphNode<Component> {
 
       const resolvedField = { ...field };
 
-      // Resolve bloks and richtext field references (both support component whitelists)
+      // Resolve bloks and richtext field references, both halves of each
+      // dimension. An unresolved entry falls back to the source value, which in
+      // the target space points at nothing.
       if (fieldTypesWithDependencies.includes(resolvedField.type)) {
-        // Resolve component group whitelist
-        if (
-          resolvedField.component_group_whitelist &&
-          Array.isArray(resolvedField.component_group_whitelist)
-        ) {
-          resolvedField.component_group_whitelist = resolvedField.component_group_whitelist.map(
-            (groupUuid: string) => {
-              const groupNodeId = `group:${groupUuid}`;
-              const groupNode = graph.nodes.get(groupNodeId) as GroupNode;
+        for (const key of GROUP_LIST_KEYS) {
+          if (Array.isArray(resolvedField[key])) {
+            resolvedField[key] = resolvedField[key].map((groupUuid: string) => {
+              const groupNode = graph.nodes.get(`group:${groupUuid}`) as GroupNode;
               return groupNode?.targetData?.resource.uuid || groupUuid;
-            },
-          );
+            });
+          }
         }
 
-        // Resolve component tag whitelist
-        if (
-          resolvedField.component_tag_whitelist &&
-          Array.isArray(resolvedField.component_tag_whitelist)
-        ) {
-          resolvedField.component_tag_whitelist = resolvedField.component_tag_whitelist.map(
-            (tagId: number) => {
-              const tagNodeId = `tag:${tagId}`;
-              const tagNode = graph.nodes.get(tagNodeId) as TagNode;
+        for (const key of TAG_LIST_KEYS) {
+          if (Array.isArray(resolvedField[key])) {
+            resolvedField[key] = resolvedField[key].map((tagId: number) => {
+              const tagNode = graph.nodes.get(`tag:${tagId}`) as TagNode;
               return tagNode?.targetData?.id || tagId;
-            },
-          );
+            });
+          }
         }
 
-        // Component whitelist doesn't need ID resolution as it uses names
+        // The component name lists need no translation: a block's name is its
+        // identity in every space.
       }
 
       // Note: Datasource references are not resolved by the components push command.

--- a/packages/cli/src/commands/schema/folders.test.ts
+++ b/packages/cli/src/commands/schema/folders.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { ComponentFolder } from "../../types";
-import { buildGroupPathByUuid, expandFolderPath, slugifyPath } from "./folders";
+import {
+  buildGroupPathByUuid,
+  expandFolderPath,
+  mapSchemaGroupLists,
+  slugifyPath,
+} from "./folders";
 
 function folder(
   partial: Partial<ComponentFolder> & { name: string; uuid: string },
@@ -94,5 +99,41 @@ describe("expandFolderPath", () => {
       { name: "Layout", path: "layout", parentPath: null },
       { name: "Heros", path: "layout/heros", parentPath: "layout" },
     ]);
+  });
+});
+
+describe("mapSchemaGroupLists", () => {
+  it("should map both the group whitelist and the group denylist", () => {
+    const schema = {
+      body: {
+        type: "bloks",
+        component_group_whitelist: ["path-a"],
+        component_group_denylist: ["path-b"],
+      },
+    };
+
+    expect(mapSchemaGroupLists(schema, (entry) => `uuid-${entry}`)).toEqual({
+      body: {
+        type: "bloks",
+        component_group_whitelist: ["uuid-path-a"],
+        component_group_denylist: ["uuid-path-b"],
+      },
+    });
+  });
+
+  it("should leave fields without a group list untouched and never mutate the source", () => {
+    const field = { type: "bloks", component_whitelist: ["hero"] };
+    const schema = { body: field };
+
+    expect(mapSchemaGroupLists(schema, () => "mapped")).toEqual(schema);
+    expect(field.component_whitelist).toEqual(["hero"]);
+  });
+
+  it("should keep non-string entries as they are", () => {
+    const schema = { body: { component_group_denylist: [null, "path-a"] } };
+
+    expect(mapSchemaGroupLists(schema, () => "mapped")).toEqual({
+      body: { component_group_denylist: [null, "mapped"] },
+    });
   });
 });

--- a/packages/cli/src/commands/schema/folders.ts
+++ b/packages/cli/src/commands/schema/folders.ts
@@ -1,5 +1,6 @@
 import type { ComponentFolder } from "../../types";
 import { slugify } from "../../utils/format";
+import { isRecord } from "./utils";
 import type { LocalFolder } from "./types";
 
 /**
@@ -73,6 +74,45 @@ export function slugifyPath(displayPath: string): string {
     .map((segment) => slugify(segment))
     .filter(Boolean)
     .join("/");
+}
+
+/**
+ * The wire field keys holding component group references. Both the whitelist
+ * (`allow`) and the denylist (`deny`) name groups, so anything translating
+ * between the transient slug-path space and the server's uuid space has to walk
+ * both — translating only the whitelist would leave a denylist pointing at slug
+ * paths the API cannot resolve.
+ */
+export const GROUP_LIST_KEYS = ["component_group_whitelist", "component_group_denylist"] as const;
+
+/**
+ * Returns a copy of a wire `schema` record with every field's group list entries
+ * (see {@link GROUP_LIST_KEYS}) passed through `mapEntry`. Fields carrying
+ * neither key, and non-string entries, are copied through untouched; the source
+ * objects are never mutated. An entry `mapEntry` cannot translate should be
+ * returned as-is by the caller, so it still produces a visible diff or reaches
+ * the API for the server to reject.
+ */
+export function mapSchemaGroupLists(schema: unknown, mapEntry: (entry: string) => string): unknown {
+  if (!isRecord(schema)) {
+    return schema;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [fieldName, field] of Object.entries(schema)) {
+    if (!isRecord(field) || !GROUP_LIST_KEYS.some((key) => Array.isArray(field[key]))) {
+      result[fieldName] = field;
+      continue;
+    }
+    const mapped: Record<string, unknown> = { ...field };
+    for (const key of GROUP_LIST_KEYS) {
+      const list = field[key];
+      if (Array.isArray(list)) {
+        mapped[key] = list.map((entry) => (typeof entry === "string" ? mapEntry(entry) : entry));
+      }
+    }
+    result[fieldName] = mapped;
+  }
+  return result;
 }
 
 /**

--- a/packages/cli/src/commands/schema/init/generate-code.test.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.test.ts
@@ -236,6 +236,156 @@ describe("generateComponentFile", () => {
     expect(result).not.toContain("component_group_whitelist");
   });
 
+  it("should map a component_denylist back to deny and round-trip it on push", () => {
+    const component = {
+      id: 1,
+      name: "page",
+      created_at: "",
+      updated_at: "",
+      schema: {
+        body: {
+          type: "bloks",
+          pos: 0,
+          restrict_components: true,
+          restrict_type: "",
+          component_denylist: ["banner"],
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any);
+
+    expect(result).toContain("deny: [");
+    expect(result).toContain("'banner',");
+    expect(result).not.toContain("component_denylist");
+    expect(result).not.toContain("restrict_components");
+
+    // Push the emitted config back: the denylist and its flags must reappear.
+    const { value } = mapFieldToWire({ name: "body", type: "bloks", pos: 0, deny: ["banner"] });
+    expect(value).toEqual({
+      type: "bloks",
+      pos: 0,
+      component_denylist: ["banner"],
+      restrict_components: true,
+      restrict_type: "",
+    });
+  });
+
+  it("should map both a whitelist and a denylist back to allow and deny", () => {
+    const component = {
+      id: 1,
+      name: "page",
+      created_at: "",
+      updated_at: "",
+      schema: {
+        body: {
+          type: "bloks",
+          pos: 0,
+          restrict_components: true,
+          restrict_type: "",
+          component_whitelist: ["teaser", "banner"],
+          component_denylist: ["banner"],
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any);
+
+    expect(result).toContain("allow: [");
+    expect(result).toContain("deny: [");
+    expect(result).not.toContain("component_whitelist");
+    expect(result).not.toContain("component_denylist");
+  });
+
+  it("should resolve a group denylist to deny: [folderVar] and import the folder", () => {
+    const component = {
+      id: 1,
+      name: "landing",
+      created_at: "",
+      updated_at: "",
+      schema: {
+        body: {
+          type: "bloks",
+          pos: 0,
+          restrict_components: true,
+          restrict_type: "groups",
+          component_group_denylist: ["uuid-legacy"],
+        },
+      },
+    };
+
+    const result = generateComponentFile(
+      component as any,
+      undefined,
+      undefined,
+      new Map([["uuid-legacy", "legacyFolder"]]),
+    );
+
+    expect(result).toContain("import { legacyFolder } from '../folders';");
+    expect(result).toContain("deny: [");
+    expect(result).toContain("legacyFolder,");
+    expect(result).not.toContain("component_group_denylist");
+    expect(result).not.toContain("restrict_components");
+  });
+
+  it("should keep the raw group lists when only one of the two resolves to folder refs", () => {
+    // Emitting the resolvable half as DSL refs while dropping the other would lose
+    // a restriction that is in force, so the whole field keeps its wire form.
+    const component = {
+      id: 1,
+      name: "landing",
+      created_at: "",
+      updated_at: "",
+      schema: {
+        body: {
+          type: "bloks",
+          pos: 0,
+          restrict_components: true,
+          restrict_type: "groups",
+          component_group_whitelist: ["uuid-heros"],
+          component_group_denylist: ["uuid-unknown"],
+        },
+      },
+    };
+
+    const result = generateComponentFile(
+      component as any,
+      undefined,
+      undefined,
+      new Map([["uuid-heros", "herosFolder"]]),
+    );
+
+    expect(result).toContain("component_group_whitelist");
+    expect(result).toContain("component_group_denylist");
+    expect(result).toContain("restrict_components: true,");
+    expect(result).not.toContain("allow");
+    expect(result).not.toContain("deny:");
+    expect(result).not.toContain("herosFolder");
+  });
+
+  it("should keep a disabled restriction disabled instead of mapping a stale denylist to deny", () => {
+    const component = {
+      id: 1,
+      name: "page",
+      created_at: "",
+      updated_at: "",
+      schema: {
+        body: {
+          type: "bloks",
+          pos: 0,
+          restrict_components: false,
+          component_denylist: ["banner"],
+        },
+      },
+    };
+
+    const result = generateComponentFile(component as any);
+
+    expect(result).toContain("restrict_components: false,");
+    expect(result).not.toContain("deny");
+    expect(result).not.toContain("component_denylist");
+  });
+
   it("should drop orphaned restrict flags when a restricted field has no names and no groups", () => {
     // `restrict_components: true` with an empty `component_whitelist` and no group
     // whitelist is a wire byproduct that `allow` re-derives on push; without an

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -271,8 +271,15 @@ type FieldRestriction =
  * dimensions are mutually exclusive in the editor, which clears one dimension's
  * lists when you switch to the other, so a field restricted by folder carries an
  * empty `component_whitelist: []` alongside its group list. Non-emptiness is
- * therefore what picks the dimension, and block names win the (unreachable
- * through the editor) tie so a name restriction is never silently dropped.
+ * therefore what picks the dimension.
+ *
+ * When both dimensions somehow hold a list, block names win here while the editor
+ * would evaluate the folder list and ignore the names. The orders disagree on
+ * purpose: whichever one loses gets dropped from the emitted DSL, and dropping a
+ * name list is the more visible loss. Neither reading is faithful, so the shape is
+ * a round-trip hazard either way. The editor cannot author it (switching dimension
+ * clears all six lists) and the Management API only backstops that for `bloks`
+ * fields, so reaching it takes a `richtext` written through the API.
  */
 function resolveFieldRestriction(
   field: Record<string, unknown>,
@@ -331,8 +338,15 @@ function resolveFieldRestriction(
  * `schema push` re-derive `restrict_components: true` and silently switch the
  * restriction back on, changing what editors may insert. So a disabled
  * restriction keeps its flag and drops the lists: the flag round-trips
- * losslessly, at the cost of discarding lists that are not in force anyway. An
- * absent `restrict_components` counts as active, matching backend enforcement.
+ * losslessly, at the cost of discarding lists that are not in force anyway.
+ *
+ * An absent `restrict_components` counts as active, which is a deliberate
+ * narrowing rather than a faithful read. The editor treats the flag's absence as
+ * "no restriction at all", so a legacy field carrying a bare `component_whitelist`
+ * accepts anything today. Emitting it as `allow` makes push re-derive
+ * `restrict_components: true` and the restriction starts being enforced. That
+ * matches the list's apparent intent, and the alternative is discarding a list
+ * someone wrote on purpose, but it does change what editors may insert.
  *
  * See {@link resolveFieldRestriction} for how the block-name and folder
  * dimensions are told apart.

--- a/packages/cli/src/commands/schema/init/generate-code.ts
+++ b/packages/cli/src/commands/schema/init/generate-code.ts
@@ -221,20 +221,20 @@ export function resolveFolders(folders: ComponentFolder[]): ResolvedFolder[] {
 }
 
 /**
- * Resolves a field's `component_group_whitelist` uuids to `defineFolder` ref
- * identifiers when every uuid maps to a known folder var, returning the ordered
- * {@link RawCode} refs. Returns `undefined` when there is nothing to resolve or
- * any uuid is unknown, so the caller keeps the raw wire form (still round-trips
- * via the diff's uuid↔path translation) rather than emitting a broken ref.
+ * Resolves a field's group list uuids to `defineFolder` ref identifiers when
+ * every uuid maps to a known folder var, returning the ordered {@link RawCode}
+ * refs. Returns `undefined` when there is nothing to resolve or any uuid is
+ * unknown, so the caller keeps the raw wire form (still round-trips via the
+ * diff's uuid↔path translation) rather than emitting a broken ref.
  */
-function resolveGroupWhitelistRefs(
-  whitelist: unknown,
+function resolveGroupRefs(
+  groupList: unknown,
   folderVarByUuid?: Map<string, string>,
 ): RawCode[] | undefined {
-  if (!folderVarByUuid || !Array.isArray(whitelist) || whitelist.length === 0) {
+  if (!folderVarByUuid || !Array.isArray(groupList) || groupList.length === 0) {
     return undefined;
   }
-  const vars = whitelist.map((uuid) =>
+  const vars = groupList.map((uuid) =>
     typeof uuid === "string" ? folderVarByUuid.get(uuid) : undefined,
   );
   if (!vars.every((v): v is string => typeof v === "string")) {
@@ -243,29 +243,99 @@ function resolveGroupWhitelistRefs(
   return vars.map((v) => new RawCode(v));
 }
 
+/** Whether a wire restriction list holds entries (an absent or empty list is no restriction). */
+function isNonEmptyList(list: unknown): boolean {
+  return Array.isArray(list) && list.length > 0;
+}
+
+/**
+ * How a field's wire restriction keys map back to the DSL, resolved once so
+ * {@link toDslField} and {@link collectRestrictionFolderVars} can never disagree
+ * about whether a field's folder refs are emitted (and therefore imported).
+ *
+ * - `disabled` — `restrict_components: false`: the flag round-trips, the lists do not.
+ * - `names` — restricted by block name: `allow`/`deny` hold plain names.
+ * - `folders` — restricted by folder, every uuid resolved to a `defineFolder` ref.
+ * - `raw` — restricted by folder, but at least one uuid is unknown: keep the wire keys.
+ * - `none` — no restriction in force.
+ */
+type FieldRestriction =
+  | { kind: "disabled" }
+  | { kind: "names"; allow?: unknown; deny?: unknown }
+  | { kind: "folders"; allow?: RawCode[]; deny?: RawCode[] }
+  | { kind: "raw" }
+  | { kind: "none" };
+
+/**
+ * Classifies a field's wire restriction keys. The block-name and folder
+ * dimensions are mutually exclusive in the editor, which clears one dimension's
+ * lists when you switch to the other, so a field restricted by folder carries an
+ * empty `component_whitelist: []` alongside its group list. Non-emptiness is
+ * therefore what picks the dimension, and block names win the (unreachable
+ * through the editor) tie so a name restriction is never silently dropped.
+ */
+function resolveFieldRestriction(
+  field: Record<string, unknown>,
+  folderVarByUuid?: Map<string, string>,
+): FieldRestriction {
+  if (field.restrict_components === false) {
+    return { kind: "disabled" };
+  }
+  const hasNameAllow = isNonEmptyList(field.component_whitelist);
+  const hasNameDeny = isNonEmptyList(field.component_denylist);
+  if (hasNameAllow || hasNameDeny) {
+    return {
+      kind: "names",
+      allow: hasNameAllow ? field.component_whitelist : undefined,
+      deny: hasNameDeny ? field.component_denylist : undefined,
+    };
+  }
+  const hasGroupAllow = isNonEmptyList(field.component_group_whitelist);
+  const hasGroupDeny = isNonEmptyList(field.component_group_denylist);
+  if (hasGroupAllow || hasGroupDeny) {
+    const allow = hasGroupAllow
+      ? resolveGroupRefs(field.component_group_whitelist, folderVarByUuid)
+      : undefined;
+    const deny = hasGroupDeny
+      ? resolveGroupRefs(field.component_group_denylist, folderVarByUuid)
+      : undefined;
+    // Partial resolution is not good enough: emitting the resolvable list as DSL
+    // refs while dropping the other would lose a restriction that is in force.
+    return (!hasGroupAllow || allow) && (!hasGroupDeny || deny)
+      ? { kind: "folders", allow, deny }
+      : { kind: "raw" };
+  }
+  if (
+    field.component_group_whitelist !== undefined ||
+    field.component_group_denylist !== undefined
+  ) {
+    return { kind: "raw" };
+  }
+  return { kind: "none" };
+}
+
 /**
  * Reverse of the push-time DSL→wire field mapping: renames the wire reference
- * keys back to their DSL form (`component_whitelist`→`allow`,
- * `component_group_whitelist`→`allow` with folder refs, `datasource_slug`→`datasource`).
- * The `source` selector is left untouched.
+ * keys back to their DSL form (`component_whitelist`/`component_group_whitelist`
+ * → `allow`, `component_denylist`/`component_group_denylist` → `deny`, either as
+ * plain block names or as `defineFolder` refs, and `datasource_slug` →
+ * `datasource`). The `source` selector is left untouched.
  *
  * `restrict_components: true` and `restrict_type` are dropped alongside a
- * resolved `allow` — they're the wire byproduct `defineField`'s `allow`
- * re-derives on push, not independent DSL state. A group whitelist that cannot
- * be fully resolved to folder refs keeps its raw wire form.
- *
- * A field restricted to a component *group* carries both a `component_group_whitelist`
- * and an empty `component_whitelist: []` on the wire; the group whitelist takes
- * precedence, so `allow` is only sourced from `component_whitelist` when it holds
- * actual block names — otherwise the resolved folder refs win.
+ * resolved `allow`/`deny` — they're the wire byproduct `defineField` re-derives on
+ * push, not independent DSL state. Group lists that cannot be fully resolved to
+ * folder refs keep their raw wire form.
  *
  * `restrict_components: false` disables the restriction while the space may still
- * store a stale whitelist. Emitting that inactive list as `allow` would make
+ * store stale lists. Emitting an inactive list as `allow`/`deny` would make
  * `schema push` re-derive `restrict_components: true` and silently switch the
  * restriction back on, changing what editors may insert. So a disabled
- * restriction keeps its flag and drops the whitelist: the flag round-trips
- * losslessly, at the cost of discarding a list that is not in force anyway. An
+ * restriction keeps its flag and drops the lists: the flag round-trips
+ * losslessly, at the cost of discarding lists that are not in force anyway. An
  * absent `restrict_components` counts as active, matching backend enforcement.
+ *
+ * See {@link resolveFieldRestriction} for how the block-name and folder
+ * dimensions are told apart.
  */
 function toDslField(
   field: Record<string, unknown>,
@@ -273,42 +343,54 @@ function toDslField(
 ): Record<string, unknown> {
   const {
     component_whitelist,
+    component_denylist,
     component_group_whitelist,
+    component_group_denylist,
     datasource_slug,
     restrict_components,
     restrict_type,
     ...rest
   } = field;
   const out: Record<string, unknown> = { ...rest };
-  const restrictionDisabled = restrict_components === false;
-  const groupRefs = restrictionDisabled
-    ? undefined
-    : resolveGroupWhitelistRefs(component_group_whitelist, folderVarByUuid);
-  const hasBlockNames =
-    !restrictionDisabled && Array.isArray(component_whitelist) && component_whitelist.length > 0;
-  if (restrictionDisabled) {
-    out.restrict_components = false;
-    if (restrict_type !== undefined) {
-      out.restrict_type = restrict_type;
-    }
-  } else if (hasBlockNames) {
-    out.allow = component_whitelist;
-  } else if (groupRefs) {
-    out.allow = groupRefs;
-  } else if (component_group_whitelist !== undefined) {
-    // A group whitelist we could not resolve to folder refs: keep the raw wire
-    // form (whitelist + restrict flags) so it still round-trips on push.
-    out.component_group_whitelist = component_group_whitelist;
-    if (restrict_components !== undefined) {
-      out.restrict_components = restrict_components;
-    }
-    if (restrict_type !== undefined) {
-      out.restrict_type = restrict_type;
-    }
+  const restriction = resolveFieldRestriction(field, folderVarByUuid);
+
+  switch (restriction.kind) {
+    case "disabled":
+      out.restrict_components = false;
+      if (restrict_type !== undefined) {
+        out.restrict_type = restrict_type;
+      }
+      break;
+    case "names":
+    case "folders":
+      if (restriction.allow !== undefined) {
+        out.allow = restriction.allow;
+      }
+      if (restriction.deny !== undefined) {
+        out.deny = restriction.deny;
+      }
+      break;
+    case "raw":
+      if (component_group_whitelist !== undefined) {
+        out.component_group_whitelist = component_group_whitelist;
+      }
+      if (component_group_denylist !== undefined) {
+        out.component_group_denylist = component_group_denylist;
+      }
+      if (restrict_components !== undefined) {
+        out.restrict_components = restrict_components;
+      }
+      if (restrict_type !== undefined) {
+        out.restrict_type = restrict_type;
+      }
+      break;
+    case "none":
+      // No restriction is in force (lists absent or empty);
+      // `restrict_components`/`restrict_type` are byproducts `allow`/`deny`
+      // re-derive on push, so they are dropped rather than emitted as orphaned
+      // DSL state.
+      break;
   }
-  // Otherwise there is no allow list (name whitelist absent or empty, no groups);
-  // `restrict_components`/`restrict_type` are byproducts `allow` re-derives on
-  // push, so they are dropped rather than emitted as orphaned DSL state.
   if (datasource_slug !== undefined) {
     out.datasource = datasource_slug;
   }
@@ -350,10 +432,11 @@ function generateFieldCode(
 
 /**
  * Collects the sorted, unique `defineFolder` var names a component's fields
- * reference through fully-resolvable group whitelists, so the generated file can
- * import them.
+ * reference through fully-resolvable group lists, so the generated file can
+ * import them. Shares {@link resolveFieldRestriction} with {@link toDslField} so
+ * only folders that actually reach the emitted `allow`/`deny` are imported.
  */
-function collectWhitelistFolderVars(
+function collectRestrictionFolderVars(
   schema: Record<string, Record<string, unknown>>,
   folderVarByUuid?: Map<string, string>,
 ): string[] {
@@ -362,14 +445,12 @@ function collectWhitelistFolderVars(
     if (!isRecord(field)) {
       continue;
     }
-    // Mirrors `toDslField`: a disabled restriction emits no `allow`, so its
-    // folders must not be imported either.
-    if (field.restrict_components === false) {
+    const restriction = resolveFieldRestriction(field, folderVarByUuid);
+    if (restriction.kind !== "folders") {
       continue;
     }
-    const refs = resolveGroupWhitelistRefs(field.component_group_whitelist, folderVarByUuid);
-    if (refs) {
-      refs.forEach((ref) => vars.add(ref.code));
+    for (const ref of [...(restriction.allow ?? []), ...(restriction.deny ?? [])]) {
+      vars.add(ref.code);
     }
   }
   return [...vars].sort();
@@ -443,7 +524,7 @@ export function generateComponentFile(
   const folderVars = [
     ...new Set([
       ...(folderRef ? [folderRef.varName] : []),
-      ...collectWhitelistFolderVars(schema, folderVarByUuid),
+      ...collectRestrictionFolderVars(schema, folderVarByUuid),
     ]),
   ].sort();
   if (folderVars.length > 0) {

--- a/packages/cli/src/commands/schema/map-to-wire.test.ts
+++ b/packages/cli/src/commands/schema/map-to-wire.test.ts
@@ -81,6 +81,86 @@ describe("mapFieldToWire", () => {
       restrict_type: "",
     });
   });
+
+  it("should rename deny to component_denylist and activate the restriction on bloks fields", () => {
+    const { value } = mapFieldToWire({ name: "body", type: "bloks", pos: 0, deny: ["banner"] });
+    expect(value).toEqual({
+      type: "bloks",
+      pos: 0,
+      component_denylist: ["banner"],
+      restrict_components: true,
+      restrict_type: "",
+    });
+  });
+
+  it("should never leave a raw deny key on the wire payload", () => {
+    // Regression: `deny` used to fall through into the spread rest and reach the
+    // Management API verbatim, persisting a junk key in the remote schema.
+    const { value } = mapFieldToWire({ name: "body", type: "bloks", deny: ["banner"] });
+    expect(value).not.toHaveProperty("deny");
+  });
+
+  it("should map folder deny entries to a group denylist with slug paths", () => {
+    const { value } = mapFieldToWire({
+      name: "body",
+      type: "bloks",
+      deny: [{ folder: "My Layout/Heros" }],
+    });
+    expect(value).toMatchObject({
+      component_group_denylist: ["my-layout/heros"],
+      restrict_components: true,
+      restrict_type: "groups",
+    });
+    expect(value).not.toHaveProperty("component_denylist");
+  });
+
+  it("should emit both lists when allow and deny restrict by block name", () => {
+    const { value } = mapFieldToWire({
+      name: "body",
+      type: "bloks",
+      allow: ["teaser", "banner"],
+      deny: ["banner"],
+    });
+    expect(value).toEqual({
+      type: "bloks",
+      component_whitelist: ["teaser", "banner"],
+      component_denylist: ["banner"],
+      restrict_components: true,
+      restrict_type: "",
+    });
+  });
+
+  it("should emit both group lists when allow and deny restrict by folder", () => {
+    const { value } = mapFieldToWire({
+      name: "body",
+      type: "bloks",
+      allow: [{ folder: "Layout" }],
+      deny: [{ folder: "Layout/Legacy" }],
+    });
+    expect(value).toEqual({
+      type: "bloks",
+      component_group_whitelist: ["layout"],
+      component_group_denylist: ["layout/legacy"],
+      restrict_components: true,
+      restrict_type: "groups",
+    });
+  });
+
+  it("should activate the block-name restriction for richtext fields too", () => {
+    // The editor ignores a bare list: without `restrict_components` the picker
+    // offers every block, so a richtext name restriction would be inert.
+    const { value } = mapFieldToWire({ name: "text", type: "richtext", deny: ["banner"] });
+    expect(value).toMatchObject({
+      component_denylist: ["banner"],
+      restrict_components: true,
+      restrict_type: "",
+    });
+  });
+
+  it("should not add restriction flags to a deny on other field types", () => {
+    const { value } = mapFieldToWire({ name: "link", type: "multilink", pos: 0, deny: ["page"] });
+    expect(value).toEqual({ type: "multilink", pos: 0, component_denylist: ["page"] });
+  });
 });
 
 describe("mapBlockToWire", () => {

--- a/packages/cli/src/commands/schema/map-to-wire.test.ts
+++ b/packages/cli/src/commands/schema/map-to-wire.test.ts
@@ -157,9 +157,19 @@ describe("mapFieldToWire", () => {
     });
   });
 
-  it("should not add restriction flags to a deny on other field types", () => {
+  it("should drop a deny on a field type that has no denylist", () => {
+    // Only `bloks` and `richtext` read the restriction lists. Writing a
+    // `component_denylist` on a `multilink` would store a key nothing reads,
+    // which is the defect this mapping exists to fix.
     const { value } = mapFieldToWire({ name: "link", type: "multilink", pos: 0, deny: ["page"] });
-    expect(value).toEqual({ type: "multilink", pos: 0, component_denylist: ["page"] });
+    expect(value).toEqual({ type: "multilink", pos: 0 });
+  });
+
+  it("should keep an allow on a field type whose whitelist is real", () => {
+    // `component_whitelist` on a `multilink` selects story content types, so it
+    // is not the denylist's mirror image and stays.
+    const { value } = mapFieldToWire({ name: "link", type: "multilink", pos: 0, allow: ["page"] });
+    expect(value).toEqual({ type: "multilink", pos: 0, component_whitelist: ["page"] });
   });
 });
 

--- a/packages/cli/src/commands/schema/map-to-wire.ts
+++ b/packages/cli/src/commands/schema/map-to-wire.ts
@@ -1,3 +1,5 @@
+import { DENIABLE_FIELD_TYPES } from "@storyblok/schema";
+
 import type { Component, Datasource, Field } from "../../types";
 import { isRecord } from "./utils";
 import { slugifyPath } from "./folders";
@@ -42,14 +44,18 @@ function splitRestriction(input: unknown): SplitRestriction | undefined {
  * - `datasource` → `datasource_slug` (the `source` selector passes through)
  *
  * A bare list is ignored by the editor, so a restriction from either key also
- * activates `restrict_components: true` on `bloks` and `richtext` fields — the two
- * types whose nested-block picker consults these lists — with `restrict_type:
+ * activates `restrict_components: true` on `bloks` and `richtext` fields, the two
+ * types whose nested-block picker consults these lists, with `restrict_type:
  * 'groups'` for folder entries and `''` (the editor's v1-compatible spelling of
  * "by block name") otherwise. `defineField` rejects an `allow`/`deny` pair that
  * disagrees on which of the two dimensions to restrict by, so the folder dimension
- * of either key settles it for both. Other field types (e.g. a `multilink`
- * `component_whitelist`, which selects story content types) keep the plain list
- * with no restriction flags.
+ * of either key settles it for both.
+ *
+ * On any other field type a `deny` is dropped: those types have no denylist, so
+ * writing one would leave a key nothing reads. `allow` still passes through,
+ * because `component_whitelist` is real on `multilink`, where it selects story
+ * content types rather than blocks, and it keeps the plain list with no
+ * restriction flags.
  *
  * Every other key (`type`, `pos`, `source`, `required`, validation options, and
  * `type: 'custom'` plugin extras) is preserved verbatim.
@@ -68,14 +74,19 @@ export function mapFieldToWire(field: Record<string, unknown>): { name: string; 
       value.component_whitelist = allowed.names;
     }
   }
-  if (denied) {
+  // Only `bloks` and `richtext` have a denylist, so a `deny` elsewhere is
+  // dropped rather than written. `defineField` rejects it outright; this is the
+  // backstop for a schema authored in plain JavaScript, which never goes through
+  // that guard.
+  const isDeniable = DENIABLE_FIELD_TYPES.includes(String(rest.type));
+  if (denied && isDeniable) {
     if (denied.folderPaths.length > 0) {
       value.component_group_denylist = denied.folderPaths;
     } else {
       value.component_denylist = denied.names;
     }
   }
-  if ((allowed || denied) && (rest.type === "bloks" || rest.type === "richtext")) {
+  if ((allowed || denied) && isDeniable) {
     const byFolder = Boolean(allowed?.folderPaths.length || denied?.folderPaths.length);
     value.restrict_components = true;
     value.restrict_type = byFolder ? "groups" : "";

--- a/packages/cli/src/commands/schema/map-to-wire.ts
+++ b/packages/cli/src/commands/schema/map-to-wire.ts
@@ -2,50 +2,83 @@ import type { Component, Datasource, Field } from "../../types";
 import { isRecord } from "./utils";
 import { slugifyPath } from "./folders";
 
+/** The two halves of an `allow`/`deny` list: block names and slugified folder paths. */
+interface SplitRestriction {
+  names: unknown;
+  folderPaths: string[];
+}
+
+/**
+ * Splits an `allow`/`deny` value into its block-name and folder halves. Folder
+ * entries arrive as `{ folder: displayPath }` from `defineField` and are
+ * slugified into the transient slug-path space that `schema push` later resolves
+ * to group uuids. A non-array value is passed through as the name list, since
+ * hand-written schema data may hold a bare name.
+ */
+function splitRestriction(input: unknown): SplitRestriction | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(input)) {
+    return { names: input, folderPaths: [] };
+  }
+  return {
+    names: input.filter((entry) => typeof entry === "string"),
+    folderPaths: input
+      .filter(
+        (entry): entry is { folder: string } => isRecord(entry) && typeof entry.folder === "string",
+      )
+      .map((entry) => slugifyPath(entry.folder)),
+  };
+}
+
 /**
  * Maps a single content-shape DSL field to its MAPI wire form. The field's
  * `name` becomes the schema record key (returned separately); the DSL reference
  * keys are renamed to their wire equivalents:
  * - `allow` → `component_whitelist` (for block-name entries) or
- *   `component_group_whitelist` (for folder entries), plus `restrict_components: true`
- *   and `restrict_type: ''` on `bloks` fields, or `restrict_type: 'groups'` for
- *   folder entries on both `bloks` and `richtext` fields. A bare whitelist is
- *   otherwise ignored by MAPI.
+ *   `component_group_whitelist` (for folder entries)
+ * - `deny` → `component_denylist` / `component_group_denylist`, the same split
  * - `datasource` → `datasource_slug` (the `source` selector passes through)
+ *
+ * A bare list is ignored by the editor, so a restriction from either key also
+ * activates `restrict_components: true` on `bloks` and `richtext` fields — the two
+ * types whose nested-block picker consults these lists — with `restrict_type:
+ * 'groups'` for folder entries and `''` (the editor's v1-compatible spelling of
+ * "by block name") otherwise. `defineField` rejects an `allow`/`deny` pair that
+ * disagrees on which of the two dimensions to restrict by, so the folder dimension
+ * of either key settles it for both. Other field types (e.g. a `multilink`
+ * `component_whitelist`, which selects story content types) keep the plain list
+ * with no restriction flags.
  *
  * Every other key (`type`, `pos`, `source`, `required`, validation options, and
  * `type: 'custom'` plugin extras) is preserved verbatim.
  */
 export function mapFieldToWire(field: Record<string, unknown>): { name: string; value: Field } {
-  const { name, allow, datasource, ...rest } = field;
+  const { name, allow, deny, datasource, ...rest } = field;
 
   const value: Record<string, unknown> = { ...rest };
-  if (allow !== undefined && Array.isArray(allow)) {
-    const folderPaths = allow
-      .filter(
-        (entry): entry is { folder: string } => isRecord(entry) && typeof entry.folder === "string",
-      )
-      .map((entry) => slugifyPath(entry.folder));
-    const blockNames = allow.filter((entry) => typeof entry === "string");
-    if (folderPaths.length > 0) {
-      value.component_group_whitelist = folderPaths;
-      if (rest.type === "bloks" || rest.type === "richtext") {
-        value.restrict_components = true;
-        value.restrict_type = "groups";
-      }
+  const allowed = splitRestriction(allow);
+  const denied = splitRestriction(deny);
+
+  if (allowed) {
+    if (allowed.folderPaths.length > 0) {
+      value.component_group_whitelist = allowed.folderPaths;
     } else {
-      value.component_whitelist = blockNames;
-      if (rest.type === "bloks") {
-        value.restrict_components = true;
-        value.restrict_type = "";
-      }
+      value.component_whitelist = allowed.names;
     }
-  } else if (allow !== undefined) {
-    value.component_whitelist = allow;
-    if (rest.type === "bloks") {
-      value.restrict_components = true;
-      value.restrict_type = "";
+  }
+  if (denied) {
+    if (denied.folderPaths.length > 0) {
+      value.component_group_denylist = denied.folderPaths;
+    } else {
+      value.component_denylist = denied.names;
     }
+  }
+  if ((allowed || denied) && (rest.type === "bloks" || rest.type === "richtext")) {
+    const byFolder = Boolean(allowed?.folderPaths.length || denied?.folderPaths.length);
+    value.restrict_components = true;
+    value.restrict_type = byFolder ? "groups" : "";
   }
   if (datasource !== undefined) {
     value.datasource_slug = datasource;

--- a/packages/cli/src/commands/schema/push/actions.test.ts
+++ b/packages/cli/src/commands/schema/push/actions.test.ts
@@ -730,6 +730,54 @@ describe("executePush - folders", () => {
     expect(schema.blocks.component_group_whitelist).toEqual(["uuid-layout"]);
   });
 
+  it("resolves component_group_denylist slug paths to remote group uuids", async () => {
+    let capturedComponent: Record<string, unknown> | undefined;
+    server.use(
+      http.post(CREATE_COMPONENTS_URL, async ({ request }) => {
+        const body = (await request.json()) as { component: Record<string, unknown> };
+        capturedComponent = body.component;
+        return HttpResponse.json({ component: { id: 302, name: "grid" } }, { status: 201 });
+      }),
+    );
+
+    const local: SchemaData = {
+      components: [
+        {
+          name: "grid",
+          schema: {
+            blocks: {
+              type: "bloks",
+              component_group_whitelist: ["layout"],
+              component_group_denylist: ["legacy"],
+            },
+          },
+        } as unknown as Component,
+      ],
+      folders: [],
+      datasources: [],
+    };
+    const remote: RemoteSchemaData = {
+      components: new Map(),
+      componentFolders: new Map([
+        ["Layout", { id: 10, uuid: "uuid-layout", name: "Layout" } as unknown as ComponentFolder],
+        ["Legacy", { id: 11, uuid: "uuid-legacy", name: "Legacy" } as unknown as ComponentFolder],
+      ]),
+      datasources: new Map(),
+    };
+    const diffResult = makeDiffResult([
+      { type: "component", name: "grid", action: "create", diff: null, local: null, remote: null },
+    ]);
+
+    await executePush("12345", local, remote, diffResult, { delete: false });
+
+    const schema = capturedComponent!.schema as Record<
+      string,
+      { component_group_whitelist: string[]; component_group_denylist: string[] }
+    >;
+    expect(schema.blocks.component_group_whitelist).toEqual(["uuid-layout"]);
+    expect(schema.blocks.component_group_denylist).toEqual(["uuid-legacy"]);
+  });
+
   it("leaves an already-uuid component_group_whitelist untouched (schema init round-trip)", async () => {
     let capturedComponent: Record<string, unknown> | undefined;
     server.use(

--- a/packages/cli/src/commands/schema/push/actions.ts
+++ b/packages/cli/src/commands/schema/push/actions.ts
@@ -17,8 +17,7 @@ import {
   toDatasourceCreate,
   toDatasourceUpdate,
 } from "../transform";
-import { buildGroupPathByUuid } from "../folders";
-import { isRecord } from "../utils";
+import { buildGroupPathByUuid, mapSchemaGroupLists } from "../folders";
 
 /** A resolved component group reference: its numeric id and server uuid. */
 interface GroupRef {
@@ -29,12 +28,11 @@ interface GroupRef {
 /**
  * Resolves a local block's transient path-space group keys to server uuids and
  * strips the `folder` key. A `folder` string path becomes `component_group_uuid`
- * (the resolved group's uuid); `folder: null` clears it. Each field's
- * `component_group_whitelist` slug paths are mapped to uuids (unknown paths —
- * e.g. already-uuid entries — are left as-is). Blocks without a `folder` key are
- * untouched. An unresolvable `folder` path throws a {@link CommandError}: this
- * is a defensive invariant, since folder creation precedes this step and aborts
- * the push on failure.
+ * (the resolved group's uuid); `folder: null` clears it. Each field's group list
+ * slug paths are mapped to uuids (unknown paths — e.g. already-uuid entries — are
+ * left as-is). Blocks without a `folder` key are untouched. An unresolvable
+ * `folder` path throws a {@link CommandError}: this is a defensive invariant,
+ * since folder creation precedes this step and aborts the push on failure.
  */
 function resolveGroupRefs(comp: Component, groupByPath: Map<string, GroupRef>): Component {
   const { folder, ...rest } = comp as Record<string, unknown>;
@@ -53,22 +51,10 @@ function resolveGroupRefs(comp: Component, groupByPath: Map<string, GroupRef>): 
     resolved.component_group_uuid = null;
   }
 
-  if (isRecord(resolved.schema)) {
-    const schema: Record<string, unknown> = {};
-    for (const [key, field] of Object.entries(resolved.schema)) {
-      if (isRecord(field) && Array.isArray(field.component_group_whitelist)) {
-        schema[key] = {
-          ...field,
-          component_group_whitelist: field.component_group_whitelist.map((path) =>
-            typeof path === "string" ? (groupByPath.get(path)?.uuid ?? path) : path,
-          ),
-        };
-      } else {
-        schema[key] = field;
-      }
-    }
-    resolved.schema = schema;
-  }
+  resolved.schema = mapSchemaGroupLists(
+    resolved.schema,
+    (path) => groupByPath.get(path)?.uuid ?? path,
+  );
 
   return resolved as unknown as Component;
 }

--- a/packages/cli/src/commands/schema/push/diff-schema.test.ts
+++ b/packages/cli/src/commands/schema/push/diff-schema.test.ts
@@ -373,6 +373,35 @@ describe("diffSchema", () => {
     expect(diff?.action).toBe("unchanged");
   });
 
+  it("should translate remote component_group_denylist uuids to paths for diffing", () => {
+    const local: SchemaData = {
+      components: [
+        makeComponent("page", {
+          body: {
+            type: "bloks",
+            pos: 0,
+            restrict_components: true,
+            component_group_denylist: ["layout"],
+          },
+        }),
+      ],
+      datasources: [],
+      folders: [{ name: "Layout", path: "layout", parentPath: null }],
+    };
+    const remoteComp = makeComponent("page", {
+      body: { type: "bloks", pos: 0, restrict_components: true, component_group_denylist: ["u1"] },
+    });
+    const remote: RemoteSchemaData = {
+      components: new Map([["page", remoteComp]]),
+      datasources: new Map(),
+      componentFolders: remoteFolders([{ uuid: "u1", name: "Layout" }]),
+    };
+    const diff = diffSchema(local, remote).diffs.find(
+      (d) => d.type === "component" && d.name === "page",
+    );
+    expect(diff?.action).toBe("unchanged");
+  });
+
   it("should treat a local uuid whitelist as unchanged against the same remote uuid (schema init passthrough)", () => {
     // `schema init` emits raw uuid `component_group_whitelist` entries; both
     // sides must translate uuid → slug path so the whitelist does not diff forever.

--- a/packages/cli/src/commands/schema/push/diff-schema.ts
+++ b/packages/cli/src/commands/schema/push/diff-schema.ts
@@ -1,39 +1,22 @@
 import { createTwoFilesPatch } from "diff";
 
 import type { DiffResult, EntityDiff, RemoteSchemaData, SchemaData } from "../types";
-import { applyDefaults, COMPONENT_DEFAULTS, DATASOURCE_DEFAULTS, isRecord } from "../utils";
+import { applyDefaults, COMPONENT_DEFAULTS, DATASOURCE_DEFAULTS } from "../utils";
 import { serializeComponent, serializeDatasource } from "../serialize";
-import { buildGroupPathByUuid } from "../folders";
+import { buildGroupPathByUuid, mapSchemaGroupLists } from "../folders";
 
 type EntityType = "component" | "datasource";
 
 /**
- * Deep-copies a component's `schema`, translating each field's
- * `component_group_whitelist` uuid entries to slug paths so both sides diff in
- * the same slug-path space. Applied symmetrically to remote (whose whitelist is
- * always uuids) and local (which may carry raw uuids when produced by
- * `schema init`; slug-path entries are not uuid keys in the map and pass
- * through unchanged). Unknown uuids are left as-is so they still produce a
- * visible diff. The source schema objects are never mutated.
+ * Deep-copies a component's `schema`, translating each field's group list uuid
+ * entries to slug paths so both sides diff in the same slug-path space. Applied
+ * symmetrically to remote (whose lists are always uuids) and local (which may
+ * carry raw uuids when produced by `schema init`; slug-path entries are not uuid
+ * keys in the map and pass through unchanged). Unknown uuids are left as-is so
+ * they still produce a visible diff. The source schema objects are never mutated.
  */
-function translateGroupWhitelist(schema: unknown, uuidToPath: Map<string, string>): unknown {
-  if (!isRecord(schema)) {
-    return schema;
-  }
-  const result: Record<string, unknown> = {};
-  for (const [fieldName, field] of Object.entries(schema)) {
-    if (isRecord(field) && Array.isArray(field.component_group_whitelist)) {
-      result[fieldName] = {
-        ...field,
-        component_group_whitelist: field.component_group_whitelist.map((entry: unknown) =>
-          typeof entry === "string" ? (uuidToPath.get(entry) ?? entry) : entry,
-        ),
-      };
-    } else {
-      result[fieldName] = field;
-    }
-  }
-  return result;
+function translateGroupLists(schema: unknown, uuidToPath: Map<string, string>): unknown {
+  return mapSchemaGroupLists(schema, (entry) => uuidToPath.get(entry) ?? entry);
 }
 
 function diffEntity(
@@ -116,7 +99,7 @@ export function diffSchema(local: SchemaData, remote: RemoteSchemaData): DiffRes
     // untouched and no false diff is produced.
     const includeGroupUuid = typeof comp.component_group_uuid === "string";
 
-    // Shallow copies so group membership (`folder`) and whitelist path
+    // Shallow copies so group membership (`folder`) and group list path
     // translation never mutate the local schema or the remote component map.
     const localForDiff: Record<string, unknown> = { ...comp };
     const remoteForDiff: Record<string, unknown> | undefined = remoteComp
@@ -141,12 +124,12 @@ export function diffSchema(local: SchemaData, remote: RemoteSchemaData): DiffRes
       }
     }
 
-    // Translate whitelist uuids → slug paths on both sides. `schema init` emits
-    // raw uuid whitelists locally; without translating the local copy too, a
-    // local uuid vs remote-translated path would diff dirty forever.
-    localForDiff.schema = translateGroupWhitelist(localForDiff.schema, uuidToPath);
+    // Translate group list uuids → slug paths on both sides. `schema init` emits
+    // raw uuid lists locally; without translating the local copy too, a local
+    // uuid vs remote-translated path would diff dirty forever.
+    localForDiff.schema = translateGroupLists(localForDiff.schema, uuidToPath);
     if (remoteForDiff) {
-      remoteForDiff.schema = translateGroupWhitelist(remoteForDiff.schema, uuidToPath);
+      remoteForDiff.schema = translateGroupLists(remoteForDiff.schema, uuidToPath);
     }
 
     const localSerialized = serializeComponent(applyDefaults(localForDiff, COMPONENT_DEFAULTS), {

--- a/packages/cli/src/commands/schema/push/load-schema.test.ts
+++ b/packages/cli/src/commands/schema/push/load-schema.test.ts
@@ -213,6 +213,37 @@ describe("classifyExports folders", () => {
     expect(data.folders).toEqual([{ name: "Marketing", path: "marketing", parentPath: null }]);
   });
 
+  it("should materialize folders from deny entries", () => {
+    // Without this the folder never reaches `local.folders`, so push resolves the
+    // group denylist against nothing and writes a slug path where a uuid belongs.
+    const data = classifyExports({
+      page: {
+        name: "page",
+        fields: [{ name: "body", type: "bloks", deny: [{ folder: "Legacy" }] }],
+      },
+    });
+    expect(data.folders).toEqual([{ name: "Legacy", path: "legacy", parentPath: null }]);
+  });
+
+  it("should materialize folders from both restriction lists on one field", () => {
+    const data = classifyExports({
+      page: {
+        name: "page",
+        fields: [
+          { name: "body", type: "bloks", allow: [{ folder: "Marketing" }] },
+          { name: "aside", type: "bloks", deny: [{ folder: "Legacy/Archive" }] },
+        ],
+      },
+    });
+    // Order comes from `buildLocalFolders` (parents before children), so assert
+    // membership rather than coupling this to its sort.
+    expect(data.folders.map((f) => f.path).sort()).toEqual([
+      "legacy",
+      "legacy/archive",
+      "marketing",
+    ]);
+  });
+
   it("should dedupe by slug path with registered display name winning", () => {
     const data = classifyExports({
       myLayout: folder("My Layout"),

--- a/packages/cli/src/commands/schema/push/load-schema.ts
+++ b/packages/cli/src/commands/schema/push/load-schema.ts
@@ -121,6 +121,8 @@ function assertUniqueIdentities(
   }
 }
 
+const toArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
 /**
  * Classifies a module's exports into wire components, datasources, and folders,
  * mapping the content-shape DSL (`fields`/`allow`/`datasource`/`folder`) to the
@@ -133,8 +135,16 @@ export function classifyExports(moduleExports: Record<string, unknown>): SchemaD
   assertUniqueIdentities(components, datasources);
 
   // Harvest derived (unregistered) folder display paths from each component's
-  // `folder` field and its `allow` entries. Reads the raw DSL objects, before
-  // `mapBlockToWire` slugifies wire-side keys and loses display names.
+  // `folder` field and from both of its restriction lists. Reads the raw DSL
+  // objects, before `mapBlockToWire` slugifies wire-side keys and loses display
+  // names.
+  //
+  // A folder that only ever appears in a restriction still has to be harvested.
+  // Push resolves group lists from path to uuid against the folders it knows
+  // about, and passes an unknown path straight through, so an unharvested folder
+  // reaches the wire as a slug where a uuid belongs and the restriction matches
+  // nothing. `push --delete` compounds it: a remote folder missing from the local
+  // set reads as stale and gets deleted.
   const registered = folders.map((folder) => folder.path as string);
   const derived: string[] = [];
   for (const component of components) {
@@ -143,10 +153,10 @@ export function classifyExports(moduleExports: Record<string, unknown>): SchemaD
     }
     if (Array.isArray(component.fields)) {
       for (const field of component.fields) {
-        if (!isRecord(field) || !Array.isArray(field.allow)) {
+        if (!isRecord(field)) {
           continue;
         }
-        for (const entry of field.allow) {
+        for (const entry of [...toArray(field.allow), ...toArray(field.deny)]) {
           if (isRecord(entry) && typeof entry.folder === "string") {
             derived.push(entry.folder);
           }

--- a/packages/cli/src/commands/schema/push/write-local-components.test.ts
+++ b/packages/cli/src/commands/schema/push/write-local-components.test.ts
@@ -114,6 +114,41 @@ describe("writeLocalComponents", () => {
     expect(content).toHaveProperty("component_group_uuid", null);
   });
 
+  it("drops a path-space group denylist and its restriction flags", async () => {
+    const resolved = makeSchema({
+      components: [
+        {
+          name: "hero",
+          folder: "layout/heros",
+          component_group_uuid: null,
+          schema: {
+            blocks: {
+              type: "bloks",
+              restrict_type: "groups",
+              restrict_components: true,
+              component_group_denylist: ["legacy"],
+            },
+          },
+        } as any,
+      ],
+    });
+
+    await writeLocalComponents({
+      space: SPACE,
+      basePath: undefined,
+      resolved,
+      diffResult: makeDiff([]),
+      deleteRemoved: false,
+      ui,
+      logger,
+    });
+
+    const files = Object.keys(vol.toJSON()).map(stripDriveLetter);
+    const heroFile = files.find((f) => f.endsWith(join(componentsDir, "hero.json")));
+    const content = JSON.parse(vol.readFileSync(heroFile!, "utf-8") as string);
+    expect(content.schema.blocks).toEqual({ type: "bloks" });
+  });
+
   it("drops orphaned group-restriction keys but leaves component-whitelist fields untouched", async () => {
     const resolved = makeSchema({
       components: [

--- a/packages/cli/src/commands/schema/push/write-local-components.ts
+++ b/packages/cli/src/commands/schema/push/write-local-components.ts
@@ -13,6 +13,7 @@ import {
 import type { Component } from "../../../types";
 import type { DiffResult, SchemaData } from "../types";
 import { displayPath, isRecord } from "../utils";
+import { GROUP_LIST_KEYS } from "../folders";
 
 const DEFAULT_GROUPS_FILENAME = "groups.json";
 const CONSOLIDATED_COMPONENTS_FILENAME = "components.json";
@@ -20,26 +21,32 @@ const CONSOLIDATED_COMPONENTS_FILENAME = "components.json";
 /**
  * Strips transient, push-time-only keys before a component is written to local
  * JSON. `folder` is an internal slug-path key that never belongs on disk, and
- * each field's `component_group_whitelist` here holds slug paths, not the group
- * uuids that local JSON consumers (e.g. `stories push` schema validation)
- * expect. Only `local` schema data reaches this function — the remote/created
- * group set needed to resolve paths → uuids is not available here — so the
- * path-space whitelist is dropped rather than written in a form no consumer can
- * use. The escape-hatch `component_group_uuid` (a real uuid) is preserved.
+ * each field's group lists (`component_group_whitelist` /
+ * `component_group_denylist`) here hold slug paths, not the group uuids that
+ * local JSON consumers (e.g. `stories push` schema validation) expect. Only
+ * `local` schema data reaches this function — the remote/created group set needed
+ * to resolve paths → uuids is not available here — so the path-space lists are
+ * dropped rather than written in a form no consumer can use. The escape-hatch
+ * `component_group_uuid` (a real uuid) is preserved.
  *
- * A field carrying `component_group_whitelist` also has its `restrict_type:
- * 'groups'` and `restrict_components` keys dropped alongside it, so the
- * written JSON never has a group restriction with no group list left behind
- * (orphaned keys). Folder and block whitelists never coexist — the schema
- * throws on mixing — so this is safe: such a field has no `component_whitelist`.
+ * A field carrying either group list also has its `restrict_type: 'groups'` and
+ * `restrict_components` keys dropped alongside them, so the written JSON never
+ * has a group restriction with no group list left behind (orphaned keys). Folder
+ * and block restrictions never coexist on one field — `defineField` throws on
+ * mixing them, across `allow` and `deny` alike — so this is safe: such a field
+ * has no `component_whitelist` or `component_denylist`.
  */
 function sanitizeForLocalWrite(component: Component): Record<string, unknown> {
   const { folder, ...rest } = component as Record<string, unknown>;
   if (isRecord(rest.schema)) {
     const schema: Record<string, unknown> = {};
     for (const [key, field] of Object.entries(rest.schema)) {
-      if (isRecord(field) && "component_group_whitelist" in field) {
-        const { component_group_whitelist, restrict_components, ...fieldRest } = field;
+      if (isRecord(field) && GROUP_LIST_KEYS.some((groupKey) => groupKey in field)) {
+        const fieldRest = { ...field };
+        for (const groupKey of GROUP_LIST_KEYS) {
+          delete fieldRest[groupKey];
+        }
+        delete fieldRest.restrict_components;
         if (fieldRest.restrict_type === "groups") {
           delete fieldRest.restrict_type;
         }

--- a/packages/cli/src/commands/schema/rollback/actions.ts
+++ b/packages/cli/src/commands/schema/rollback/actions.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import { createTwoFilesPatch } from "diff";
 
 import type { ChangesetData, ChangesetEntry, RemoteSchemaData } from "../types";
-import { applyDefaults, COMPONENT_DEFAULTS, isRecord } from "../utils";
+import { applyDefaults, COMPONENT_DEFAULTS } from "../utils";
 import { serializeComponent, serializeDatasource } from "../serialize";
 import { getMapiClient } from "../../../api";
 import { handleAPIError } from "../../../utils";
@@ -15,7 +15,7 @@ import {
   toDatasourceCreate,
   toDatasourceUpdate,
 } from "../transform";
-import { buildGroupPathByUuid } from "../folders";
+import { buildGroupPathByUuid, mapSchemaGroupLists } from "../folders";
 
 /** API-assigned fields stripped before sending a rollback create payload to MAPI. */
 const API_ASSIGNED_FIELDS = [
@@ -243,11 +243,10 @@ function parentPathOf(path: string): string | null {
  * Remaps a snapshot's stored component group uuids to their live equivalents.
  *
  * When a rollback recreates a folder the Management API assigns it a *new* uuid,
- * so a component's stored `component_group_uuid` (and any field's
- * `component_group_whitelist`) from the pre-push snapshot would otherwise point
- * at a group that no longer exists. `uuidMap` (old uuid → new uuid) is populated
- * as folders are recreated; entries not in the map (groups this push never
- * touched) are left as-is.
+ * so a component's stored `component_group_uuid` (and any field's group lists)
+ * from the pre-push snapshot would otherwise point at a group that no longer
+ * exists. `uuidMap` (old uuid → new uuid) is populated as folders are recreated;
+ * entries not in the map (groups this push never touched) are left as-is.
  */
 function remapGroupUuids(
   payload: Record<string, unknown>,
@@ -261,22 +260,7 @@ function remapGroupUuids(
     result.component_group_uuid =
       uuidMap.get(result.component_group_uuid) ?? result.component_group_uuid;
   }
-  if (isRecord(result.schema)) {
-    const schema: Record<string, unknown> = {};
-    for (const [key, field] of Object.entries(result.schema)) {
-      if (isRecord(field) && Array.isArray(field.component_group_whitelist)) {
-        schema[key] = {
-          ...field,
-          component_group_whitelist: field.component_group_whitelist.map((uuid) =>
-            typeof uuid === "string" ? (uuidMap.get(uuid) ?? uuid) : uuid,
-          ),
-        };
-      } else {
-        schema[key] = field;
-      }
-    }
-    result.schema = schema;
-  }
+  result.schema = mapSchemaGroupLists(result.schema, (uuid) => uuidMap.get(uuid) ?? uuid);
   return result;
 }
 

--- a/packages/live-preview/src/generated/types/field.ts
+++ b/packages/live-preview/src/generated/types/field.ts
@@ -227,21 +227,44 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
+/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
+type FolderOf<T> =
+  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+
 /**
- * Removes the registry blocks named in `deny`, the `Exclude` counterpart to
- * {@link ApplyAllow}. The wire `component_denylist` denies by block name only,
- * so folder refs are not accepted. A `deny` entry naming no known block is
- * inert: it removes nothing rather than collapsing the field.
+ * Removes the registry blocks in `TFolders` (or any nested folder), the
+ * {@link MatchesFolder} counterpart for `deny`. A `never` folder set removes
+ * nothing, so a block-name-only `deny` leaves the union untouched.
+ */
+type DenyFolders<TBlocks, TFolders extends string> = [TFolders] extends [never]
+  ? TBlocks
+  : TBlocks extends any
+    ? [MatchesFolder<TBlocks, TFolders>] extends [never]
+      ? TBlocks
+      : never
+    : never;
+
+/**
+ * Removes the registry blocks named in `deny`, or living in a folder it names,
+ * the `Exclude` counterpart to {@link ApplyAllow}. A `deny` entry naming no known
+ * block or folder is inert: it removes nothing rather than collapsing the field.
+ *
+ * `TDenied` is split with `Extract` rather than a `TDenied extends string`
+ * conditional, because that conditional would distribute over the deny union and
+ * union the per-entry `Exclude` results back together — re-admitting every denied
+ * block. Names and folders are therefore removed in one pass each.
  */
 type ApplyDeny<TField, TBlocks> = TField extends {
-  deny: ReadonlyArray<infer TDenied extends string>;
+  deny: ReadonlyArray<infer TDenied extends AllowEntry>;
 }
-  ? Exclude<TBlocks, { name: TDenied }>
+  ? DenyFolders<Exclude<TBlocks, { name: Extract<TDenied, string> }>, FolderOf<TDenied>>
   : TBlocks;
 
 /**
  * Resolves the block union a `bloks` field accepts: `allow` narrows the registry
- * first, then `deny` removes from what is left, so the two compose.
+ * first, then `deny` removes from what is left, so the two compose. The editor
+ * instead gives a non-empty `allow` precedence and ignores `deny` beside it, so on
+ * a field carrying both these types are the stricter of the two views.
  */
 type ApplyRestrictions<TField, TBlocks> = ApplyDeny<TField, ApplyAllow<TField, TBlocks>>;
 

--- a/packages/live-preview/src/generated/types/field.ts
+++ b/packages/live-preview/src/generated/types/field.ts
@@ -227,9 +227,16 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
-/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
-type FolderOf<T> =
-  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+/**
+ * The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union.
+ *
+ * Written as an indexed access rather than a conditional with `infer`: when the
+ * union names no folder at all, `Extract` yields `never`, and `never extends
+ * { folder: infer F extends string }` takes the *true* branch with no inference
+ * candidate for `F`, which then falls back to its `string` constraint. That turned
+ * a block-name-only `deny` into "deny every folder".
+ */
+type FolderOf<T> = Extract<T, { folder: string }>["folder"];
 
 /**
  * Removes the registry blocks in `TFolders` (or any nested folder), the

--- a/packages/mapi-client/src/generated/types/field.ts
+++ b/packages/mapi-client/src/generated/types/field.ts
@@ -227,21 +227,44 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
+/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
+type FolderOf<T> =
+  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+
 /**
- * Removes the registry blocks named in `deny`, the `Exclude` counterpart to
- * {@link ApplyAllow}. The wire `component_denylist` denies by block name only,
- * so folder refs are not accepted. A `deny` entry naming no known block is
- * inert: it removes nothing rather than collapsing the field.
+ * Removes the registry blocks in `TFolders` (or any nested folder), the
+ * {@link MatchesFolder} counterpart for `deny`. A `never` folder set removes
+ * nothing, so a block-name-only `deny` leaves the union untouched.
+ */
+type DenyFolders<TBlocks, TFolders extends string> = [TFolders] extends [never]
+  ? TBlocks
+  : TBlocks extends any
+    ? [MatchesFolder<TBlocks, TFolders>] extends [never]
+      ? TBlocks
+      : never
+    : never;
+
+/**
+ * Removes the registry blocks named in `deny`, or living in a folder it names,
+ * the `Exclude` counterpart to {@link ApplyAllow}. A `deny` entry naming no known
+ * block or folder is inert: it removes nothing rather than collapsing the field.
+ *
+ * `TDenied` is split with `Extract` rather than a `TDenied extends string`
+ * conditional, because that conditional would distribute over the deny union and
+ * union the per-entry `Exclude` results back together — re-admitting every denied
+ * block. Names and folders are therefore removed in one pass each.
  */
 type ApplyDeny<TField, TBlocks> = TField extends {
-  deny: ReadonlyArray<infer TDenied extends string>;
+  deny: ReadonlyArray<infer TDenied extends AllowEntry>;
 }
-  ? Exclude<TBlocks, { name: TDenied }>
+  ? DenyFolders<Exclude<TBlocks, { name: Extract<TDenied, string> }>, FolderOf<TDenied>>
   : TBlocks;
 
 /**
  * Resolves the block union a `bloks` field accepts: `allow` narrows the registry
- * first, then `deny` removes from what is left, so the two compose.
+ * first, then `deny` removes from what is left, so the two compose. The editor
+ * instead gives a non-empty `allow` precedence and ignores `deny` beside it, so on
+ * a field carrying both these types are the stricter of the two views.
  */
 type ApplyRestrictions<TField, TBlocks> = ApplyDeny<TField, ApplyAllow<TField, TBlocks>>;
 

--- a/packages/mapi-client/src/generated/types/field.ts
+++ b/packages/mapi-client/src/generated/types/field.ts
@@ -227,9 +227,16 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
-/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
-type FolderOf<T> =
-  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+/**
+ * The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union.
+ *
+ * Written as an indexed access rather than a conditional with `infer`: when the
+ * union names no folder at all, `Extract` yields `never`, and `never extends
+ * { folder: infer F extends string }` takes the *true* branch with no inference
+ * candidate for `F`, which then falls back to its `string` constraint. That turned
+ * a block-name-only `deny` into "deny every folder".
+ */
+type FolderOf<T> = Extract<T, { folder: string }>["folder"];
 
 /**
  * Removes the registry blocks in `TFolders` (or any nested folder), the

--- a/packages/schema/src/generated/types/field.ts
+++ b/packages/schema/src/generated/types/field.ts
@@ -227,21 +227,44 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
+/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
+type FolderOf<T> =
+  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+
 /**
- * Removes the registry blocks named in `deny`, the `Exclude` counterpart to
- * {@link ApplyAllow}. The wire `component_denylist` denies by block name only,
- * so folder refs are not accepted. A `deny` entry naming no known block is
- * inert: it removes nothing rather than collapsing the field.
+ * Removes the registry blocks in `TFolders` (or any nested folder), the
+ * {@link MatchesFolder} counterpart for `deny`. A `never` folder set removes
+ * nothing, so a block-name-only `deny` leaves the union untouched.
+ */
+type DenyFolders<TBlocks, TFolders extends string> = [TFolders] extends [never]
+  ? TBlocks
+  : TBlocks extends any
+    ? [MatchesFolder<TBlocks, TFolders>] extends [never]
+      ? TBlocks
+      : never
+    : never;
+
+/**
+ * Removes the registry blocks named in `deny`, or living in a folder it names,
+ * the `Exclude` counterpart to {@link ApplyAllow}. A `deny` entry naming no known
+ * block or folder is inert: it removes nothing rather than collapsing the field.
+ *
+ * `TDenied` is split with `Extract` rather than a `TDenied extends string`
+ * conditional, because that conditional would distribute over the deny union and
+ * union the per-entry `Exclude` results back together — re-admitting every denied
+ * block. Names and folders are therefore removed in one pass each.
  */
 type ApplyDeny<TField, TBlocks> = TField extends {
-  deny: ReadonlyArray<infer TDenied extends string>;
+  deny: ReadonlyArray<infer TDenied extends AllowEntry>;
 }
-  ? Exclude<TBlocks, { name: TDenied }>
+  ? DenyFolders<Exclude<TBlocks, { name: Extract<TDenied, string> }>, FolderOf<TDenied>>
   : TBlocks;
 
 /**
  * Resolves the block union a `bloks` field accepts: `allow` narrows the registry
- * first, then `deny` removes from what is left, so the two compose.
+ * first, then `deny` removes from what is left, so the two compose. The editor
+ * instead gives a non-empty `allow` precedence and ignores `deny` beside it, so on
+ * a field carrying both these types are the stricter of the two views.
  */
 type ApplyRestrictions<TField, TBlocks> = ApplyDeny<TField, ApplyAllow<TField, TBlocks>>;
 

--- a/packages/schema/src/generated/types/field.ts
+++ b/packages/schema/src/generated/types/field.ts
@@ -227,9 +227,16 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
-/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
-type FolderOf<T> =
-  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+/**
+ * The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union.
+ *
+ * Written as an indexed access rather than a conditional with `infer`: when the
+ * union names no folder at all, `Extract` yields `never`, and `never extends
+ * { folder: infer F extends string }` takes the *true* branch with no inference
+ * candidate for `F`, which then falls back to its `string` constraint. That turned
+ * a block-name-only `deny` into "deny every folder".
+ */
+type FolderOf<T> = Extract<T, { folder: string }>["folder"];
 
 /**
  * Removes the registry blocks in `TFolders` (or any nested folder), the

--- a/packages/schema/src/helpers/define-field.test-d.ts
+++ b/packages/schema/src/helpers/define-field.test-d.ts
@@ -164,6 +164,65 @@ describe("defineField type inference", () => {
     expectTypeOf<Body[number]["component"]>().toEqualTypeOf<"hero" | "teaser">();
   });
 
+  it("should remove every block named in a multi-entry `deny`", () => {
+    // Regression: splitting the deny union with a distributive conditional would
+    // union the per-entry `Exclude` results back together, re-admitting both.
+    const _heroBlock = defineBlock({ name: "hero", is_nestable: true, fields: [] });
+    const _teaserBlock = defineBlock({ name: "teaser", is_nestable: true, fields: [] });
+    const _bannerBlock = defineBlock({ name: "banner", is_nestable: true, fields: [] });
+    const _pageBlock = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", deny: ["teaser", "banner"] })],
+    });
+    type Body = FieldValue<
+      (typeof _pageBlock)["fields"][0],
+      typeof _heroBlock | typeof _teaserBlock | typeof _bannerBlock
+    >;
+    expectTypeOf<Body[number]["component"]>().toEqualTypeOf<"hero">();
+  });
+
+  it("should normalize folder refs in `deny` to tagged path entries", () => {
+    const heros = defineFolder({ name: "Heros" });
+    const f = defineField("body", { type: "bloks", deny: [heros] });
+    expectTypeOf(f.deny).toEqualTypeOf<readonly [{ folder: "Heros" }]>();
+  });
+
+  it("should narrow bloks content by folder `deny` entries, including nested folders", () => {
+    const layout = defineFolder({ name: "Layout" });
+    const heros = defineFolder({ name: "Heros", parent: layout });
+    const _heroBlock = defineBlock({ name: "hero", folder: heros, fields: [] });
+    const _teaserBlock = defineBlock({ name: "teaser", fields: [] });
+    const _pageBlock = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", deny: [layout] })],
+    });
+    type Body = FieldValue<
+      (typeof _pageBlock)["fields"][0],
+      typeof _heroBlock | typeof _teaserBlock
+    >;
+    // `hero` sits in a subfolder of the denied `Layout`, so only the unfoldered
+    // `teaser` survives.
+    expectTypeOf<Body[number]["component"]>().toEqualTypeOf<"teaser">();
+  });
+
+  it("should treat a folder `deny` naming no populated folder as inert", () => {
+    const empty = defineFolder({ name: "Empty" });
+    const _heroBlock = defineBlock({ name: "hero", is_nestable: true, fields: [] });
+    const _teaserBlock = defineBlock({ name: "teaser", is_nestable: true, fields: [] });
+    const _pageBlock = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", deny: [empty] })],
+    });
+    type Body = FieldValue<
+      (typeof _pageBlock)["fields"][0],
+      typeof _heroBlock | typeof _teaserBlock
+    >;
+    expectTypeOf<Body[number]["component"]>().toEqualTypeOf<"hero" | "teaser">();
+  });
+
   it("should treat a `deny` entry naming an unknown block as inert", () => {
     const _heroBlock = defineBlock({ name: "hero", is_nestable: true, fields: [] });
     const _teaserBlock = defineBlock({ name: "teaser", is_nestable: true, fields: [] });

--- a/packages/schema/src/helpers/define-field.test-d.ts
+++ b/packages/schema/src/helpers/define-field.test-d.ts
@@ -223,6 +223,33 @@ describe("defineField type inference", () => {
     expectTypeOf<Body[number]["component"]>().toEqualTypeOf<"hero" | "teaser">();
   });
 
+  it("should leave foldered blocks alone when `deny` names only block names", () => {
+    // Regression: deriving the denied folder set with `Extract<...> extends
+    // { folder: infer F extends string }` resolved to `string` rather than `never`
+    // for a name-only deny, because `never` takes the true branch and `F` fell back
+    // to its constraint. Every block with a `folder` was then denied.
+    const layout = defineFolder({ name: "Layout" });
+    const _heroBlock = defineBlock({ name: "hero", folder: layout, is_nestable: true, fields: [] });
+    const _bannerBlock = defineBlock({
+      name: "banner",
+      folder: layout,
+      is_nestable: true,
+      fields: [],
+    });
+    const _teaserBlock = defineBlock({ name: "teaser", is_nestable: true, fields: [] });
+    const _pageBlock = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", deny: ["banner"] })],
+    });
+    type Body = FieldValue<
+      (typeof _pageBlock)["fields"][0],
+      typeof _heroBlock | typeof _bannerBlock | typeof _teaserBlock
+    >;
+    // Only `banner` is denied; `hero` keeps its place despite sharing a folder.
+    expectTypeOf<Body[number]["component"]>().toEqualTypeOf<"hero" | "teaser">();
+  });
+
   it("should treat a `deny` entry naming an unknown block as inert", () => {
     const _heroBlock = defineBlock({ name: "hero", is_nestable: true, fields: [] });
     const _teaserBlock = defineBlock({ name: "teaser", is_nestable: true, fields: [] });

--- a/packages/schema/src/helpers/define-field.test.ts
+++ b/packages/schema/src/helpers/define-field.test.ts
@@ -59,6 +59,21 @@ describe("defineField", () => {
     );
   });
 
+  it("should throw when deny is used on a field type with no denylist", () => {
+    expect(() => defineField("link", { type: "multilink", deny: ["page"] })).toThrow(
+      'defineField: "deny" on field "link" has no effect on a "multilink" field; only bloks and richtext fields have a block denylist',
+    );
+  });
+
+  it("should allow deny on richtext as well as bloks", () => {
+    expect(defineField("prose", { type: "richtext", deny: ["banner"] }).deny).toEqual(["banner"]);
+    expect(defineField("body", { type: "bloks", deny: ["banner"] }).deny).toEqual(["banner"]);
+  });
+
+  it("should not throw on an empty deny list, whatever the field type", () => {
+    expect(() => defineField("title", { type: "text", deny: [] })).not.toThrow();
+  });
+
   it("should not treat an empty allow list as a conflicting dimension", () => {
     const heros = defineFolder({ name: "Heros" });
     const field = defineField("body", { type: "bloks", allow: [], deny: [heros] });

--- a/packages/schema/src/helpers/define-field.test.ts
+++ b/packages/schema/src/helpers/define-field.test.ts
@@ -27,12 +27,42 @@ describe("defineField", () => {
     expect(field.deny).toEqual(["hero", "banner"]);
   });
 
-  it("should throw when deny holds a folder reference", () => {
-    // A folder ref carries a `name`, so it structurally passes for a block ref;
-    // the runtime guard is what keeps it from silently denying by folder name.
+  it("should normalize folder refs in deny to tagged path entries", () => {
+    // A folder ref carries a `name` too, so it structurally passes for a block
+    // ref; only the `path` guard tells the two apart.
+    const heros = defineFolder({ name: "Heros", parent: defineFolder({ name: "Layout" }) });
+    const field = defineField("body", { type: "bloks", deny: [heros] });
+    expect(field.deny).toEqual([{ folder: "Layout/Heros" }]);
+  });
+
+  it("should throw when deny mixes blocks and folders", () => {
     const heros = defineFolder({ name: "Heros" });
-    expect(() => defineField("body", { type: "bloks", deny: [heros] })).toThrow(
-      'defineField: "deny" on field "body" does not accept folder references; the editor denies by block name only',
+    expect(() => defineField("body", { type: "bloks", deny: [heros, "teaser"] })).toThrow(
+      'defineField: "deny" on field "body" mixes block and folder references; the editor restricts by either blocks or folders, not both',
     );
+  });
+
+  it("should keep allow and deny that restrict by the same dimension", () => {
+    const field = defineField("body", {
+      type: "bloks",
+      allow: ["teaser", "banner"],
+      deny: ["banner"],
+    });
+    expect(field.allow).toEqual(["teaser", "banner"]);
+    expect(field.deny).toEqual(["banner"]);
+  });
+
+  it("should throw when allow and deny restrict by different dimensions", () => {
+    const heros = defineFolder({ name: "Heros" });
+    expect(() => defineField("body", { type: "bloks", allow: [heros], deny: ["teaser"] })).toThrow(
+      'defineField: "allow" and "deny" on field "body" mix block and folder references; the editor restricts by either blocks or folders, not both',
+    );
+  });
+
+  it("should not treat an empty allow list as a conflicting dimension", () => {
+    const heros = defineFolder({ name: "Heros" });
+    const field = defineField("body", { type: "bloks", allow: [], deny: [heros] });
+    expect(field.allow).toEqual([]);
+    expect(field.deny).toEqual([{ folder: "Heros" }]);
   });
 });

--- a/packages/schema/src/helpers/define-field.ts
+++ b/packages/schema/src/helpers/define-field.ts
@@ -33,51 +33,77 @@ export type {
   TableFieldValue,
 };
 
-/** A block reference for `allow`: a defined block object or its name. */
-type AllowRef = string | { name: string };
-/** A folder reference for `allow`: a defined folder object (no string shorthand — bare strings are block names). */
-type FolderAllowRef = BlockFolder;
+/** A block reference for `allow`/`deny`: a defined block object or its name. */
+type BlockRef = string | { name: string };
+/** A folder reference for `allow`/`deny`: a defined folder object (no string shorthand — bare strings are block names). */
+type FolderRef = BlockFolder;
 /** A datasource reference for `datasource`: a defined datasource object or its slug. */
 type DatasourceRef = string | { slug: string };
 
 type NameOf<T> = T extends string ? T : T extends { name: infer N extends string } ? N : never;
 type SlugOf<T> = T extends string ? T : T extends { slug: infer S extends string } ? S : never;
 
-/** Normalizes a single `allow` entry: folder refs to `{ folder: path }`, everything else to a name string. */
-type NormalizeAllowEntry<T> = T extends { path: infer P extends string }
+/** Normalizes a single `allow`/`deny` entry: folder refs to `{ folder: path }`, everything else to a name string. */
+type NormalizeRestrictionEntry<T> = T extends { path: infer P extends string }
   ? { folder: P }
   : NameOf<T>;
-/** Normalizes an `allow` input (ref, name, or array thereof) to a tuple of normalized entries. */
-type NormalizeAllow<T> = T extends readonly any[]
-  ? { [I in keyof T]: NormalizeAllowEntry<T[I]> }
-  : readonly [NormalizeAllowEntry<T>];
-/** Normalizes a `deny` input (ref, name, or array thereof) to a tuple of block names. */
-type NormalizeDeny<T> = T extends readonly any[]
-  ? { [I in keyof T]: NameOf<T[I]> }
-  : readonly [NameOf<T>];
+/** Normalizes an `allow`/`deny` input (ref, name, or array thereof) to a tuple of normalized entries. */
+type NormalizeRestriction<T> = T extends readonly any[]
+  ? { [I in keyof T]: NormalizeRestrictionEntry<T[I]> }
+  : readonly [NormalizeRestrictionEntry<T>];
 
 /** Type guard for a defined folder ref: has `path`, and never `fields` (defined block) or `slug` (datasource). */
 const isFolderRef = (ref: unknown): ref is BlockFolder =>
   isRecord(ref) && typeof ref.path === "string" && !Array.isArray(ref.fields) && !("slug" in ref);
 
+/** Whether a normalized `allow`/`deny` list restricts by folder rather than by block name. */
+const isFolderList = (entries: readonly unknown[]): boolean =>
+  entries.some((entry) => isRecord(entry) && typeof entry.folder === "string");
+
+/**
+ * Normalizes an `allow`/`deny` input to plain block names and `{ folder: path }`
+ * entries. The editor restricts by either blocks or folders, not both, so a list
+ * mixing the two would leave part of itself inert and throws instead.
+ */
+function normalizeRestriction(key: string, name: string, input: unknown): unknown[] {
+  const refs = Array.isArray(input) ? input : [input];
+  const folderRefs = refs.filter(isFolderRef);
+  if (folderRefs.length > 0 && folderRefs.length < refs.length) {
+    throw new Error(
+      `defineField: "${key}" on field "${name}" mixes block and folder references; the editor restricts by either blocks or folders, not both`,
+    );
+  }
+  return refs.map((ref) =>
+    isFolderRef(ref)
+      ? { folder: ref.path }
+      : typeof ref === "string"
+        ? ref
+        : isRecord(ref)
+          ? ref.name
+          : undefined,
+  );
+}
+
 /**
  * Field config accepted by {@link defineField}: the content-shape field plus the
- * DSL reference keys. `allow` replaces the wire `component_whitelist`, `deny` the
- * wire `component_denylist`; `datasource` holds the datasource ref/slug (the wire
- * `source` selector still passes through).
+ * DSL reference keys. `allow` replaces the wire `component_whitelist` /
+ * `component_group_whitelist`, `deny` the wire `component_denylist` /
+ * `component_group_denylist`; `datasource` holds the datasource ref/slug (the
+ * wire `source` selector still passes through).
  */
 export type FieldInput = Field & {
-  allow?: AllowRef | FolderAllowRef | readonly (AllowRef | FolderAllowRef)[];
+  allow?: BlockRef | FolderRef | readonly (BlockRef | FolderRef)[];
   /**
-   * Blocks this field must not accept, by ref or name. Narrows the field's
-   * content type as the counterpart to `allow`, and composes with it.
+   * Blocks this field must not accept, by block ref/name or `defineFolder` ref.
+   * The `Exclude` counterpart to `allow`: it narrows the field's content type and
+   * `schema push` applies the matching editor restriction.
    *
-   * The Storyblok CLI does not translate `deny` to the wire
-   * `component_denylist` yet, so `schema push` does not enforce it in the space:
-   * use it for type narrowing, and set `component_denylist` alongside it when
-   * you need the editor restriction too.
+   * The editor restricts by either blocks or folders, never both, so `allow` and
+   * `deny` on one field must not disagree on which. Where they agree, the editor
+   * gives `allow` precedence: a non-empty allow list decides on its own and
+   * leaves `deny` inert, so reach for `deny` when you mean "everything except".
    */
-  deny?: AllowRef | readonly AllowRef[];
+  deny?: BlockRef | FolderRef | readonly (BlockRef | FolderRef)[];
   datasource?: DatasourceRef;
   required?: boolean;
 };
@@ -87,16 +113,17 @@ export type DefinedField<TName extends string, TField extends FieldInput> = Pret
   Omit<TField, "allow" | "deny" | "datasource" | "name"> & { name: TName } & (TField extends {
       allow: infer A;
     }
-      ? { allow: NormalizeAllow<A> }
+      ? { allow: NormalizeRestriction<A> }
       : unknown) &
-    (TField extends { deny: infer D } ? { deny: NormalizeDeny<D> } : unknown) &
+    (TField extends { deny: infer D } ? { deny: NormalizeRestriction<D> } : unknown) &
     (TField extends { datasource: infer D } ? { datasource: SlugOf<D> } : unknown)
 >;
 
 /**
  * Returns a {@link Field} stamped with the given `name`, normalizing reference
  * keys to strings so everything downstream sees plain names/slugs. A thin,
- * strongly-typed identity helper — it does not validate or throw.
+ * strongly-typed identity helper: it validates only that `allow` and `deny` pick
+ * a single restriction dimension, and otherwise does not check the field.
  *
  * Use inside a {@link defineBlock} `fields` array — `pos` is injected from the
  * array index by `defineBlock`.
@@ -105,6 +132,7 @@ export type DefinedField<TName extends string, TField extends FieldInput> = Pret
  * defineField('headline', { type: 'text', max_length: 100, required: true });
  * defineField('body', { type: 'bloks', allow: [heroBlock, 'teaser'] });
  * defineField('body', { type: 'bloks', deny: ['banner'] });
+ * defineField('body', { type: 'bloks', deny: [legacyFolder] });
  * defineField('theme', { type: 'option', source: 'internal', datasource: colors });
  */
 export function defineField<const TName extends string, const TField extends FieldInput>(
@@ -114,34 +142,22 @@ export function defineField<const TName extends string, const TField extends Fie
 export function defineField(name: string, field: Record<string, unknown>): Record<string, unknown> {
   const { allow, deny, datasource, ...rest } = field;
   const normalized: Record<string, unknown> = { ...rest, name };
-  if (allow !== undefined) {
-    const refs = Array.isArray(allow) ? allow : [allow];
-    const folderRefs = refs.filter(isFolderRef);
-    if (folderRefs.length > 0 && folderRefs.length < refs.length) {
-      throw new Error(
-        `defineField: "allow" on field "${name}" mixes block and folder references; the editor restricts by either blocks or folders, not both`,
-      );
-    }
-    normalized.allow = refs.map((ref) =>
-      isFolderRef(ref)
-        ? { folder: ref.path }
-        : typeof ref === "string"
-          ? ref
-          : isRecord(ref)
-            ? ref.name
-            : undefined,
+  const allowList = allow === undefined ? undefined : normalizeRestriction("allow", name, allow);
+  const denyList = deny === undefined ? undefined : normalizeRestriction("deny", name, deny);
+  // The editor picks one restriction dimension per field, so an `allow` that
+  // restricts by folder alongside a `deny` that restricts by block name (or the
+  // reverse) would silently drop one of the two lists. Empty lists carry no
+  // dimension, so they never conflict.
+  if (allowList?.length && denyList?.length && isFolderList(allowList) !== isFolderList(denyList)) {
+    throw new Error(
+      `defineField: "allow" and "deny" on field "${name}" mix block and folder references; the editor restricts by either blocks or folders, not both`,
     );
   }
-  if (deny !== undefined) {
-    const refs = Array.isArray(deny) ? deny : [deny];
-    if (refs.some(isFolderRef)) {
-      throw new Error(
-        `defineField: "deny" on field "${name}" does not accept folder references; the editor denies by block name only`,
-      );
-    }
-    normalized.deny = refs.map((ref) =>
-      typeof ref === "string" ? ref : isRecord(ref) ? ref.name : undefined,
-    );
+  if (allowList !== undefined) {
+    normalized.allow = allowList;
+  }
+  if (denyList !== undefined) {
+    normalized.deny = denyList;
   }
   if (datasource !== undefined) {
     normalized.datasource =

--- a/packages/schema/src/helpers/define-field.ts
+++ b/packages/schema/src/helpers/define-field.ts
@@ -61,6 +61,17 @@ const isFolderList = (entries: readonly unknown[]): boolean =>
   entries.some((entry) => isRecord(entry) && typeof entry.folder === "string");
 
 /**
+ * The field types whose nested-block picker reads the restriction lists, and so
+ * the only ones a `deny` can mean anything on.
+ *
+ * `allow` is deliberately not limited to these: `component_whitelist` is also
+ * real on `multilink`, where it selects story content types rather than blocks.
+ * There is no denylist counterpart to that, so a `deny` anywhere else writes a
+ * key nothing reads.
+ */
+export const DENIABLE_FIELD_TYPES: readonly string[] = ["bloks", "richtext"];
+
+/**
  * Normalizes an `allow`/`deny` input to plain block names and `{ folder: path }`
  * entries. The editor restricts by either blocks or folders, not both, so a list
  * mixing the two would leave part of itself inert and throws instead.
@@ -96,12 +107,18 @@ export type FieldInput = Field & {
   /**
    * Blocks this field must not accept, by block ref/name or `defineFolder` ref.
    * The `Exclude` counterpart to `allow`: it narrows the field's content type and
-   * `schema push` applies the matching editor restriction.
+   * `schema push` applies the matching editor restriction. Only `bloks` and
+   * `richtext` fields have a denylist; anywhere else this throws.
    *
    * The editor restricts by either blocks or folders, never both, so `allow` and
    * `deny` on one field must not disagree on which. Where they agree, the editor
    * gives `allow` precedence: a non-empty allow list decides on its own and
    * leaves `deny` inert, so reach for `deny` when you mean "everything except".
+   *
+   * A denial governs the block picker, not the stored content. Pasting a block
+   * from the clipboard is checked against the allow list only, so a denied block
+   * can still be pasted in. Treat `deny` as authoring guidance rather than a
+   * boundary, and use `allow` where a block genuinely must never appear.
    */
   deny?: BlockRef | FolderRef | readonly (BlockRef | FolderRef)[];
   datasource?: DatasourceRef;
@@ -151,6 +168,14 @@ export function defineField(name: string, field: Record<string, unknown>): Recor
   if (allowList?.length && denyList?.length && isFolderList(allowList) !== isFolderList(denyList)) {
     throw new Error(
       `defineField: "allow" and "deny" on field "${name}" mix block and folder references; the editor restricts by either blocks or folders, not both`,
+    );
+  }
+  // Rejected rather than dropped: a `deny` the editor cannot read is the bug this
+  // key was added to fix, so failing loudly beats writing a dead wire key that
+  // round-trips and looks intentional.
+  if (denyList?.length && !DENIABLE_FIELD_TYPES.includes(String(rest.type))) {
+    throw new Error(
+      `defineField: "deny" on field "${name}" has no effect on a "${String(rest.type)}" field; only ${DENIABLE_FIELD_TYPES.join(" and ")} fields have a block denylist`,
     );
   }
   if (allowList !== undefined) {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -22,7 +22,7 @@ export type { ConditionOptions, FieldCondition } from "./helpers/define-conditio
 export { defineDatasource } from "./helpers/define-datasource";
 export type { Datasource } from "./helpers/define-datasource";
 // Field
-export { defineField } from "./helpers/define-field";
+export { DENIABLE_FIELD_TYPES, defineField } from "./helpers/define-field";
 export type {
   AssetFieldValue,
   BlockContent,

--- a/packages/schema/src/validators/shapes.ts
+++ b/packages/schema/src/validators/shapes.ts
@@ -19,6 +19,11 @@ export interface SchemaFieldLike {
   required?: boolean;
   /** Normalized block-name or folder-path references for `bloks` fields. */
   allow?: readonly (string | { folder: string })[];
+  /**
+   * The `deny` counterpart, same normalized shape. Only in force when `allow` is
+   * empty: the editor lets a non-empty allow list decide on its own.
+   */
+  deny?: readonly (string | { folder: string })[];
   /** Normalized datasource slug for option/options fields. */
   datasource?: string;
   /** `option`/`options`: the self-sourced selectable options. */

--- a/packages/schema/src/validators/validate-schema.test.ts
+++ b/packages/schema/src/validators/validate-schema.test.ts
@@ -124,6 +124,26 @@ describe("validateSchema", () => {
     expect(codesFor(result)).toContain("unresolved_allow");
   });
 
+  it("flags a deny reference to an unknown block", () => {
+    const block = defineBlock({
+      name: "page",
+      fields: [defineField("body", { type: "bloks", deny: ["ghost"] })],
+    });
+    const result = validateSchema({ blocks: [block] });
+    expect(result.ok).toBe(false);
+    expect(codesFor(result)).toContain("unresolved_deny");
+  });
+
+  it("does not flag a folder deny entry as unresolved", () => {
+    const legacy = defineFolder({ name: "Legacy" });
+    const block = defineBlock({
+      name: "page",
+      fields: [defineField("body", { type: "bloks", deny: [legacy] })],
+    });
+    const result = validateSchema({ blocks: [block] });
+    expect(codesFor(result)).not.toContain("unresolved_deny");
+  });
+
   it("does not flag a folder allow entry as unresolved", () => {
     const layout = defineFolder({ name: "Layout" });
     const block = defineBlock({

--- a/packages/schema/src/validators/validate-schema.ts
+++ b/packages/schema/src/validators/validate-schema.ts
@@ -178,6 +178,22 @@ export function validateSchema(schema: SchemaLike): ValidationResult {
         }
       }
 
+      // A misspelled `deny` entry is worse than a misspelled `allow` one: the
+      // allow list still restricts, so the mistake shows up as blocks going
+      // missing from the picker, while a deny list that matches nothing silently
+      // restricts nothing at all.
+      for (const denied of field.deny ?? []) {
+        if (typeof denied === "string" && !blockNames.has(denied)) {
+          issues.push({
+            severity: "error",
+            code: "unresolved_deny",
+            path: ["blocks", blockKey, fieldName ?? index, "deny"],
+            entity: blockEntity,
+            message: `Field "${fieldName}" denies unknown block "${denied}".`,
+          });
+        }
+      }
+
       const datasource = field.datasource;
       if (typeof datasource === "string" && !datasourceSlugs.has(datasource)) {
         issues.push({

--- a/packages/schema/src/validators/validate-story.test.ts
+++ b/packages/schema/src/validators/validate-story.test.ts
@@ -1159,3 +1159,107 @@ describe("validateStory — subsumed issues", () => {
     ]);
   });
 });
+
+describe("validateStory — deny entries", () => {
+  const legacy = defineFolder({ name: "Legacy" });
+  const legacyArchive = defineFolder({ name: "Archive", parent: legacy });
+  const banner = defineBlock({
+    name: "banner",
+    fields: [defineField("text", { type: "text" })],
+  });
+  const oldBanner = defineBlock({
+    name: "old_banner",
+    folder: legacyArchive,
+    fields: [defineField("text", { type: "text" })],
+  });
+  const teaserBlock = defineBlock({
+    name: "teaser",
+    fields: [defineField("text", { type: "text" })],
+  });
+
+  const storyWith = (component: string) => ({
+    content: { component: "page", body: [{ component, text: "hi" }] },
+  });
+
+  it("rejects a component named in deny", () => {
+    const page = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", deny: ["banner"] })],
+    });
+    const result = validateStory(storyWith("banner"), {
+      blocks: { page, banner, teaser: teaserBlock },
+    });
+    const disallowed = result.issues.find((i) => i.code === "disallowed_component");
+    expect(disallowed?.message).toBe(
+      'Component "banner" is denied in field "body"; denied: banner.',
+    );
+  });
+
+  it("accepts a component the deny list does not name", () => {
+    const page = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", deny: ["banner"] })],
+    });
+    const result = validateStory(storyWith("teaser"), {
+      blocks: { page, banner, teaser: teaserBlock },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a component in a nested subfolder of a denied folder", () => {
+    const page = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", deny: [legacy] })],
+    });
+    const result = validateStory(storyWith("old_banner"), {
+      blocks: { page, old_banner: oldBanner, teaser: teaserBlock },
+    });
+    const disallowed = result.issues.find((i) => i.code === "disallowed_component");
+    expect(disallowed?.message).toBe(
+      'Component "old_banner" is denied in field "body"; denied: folder:Legacy.',
+    );
+  });
+
+  it("lets a non-empty allow list decide on its own, matching the editor", () => {
+    // The editor never consults the denylist while the allow list has entries.
+    // Enforcing both would be stricter than the runtime it is validating for.
+    const page = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "bloks", allow: ["banner"], deny: ["banner"] })],
+    });
+    const result = validateStory(storyWith("banner"), {
+      blocks: { page, banner, teaser: teaserBlock },
+    });
+    expect(result.issues.find((i) => i.code === "disallowed_component")).toBeUndefined();
+  });
+
+  it("enforces deny on bloks embedded in richtext", () => {
+    const page = defineBlock({
+      name: "page",
+      is_root: true,
+      fields: [defineField("body", { type: "richtext", deny: ["banner"] })],
+    });
+    const result = validateStory(
+      {
+        content: {
+          component: "page",
+          body: {
+            type: "doc",
+            content: [
+              {
+                type: "blok",
+                attrs: { id: "x", body: [{ _uid: "uid-1", component: "banner", text: "hi" }] },
+              },
+            ],
+          },
+        },
+      },
+      { blocks: { page, banner } },
+    );
+    expect(result.issues.find((i) => i.code === "disallowed_component")).toBeDefined();
+  });
+});

--- a/packages/schema/src/validators/validate-story.ts
+++ b/packages/schema/src/validators/validate-story.ts
@@ -427,18 +427,54 @@ function validateFieldValue(
   }
 }
 
+type RestrictionEntry = string | { folder: string };
+
+/** Renders a restriction list the way the error message names it. */
+const describeRestriction = (entries: readonly RestrictionEntry[]): string =>
+  entries.map((entry) => (typeof entry === "string" ? entry : `folder:${entry.folder}`)).join(", ");
+
 /**
- * Enforces a field's `allow` list for one embedded blok. Shared by the `bloks`
- * case and the richtext walk so both apply the same rule: `mapFieldToWire`
- * pushes folder/name `allow` as an editor/API restriction on *both* field types,
- * so validation must reject the same components the editor and API would.
+ * Whether a block is named by a restriction list, directly or through a folder
+ * it sits in. Both sides are canonicalized to slug space, so a folder referenced
+ * two ways (a `defineFolder` ref vs. a string shorthand with different
+ * casing/separators) matches the way the CLI and editor group it. A folder entry
+ * covers its nested folders too, mirroring the editor.
+ */
+function matchesRestriction(
+  entries: readonly RestrictionEntry[],
+  block: SchemaBlockLike | undefined,
+  componentName: string,
+): boolean {
+  if (entries.includes(componentName)) {
+    return true;
+  }
+  const blockFolder = block?.folder;
+  if (typeof blockFolder !== "string") {
+    return false;
+  }
+  const blockFolderSlug = slugifyFolderPath(blockFolder);
+  return entries.some((entry) => {
+    if (typeof entry === "string") {
+      return false;
+    }
+    const entrySlug = slugifyFolderPath(entry.folder);
+    return blockFolderSlug === entrySlug || blockFolderSlug.startsWith(`${entrySlug}/`);
+  });
+}
+
+/**
+ * Enforces a field's `allow`/`deny` lists for one embedded blok. Shared by the
+ * `bloks` case and the richtext walk so both apply the same rule:
+ * `mapFieldToWire` pushes either list as an editor restriction on *both* field
+ * types, so validation must reject the same components the editor would.
+ *
+ * The editor gives `allow` precedence within a dimension: a non-empty allow list
+ * decides on its own and the denylist is never consulted. That is mirrored here,
+ * so a field carrying both validates as the allow list alone rather than as the
+ * stricter intersection.
  *
  * `itemPath` is the path to the blok item (its index); the reported issue points
- * at that item's `component` key. A component is allowed when it is named
- * directly in `allow` or its block sits in (or under) an allowed folder — both
- * sides canonicalized to slug space so a folder referenced two ways (a
- * `defineFolder` ref vs. a string shorthand with different casing/separators)
- * matches the way the CLI/editor group it.
+ * at that item's `component` key.
  */
 function checkComponentAllowed(
   field: SchemaFieldLike,
@@ -449,7 +485,12 @@ function checkComponentAllowed(
   issues: ValidationIssue[],
 ): void {
   const allowEntries = field.allow ?? [];
-  if (allowEntries.length === 0 || !isRecord(item) || typeof item.component !== "string") {
+  const denyEntries = field.deny ?? [];
+  if (
+    (allowEntries.length === 0 && denyEntries.length === 0) ||
+    !isRecord(item) ||
+    typeof item.component !== "string"
+  ) {
     return;
   }
   // A component the schema does not define at all is reported once as
@@ -458,34 +499,28 @@ function checkComponentAllowed(
   if (!blocksByName.has(item.component)) {
     return;
   }
-  const blockNamesAllowed = allowEntries.filter(
-    (entry): entry is string => typeof entry === "string",
-  );
-  const folderPathsAllowed = allowEntries.filter(
-    (entry): entry is { folder: string } =>
-      typeof entry === "object" && entry !== null && typeof entry.folder === "string",
-  );
-  const itemBlock = blocksByName.get(item.component);
-  const itemBlockFolder = itemBlock?.folder;
-  const allowedByName = blockNamesAllowed.includes(item.component);
-  const itemFolderSlug =
-    typeof itemBlockFolder === "string" ? slugifyFolderPath(itemBlockFolder) : undefined;
-  const allowedByFolder =
-    itemFolderSlug !== undefined &&
-    folderPathsAllowed.some(({ folder }) => {
-      const allowedSlug = slugifyFolderPath(folder);
-      return itemFolderSlug === allowedSlug || itemFolderSlug.startsWith(`${allowedSlug}/`);
-    });
-  if (!allowedByName && !allowedByFolder) {
-    const allowedList = allowEntries
-      .map((entry) => (typeof entry === "string" ? entry : `folder:${entry.folder}`))
-      .join(", ");
+  const block = blocksByName.get(item.component);
+
+  if (allowEntries.length > 0) {
+    if (!matchesRestriction(allowEntries, block, item.component)) {
+      issues.push({
+        severity: "error",
+        code: "disallowed_component",
+        path: [...itemPath, "component"],
+        entity,
+        message: `Component "${item.component}" is not allowed in field "${field.name}"; allowed: ${describeRestriction(allowEntries)}.`,
+      });
+    }
+    return;
+  }
+
+  if (matchesRestriction(denyEntries, block, item.component)) {
     issues.push({
       severity: "error",
       code: "disallowed_component",
       path: [...itemPath, "component"],
       entity,
-      message: `Component "${item.component}" is not allowed in field "${field.name}"; allowed: ${allowedList}.`,
+      message: `Component "${item.component}" is denied in field "${field.name}"; denied: ${describeRestriction(denyEntries)}.`,
     });
   }
 }

--- a/tools/openapi-codegen/templates/field.ts
+++ b/tools/openapi-codegen/templates/field.ts
@@ -224,21 +224,44 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
+/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
+type FolderOf<T> =
+  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+
 /**
- * Removes the registry blocks named in `deny`, the `Exclude` counterpart to
- * {@link ApplyAllow}. The wire `component_denylist` denies by block name only,
- * so folder refs are not accepted. A `deny` entry naming no known block is
- * inert: it removes nothing rather than collapsing the field.
+ * Removes the registry blocks in `TFolders` (or any nested folder), the
+ * {@link MatchesFolder} counterpart for `deny`. A `never` folder set removes
+ * nothing, so a block-name-only `deny` leaves the union untouched.
+ */
+type DenyFolders<TBlocks, TFolders extends string> = [TFolders] extends [never]
+  ? TBlocks
+  : TBlocks extends any
+    ? [MatchesFolder<TBlocks, TFolders>] extends [never]
+      ? TBlocks
+      : never
+    : never;
+
+/**
+ * Removes the registry blocks named in `deny`, or living in a folder it names,
+ * the `Exclude` counterpart to {@link ApplyAllow}. A `deny` entry naming no known
+ * block or folder is inert: it removes nothing rather than collapsing the field.
+ *
+ * `TDenied` is split with `Extract` rather than a `TDenied extends string`
+ * conditional, because that conditional would distribute over the deny union and
+ * union the per-entry `Exclude` results back together — re-admitting every denied
+ * block. Names and folders are therefore removed in one pass each.
  */
 type ApplyDeny<TField, TBlocks> = TField extends {
-  deny: ReadonlyArray<infer TDenied extends string>;
+  deny: ReadonlyArray<infer TDenied extends AllowEntry>;
 }
-  ? Exclude<TBlocks, { name: TDenied }>
+  ? DenyFolders<Exclude<TBlocks, { name: Extract<TDenied, string> }>, FolderOf<TDenied>>
   : TBlocks;
 
 /**
  * Resolves the block union a `bloks` field accepts: `allow` narrows the registry
- * first, then `deny` removes from what is left, so the two compose.
+ * first, then `deny` removes from what is left, so the two compose. The editor
+ * instead gives a non-empty `allow` precedence and ignores `deny` beside it, so on
+ * a field carrying both these types are the stricter of the two views.
  */
 type ApplyRestrictions<TField, TBlocks> = ApplyDeny<TField, ApplyAllow<TField, TBlocks>>;
 

--- a/tools/openapi-codegen/templates/field.ts
+++ b/tools/openapi-codegen/templates/field.ts
@@ -224,9 +224,16 @@ type ApplyAllow<TField, TBlocks> = TField extends {
       : never
     : never;
 
-/** The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union. */
-type FolderOf<T> =
-  Extract<T, { folder: string }> extends { folder: infer F extends string } ? F : never;
+/**
+ * The folder paths named by the `{ folder: path }` entries of an `allow`/`deny` union.
+ *
+ * Written as an indexed access rather than a conditional with `infer`: when the
+ * union names no folder at all, `Extract` yields `never`, and `never extends
+ * { folder: infer F extends string }` takes the *true* branch with no inference
+ * candidate for `F`, which then falls back to its `string` constraint. That turned
+ * a block-name-only `deny` into "deny every folder".
+ */
+type FolderOf<T> = Extract<T, { folder: string }>["folder"];
 
 /**
  * Removes the registry blocks in `TFolders` (or any nested folder), the


### PR DESCRIPTION
`deny` was a DSL-only key that never reached the wire mapping. `mapFieldToWire` destructured `allow` and `datasource` but not `deny`, so `deny` fell into `...rest` and was spread into the Management API payload verbatim.

The result was worse than "not translated":

- Spaces stored a non-standard `deny` key next to the real restriction keys.
- `component_denylist` was never written, so the restriction had no effect in the editor.
- `schema init` read the junk key back and re-emitted it, so it round-tripped cleanly and looked intentional.

## What this does

Translates `deny` to `component_denylist` / `component_group_denylist`, symmetric with `allow`, teaches `schema init` the reverse mapping, and makes the rest of the toolchain agree with that translation: folder harvesting, cross-space pushes, and the story and schema validators.

**`deny` now accepts folder refs.** Group denial is real: the editor blocks a denied folder and every folder nested inside it, and exposes the list in the field settings UI as a folders-mode "blocked" selector. The old runtime guard rejecting folder refs was simply wrong. `ApplyDeny` now excludes by folder as well as by name, and both group lists share one slug-path/uuid translation helper across push, diff, and rollback.

**Folders referenced only by `deny` are harvested.** `classifyExports` skipped any field without an `allow` array, so a folder that appeared only in a `deny` never reached the local folder set. Push then resolved the group denylist against nothing and sent the slug path where a uuid belongs, so the denial matched nothing and round-tripped looking deliberate, and `push --delete` read the same folder as stale and deleted it. Denying an unmanaged legacy folder is the motivating use case for the feature, so both paths were reachable from its own JSDoc example.

**`allow` and `deny` are mutually exclusive.** `defineField` throws when both are set — see the review follow-ups below. This started as a narrower guard against the two disagreeing about restricting by block vs. by folder, which the editor's folders-before-blocks precedence would silently resolve by dropping one list.

**The editor gives `allow` precedence.** A non-empty whitelist decides on its own and the denylist is never consulted, for blocks and for folders alike. That is why the pair is rejected outright rather than silently reduced. Documented on both the DSL JSDoc and the docs page.

**`deny` is rejected on field types that have no denylist.** `defineField('link', { type: 'multilink', deny: ['page'] })` used to store a `component_denylist` that nothing reads, and a test had blessed it. Only `bloks` and `richtext` carry a denylist, so `defineField` now throws and `mapFieldToWire` drops the key as a backstop for plain-JavaScript schemas. `allow` is deliberately not restricted the same way, because `component_whitelist` is real on `multilink`, where it selects story content types.

**The validators apply `deny`, not just the types.** `deny` narrows the generated `FieldValue` and now reaches the wire as a real restriction, so without this a story holding a denied block would pass `validateStory` and `stories push` while the types excluded that very block. `validateStory` applies the deny list, by name and by folder including nested folders, for both `bloks` fields and richtext-embedded bloks, and `validateSchema` reports `unresolved_deny`. A non-empty `allow` still decides on its own, matching the editor.

**Cross-space `components push` translates denylists.** Group uuids and tag ids are per-space identities, so an untranslated denylist arrived in the target pointing at source-space entities. Both halves of each dimension are now driven from one pair of key constants.

## Richtext restriction behavior changes

Name-based restrictions on `richtext` fields previously emitted no `restrict_components`. The editor's block picker returns everything when that flag is absent, so a richtext `allow` list was already inert, and a richtext `deny` would have been too. This PR sets the flag for `richtext` as well as `bloks`, which tightens what content editors may insert in existing spaces that carry a richtext `allow` list.

It is a CLI behavior change riding a `fix(schema):` patch bump, so it deserves a dedicated release note.

## Notes for reviewers

- `tools/openapi-codegen/templates/field.ts` changed, so every consumer was regenerated with `pnpm nx run-many -t generate:openapi`. The only generated diff is `types/field.ts` in each of the four packages that export it.
- `ApplyDeny` splits the deny union with `Extract` rather than a `TDenied extends string` conditional on purpose. That conditional distributes, which would union the per-entry `Exclude` results back together and re-admit every denied block. There is a regression test for it.
- Spaces already carrying the stray `deny` key are cleaned up automatically: push replaces the whole field object.
- Two comments claimed the wrong runtime and are corrected. `resolveFieldRestriction` implied the editor agrees that block names win the both-dimensions tie, when it evaluates folders first and ignores the names. `toDslField` claimed an absent `restrict_components` counts as active "matching backend enforcement", but the lists are not enforced server-side in production and the editor reads the flag's absence as no restriction, so the round trip narrows rather than merely not widening.
- A denial governs the block picker, not the stored content. Clipboard paste is validated against the allow list only, so a denied block can still be pasted in. `deny` is authoring guidance, not a boundary. This is documented.

## Deliberately out of scope

`types generate` narrows a `bloks` field from whitelists only, so a deny-only field emits the unnarrowed union while `@storyblok/schema`'s `FieldValue` excludes the denied blocks. Pre-existing, in a different command, and left alone on purpose: it has nothing to do with getting `deny` onto the wire.

## Review follow-ups

Four defects from review, fixed here.

**`schema init` generated code that no push could load.** A remote field can store
a `component_denylist` the editor never reads — on a field type that has no
denylist, or beside a non-empty whitelist, which takes precedence and leaves the
denylist inert. Init mapped either one back to a DSL `deny`, which `defineField`
rejects, so the next `schema push` failed while *loading* the schema: the whole
file, not the one field. A denylist is now read back only where the editor reads
one. Nothing enforced is lost, and push replaces the whole field object, so the
stray key is cleared from the space on the way through.

**Folder harvesting and the wire mapping disagreed about `deny`.** Folder refs
were harvested from every field's `deny`, including the types where
`mapFieldToWire` then drops it, so push created a component group for a
restriction nothing references. Harvesting now follows the mapping. Reachable
only from a plain-object schema, since `defineField` rejects the same field.

**`allow` and `deny` on one field are now rejected.** The editor consults a
denylist only while the allow list is empty, so a `deny` beside a non-empty
`allow` governs nothing — while the generated types applied both and were
therefore stricter than both the editor and `validateStory`. The previous
cross-dimension guard folds into this one. Where the pair still reaches the types
without passing that guard — a plain-object schema, or a field read off the wire —
the composition stands, and the stricter reading is the safer default.

**Richtext restrictions now reach the generated types.** `deny` on a `richtext`
field reached the wire and `validateStory` enforced it, but `FieldValue` resolved
every richtext field to the unrestricted document type, so content the validator
rejects still compiled. The document walk now substitutes the narrowed block union
into every embedded-blok body at any depth. It is applied only to a field that
declares `allow`/`deny`: narrowing every richtext field would newly reject any
component outside the block registry, far wider than reflecting a declared
restriction.

### Not fixed: tag ids are not translated on `schema push`

Also raised in review, and out of reach here rather than deferred by preference.
`components push` remaps tag references by **name**, from the tag inventory its
source dump carries. A code-authored schema has no such inventory: a
`component_tag_whitelist` holds bare numeric ids, which are per-space and carry
nothing to match on. The gap is not specific to denylists — the whitelist and a
component's own `internal_tag_ids` are equally untranslated — and closing it means
making tags nameable in the DSL first, the way folders already are. That is a
feature, not a fix, and unrelated to getting `deny` onto the wire.

## Related

- Docs PR: storyblok/storyblok-docs-platform#620

Fixes DX-549

