### PR TITLE
fix(schema): match field types, options and QA fixtures to the real wire formats

### DIFF
--- a/.agents/skills/qa-engineer-manual/SKILL.md
+++ b/.agents/skills/qa-engineer-manual/SKILL.md
@@ -42,6 +42,32 @@ You seed Storyblok QA spaces with predefined test scenarios. Packages might defi
 - **Trust the seed's exit status, not just its log.** The seed now verifies each staged resource
   actually landed remotely and exits non-zero with a `Verification FAILED` message when a push
   reports success but creates nothing, so check the exit status.
+- **A green seed proves the API accepted your JSON, not that the JSON is shaped like something the
+  editor would produce.** The Management API stores component schemas and story content as opaque
+  blobs: it takes almost any structure and echoes it back. Seeding a fixture and reading it back is
+  circular, because you authored the input, so it can never validate a shape. It is still a useful
+  fixed-point check, and it can prove server-side _transformation_ (normalization, defaults,
+  rejection) - just never correctness.
+
+### Grounding a shape
+
+When you need to know what a field option or content value really looks like, work down this list
+and stop at the first step that answers it:
+
+1. **Existing seeds.** Check the scenario fixtures for a field or value of that type. The corpus is
+   kept aligned with real wire formats, so a shape already in there is usually your answer.
+2. **`../storyrails`.** The backend truth for what is stored, normalized, and enforced.
+   `spec/integration/openapi/` is the source of truth for schemas and error shapes.
+3. **`../storyfront`.** The editor is what writes component schemas and content values:
+   `packages/openapi/src/FieldType.ts` declares the shapes, `Schema/*/index.vue` is what it
+   **writes**, `EditorForm/FieldType*/` is what it **reads**.
+4. **Ask the user to author it in the UI.** Last resort, when the source does not settle it. Ask
+   them to create the field or story by hand in a QA space and give you the id, then read it back
+   via MAPI (`curl` the component or story) and copy the result into the fixture verbatim. This is
+   the only empirical evidence that exists - everything you push yourself is circular.
+
+Never infer a shape from the schema form alone: the editor offers options it does not write, and
+spaces hold keys the editor no longer offers.
 
 ### Prerequisites
 

--- a/.agents/skills/qa-engineer-manual/SKILL.md
+++ b/.agents/skills/qa-engineer-manual/SKILL.md
@@ -60,9 +60,7 @@ and stop at the first step that answers it:
    kept aligned with real wire formats, so a shape already in there is usually your answer.
 2. **`../storyrails`.** The backend truth for what is stored, normalized, and enforced.
    `spec/integration/openapi/` is the source of truth for schemas and error shapes.
-3. **`../storyfront`.** The editor is what writes component schemas and content values:
-   `packages/openapi/src/FieldType.ts` declares the shapes, `Schema/*/index.vue` is what it
-   **writes**, `EditorForm/FieldType*/` is what it **reads**.
+3. **`../storyfront`.** The editor is what writes component schemas and content values.
 4. **Ask the user to author it in the UI.** Last resort, when the source does not settle it. Ask
    them to create the field or story by hand in a QA space and give you the id, then read it back
    via MAPI (`curl` the component or story) and copy the result into the fixture verbatim. This is

--- a/.agents/skills/qa-engineer-manual/SKILL.md
+++ b/.agents/skills/qa-engineer-manual/SKILL.md
@@ -43,11 +43,13 @@ You seed Storyblok QA spaces with predefined test scenarios. Packages might defi
   actually landed remotely and exits non-zero with a `Verification FAILED` message when a push
   reports success but creates nothing, so check the exit status.
 - **A green seed proves the API accepted your JSON, not that the JSON is shaped like something the
-  editor would produce.** The Management API stores component schemas and story content as opaque
-  blobs: it takes almost any structure and echoes it back. Seeding a fixture and reading it back is
-  circular, because you authored the input, so it can never validate a shape. It is still a useful
-  fixed-point check, and it can prove server-side _transformation_ (normalization, defaults,
-  rejection) - just never correctness.
+  editor would produce.** The Management API checks a component schema field's `type` against a
+  closed list and 422s on an unknown one, but everything past that is an opaque blob: the rest of
+  the schema always, and story content unless the space enables field constraints. Seeding a fixture
+  and reading it back is circular, because you authored the input, so it can never validate a shape.
+  It is still a useful fixed-point check, and whatever the API enforces it can prove: a bogus `type`
+  returns a 422 listing the permitted values, and normalization and server-set defaults show up the
+  same way.
 
 ### Grounding a shape
 

--- a/.agents/skills/qa-engineer-manual/scenarios/has-default-components/components/blog.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-default-components/components/blog.json
@@ -6,17 +6,35 @@
   "is_root": true,
   "is_nestable": false,
   "schema": {
-    "title": { "type": "text", "pos": 0 },
-    "body": { "type": "richtext", "pos": 1 },
-    "featured_image": { "type": "asset", "pos": 2, "filetypes": ["images"] },
-    "author": { "type": "text", "pos": 3 },
+    "title": {
+      "type": "text",
+      "pos": 0
+    },
+    "body": {
+      "type": "richtext",
+      "pos": 1
+    },
+    "featured_image": {
+      "type": "asset",
+      "pos": 2,
+      "filetypes": ["images"]
+    },
+    "author": {
+      "type": "text",
+      "pos": 3
+    },
     "category": {
       "type": "option",
       "pos": 4,
-      "source": "internal_stories",
+      "source": "internal",
       "datasource_slug": "categories"
     },
-    "related_post": { "type": "multilink", "pos": 5, "restrict_content_types": true }
+    "related_post": {
+      "type": "multilink",
+      "pos": 5,
+      "restrict_content_types": true,
+      "component_whitelist": ["blog"]
+    }
   },
   "created_at": "2024-01-01T00:00:00.000Z",
   "updated_at": "2024-01-01T00:00:00.000Z"

--- a/.agents/skills/qa-engineer-manual/scenarios/has-default-components/components/page.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-default-components/components/page.json
@@ -6,15 +6,27 @@
   "is_root": true,
   "is_nestable": false,
   "schema": {
-    "headline": { "type": "text", "pos": 0 },
+    "headline": {
+      "type": "text",
+      "pos": 0
+    },
     "body": {
       "type": "bloks",
       "pos": 1,
       "restrict_components": true,
-      "component_whitelist": ["hero", "cta"]
+      "component_whitelist": ["hero", "cta"],
+      "restrict_type": "",
+      "component_denylist": []
     },
-    "hero_image": { "type": "asset", "pos": 2, "filetypes": ["images"] },
-    "seo_description": { "type": "textarea", "pos": 3 }
+    "hero_image": {
+      "type": "asset",
+      "pos": 2,
+      "filetypes": ["images"]
+    },
+    "seo_description": {
+      "type": "textarea",
+      "pos": 3
+    }
   },
   "created_at": "2024-01-01T00:00:00.000Z",
   "updated_at": "2024-01-01T00:00:00.000Z"

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/blog-cover.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/blog-cover.json
@@ -1,0 +1,15 @@
+{
+  "id": 2,
+  "short_filename": "blog-cover.png",
+  "alt": "Blog cover",
+  "title": "Blog Cover",
+  "copyright": "",
+  "source": "",
+  "focus": "",
+  "meta_data": {
+    "alt": "Blog cover",
+    "title": "Blog Cover",
+    "copyright": "",
+    "source": ""
+  }
+}

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/blog-cover.png.meta.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/blog-cover.png.meta.json
@@ -1,8 +1,0 @@
-{
-  "id": 2,
-  "short_filename": "blog-cover.png",
-  "meta_data": {
-    "alt": "Blog cover",
-    "title": "Blog Cover"
-  }
-}

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/hero.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/hero.json
@@ -1,0 +1,15 @@
+{
+  "id": 1,
+  "short_filename": "hero.png",
+  "alt": "Hero image",
+  "title": "Hero",
+  "copyright": "",
+  "source": "",
+  "focus": "",
+  "meta_data": {
+    "alt": "Hero image",
+    "title": "Hero",
+    "copyright": "",
+    "source": ""
+  }
+}

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/hero.png.meta.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/assets/hero.png.meta.json
@@ -1,8 +1,0 @@
-{
-  "id": 1,
-  "short_filename": "hero.png",
-  "meta_data": {
-    "alt": "Hero image",
-    "title": "Hero"
-  }
-}

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/datasources/categories_1.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/datasources/categories_1.json
@@ -4,7 +4,7 @@
   "slug": "categories",
   "dimensions": [],
   "entries": [
-    { "id": 1, "name": "Technology", "value": "technology", "dimension_value": null },
-    { "id": 2, "name": "Design", "value": "design", "dimension_value": null }
+    { "id": 1, "name": "Technology", "value": "technology", "dimension_value": "" },
+    { "id": 2, "name": "Design", "value": "design", "dimension_value": "" }
   ]
 }

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/about_2.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/about_2.json
@@ -1,33 +1,60 @@
 {
   "id": 2,
-  "uuid": "2",
+  "uuid": "b2c5d3e1-82e2-4a3b-9c4d-1b6e7f809102",
   "name": "About",
   "slug": "about",
   "full_slug": "about",
   "content": {
+    "_uid": "b6a1f791-3aac-4aee-8469-b8576132a6c6",
     "component": "page",
     "headline": "About Us",
     "hero_image": {
       "id": 2,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/bbbbbbbbbb/blog-cover.png",
+      "alt": "About hero",
+      "title": "Blog Cover",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/blog-cover.png",
-      "alt": "About hero"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "About hero",
+        "title": "Blog Cover",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "body": [
       {
+        "_uid": "fd2f2548-e919-49c9-884f-15e7c2488aa2",
         "component": "hero",
-        "_uid": "hero-about-1",
         "title": "Who We Are",
         "image": {
           "id": 2,
+          "name": "",
+          "filename": "https://a.storyblok.com/f/1/1200x600/bbbbbbbbbb/blog-cover.png",
+          "alt": "About image",
+          "title": "Blog Cover",
+          "source": "",
+          "copyright": "",
+          "focus": "",
           "fieldtype": "asset",
-          "filename": "https://placeholder.example.com/blog-cover.png",
-          "alt": "About image"
+          "is_external_url": false,
+          "meta_data": {
+            "alt": "About image",
+            "title": "Blog Cover",
+            "source": "",
+            "copyright": "",
+            "size": "1200x600"
+          }
         },
         "link": {
           "fieldtype": "multilink",
           "linktype": "story",
-          "id": "1",
+          "id": "a1f4e2c0-91d1-4f2a-8b3c-0a5d6e7f8091",
           "url": "",
           "cached_url": "home"
         },

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-color-theory_7.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-color-theory_7.json
@@ -1,25 +1,39 @@
 {
   "id": 7,
-  "uuid": "7",
+  "uuid": "07182836-37d7-4f80-8192-60b324354657",
   "name": "Color Theory for Teams",
   "slug": "blog-color-theory",
   "full_slug": "blog-index/blog-color-theory",
   "parent_id": 3,
   "content": {
+    "_uid": "7ba46cc6-0afe-4aab-866b-9b479d0157ea",
     "component": "blog",
     "title": "Color Theory for Teams",
     "featured_image": {
       "id": 2,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/bbbbbbbbbb/blog-cover.png",
+      "alt": "Color theory",
+      "title": "Blog Cover",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/blog-cover.png",
-      "alt": "Color theory"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "Color theory",
+        "title": "Blog Cover",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "author": "QA Bot",
     "category": "design",
     "related_post": {
       "fieldtype": "multilink",
       "linktype": "story",
-      "id": "5",
+      "id": "e5f80614-55b5-4d6e-8f70-4e91a2132435",
       "url": "",
       "cached_url": "blog-index/blog-design-tips"
     },

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-design-tips_5.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-design-tips_5.json
@@ -1,25 +1,39 @@
 {
   "id": 5,
-  "uuid": "5",
+  "uuid": "e5f80614-55b5-4d6e-8f70-4e91a2132435",
   "name": "Design Tips for Better UX",
   "slug": "blog-design-tips",
   "full_slug": "blog-index/blog-design-tips",
   "parent_id": 3,
   "content": {
+    "_uid": "64ea3210-f1eb-40fa-815d-370be17b251a",
     "component": "blog",
     "title": "Design Tips for Better UX",
     "featured_image": {
       "id": 2,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/bbbbbbbbbb/blog-cover.png",
+      "alt": "Design",
+      "title": "Blog Cover",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/blog-cover.png",
-      "alt": "Design"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "Design",
+        "title": "Blog Cover",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "author": "QA Bot",
     "category": "design",
     "related_post": {
       "fieldtype": "multilink",
       "linktype": "story",
-      "id": "4",
+      "id": "d4e7f503-64a4-4c5d-9e6f-3d8091a21324",
       "url": "",
       "cached_url": "blog-index/blog-tech-intro"
     },

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-getting-started_6.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-getting-started_6.json
@@ -1,25 +1,39 @@
 {
   "id": 6,
-  "uuid": "6",
+  "uuid": "f6091725-46c6-4e7f-9081-5fa213243546",
   "name": "Blog Getting Started",
   "slug": "blog-getting-started",
   "full_slug": "blog-index/blog-getting-started",
   "parent_id": 3,
   "content": {
+    "_uid": "72928fd8-9b68-4bd4-853d-90ed34768f2f",
     "component": "blog",
     "title": "Blog Getting Started",
     "featured_image": {
       "id": 1,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/aaaaaaaaaa/hero.png",
+      "alt": "Start",
+      "title": "Hero",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/hero.png",
-      "alt": "Start"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "Start",
+        "title": "Hero",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "author": "QA Bot",
     "category": "technology",
     "related_post": {
       "fieldtype": "multilink",
       "linktype": "story",
-      "id": "4",
+      "id": "d4e7f503-64a4-4c5d-9e6f-3d8091a21324",
       "url": "",
       "cached_url": "blog-index/blog-tech-intro"
     },

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-index_3.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-index_3.json
@@ -1,19 +1,13 @@
 {
   "id": 3,
-  "uuid": "3",
+  "uuid": "c3d6e4f2-73f3-4b4c-8d5e-2c7f8091a213",
   "name": "Blog",
   "slug": "blog-index",
   "full_slug": "blog-index",
   "is_folder": true,
   "content": {
-    "component": "page",
-    "headline": "Blog",
-    "hero_image": {
-      "id": 1,
-      "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/hero.png",
-      "alt": "Blog hero"
-    },
-    "seo_description": "Our blog"
-  }
+    "content_types": ["blog"],
+    "lock_subfolders_content_types": true
+  },
+  "default_root": "blog"
 }

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-responsive_8.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-responsive_8.json
@@ -1,25 +1,39 @@
 {
   "id": 8,
-  "uuid": "8",
+  "uuid": "18293947-28e8-4091-92a3-71c435465768",
   "name": "Responsive Patterns",
   "slug": "blog-responsive",
   "full_slug": "blog-index/blog-responsive",
   "parent_id": 3,
   "content": {
+    "_uid": "41bf1ce3-92d7-4d75-834e-a7688a688889",
     "component": "blog",
     "title": "Responsive Patterns",
     "featured_image": {
       "id": 1,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/aaaaaaaaaa/hero.png",
+      "alt": "Responsive",
+      "title": "Hero",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/hero.png",
-      "alt": "Responsive"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "Responsive",
+        "title": "Hero",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "author": "QA Bot",
     "category": "design",
     "related_post": {
       "fieldtype": "multilink",
       "linktype": "story",
-      "id": "7",
+      "id": "07182836-37d7-4f80-8192-60b324354657",
       "url": "",
       "cached_url": "blog-index/blog-color-theory"
     },

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-tech-intro_4.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/blog-tech-intro_4.json
@@ -1,25 +1,39 @@
 {
   "id": 4,
-  "uuid": "4",
+  "uuid": "d4e7f503-64a4-4c5d-9e6f-3d8091a21324",
   "name": "Getting Started with Tech",
   "slug": "blog-tech-intro",
   "full_slug": "blog-index/blog-tech-intro",
   "parent_id": 3,
   "content": {
+    "_uid": "59bc40b3-6eb8-467d-84c0-6b394339accf",
     "component": "blog",
     "title": "Getting Started with Tech",
     "featured_image": {
       "id": 1,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/aaaaaaaaaa/hero.png",
+      "alt": "Tech",
+      "title": "Hero",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/hero.png",
-      "alt": "Tech"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "Tech",
+        "title": "Hero",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "author": "QA Bot",
     "category": "technology",
     "related_post": {
       "fieldtype": "multilink",
       "linktype": "story",
-      "id": "5",
+      "id": "e5f80614-55b5-4d6e-8f70-4e91a2132435",
       "url": "",
       "cached_url": "blog-index/blog-design-tips"
     },

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/contact_9.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/contact_9.json
@@ -1,27 +1,41 @@
 {
   "id": 9,
-  "uuid": "9",
+  "uuid": "293a4a58-19f9-40a2-83b4-82d546576879",
   "name": "Contact",
   "slug": "contact",
   "full_slug": "contact",
   "content": {
+    "_uid": "891c29b3-4154-4765-8778-0595e4b25b4b",
     "component": "page",
     "headline": "Contact Us",
     "hero_image": {
       "id": 2,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/bbbbbbbbbb/blog-cover.png",
+      "alt": "Contact hero",
+      "title": "Blog Cover",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/blog-cover.png",
-      "alt": "Contact hero"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "Contact hero",
+        "title": "Blog Cover",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "body": [
       {
+        "_uid": "6b1cdc34-8417-4160-83da-ac8be08d40d6",
         "component": "cta",
-        "_uid": "cta-contact-1",
         "label": "Go back home",
         "link": {
           "fieldtype": "multilink",
           "linktype": "story",
-          "id": "1",
+          "id": "a1f4e2c0-91d1-4f2a-8b3c-0a5d6e7f8091",
           "url": "",
           "cached_url": "home"
         }

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/faq_10.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/faq_10.json
@@ -1,46 +1,73 @@
 {
   "id": 10,
-  "uuid": "10",
+  "uuid": "3a4b5b69-0a0a-41b3-94c5-93e65768798a",
   "name": "FAQ",
   "slug": "faq",
   "full_slug": "faq",
   "content": {
+    "_uid": "b4093ada-b060-4a1b-82c3-e9cf4a6a9811",
     "component": "page",
     "headline": "Frequently Asked Questions",
     "hero_image": {
       "id": 1,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/aaaaaaaaaa/hero.png",
+      "alt": "FAQ hero",
+      "title": "Hero",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/hero.png",
-      "alt": "FAQ hero"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "FAQ hero",
+        "title": "Hero",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "body": [
       {
+        "_uid": "7bc67332-0b35-499d-8363-36de93ed8f88",
         "component": "hero",
-        "_uid": "hero-faq-1",
         "title": "Need more help?",
         "image": {
           "id": 2,
+          "name": "",
+          "filename": "https://a.storyblok.com/f/1/1200x600/bbbbbbbbbb/blog-cover.png",
+          "alt": "Help",
+          "title": "Blog Cover",
+          "source": "",
+          "copyright": "",
+          "focus": "",
           "fieldtype": "asset",
-          "filename": "https://placeholder.example.com/blog-cover.png",
-          "alt": "Help"
+          "is_external_url": false,
+          "meta_data": {
+            "alt": "Help",
+            "title": "Blog Cover",
+            "source": "",
+            "copyright": "",
+            "size": "1200x600"
+          }
         },
         "link": {
           "fieldtype": "multilink",
           "linktype": "story",
-          "id": "9",
+          "id": "293a4a58-19f9-40a2-83b4-82d546576879",
           "url": "",
           "cached_url": "contact"
         },
         "subtitle": "Reach out anytime"
       },
       {
+        "_uid": "4d7bbddd-1ae5-4003-8f3b-fc8e4c117ccb",
         "component": "cta",
-        "_uid": "cta-faq-1",
         "label": "Learn about us",
         "link": {
           "fieldtype": "multilink",
           "linktype": "story",
-          "id": "2",
+          "id": "b2c5d3e1-82e2-4a3b-9c4d-1b6e7f809102",
           "url": "",
           "cached_url": "about"
         }

--- a/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/home_1.json
+++ b/.agents/skills/qa-engineer-manual/scenarios/has-stories/stories/home_1.json
@@ -1,46 +1,73 @@
 {
   "id": 1,
-  "uuid": "1",
+  "uuid": "a1f4e2c0-91d1-4f2a-8b3c-0a5d6e7f8091",
   "name": "Home",
   "slug": "home",
   "full_slug": "home",
   "content": {
+    "_uid": "9679d637-59e7-4f5b-85a6-57838f27b586",
     "component": "page",
     "headline": "Welcome Home",
     "hero_image": {
       "id": 1,
+      "name": "",
+      "filename": "https://a.storyblok.com/f/1/1200x600/aaaaaaaaaa/hero.png",
+      "alt": "Hero image",
+      "title": "Hero",
+      "source": "",
+      "copyright": "",
+      "focus": "",
       "fieldtype": "asset",
-      "filename": "https://placeholder.example.com/hero.png",
-      "alt": "Hero image"
+      "is_external_url": false,
+      "meta_data": {
+        "alt": "Hero image",
+        "title": "Hero",
+        "source": "",
+        "copyright": "",
+        "size": "1200x600"
+      }
     },
     "body": [
       {
+        "_uid": "40754cda-5a78-4299-8cea-cd49bb299137",
         "component": "hero",
-        "_uid": "hero-home-1",
         "title": "Main Hero",
         "image": {
           "id": 1,
+          "name": "",
+          "filename": "https://a.storyblok.com/f/1/1200x600/aaaaaaaaaa/hero.png",
+          "alt": "Hero",
+          "title": "Hero",
+          "source": "",
+          "copyright": "",
+          "focus": "",
           "fieldtype": "asset",
-          "filename": "https://placeholder.example.com/hero.png",
-          "alt": "Hero"
+          "is_external_url": false,
+          "meta_data": {
+            "alt": "Hero",
+            "title": "Hero",
+            "source": "",
+            "copyright": "",
+            "size": "1200x600"
+          }
         },
         "link": {
           "fieldtype": "multilink",
           "linktype": "story",
-          "id": "2",
+          "id": "b2c5d3e1-82e2-4a3b-9c4d-1b6e7f809102",
           "url": "",
           "cached_url": "about"
         },
         "subtitle": "Discover our story"
       },
       {
+        "_uid": "047df478-5fe7-4534-83de-169f0a00318e",
         "component": "cta",
-        "_uid": "cta-home-1",
         "label": "Read our blog",
         "link": {
           "fieldtype": "multilink",
           "linktype": "story",
-          "id": "3",
+          "id": "c3d6e4f2-73f3-4b4c-8d5e-2c7f8091a213",
           "url": "",
           "cached_url": "blog-index"
         }

--- a/.agents/skills/qa-engineer-manual/scripts/seed-scenario.sh
+++ b/.agents/skills/qa-engineer-manual/scripts/seed-scenario.sh
@@ -144,6 +144,12 @@ trap cleanup EXIT
 
 # Counts staged files for a resource (assets are the non-JSON files; every
 # other resource is one *.json per entity).
+#
+# A components directory may also hold `groups.json` and `tags.json`. The CLI
+# classifies staged items by shape, not by filename, so those become component
+# groups and internal tags rather than components. Counting them here would
+# make `verify_seeded` expect more components than the scenario defines and
+# report a failure for a push that fully succeeded.
 count_staged() {
   local resource="$1"
   local dir="${staging_dir}/${resource}/${FAKE_ID}"
@@ -153,6 +159,9 @@ count_staged() {
   fi
   if [ "${resource}" = "assets" ]; then
     find "${dir}" -maxdepth 1 -type f ! -name '*.json' ! -name '*.jsonl' | wc -l | tr -d ' '
+  elif [ "${resource}" = "components" ]; then
+    find "${dir}" -maxdepth 1 -type f -name '*.json' \
+      ! -name 'groups.json' ! -name 'tags.json' | wc -l | tr -d ' '
   else
     find "${dir}" -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' '
   fi

--- a/.agents/skills/qa-engineer-manual/scripts/seed-scenario.sh
+++ b/.agents/skills/qa-engineer-manual/scripts/seed-scenario.sh
@@ -142,14 +142,21 @@ trap cleanup EXIT
 # Helpers
 # ---------------------------------------------------------------------------
 
+# A staged components directory holds more than components: a scenario may ship
+# sidecars for component groups and internal tags. The CLI classifies what it
+# pushes by data shape rather than by filename — a top-level array is a sidecar,
+# a top-level object is a component — so everything here keys on shape too.
+# Matching on `groups.json`/`tags.json` instead would break silently the day a
+# scenario names its sidecar something else.
+is_component_file() {
+  node -e "
+    const json = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    process.exit(json !== null && typeof json === 'object' && !Array.isArray(json) ? 0 : 1);
+  " "$1"
+}
+
 # Counts staged files for a resource (assets are the non-JSON files; every
 # other resource is one *.json per entity).
-#
-# A components directory may also hold `groups.json` and `tags.json`. The CLI
-# classifies staged items by shape, not by filename, so those become component
-# groups and internal tags rather than components. Counting them here would
-# make `verify_seeded` expect more components than the scenario defines and
-# report a failure for a push that fully succeeded.
 count_staged() {
   local resource="$1"
   local dir="${staging_dir}/${resource}/${FAKE_ID}"
@@ -160,8 +167,12 @@ count_staged() {
   if [ "${resource}" = "assets" ]; then
     find "${dir}" -maxdepth 1 -type f ! -name '*.json' ! -name '*.jsonl' | wc -l | tr -d ' '
   elif [ "${resource}" = "components" ]; then
-    find "${dir}" -maxdepth 1 -type f -name '*.json' \
-      ! -name 'groups.json' ! -name 'tags.json' | wc -l | tr -d ' '
+    local count=0
+    for file in "${dir}"/*.json; do
+      [ -f "${file}" ] || continue
+      if is_component_file "${file}"; then count=$((count + 1)); fi
+    done
+    printf "%s" "${count}"
   else
     find "${dir}" -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' '
   fi
@@ -213,6 +224,14 @@ printf "Staging scenario '%s' ... " "${scenario}"
 
 staged=()
 
+# Staging is additive (`cp` into a shared directory), so a run killed before its
+# EXIT trap fired leaves another scenario's files behind and they get pushed as
+# if they belonged to this one. Purge first: the staging tree is scratch space
+# owned by this script, never a place to accumulate.
+for resource in components stories assets datasources; do
+  rm -rf "${staging_dir}/${resource}/${FAKE_ID}"
+done
+
 # Stage default components first (every scenario gets them unless skipped)
 if [ "${skip_components}" = false ] && [ -d "${default_components_dir}/components" ]; then
   mkdir -p "${staging_dir}/components/${FAKE_ID}"
@@ -231,6 +250,7 @@ fi
 if [ "${skip_components}" = false ] && [ -d "${staging_dir}/components/${FAKE_ID}" ]; then
   for component_file in "${staging_dir}/components/${FAKE_ID}"/*.json; do
     [ -f "${component_file}" ] || continue
+    is_component_file "${component_file}" || continue
     if ! node -e "
       const json = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
       process.exit('component_group_uuid' in json ? 0 : 1);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,7 @@ We use `nx` and `pnpm` workspaces. Use commands like `pnpm nx build <package>` a
 - `../storyfront` (headless CMS frontend) - Consult when matching UI/app behavior and you need
   information about the visual editor, bridge protocol, or rendering in the Storyblok UI, and
   whenever you need the real shape of a component schema field or a story content value. The editor
-  is what writes them: `packages/openapi/src/FieldType.ts` declares the shapes, `Schema/*/index.vue`
-  is what the editor **writes**, `EditorForm/FieldType*/` is what it **reads**.
+  is what writes them.
 - `../storyblok-bridge` (Storyblok Bridge) - Consult when verifying bridge behavior: the
   `postMessage` protocol between the editor and a preview iframe, the editable-block attributes it
   writes into the page, the overlay/click-to-edit UI, or the bridge lifecycle.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,18 +46,22 @@ These sibling repos may not be available; ignore them if absent.
   reference them, their paths, file names, or internal implementation details in commit messages, PR
   titles and descriptions, issue comments, code comments, or any other public-facing text. Describe
   the observable API or behavior instead.
-- **IMPORTANT:** The Management API stores component schemas and story content as opaque blobs. It
-  accepts almost any JSON and echoes it back, so a successful round trip proves storage, not shape.
-  Never treat "I pushed it and read it back" as evidence that a shape is real: you authored the
-  input, so the check could not have failed. Only two things can ground a shape:
-  1. **Sibling-repo source** - `../storyfront` for what the editor writes and reads,
-     `../storyrails` for what the backend normalizes and enforces.
+- **IMPORTANT:** The Management API validates a component schema field's `type` against a closed
+  list and rejects an unknown one outright. Everything else it treats as an opaque blob: the rest of
+  the schema unconditionally, and story content unless the space has field constraints enabled. So a
+  successful round trip proves storage, not shape. Never treat "I pushed it and read it back" as
+  evidence that a shape is real: you authored the input, so the check could not have failed. Only
+  two things can ground a shape:
+  1. **Sibling-repo source** - `../storyfront` for what the editor writes and reads, `../storyrails`
+     for what the backend normalizes and enforces.
   2. **Operator-authored data** - ask the user to create it by hand in the Storyblok UI, then read
      it back via MAPI. You cannot produce this yourself, so treat it as the last resort, for when
      the source does not settle it.
 
-  The API can still prove server-side *transformation* (normalization, defaults, rejection), just
-  never that a shape is correct.
+  Whatever the API actively enforces, it can prove: push a field with a bogus `type` and the 422
+  names the permitted values, which is cheaper than reading either sibling repo. The same goes for
+  normalization and server-set defaults. What it cannot prove is that a shape it merely stored is
+  one any real space holds.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,10 @@ We use `nx` and `pnpm` workspaces. Use commands like `pnpm nx build <package>` a
 - `../storyrails` (Storyblok backend) - Consult when verifying REST/MAPI/CAPI schemas, error shapes,
   or endpoint behavior; `../storyrails/spec/integration/openapi/` is the source of truth.
 - `../storyfront` (headless CMS frontend) - Consult when matching UI/app behavior and you need
-  information about the visual editor, bridge protocol, or rendering in the Storyblok UI.
+  information about the visual editor, bridge protocol, or rendering in the Storyblok UI, and
+  whenever you need the real shape of a component schema field or a story content value. The editor
+  is what writes them: `packages/openapi/src/FieldType.ts` declares the shapes, `Schema/*/index.vue`
+  is what the editor **writes**, `EditorForm/FieldType*/` is what it **reads**.
 - `../storyblok-bridge` (Storyblok Bridge) - Consult when verifying bridge behavior: the
   `postMessage` protocol between the editor and a preview iframe, the editable-block attributes it
   writes into the page, the overlay/click-to-edit UI, or the bridge lifecycle.
@@ -43,6 +46,18 @@ These sibling repos may not be available; ignore them if absent.
   reference them, their paths, file names, or internal implementation details in commit messages, PR
   titles and descriptions, issue comments, code comments, or any other public-facing text. Describe
   the observable API or behavior instead.
+- **IMPORTANT:** The Management API stores component schemas and story content as opaque blobs. It
+  accepts almost any JSON and echoes it back, so a successful round trip proves storage, not shape.
+  Never treat "I pushed it and read it back" as evidence that a shape is real: you authored the
+  input, so the check could not have failed. Only two things can ground a shape:
+  1. **Sibling-repo source** - `../storyfront` for what the editor writes and reads,
+     `../storyrails` for what the backend normalizes and enforces.
+  2. **Operator-authored data** - ask the user to create it by hand in the Storyblok UI, then read
+     it back via MAPI. You cannot produce this yourself, so treat it as the last resort, for when
+     the source does not settle it.
+
+  The API can still prove server-side *transformation* (normalization, defaults, rejection), just
+  never that a shape is correct.
 
 ## Conventions
 

--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -161,7 +161,11 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_custom_attributes?: boolean;
     /**
-     * Path of the folder internal links are restricted to
+     * Path of the folder internal links are restricted to. The richtext
+     * schema form does not write this option itself; it belongs to the
+     * multilink field's editor. Kept here because a space can carry it as
+     * a legacy value, not because the richtext editor produces it.
+     *
      */
     link_scope?: string;
     /**
@@ -172,7 +176,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     max_length?: number | string;
     /**
-     * Whether to enable right-to-left text direction
+     * Whether to enable right-to-left text direction. The richtext schema
+     * form does not write this option itself; it belongs to the text,
+     * textarea, and markdown fields' editors. Kept here because a space
+     * can carry it as a legacy value, not because the richtext editor
+     * produces it.
+     *
      */
     rtl?: boolean;
 };

--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -488,6 +488,66 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Minimum number of entries
      */
     minimum_entries?: number;
+};
+
+export type ImageFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'image';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Whether to force editors to crop the image to a fixed size
+     */
+    image_crop?: boolean;
+    /**
+     * Crop width in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_width?: number | string;
+    /**
+     * Crop height in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_height?: number | string;
+    /**
+     * Whether to keep the original image size when `image_crop` is true
+     */
+    keep_image_size?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
+};
+
+export type FileFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'file';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
 };
 
 export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {

--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | LinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | GroupFieldRoot | CommerceFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -29,9 +29,12 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -60,9 +63,12 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -159,9 +165,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     link_scope?: string;
     /**
-     * Maximum length of the input text
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Whether to enable right-to-left text direction
      */
@@ -198,9 +207,12 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_multiline?: boolean;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
 };
 
 export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -597,6 +609,17 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     asset_link_type?: boolean;
 };
 
+export type LinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'link';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+};
+
 export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     /**
      * Field type discriminant
@@ -712,6 +735,20 @@ export type TabFieldRoot = BaseFieldRoot & {
      * Field keys that belong to this tab
      */
     keys?: Array<string>;
+};
+
+export type GroupFieldRoot = BaseFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'group';
+};
+
+export type CommerceFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'commerce';
 };
 
 export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -941,7 +978,10 @@ export type BaseFieldRoot = {
     pos?: number;
     /**
      * Conditions set on the field for conditional visibility. The editor writes
-     * one setting and evaluates only the first, so further entries are inert.
+     * one setting and reads only the first, so an extra entry is invisible to it.
+     * It is not inert server-side: the conditional-required check requires every
+     * setting to match, so a second entry can only make a field harder to leave
+     * empty. Write one setting unless you mean that.
      *
      */
     conditional_settings?: Array<ConditionalSettingRoot>;
@@ -1108,18 +1148,26 @@ export type ConditionalSettingRoot = {
     }>;
     /**
      * What to apply to this field when the conditions match. The editor writes
-     * one entry and reads only the first, so further entries are inert.
+     * one entry and reads only the first.
      *
      */
     modifications?: Array<{
         /**
-         * Set to `hide` to hide the field
+         * Hides the field. Both spellings are live: the editor writes `hide`
+         * and reads it back, while the server's conditional-required check
+         * recognizes only `hidden`. Neither side accepts the other's value, so
+         * a rule authored through the API with `hidden` hides nothing in the
+         * editor, and one authored in the editor does not relax a required
+         * field on save. Both are declared because real spaces hold both;
+         * prefer `hide` for anything the editor will open.
+         *
          */
-        display?: 'hide';
+        display?: 'hide' | 'hidden';
         /**
          * `true` makes the field required, `false` makes it explicitly not
-         * required. The two modifications are mutually exclusive: `display`
-         * wins when both are set.
+         * required. Setting it alongside `display` is ambiguous rather than
+         * layered: the editor lets `display` win, while the server only skips
+         * the required check for the `hidden` spelling. Set one or the other.
          *
          */
         required?: boolean;

--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -940,11 +940,11 @@ export type BaseFieldRoot = {
      */
     pos?: number;
     /**
-     * Conditions set on the field for conditional visibility
+     * Conditions set on the field for conditional visibility. The editor writes
+     * one setting and evaluates only the first, so further entries are inert.
+     *
      */
-    conditional_settings?: Array<{
-        [key: string]: unknown;
-    }>;
+    conditional_settings?: Array<ConditionalSettingRoot>;
 };
 
 /**
@@ -1052,6 +1052,79 @@ export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+/**
+ * A conditional rule attached to a field: when `rule_conditions` match the
+ * block's content, the editor applies `modifications` to this field.
+ *
+ * Nothing here is required. The editor writes a setting the moment the operator
+ * adds a rule row, before any of it is filled in, so a saved block can hold a
+ * half-configured setting.
+ *
+ */
+export type ConditionalSettingRoot = {
+    /**
+     * Whether every condition must match (`all`) or any one of them (`any`).
+     * A setting the editor creates starts out as `any`.
+     *
+     */
+    rule_match?: 'all' | 'any';
+    /**
+     * The conditions evaluated against the block's content
+     */
+    rule_conditions?: Array<{
+        /**
+         * The field this condition reads. `null` until the operator picks one.
+         *
+         */
+        validated_object?: {
+            /**
+             * What the condition reads; only a sibling field is supported
+             */
+            type?: 'field';
+            /**
+             * Key of the sibling field within the same block
+             */
+            field_key?: string;
+            /**
+             * Which attribute of that field is compared
+             */
+            field_attr?: 'value';
+        } | null;
+        /**
+         * The comparison to run. `null` until the operator picks one.
+         * `gt`/`lt` compare numbers, or dates when both sides parse as
+         * `YYYY-MM-DD HH:mm`.
+         *
+         */
+        validation?: 'equals' | 'not_equals' | 'empty' | 'not_empty' | 'gt' | 'lt' | null;
+        /**
+         * The value compared against. Its shape follows the validated field:
+         * a string, number or boolean for most types, an asset object for an
+         * `asset` field, and `null` for `empty`/`not_empty`, which ignore it.
+         *
+         */
+        value?: unknown;
+    }>;
+    /**
+     * What to apply to this field when the conditions match. The editor writes
+     * one entry and reads only the first, so further entries are inert.
+     *
+     */
+    modifications?: Array<{
+        /**
+         * Set to `hide` to hide the field
+         */
+        display?: 'hide';
+        /**
+         * `true` makes the field required, `false` makes it explicitly not
+         * required. The two modifications are mutually exclusive: `display`
+         * wins when both are set.
+         *
+         */
+        required?: boolean;
+    }>;
+};
 
 export type MultilinkFieldValueSharedLink = {
     /**

--- a/packages/capi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/capi-client/src/generated/overlay/_internal.gen.ts
@@ -154,6 +154,18 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to allow custom link attributes
      */
     allow_custom_attributes?: boolean;
+    /**
+     * Path of the folder internal links are restricted to
+     */
+    link_scope?: string;
+    /**
+     * Maximum length of the input text
+     */
+    max_length?: number;
+    /**
+     * Whether to enable right-to-left text direction
+     */
+    rtl?: boolean;
 };
 
 export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -362,6 +374,10 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to use UUID for the option values
      */
     use_uuid?: boolean;
+    /**
+     * Whether to exclude the empty option
+     */
+    exclude_empty_option?: boolean;
     /**
      * Whether this Multi-Options field is a References field
      */

--- a/packages/capi-client/src/generated/types/field.ts
+++ b/packages/capi-client/src/generated/types/field.ts
@@ -155,16 +155,29 @@ interface FieldTypeValueMap {
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
   /**
-   * The legacy `image`/`file` types predate the asset object: they store the
-   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   * The legacy `image`/`file` types predate the asset object: they store the URL
+   * as a plain string, protocol-relative (`//a.storyblok.com/…`) unless the field
+   * sets `add_https`, which makes it absolute.
    */
   image: string;
   file: string;
   multilink: MultilinkFieldValue;
+  /**
+   * Legacy predecessor of `multilink`, storing a bare URL string rather than a
+   * link object. Read-only in practice: the editor no longer writes it.
+   */
+  link: string;
   bloks: BlockContentBase[];
   table: TableFieldValue;
   section: never;
   tab: never;
+  group: never;
+  /**
+   * Owned by a commerce integration rather than the editor, and exempt from
+   * server-side content type-checking, so the integration is the only thing that
+   * knows the shape. Narrow it where you know which one wrote the field.
+   */
+  commerce: unknown;
   custom: PluginFieldValue;
 }
 

--- a/packages/capi-client/src/generated/types/field.ts
+++ b/packages/capi-client/src/generated/types/field.ts
@@ -154,6 +154,12 @@ interface FieldTypeValueMap {
   options: string[];
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
+  /**
+   * The legacy `image`/`file` types predate the asset object: they store the
+   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   */
+  image: string;
+  file: string;
   multilink: MultilinkFieldValue;
   bloks: BlockContentBase[];
   table: TableFieldValue;

--- a/packages/cli/src/commands/stories/ref-mapper.test.ts
+++ b/packages/cli/src/commands/stories/ref-mapper.test.ts
@@ -364,4 +364,86 @@ describe("storyRefMapper", () => {
       'Invalid multiasset field: expected an array, but received {"filename":"image.png"}',
     );
   });
+
+  describe("option and options fields", () => {
+    const referencePage = {
+      name: "Reference Page",
+      schema: {
+        picked_story: { type: "option", source: "internal_stories", use_uuid: true },
+        picked_stories: { type: "options", source: "internal_stories", use_uuid: true },
+        picked_language: { type: "option", source: "internal_languages" },
+        picked_entries: { type: "options", source: "internal" },
+      },
+    } as const;
+
+    const makeStory = (content: Record<string, unknown>) => ({
+      name: "Reference Page",
+      id: getID(),
+      uuid: randomUUID(),
+      parent_id: 0,
+      is_folder: false,
+      slug: "reference-page",
+      content: { _uid: randomUUID(), component: "reference_page", ...content },
+    });
+
+    const mapStory = (story: ReturnType<typeof makeStory>, stories: Map<unknown, string>) =>
+      // @ts-expect-error Our types are wrong.
+      storyRefMapper(story, {
+        schemas: { reference_page: referencePage.schema },
+        maps: { assets: new Map(), stories },
+      });
+
+    it("should remap a single option field sourced from stories", () => {
+      const sourceUuid = randomUUID();
+      const targetUuid = randomUUID();
+      const story = makeStory({ picked_story: sourceUuid });
+
+      const mapped = mapStory(story, new Map([[sourceUuid, targetUuid]]));
+
+      expect(mapped.content.picked_story).toBe(targetUuid);
+    });
+
+    it("should remap every entry of a multi option field sourced from stories", () => {
+      const [firstSource, secondSource] = [randomUUID(), randomUUID()];
+      const [firstTarget, secondTarget] = [randomUUID(), randomUUID()];
+      const story = makeStory({ picked_stories: [firstSource, secondSource] });
+
+      const mapped = mapStory(
+        story,
+        new Map([
+          [firstSource, firstTarget],
+          [secondSource, secondTarget],
+        ]),
+      );
+
+      expect(mapped.content.picked_stories).toEqual([firstTarget, secondTarget]);
+    });
+
+    it("should leave option sources that are the same in every space untouched", () => {
+      // A language code and a datasource entry value mean the same thing in the
+      // target space, so a map hit on one is a collision, not a reference.
+      const story = makeStory({ picked_language: "de", picked_entries: ["tech", "design"] });
+
+      const mapped = mapStory(
+        story,
+        new Map([
+          ["de", randomUUID()],
+          ["tech", randomUUID()],
+        ]),
+      );
+
+      expect(mapped.content.picked_language).toBe("de");
+      expect(mapped.content.picked_entries).toEqual(["tech", "design"]);
+    });
+
+    it("should keep a story reference that has no mapping", () => {
+      const unmapped = randomUUID();
+      const story = makeStory({ picked_story: unmapped, picked_stories: [unmapped] });
+
+      const mapped = mapStory(story, new Map());
+
+      expect(mapped.content.picked_story).toBe(unmapped);
+      expect(mapped.content.picked_stories).toEqual([unmapped]);
+    });
+  });
 });

--- a/packages/cli/src/commands/stories/ref-mapper.ts
+++ b/packages/cli/src/commands/stories/ref-mapper.ts
@@ -216,19 +216,40 @@ const multiassetFieldRefMapper: RefMapper = (data, options) => {
 };
 
 /**
+ * An option field only holds a cross-space reference when its source is
+ * `internal_stories`: the value is then a story uuid (or id, with `use_uuid`
+ * off), which differs per space. Every other source is space-independent, so
+ * remapping it would corrupt the value: `self` holds the inline option's own
+ * `value`, `internal` and `external` hold a datasource entry's `value`, and
+ * `internal_languages` holds a language code.
+ */
+const mapOptionValue = (
+  value: unknown,
+  schema: SchemaFieldDefinition | undefined,
+  maps: RefMaps,
+): unknown => {
+  if (!schema || !("source" in schema) || schema.source !== "internal_stories") {
+    return value;
+  }
+
+  return maps.stories?.get(value) ?? value;
+};
+
+/**
+ * Single option field reference mapper.
+ */
+const optionFieldRefMapper: RefMapper = (data, { schema, maps }) =>
+  mapOptionValue(data, schema, maps) as any;
+
+/**
  * Options field reference mapper.
  */
 const optionsFieldRefMapper: RefMapper = (data, { schema, maps }) => {
-  if (
-    !schema ||
-    !("source" in schema) ||
-    schema.source !== "internal_stories" ||
-    !Array.isArray(data)
-  ) {
+  if (!Array.isArray(data)) {
     return data;
   }
 
-  return data.map((d: any) => maps.stories?.get(d) || d) as any;
+  return data.map((d: any) => mapOptionValue(d, schema, maps)) as any;
 };
 
 const fieldRefMappers = {
@@ -236,6 +257,7 @@ const fieldRefMappers = {
   bloks: bloksFieldRefMapper,
   multiasset: multiassetFieldRefMapper,
   multilink: multilinkFieldRefMapper,
+  option: optionFieldRefMapper,
   options: optionsFieldRefMapper,
   richtext: richtextFieldRefMapper,
 } as const;

--- a/packages/cli/test/scenarios/SCENARIOS.md
+++ b/packages/cli/test/scenarios/SCENARIOS.md
@@ -14,9 +14,31 @@ For basic story testing, use the global `has-stories` scenario instead:
 bash .agents/skills/qa-engineer-manual/scripts/seed-scenario.sh --scenario has-stories
 ```
 
-| Scenario                   | Seeds                                                                                                                                                                                                                         |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `has-nested-stories`       | 1 story folder and 2 nested stories inside that folder (4 components, 3 stories).                                                                                                                                             |
-| `has-private-assets`       | 1 public asset and 1 private asset (4 components, 2 assets).                                                                                                                                                                  |
-| `has-nested-asset-folders` | 2 nested asset folders (A → B) and 3 assets: 1 at root, 1 in Folder A, 1 in Folder B (4 components, 2 folders, 3 assets).                                                                                                     |
-| `has-diverse-components`   | 5 components (1 root, 4 nestable) using text, textarea, richtext, number, datetime, boolean, option, options, asset, multilink, bloks field types, plus 1 datasource. Good baseline for `schema init` and round-trip testing. |
+| Scenario                   | Seeds                                                                                                                                                                                                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `has-nested-stories`       | 2 story folders, each holding 2 nested stories with the same slugs (4 components, 6 stories). Exercises duplicate slugs across folders.                                                                                                                     |
+| `has-private-assets`       | 1 public asset and 1 private asset (4 components, 2 assets).                                                                                                                                                                                                |
+| `has-nested-asset-folders` | 2 nested asset folders (A → B) and 3 assets: 1 at root, 1 in Folder A, 1 in Folder B (4 components, 2 folders, 3 assets).                                                                                                                                   |
+| `has-diverse-components`   | 6 components (1 root, 5 nestable) covering every field type: text, textarea, richtext, markdown, number, datetime, boolean, option, options, asset, multiasset, image, file, multilink, bloks, table, section, tab, custom, plus 1 datasource with entries. |
+| `has-restrictions`         | 5 components, 2 nested component groups and 1 component tag, covering all eight `bloks` restriction shapes and four `richtext` ones. Baseline for `schema init`/`push` round trips over restrictions.                                                       |
+
+## `has-restrictions`
+
+Every `qa_restrictions` field and the first three `qa_rt_restrictions` fields are copied verbatim
+from blocks created by hand in the Storyblok editor, so they are the shapes a real space holds:
+
+- `r_allow` / `r_deny` / `r_allow_many` — the block-name dimension. The editor offers allow **or**
+  block, never both, and always writes the paired empty list.
+- `r_groups` — the folder dimension. It stores only the selected group's uuid; descendants resolve
+  at read time, so `qa_gamma` in the nested `QA Sub` is allowed by a `QA Group` restriction without
+  appearing in the list.
+- `r_tags` / `r_tags_empty` — the tag dimension, with and without a tag selected. Tag ids are
+  integers in the whitelist and strings in a component's `internal_tag_ids`.
+- `r_on_nothing` — the restriction is switched on with nothing selected: no list keys at all.
+- `r_off` — switched off; the Management API strips the name lists on `bloks` fields.
+
+`rt_stale_tags_with_name` is the one field here the editor cannot produce. Switching dimension
+clears all six lists, and the Management API only strips stale name lists on `bloks`, so a
+`richtext` can hold `restrict_type: 'tags'` next to a live `component_whitelist` from legacy or
+direct API writes. It is here to keep that path covered, not because a space would be authored that
+way.

--- a/packages/cli/test/scenarios/SCENARIOS.md
+++ b/packages/cli/test/scenarios/SCENARIOS.md
@@ -22,6 +22,11 @@ bash .agents/skills/qa-engineer-manual/scripts/seed-scenario.sh --scenario has-s
 | `has-diverse-components`   | 6 components (1 root, 5 nestable) covering every field type: text, textarea, richtext, markdown, number, datetime, boolean, option, options, asset, multiasset, image, file, multilink, bloks, table, section, tab, plus 1 datasource with entries. |
 | `has-restrictions`         | 5 components, 2 nested component groups and 1 component tag, covering all eight `bloks` restriction shapes and four `richtext` ones. Baseline for `schema init`/`push` round trips over restrictions.                                               |
 
+`kitchen_sink` carries the only `conditional_settings` in the corpus: `gallery` hides when `related`
+is empty (one condition, `display` modification) and `legacy_file` becomes required when both
+`notes` and `related` are filled (two conditions under `rule_match: 'all'`, `required`
+modification). Between them they cover both modification kinds and both rule matches.
+
 `has-diverse-components` deliberately has no `custom` field. The Management API rejects a component
 whose `custom` field names a field-type plugin the space has not installed, with
 `422 The following field-type plugin(s) are not available in this space`, so a `custom` field cannot

--- a/packages/cli/test/scenarios/SCENARIOS.md
+++ b/packages/cli/test/scenarios/SCENARIOS.md
@@ -14,24 +14,35 @@ For basic story testing, use the global `has-stories` scenario instead:
 bash .agents/skills/qa-engineer-manual/scripts/seed-scenario.sh --scenario has-stories
 ```
 
-| Scenario                   | Seeds                                                                                                                                                                                                                                               |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `has-nested-stories`       | 2 story folders, each holding 2 nested stories with the same slugs (4 components, 6 stories). Exercises duplicate slugs across folders.                                                                                                             |
-| `has-private-assets`       | 1 public asset and 1 private asset (4 components, 2 assets).                                                                                                                                                                                        |
-| `has-nested-asset-folders` | 2 nested asset folders (A → B) and 3 assets: 1 at root, 1 in Folder A, 1 in Folder B (4 components, 2 folders, 3 assets).                                                                                                                           |
-| `has-diverse-components`   | 6 components (1 root, 5 nestable) covering every field type: text, textarea, richtext, markdown, number, datetime, boolean, option, options, asset, multiasset, image, file, multilink, bloks, table, section, tab, plus 1 datasource with entries. |
-| `has-restrictions`         | 5 components, 2 nested component groups and 1 component tag, covering all eight `bloks` restriction shapes and four `richtext` ones. Baseline for `schema init`/`push` round trips over restrictions.                                               |
+| Scenario                   | Seeds                                                                                                                                                                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `has-nested-stories`       | 2 story folders, each holding 2 nested stories with the same slugs (4 components, 6 stories). Exercises duplicate slugs across folders.                                                                                                                                  |
+| `has-private-assets`       | 1 public asset and 1 private asset (4 components, 2 assets).                                                                                                                                                                                                             |
+| `has-nested-asset-folders` | 2 nested asset folders (A → B) and 3 assets: 1 at root, 1 in Folder A, 1 in Folder B (4 components, 2 folders, 3 assets).                                                                                                                                                |
+| `has-diverse-components`   | 6 components (1 root, 5 nestable) covering 20 of the 22 field types: text, textarea, richtext, markdown, number, datetime, boolean, option, options, asset, multiasset, image, file, link, multilink, bloks, table, section, tab, group, plus 1 datasource with entries. |
+| `has-restrictions`         | 5 components, 2 nested component groups and 1 component tag, covering all eight `bloks` restriction shapes and four `richtext` ones. Baseline for `schema init`/`push` round trips over restrictions.                                                                    |
 
 `kitchen_sink` carries the only `conditional_settings` in the corpus: `gallery` hides when `related`
 is empty (one condition, `display` modification) and `legacy_file` becomes required when both
 `notes` and `related` are filled (two conditions under `rule_match: 'all'`, `required`
 modification). Between them they cover both modification kinds and both rule matches.
 
-`has-diverse-components` deliberately has no `custom` field. The Management API rejects a component
-whose `custom` field names a field-type plugin the space has not installed, with
-`422 The following field-type plugin(s) are not available in this space`, so a `custom` field cannot
-be seeded into an arbitrary QA space. The type is covered by the `@storyblok/schema` type tests
-instead.
+`kitchen_sink` also carries the shapes that only exist in older or API-authored spaces, so the round
+trip has something to lose: `legacy_link` (`link`, the string-valued predecessor of `multilink`),
+`reference_group` (`group`, the layout container that predates nesting fields under a `section`),
+`legacy_image_cleared` (`image_width`/`image_height` as `""`, which is what clearing the crop inputs
+writes), `headline.max_length` as a string, and `primary_reference` (a singular `option` sourced
+from `internal_stories`, the only option source that holds a per-space reference).
+
+Two of the 22 field types are deliberately absent, and both are covered by the `@storyblok/schema`
+type tests instead:
+
+- `custom`. The Management API rejects a component whose `custom` field names a field-type plugin
+  the space has not installed, with
+  `422 The following field-type plugin(s) are not available in this space`, so it cannot be seeded
+  into an arbitrary QA space.
+- `commerce`. A commerce integration owns the field, and whether a bare QA space accepts one is not
+  something the corpus should assume.
 
 ## `has-restrictions`
 

--- a/packages/cli/test/scenarios/SCENARIOS.md
+++ b/packages/cli/test/scenarios/SCENARIOS.md
@@ -14,13 +14,19 @@ For basic story testing, use the global `has-stories` scenario instead:
 bash .agents/skills/qa-engineer-manual/scripts/seed-scenario.sh --scenario has-stories
 ```
 
-| Scenario                   | Seeds                                                                                                                                                                                                                                                       |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `has-nested-stories`       | 2 story folders, each holding 2 nested stories with the same slugs (4 components, 6 stories). Exercises duplicate slugs across folders.                                                                                                                     |
-| `has-private-assets`       | 1 public asset and 1 private asset (4 components, 2 assets).                                                                                                                                                                                                |
-| `has-nested-asset-folders` | 2 nested asset folders (A → B) and 3 assets: 1 at root, 1 in Folder A, 1 in Folder B (4 components, 2 folders, 3 assets).                                                                                                                                   |
-| `has-diverse-components`   | 6 components (1 root, 5 nestable) covering every field type: text, textarea, richtext, markdown, number, datetime, boolean, option, options, asset, multiasset, image, file, multilink, bloks, table, section, tab, custom, plus 1 datasource with entries. |
-| `has-restrictions`         | 5 components, 2 nested component groups and 1 component tag, covering all eight `bloks` restriction shapes and four `richtext` ones. Baseline for `schema init`/`push` round trips over restrictions.                                                       |
+| Scenario                   | Seeds                                                                                                                                                                                                                                               |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `has-nested-stories`       | 2 story folders, each holding 2 nested stories with the same slugs (4 components, 6 stories). Exercises duplicate slugs across folders.                                                                                                             |
+| `has-private-assets`       | 1 public asset and 1 private asset (4 components, 2 assets).                                                                                                                                                                                        |
+| `has-nested-asset-folders` | 2 nested asset folders (A → B) and 3 assets: 1 at root, 1 in Folder A, 1 in Folder B (4 components, 2 folders, 3 assets).                                                                                                                           |
+| `has-diverse-components`   | 6 components (1 root, 5 nestable) covering every field type: text, textarea, richtext, markdown, number, datetime, boolean, option, options, asset, multiasset, image, file, multilink, bloks, table, section, tab, plus 1 datasource with entries. |
+| `has-restrictions`         | 5 components, 2 nested component groups and 1 component tag, covering all eight `bloks` restriction shapes and four `richtext` ones. Baseline for `schema init`/`push` round trips over restrictions.                                               |
+
+`has-diverse-components` deliberately has no `custom` field. The Management API rejects a component
+whose `custom` field names a field-type plugin the space has not installed, with
+`422 The following field-type plugin(s) are not available in this space`, so a `custom` field cannot
+be seeded into an arbitrary QA space. The type is covered by the `@storyblok/schema` type tests
+instead.
 
 ## `has-restrictions`
 

--- a/packages/cli/test/scenarios/has-diverse-components/components/feature_grid.json
+++ b/packages/cli/test/scenarios/has-diverse-components/components/feature_grid.json
@@ -6,15 +6,28 @@
   "is_root": false,
   "is_nestable": true,
   "schema": {
-    "heading": { "type": "text", "pos": 0 },
+    "heading": {
+      "type": "text",
+      "pos": 0
+    },
     "items": {
       "type": "bloks",
       "pos": 1,
       "restrict_components": true,
-      "component_whitelist": ["feature_item"]
+      "component_whitelist": ["feature_item"],
+      "restrict_type": "",
+      "component_denylist": []
     },
-    "columns": { "type": "number", "pos": 2, "min_value": 1, "max_value": 4 },
-    "description": { "type": "richtext", "pos": 3 }
+    "columns": {
+      "type": "number",
+      "pos": 2,
+      "min_value": 1,
+      "max_value": 4
+    },
+    "description": {
+      "type": "richtext",
+      "pos": 3
+    }
   },
   "created_at": "2024-01-01T00:00:00.000Z",
   "updated_at": "2024-01-01T00:00:00.000Z"

--- a/packages/cli/test/scenarios/has-diverse-components/components/hero_banner.json
+++ b/packages/cli/test/scenarios/has-diverse-components/components/hero_banner.json
@@ -6,19 +6,51 @@
   "is_root": false,
   "is_nestable": true,
   "schema": {
-    "headline": { "type": "text", "pos": 0, "required": true },
-    "subtitle": { "type": "textarea", "pos": 1 },
-    "background": { "type": "asset", "pos": 2, "filetypes": ["images", "videos"] },
-    "cta_link": { "type": "multilink", "pos": 3, "allow_target_blank": true },
-    "cta_label": { "type": "text", "pos": 4 },
-    "overlay_opacity": { "type": "number", "pos": 5, "min_value": 0, "max_value": 100 },
+    "headline": {
+      "type": "text",
+      "pos": 0,
+      "required": true
+    },
+    "subtitle": {
+      "type": "textarea",
+      "pos": 1
+    },
+    "background": {
+      "type": "asset",
+      "pos": 2,
+      "filetypes": ["images", "videos"]
+    },
+    "cta_link": {
+      "type": "multilink",
+      "pos": 3,
+      "allow_target_blank": true
+    },
+    "cta_label": {
+      "type": "text",
+      "pos": 4
+    },
+    "overlay_opacity": {
+      "type": "number",
+      "pos": 5,
+      "min_value": 0,
+      "max_value": 100
+    },
     "style": {
       "type": "option",
       "pos": 6,
-      "source": "self",
+      "use_uuid": false,
+      "exclude_empty_option": true,
       "options": [
-        { "name": "Light", "value": "light" },
-        { "name": "Dark", "value": "dark" }
+        {
+          "_uid": "5cbb1f5c-3fdb-4b31-9c88-0b0e7f7b6a41",
+          "name": "Light",
+          "value": "light"
+        },
+        {
+          "_uid": "2a4de1a7-08a6-4f60-8f4e-6c0f8fef0a52",
+          "name": "Dark",
+          "value": "dark"
+        }
       ]
     }
   },

--- a/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
+++ b/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
@@ -1,0 +1,69 @@
+{
+  "id": 205,
+  "name": "kitchen_sink",
+  "display_name": "Kitchen Sink",
+  "component_group_uuid": null,
+  "is_root": false,
+  "is_nestable": true,
+  "schema": {
+    "layout_tab": { "type": "tab", "pos": 0, "keys": ["notes", "spec_table"] },
+    "notes": {
+      "type": "markdown",
+      "pos": 1,
+      "allow_multiline": true,
+      "customize_toolbar": true,
+      "rich_markdown": true,
+      "toolbar": ["bold", "italic", "link"]
+    },
+    "spec_table": { "type": "table", "pos": 2 },
+    "media_section": {
+      "type": "section",
+      "pos": 3,
+      "keys": ["gallery", "legacy_image", "legacy_file"]
+    },
+    "gallery": {
+      "type": "multiasset",
+      "pos": 4,
+      "filetypes": ["images"],
+      "maximum_entries": 4,
+      "minimum_entries": 1
+    },
+    "legacy_image": {
+      "type": "image",
+      "pos": 5,
+      "add_https": true,
+      "image_crop": true,
+      "image_width": 800,
+      "image_height": 600,
+      "keep_image_size": false
+    },
+    "legacy_file": { "type": "file", "pos": 6, "add_https": true },
+    "related": {
+      "type": "options",
+      "pos": 7,
+      "source": "internal_stories",
+      "is_reference_type": true,
+      "folder_slug": "blog-index/",
+      "filter_content_type": ["blog"],
+      "entry_appearance": "card",
+      "allow_advanced_search": true,
+      "use_uuid": true
+    },
+    "prose": {
+      "type": "richtext",
+      "pos": 8,
+      "customize_toolbar": true,
+      "toolbar": ["bold", "italic", "link", "blok"],
+      "style_options": [{ "name": "Lead", "value": "lead" }],
+      "allow_target_blank": true,
+      "max_length": 500,
+      "restrict_components": true,
+      "restrict_type": "",
+      "component_whitelist": ["feature_item"],
+      "component_denylist": []
+    },
+    "widget": { "type": "custom", "pos": 9, "field_type": "unregistered-plugin" }
+  },
+  "created_at": "2024-01-01T00:00:00.000Z",
+  "updated_at": "2024-01-01T00:00:00.000Z"
+}

--- a/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
+++ b/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
@@ -23,14 +23,19 @@
       "type": "table",
       "pos": 2
     },
+    "headline": {
+      "type": "text",
+      "pos": 3,
+      "max_length": "120"
+    },
     "media_section": {
       "type": "section",
-      "pos": 3,
-      "keys": ["gallery", "legacy_image", "legacy_file"]
+      "pos": 4,
+      "keys": ["gallery", "legacy_image", "legacy_image_cleared", "legacy_file", "legacy_link"]
     },
     "gallery": {
       "type": "multiasset",
-      "pos": 4,
+      "pos": 5,
       "filetypes": ["images"],
       "maximum_entries": 4,
       "minimum_entries": 1,
@@ -54,16 +59,23 @@
     },
     "legacy_image": {
       "type": "image",
-      "pos": 5,
+      "pos": 6,
       "add_https": true,
       "image_crop": true,
       "image_width": 800,
       "image_height": 600,
       "keep_image_size": false
     },
+    "legacy_image_cleared": {
+      "type": "image",
+      "pos": 7,
+      "image_crop": true,
+      "image_width": "",
+      "image_height": ""
+    },
     "legacy_file": {
       "type": "file",
-      "pos": 6,
+      "pos": 8,
       "add_https": true,
       "conditional_settings": [
         {
@@ -92,20 +104,36 @@
         }
       ]
     },
+    "legacy_link": {
+      "type": "link",
+      "pos": 9
+    },
+    "reference_group": {
+      "type": "group",
+      "pos": 10
+    },
+    "primary_reference": {
+      "type": "option",
+      "pos": 11,
+      "source": "internal_stories",
+      "use_uuid": true,
+      "exclude_empty_option": true
+    },
     "related": {
       "type": "options",
-      "pos": 7,
+      "pos": 12,
       "source": "internal_stories",
       "is_reference_type": true,
       "folder_slug": "blog-index/",
       "filter_content_type": ["blog"],
       "entry_appearance": "card",
       "allow_advanced_search": true,
+      "exclude_empty_option": true,
       "use_uuid": true
     },
     "prose": {
       "type": "richtext",
-      "pos": 8,
+      "pos": 13,
       "customize_toolbar": true,
       "toolbar": ["bold", "italic", "link", "blok"],
       "style_options": [
@@ -116,6 +144,8 @@
       ],
       "allow_target_blank": true,
       "max_length": 500,
+      "link_scope": "blog-index/",
+      "rtl": false,
       "restrict_components": true,
       "restrict_type": "",
       "component_whitelist": ["feature_item"],

--- a/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
+++ b/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
@@ -6,7 +6,11 @@
   "is_root": false,
   "is_nestable": true,
   "schema": {
-    "layout_tab": { "type": "tab", "pos": 0, "keys": ["notes", "spec_table"] },
+    "layout_tab": {
+      "type": "tab",
+      "pos": 0,
+      "keys": ["notes", "spec_table"]
+    },
     "notes": {
       "type": "markdown",
       "pos": 1,
@@ -15,7 +19,10 @@
       "rich_markdown": true,
       "toolbar": ["bold", "italic", "link"]
     },
-    "spec_table": { "type": "table", "pos": 2 },
+    "spec_table": {
+      "type": "table",
+      "pos": 2
+    },
     "media_section": {
       "type": "section",
       "pos": 3,
@@ -37,7 +44,11 @@
       "image_height": 600,
       "keep_image_size": false
     },
-    "legacy_file": { "type": "file", "pos": 6, "add_https": true },
+    "legacy_file": {
+      "type": "file",
+      "pos": 6,
+      "add_https": true
+    },
     "related": {
       "type": "options",
       "pos": 7,
@@ -54,15 +65,19 @@
       "pos": 8,
       "customize_toolbar": true,
       "toolbar": ["bold", "italic", "link", "blok"],
-      "style_options": [{ "name": "Lead", "value": "lead" }],
+      "style_options": [
+        {
+          "name": "Lead",
+          "value": "lead"
+        }
+      ],
       "allow_target_blank": true,
       "max_length": 500,
       "restrict_components": true,
       "restrict_type": "",
       "component_whitelist": ["feature_item"],
       "component_denylist": []
-    },
-    "widget": { "type": "custom", "pos": 9, "field_type": "unregistered-plugin" }
+    }
   },
   "created_at": "2024-01-01T00:00:00.000Z",
   "updated_at": "2024-01-01T00:00:00.000Z"

--- a/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
+++ b/packages/cli/test/scenarios/has-diverse-components/components/kitchen_sink.json
@@ -33,7 +33,24 @@
       "pos": 4,
       "filetypes": ["images"],
       "maximum_entries": 4,
-      "minimum_entries": 1
+      "minimum_entries": 1,
+      "conditional_settings": [
+        {
+          "modifications": [{ "display": "hide" }],
+          "rule_match": "any",
+          "rule_conditions": [
+            {
+              "validated_object": {
+                "type": "field",
+                "field_key": "related",
+                "field_attr": "value"
+              },
+              "validation": "empty",
+              "value": null
+            }
+          ]
+        }
+      ]
     },
     "legacy_image": {
       "type": "image",
@@ -47,7 +64,33 @@
     "legacy_file": {
       "type": "file",
       "pos": 6,
-      "add_https": true
+      "add_https": true,
+      "conditional_settings": [
+        {
+          "modifications": [{ "required": true }],
+          "rule_match": "all",
+          "rule_conditions": [
+            {
+              "validated_object": {
+                "type": "field",
+                "field_key": "notes",
+                "field_attr": "value"
+              },
+              "validation": "not_empty",
+              "value": null
+            },
+            {
+              "validated_object": {
+                "type": "field",
+                "field_key": "related",
+                "field_attr": "value"
+              },
+              "validation": "not_empty",
+              "value": null
+            }
+          ]
+        }
+      ]
     },
     "related": {
       "type": "options",

--- a/packages/cli/test/scenarios/has-diverse-components/components/landing_page.json
+++ b/packages/cli/test/scenarios/has-diverse-components/components/landing_page.json
@@ -6,18 +6,44 @@
   "is_root": true,
   "is_nestable": false,
   "schema": {
-    "title": { "type": "text", "pos": 0, "required": true, "max_length": 120 },
-    "slug_override": { "type": "text", "pos": 1, "regex": "^[a-z0-9-]+$" },
+    "title": {
+      "type": "text",
+      "pos": 0,
+      "required": true,
+      "max_length": 120
+    },
+    "slug_override": {
+      "type": "text",
+      "pos": 1,
+      "regex": "^[a-z0-9-]+$"
+    },
     "body": {
       "type": "bloks",
       "pos": 2,
       "restrict_components": true,
-      "component_whitelist": ["hero_banner", "feature_grid", "testimonial"]
+      "component_whitelist": ["hero_banner", "feature_grid", "testimonial"],
+      "restrict_type": "",
+      "component_denylist": []
     },
-    "seo_image": { "type": "asset", "pos": 3, "filetypes": ["images"] },
-    "seo_description": { "type": "textarea", "pos": 4, "max_length": 160 },
-    "published_at": { "type": "datetime", "pos": 5, "disable_time": false },
-    "is_featured": { "type": "boolean", "pos": 6 },
+    "seo_image": {
+      "type": "asset",
+      "pos": 3,
+      "filetypes": ["images"]
+    },
+    "seo_description": {
+      "type": "textarea",
+      "pos": 4,
+      "max_length": 160
+    },
+    "published_at": {
+      "type": "datetime",
+      "pos": 5,
+      "disable_time": false
+    },
+    "is_featured": {
+      "type": "boolean",
+      "pos": 6
+    },
     "category": {
       "type": "option",
       "pos": 7,

--- a/packages/cli/test/scenarios/has-diverse-components/datasources/page-categories.json
+++ b/packages/cli/test/scenarios/has-diverse-components/datasources/page-categories.json
@@ -1,5 +1,10 @@
 {
+  "id": 1,
   "name": "Page Categories",
   "slug": "page-categories",
-  "dimensions": []
+  "dimensions": [],
+  "entries": [
+    { "id": 1, "name": "Guides", "value": "guides", "dimension_value": "" },
+    { "id": 2, "name": "Reference", "value": "reference", "dimension_value": "" }
+  ]
 }

--- a/packages/cli/test/scenarios/has-nested-asset-folders/assets/folders/QA-Folder-A_folder-a.json
+++ b/packages/cli/test/scenarios/has-nested-asset-folders/assets/folders/QA-Folder-A_folder-a.json
@@ -1,6 +1,7 @@
 {
   "id": 1,
-  "uuid": "folder-a",
+  "uuid": "eaf8e81e-5fe1-4070-8b3d-6982940f17a7",
   "name": "QA Folder A",
-  "parent_id": null
+  "parent_id": null,
+  "parent_uuid": null
 }

--- a/packages/cli/test/scenarios/has-nested-asset-folders/assets/folders/QA-Folder-B_folder-b.json
+++ b/packages/cli/test/scenarios/has-nested-asset-folders/assets/folders/QA-Folder-B_folder-b.json
@@ -1,6 +1,7 @@
 {
   "id": 2,
-  "uuid": "folder-b",
+  "uuid": "92b5cf97-6ecb-46f6-89cc-0d44a33f3e0b",
   "name": "QA Folder B",
-  "parent_id": 1
+  "parent_id": 1,
+  "parent_uuid": "eaf8e81e-5fe1-4070-8b3d-6982940f17a7"
 }

--- a/packages/cli/test/scenarios/has-nested-asset-folders/assets/qa-in-folder-a.json
+++ b/packages/cli/test/scenarios/has-nested-asset-folders/assets/qa-in-folder-a.json
@@ -5,5 +5,7 @@
   "meta_data": {
     "alt": "Asset in Folder A",
     "title": "In Folder A"
-  }
+  },
+  "alt": "Asset in Folder A",
+  "title": "In Folder A"
 }

--- a/packages/cli/test/scenarios/has-nested-asset-folders/assets/qa-in-folder-b.json
+++ b/packages/cli/test/scenarios/has-nested-asset-folders/assets/qa-in-folder-b.json
@@ -5,5 +5,7 @@
   "meta_data": {
     "alt": "Asset in Folder B",
     "title": "In Folder B"
-  }
+  },
+  "alt": "Asset in Folder B",
+  "title": "In Folder B"
 }

--- a/packages/cli/test/scenarios/has-nested-asset-folders/assets/qa-root.json
+++ b/packages/cli/test/scenarios/has-nested-asset-folders/assets/qa-root.json
@@ -4,5 +4,7 @@
   "meta_data": {
     "alt": "Root asset",
     "title": "Root"
-  }
+  },
+  "alt": "Root asset",
+  "title": "Root"
 }

--- a/packages/cli/test/scenarios/has-nested-stories/stories/folder-b_4.json
+++ b/packages/cli/test/scenarios/has-nested-stories/stories/folder-b_4.json
@@ -1,8 +1,12 @@
 {
   "id": 4,
-  "uuid": "4",
+  "uuid": "1d997b40-3927-40aa-8a36-6e53bb3dd69c",
   "name": "QA Folder B",
   "slug": "qa-folder-b",
   "full_slug": "qa-folder-b",
-  "is_folder": true
+  "is_folder": true,
+  "content": {
+    "content_types": ["page"]
+  },
+  "default_root": "page"
 }

--- a/packages/cli/test/scenarios/has-nested-stories/stories/folder_1.json
+++ b/packages/cli/test/scenarios/has-nested-stories/stories/folder_1.json
@@ -1,8 +1,12 @@
 {
   "id": 1,
-  "uuid": "1",
+  "uuid": "674dd69a-1c69-485b-8095-4a3a5b31519a",
   "name": "QA Folder",
   "slug": "qa-folder",
   "full_slug": "qa-folder",
-  "is_folder": true
+  "is_folder": true,
+  "content": {
+    "content_types": ["page"]
+  },
+  "default_root": "page"
 }

--- a/packages/cli/test/scenarios/has-nested-stories/stories/nested-a_2.json
+++ b/packages/cli/test/scenarios/has-nested-stories/stories/nested-a_2.json
@@ -1,11 +1,12 @@
 {
   "id": 2,
-  "uuid": "2",
+  "uuid": "9accffb9-a083-41a9-85f4-04e67df59003",
   "name": "QA Nested A",
   "slug": "nested-a",
   "full_slug": "qa-folder/nested-a",
   "parent_id": 1,
   "content": {
+    "_uid": "770bf5f2-ca1b-449d-87a3-4b023e6bb1a7",
     "component": "page"
   }
 }

--- a/packages/cli/test/scenarios/has-nested-stories/stories/nested-a_5.json
+++ b/packages/cli/test/scenarios/has-nested-stories/stories/nested-a_5.json
@@ -1,11 +1,12 @@
 {
   "id": 5,
-  "uuid": "5",
+  "uuid": "8a887dcb-e364-42e9-885c-3c51175dc953",
   "name": "QA Nested A",
   "slug": "nested-a",
   "full_slug": "qa-folder-b/nested-a",
   "parent_id": 4,
   "content": {
+    "_uid": "3aedef6d-a485-494e-8b2b-030efd88aa00",
     "component": "page"
   }
 }

--- a/packages/cli/test/scenarios/has-nested-stories/stories/nested-b_3.json
+++ b/packages/cli/test/scenarios/has-nested-stories/stories/nested-b_3.json
@@ -1,11 +1,12 @@
 {
   "id": 3,
-  "uuid": "3",
+  "uuid": "b6a9e847-9ca3-4c2f-8f91-7f955bff4832",
   "name": "QA Nested B",
   "slug": "nested-b",
   "full_slug": "qa-folder/nested-b",
   "parent_id": 1,
   "content": {
+    "_uid": "62fdfab1-7e07-4eef-8922-b1fd5ec036fc",
     "component": "page"
   }
 }

--- a/packages/cli/test/scenarios/has-nested-stories/stories/nested-b_6.json
+++ b/packages/cli/test/scenarios/has-nested-stories/stories/nested-b_6.json
@@ -1,11 +1,12 @@
 {
   "id": 6,
-  "uuid": "6",
+  "uuid": "8e355975-d1bc-4582-8a8d-14130a0d9462",
   "name": "QA Nested B",
   "slug": "nested-b",
   "full_slug": "qa-folder-b/nested-b",
   "parent_id": 4,
   "content": {
+    "_uid": "ea4bcaa6-3de0-4c1d-88c4-f9d6ddb987af",
     "component": "page"
   }
 }

--- a/packages/cli/test/scenarios/has-private-assets/assets/qa-private.json
+++ b/packages/cli/test/scenarios/has-private-assets/assets/qa-private.json
@@ -5,5 +5,7 @@
   "meta_data": {
     "alt": "Private asset",
     "title": "Private"
-  }
+  },
+  "alt": "Private asset",
+  "title": "Private"
 }

--- a/packages/cli/test/scenarios/has-private-assets/assets/qa-public.json
+++ b/packages/cli/test/scenarios/has-private-assets/assets/qa-public.json
@@ -4,5 +4,7 @@
   "meta_data": {
     "alt": "Public asset",
     "title": "Public"
-  }
+  },
+  "alt": "Public asset",
+  "title": "Public"
 }

--- a/packages/cli/test/scenarios/has-restrictions/components/groups.json
+++ b/packages/cli/test/scenarios/has-restrictions/components/groups.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 208901592266228,
+    "name": "QA Group",
+    "uuid": "2b80f462-c371-4f2d-81f5-ebc3e724be5d",
+    "parent_id": null,
+    "parent_uuid": null
+  },
+  {
+    "id": 208901727520245,
+    "name": "QA Sub",
+    "uuid": "41c9ccc5-313b-4bc4-a23e-3e1b3b18ce9b",
+    "parent_id": 208901592266228,
+    "parent_uuid": "2b80f462-c371-4f2d-81f5-ebc3e724be5d"
+  }
+]

--- a/packages/cli/test/scenarios/has-restrictions/components/qa_alpha.json
+++ b/packages/cli/test/scenarios/has-restrictions/components/qa_alpha.json
@@ -1,0 +1,12 @@
+{
+  "id": 208901468910120,
+  "name": "qa_alpha",
+  "display_name": null,
+  "component_group_uuid": null,
+  "is_root": false,
+  "is_nestable": true,
+  "internal_tag_ids": [],
+  "schema": {},
+  "created_at": "2026-08-14T07:02:15.182Z",
+  "updated_at": "2026-08-14T07:02:15.182Z"
+}

--- a/packages/cli/test/scenarios/has-restrictions/components/qa_beta.json
+++ b/packages/cli/test/scenarios/has-restrictions/components/qa_beta.json
@@ -1,0 +1,12 @@
+{
+  "id": 208901504897577,
+  "name": "qa_beta",
+  "display_name": null,
+  "component_group_uuid": "2b80f462-c371-4f2d-81f5-ebc3e724be5d",
+  "is_root": false,
+  "is_nestable": true,
+  "internal_tag_ids": [],
+  "schema": {},
+  "created_at": "2026-08-14T07:02:23.969Z",
+  "updated_at": "2026-08-14T07:03:01.024Z"
+}

--- a/packages/cli/test/scenarios/has-restrictions/components/qa_gamma.json
+++ b/packages/cli/test/scenarios/has-restrictions/components/qa_gamma.json
@@ -1,0 +1,12 @@
+{
+  "id": 208901538656810,
+  "name": "qa_gamma",
+  "display_name": null,
+  "component_group_uuid": "41c9ccc5-313b-4bc4-a23e-3e1b3b18ce9b",
+  "is_root": false,
+  "is_nestable": true,
+  "internal_tag_ids": ["208901878932724"],
+  "schema": {},
+  "created_at": "2026-08-14T07:02:32.210Z",
+  "updated_at": "2026-08-14T07:06:18.855Z"
+}

--- a/packages/cli/test/scenarios/has-restrictions/components/qa_restrictions.json
+++ b/packages/cli/test/scenarios/has-restrictions/components/qa_restrictions.json
@@ -1,0 +1,79 @@
+{
+  "id": 208902708859469,
+  "name": "qa_restrictions",
+  "display_name": null,
+  "component_group_uuid": null,
+  "is_root": false,
+  "is_nestable": true,
+  "internal_tag_ids": [],
+  "schema": {
+    "r_allow": {
+      "type": "bloks",
+      "pos": 0,
+      "restrict_components": true,
+      "restrict_type": "",
+      "component_whitelist": ["qa_alpha"],
+      "component_denylist": []
+    },
+    "r_deny": {
+      "type": "bloks",
+      "pos": 1,
+      "restrict_components": true,
+      "restrict_type": "",
+      "component_whitelist": [],
+      "component_denylist": ["qa_alpha"]
+    },
+    "r_allow_many": {
+      "type": "bloks",
+      "pos": 2,
+      "restrict_components": true,
+      "restrict_type": "",
+      "component_whitelist": ["qa_alpha", "qa_beta"],
+      "component_denylist": []
+    },
+    "r_groups": {
+      "type": "bloks",
+      "pos": 3,
+      "restrict_components": true,
+      "restrict_type": "groups",
+      "component_group_whitelist": ["2b80f462-c371-4f2d-81f5-ebc3e724be5d"],
+      "component_group_denylist": [],
+      "component_tag_whitelist": [],
+      "component_tag_denylist": []
+    },
+    "r_tags": {
+      "type": "bloks",
+      "pos": 4,
+      "restrict_components": true,
+      "restrict_type": "tags",
+      "component_group_whitelist": [],
+      "component_group_denylist": [],
+      "component_tag_whitelist": [208901878932724],
+      "component_tag_denylist": []
+    },
+    "r_tags_empty": {
+      "type": "bloks",
+      "pos": 5,
+      "restrict_components": true,
+      "restrict_type": "tags",
+      "component_group_whitelist": [],
+      "component_group_denylist": [],
+      "component_tag_whitelist": [],
+      "component_tag_denylist": []
+    },
+    "r_on_nothing": {
+      "type": "bloks",
+      "pos": 6,
+      "restrict_components": true,
+      "restrict_type": ""
+    },
+    "r_off": {
+      "type": "bloks",
+      "pos": 7,
+      "restrict_components": false,
+      "restrict_type": ""
+    }
+  },
+  "created_at": "2026-08-14T07:20:00.000Z",
+  "updated_at": "2026-08-14T07:20:00.000Z"
+}

--- a/packages/cli/test/scenarios/has-restrictions/components/qa_rt_restrictions.json
+++ b/packages/cli/test/scenarios/has-restrictions/components/qa_rt_restrictions.json
@@ -1,0 +1,55 @@
+{
+  "id": 208904692642386,
+  "name": "qa_rt_restrictions",
+  "display_name": null,
+  "component_group_uuid": null,
+  "is_root": false,
+  "is_nestable": true,
+  "internal_tag_ids": [],
+  "schema": {
+    "rt_tags_cleared": {
+      "type": "richtext",
+      "pos": 0,
+      "restrict_components": true,
+      "restrict_type": "tags",
+      "component_whitelist": [],
+      "component_denylist": [],
+      "component_group_whitelist": [],
+      "component_group_denylist": [],
+      "component_tag_whitelist": [],
+      "component_tag_denylist": []
+    },
+    "rt_tags": {
+      "type": "richtext",
+      "pos": 1,
+      "restrict_components": true,
+      "restrict_type": "tags",
+      "component_whitelist": [],
+      "component_denylist": [],
+      "component_group_whitelist": [],
+      "component_group_denylist": [],
+      "component_tag_whitelist": [208901878932724],
+      "component_tag_denylist": []
+    },
+    "rt_deny": {
+      "type": "richtext",
+      "pos": 2,
+      "restrict_components": true,
+      "restrict_type": "",
+      "component_whitelist": [],
+      "component_denylist": ["qa_alpha"]
+    },
+    "rt_stale_tags_with_name": {
+      "type": "richtext",
+      "pos": 3,
+      "restrict_components": true,
+      "restrict_type": "tags",
+      "component_tag_whitelist": [],
+      "component_tag_denylist": [],
+      "component_whitelist": ["qa_alpha"],
+      "component_denylist": []
+    }
+  },
+  "created_at": "2026-08-14T07:30:00.000Z",
+  "updated_at": "2026-08-14T07:30:00.000Z"
+}

--- a/packages/cli/test/scenarios/has-restrictions/components/tags.json
+++ b/packages/cli/test/scenarios/has-restrictions/components/tags.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 208901878932724,
+    "name": "QA Tag",
+    "object_type": "component"
+  }
+]

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -161,7 +161,11 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_custom_attributes?: boolean;
     /**
-     * Path of the folder internal links are restricted to
+     * Path of the folder internal links are restricted to. The richtext
+     * schema form does not write this option itself; it belongs to the
+     * multilink field's editor. Kept here because a space can carry it as
+     * a legacy value, not because the richtext editor produces it.
+     *
      */
     link_scope?: string;
     /**
@@ -172,7 +176,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     max_length?: number | string;
     /**
-     * Whether to enable right-to-left text direction
+     * Whether to enable right-to-left text direction. The richtext schema
+     * form does not write this option itself; it belongs to the text,
+     * textarea, and markdown fields' editors. Kept here because a space
+     * can carry it as a legacy value, not because the richtext editor
+     * produces it.
+     *
      */
     rtl?: boolean;
 };

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -488,6 +488,66 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Minimum number of entries
      */
     minimum_entries?: number;
+};
+
+export type ImageFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'image';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Whether to force editors to crop the image to a fixed size
+     */
+    image_crop?: boolean;
+    /**
+     * Crop width in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_width?: number | string;
+    /**
+     * Crop height in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_height?: number | string;
+    /**
+     * Whether to keep the original image size when `image_crop` is true
+     */
+    keep_image_size?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
+};
+
+export type FileFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'file';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
 };
 
 export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | LinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | GroupFieldRoot | CommerceFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -29,9 +29,12 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -60,9 +63,12 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -159,9 +165,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     link_scope?: string;
     /**
-     * Maximum length of the input text
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Whether to enable right-to-left text direction
      */
@@ -198,9 +207,12 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_multiline?: boolean;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
 };
 
 export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -597,6 +609,17 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     asset_link_type?: boolean;
 };
 
+export type LinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'link';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+};
+
 export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     /**
      * Field type discriminant
@@ -712,6 +735,20 @@ export type TabFieldRoot = BaseFieldRoot & {
      * Field keys that belong to this tab
      */
     keys?: Array<string>;
+};
+
+export type GroupFieldRoot = BaseFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'group';
+};
+
+export type CommerceFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'commerce';
 };
 
 export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -941,7 +978,10 @@ export type BaseFieldRoot = {
     pos?: number;
     /**
      * Conditions set on the field for conditional visibility. The editor writes
-     * one setting and evaluates only the first, so further entries are inert.
+     * one setting and reads only the first, so an extra entry is invisible to it.
+     * It is not inert server-side: the conditional-required check requires every
+     * setting to match, so a second entry can only make a field harder to leave
+     * empty. Write one setting unless you mean that.
      *
      */
     conditional_settings?: Array<ConditionalSettingRoot>;
@@ -1108,18 +1148,26 @@ export type ConditionalSettingRoot = {
     }>;
     /**
      * What to apply to this field when the conditions match. The editor writes
-     * one entry and reads only the first, so further entries are inert.
+     * one entry and reads only the first.
      *
      */
     modifications?: Array<{
         /**
-         * Set to `hide` to hide the field
+         * Hides the field. Both spellings are live: the editor writes `hide`
+         * and reads it back, while the server's conditional-required check
+         * recognizes only `hidden`. Neither side accepts the other's value, so
+         * a rule authored through the API with `hidden` hides nothing in the
+         * editor, and one authored in the editor does not relax a required
+         * field on save. Both are declared because real spaces hold both;
+         * prefer `hide` for anything the editor will open.
+         *
          */
-        display?: 'hide';
+        display?: 'hide' | 'hidden';
         /**
          * `true` makes the field required, `false` makes it explicitly not
-         * required. The two modifications are mutually exclusive: `display`
-         * wins when both are set.
+         * required. Setting it alongside `display` is ambiguous rather than
+         * layered: the editor lets `display` win, while the server only skips
+         * the required check for the `hidden` spelling. Set one or the other.
          *
          */
         required?: boolean;

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -940,11 +940,11 @@ export type BaseFieldRoot = {
      */
     pos?: number;
     /**
-     * Conditions set on the field for conditional visibility
+     * Conditions set on the field for conditional visibility. The editor writes
+     * one setting and evaluates only the first, so further entries are inert.
+     *
      */
-    conditional_settings?: Array<{
-        [key: string]: unknown;
-    }>;
+    conditional_settings?: Array<ConditionalSettingRoot>;
 };
 
 /**
@@ -1052,6 +1052,79 @@ export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+/**
+ * A conditional rule attached to a field: when `rule_conditions` match the
+ * block's content, the editor applies `modifications` to this field.
+ *
+ * Nothing here is required. The editor writes a setting the moment the operator
+ * adds a rule row, before any of it is filled in, so a saved block can hold a
+ * half-configured setting.
+ *
+ */
+export type ConditionalSettingRoot = {
+    /**
+     * Whether every condition must match (`all`) or any one of them (`any`).
+     * A setting the editor creates starts out as `any`.
+     *
+     */
+    rule_match?: 'all' | 'any';
+    /**
+     * The conditions evaluated against the block's content
+     */
+    rule_conditions?: Array<{
+        /**
+         * The field this condition reads. `null` until the operator picks one.
+         *
+         */
+        validated_object?: {
+            /**
+             * What the condition reads; only a sibling field is supported
+             */
+            type?: 'field';
+            /**
+             * Key of the sibling field within the same block
+             */
+            field_key?: string;
+            /**
+             * Which attribute of that field is compared
+             */
+            field_attr?: 'value';
+        } | null;
+        /**
+         * The comparison to run. `null` until the operator picks one.
+         * `gt`/`lt` compare numbers, or dates when both sides parse as
+         * `YYYY-MM-DD HH:mm`.
+         *
+         */
+        validation?: 'equals' | 'not_equals' | 'empty' | 'not_empty' | 'gt' | 'lt' | null;
+        /**
+         * The value compared against. Its shape follows the validated field:
+         * a string, number or boolean for most types, an asset object for an
+         * `asset` field, and `null` for `empty`/`not_empty`, which ignore it.
+         *
+         */
+        value?: unknown;
+    }>;
+    /**
+     * What to apply to this field when the conditions match. The editor writes
+     * one entry and reads only the first, so further entries are inert.
+     *
+     */
+    modifications?: Array<{
+        /**
+         * Set to `hide` to hide the field
+         */
+        display?: 'hide';
+        /**
+         * `true` makes the field required, `false` makes it explicitly not
+         * required. The two modifications are mutually exclusive: `display`
+         * wins when both are set.
+         *
+         */
+        required?: boolean;
+    }>;
+};
 
 export type MultilinkFieldValueSharedLink = {
     /**

--- a/packages/live-preview/src/generated/overlay/_internal.gen.ts
+++ b/packages/live-preview/src/generated/overlay/_internal.gen.ts
@@ -154,6 +154,18 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to allow custom link attributes
      */
     allow_custom_attributes?: boolean;
+    /**
+     * Path of the folder internal links are restricted to
+     */
+    link_scope?: string;
+    /**
+     * Maximum length of the input text
+     */
+    max_length?: number;
+    /**
+     * Whether to enable right-to-left text direction
+     */
+    rtl?: boolean;
 };
 
 export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -362,6 +374,10 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to use UUID for the option values
      */
     use_uuid?: boolean;
+    /**
+     * Whether to exclude the empty option
+     */
+    exclude_empty_option?: boolean;
     /**
      * Whether this Multi-Options field is a References field
      */

--- a/packages/live-preview/src/generated/types/field.ts
+++ b/packages/live-preview/src/generated/types/field.ts
@@ -155,16 +155,29 @@ interface FieldTypeValueMap {
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
   /**
-   * The legacy `image`/`file` types predate the asset object: they store the
-   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   * The legacy `image`/`file` types predate the asset object: they store the URL
+   * as a plain string, protocol-relative (`//a.storyblok.com/…`) unless the field
+   * sets `add_https`, which makes it absolute.
    */
   image: string;
   file: string;
   multilink: MultilinkFieldValue;
+  /**
+   * Legacy predecessor of `multilink`, storing a bare URL string rather than a
+   * link object. Read-only in practice: the editor no longer writes it.
+   */
+  link: string;
   bloks: BlockContentBase[];
   table: TableFieldValue;
   section: never;
   tab: never;
+  group: never;
+  /**
+   * Owned by a commerce integration rather than the editor, and exempt from
+   * server-side content type-checking, so the integration is the only thing that
+   * knows the shape. Narrow it where you know which one wrote the field.
+   */
+  commerce: unknown;
   custom: PluginFieldValue;
 }
 

--- a/packages/live-preview/src/generated/types/field.ts
+++ b/packages/live-preview/src/generated/types/field.ts
@@ -154,6 +154,12 @@ interface FieldTypeValueMap {
   options: string[];
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
+  /**
+   * The legacy `image`/`file` types predate the asset object: they store the
+   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   */
+  image: string;
+  file: string;
   multilink: MultilinkFieldValue;
   bloks: BlockContentBase[];
   table: TableFieldValue;

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -161,7 +161,11 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_custom_attributes?: boolean;
     /**
-     * Path of the folder internal links are restricted to
+     * Path of the folder internal links are restricted to. The richtext
+     * schema form does not write this option itself; it belongs to the
+     * multilink field's editor. Kept here because a space can carry it as
+     * a legacy value, not because the richtext editor produces it.
+     *
      */
     link_scope?: string;
     /**
@@ -172,7 +176,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     max_length?: number | string;
     /**
-     * Whether to enable right-to-left text direction
+     * Whether to enable right-to-left text direction. The richtext schema
+     * form does not write this option itself; it belongs to the text,
+     * textarea, and markdown fields' editors. Kept here because a space
+     * can carry it as a legacy value, not because the richtext editor
+     * produces it.
+     *
      */
     rtl?: boolean;
 };

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -488,6 +488,66 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Minimum number of entries
      */
     minimum_entries?: number;
+};
+
+export type ImageFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'image';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Whether to force editors to crop the image to a fixed size
+     */
+    image_crop?: boolean;
+    /**
+     * Crop width in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_width?: number | string;
+    /**
+     * Crop height in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_height?: number | string;
+    /**
+     * Whether to keep the original image size when `image_crop` is true
+     */
+    keep_image_size?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
+};
+
+export type FileFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'file';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
 };
 
 export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | LinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | GroupFieldRoot | CommerceFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -29,9 +29,12 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -60,9 +63,12 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -159,9 +165,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     link_scope?: string;
     /**
-     * Maximum length of the input text
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Whether to enable right-to-left text direction
      */
@@ -198,9 +207,12 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_multiline?: boolean;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
 };
 
 export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -597,6 +609,17 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     asset_link_type?: boolean;
 };
 
+export type LinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'link';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+};
+
 export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     /**
      * Field type discriminant
@@ -712,6 +735,20 @@ export type TabFieldRoot = BaseFieldRoot & {
      * Field keys that belong to this tab
      */
     keys?: Array<string>;
+};
+
+export type GroupFieldRoot = BaseFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'group';
+};
+
+export type CommerceFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'commerce';
 };
 
 export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -941,7 +978,10 @@ export type BaseFieldRoot = {
     pos?: number;
     /**
      * Conditions set on the field for conditional visibility. The editor writes
-     * one setting and evaluates only the first, so further entries are inert.
+     * one setting and reads only the first, so an extra entry is invisible to it.
+     * It is not inert server-side: the conditional-required check requires every
+     * setting to match, so a second entry can only make a field harder to leave
+     * empty. Write one setting unless you mean that.
      *
      */
     conditional_settings?: Array<ConditionalSettingRoot>;
@@ -1108,18 +1148,26 @@ export type ConditionalSettingRoot = {
     }>;
     /**
      * What to apply to this field when the conditions match. The editor writes
-     * one entry and reads only the first, so further entries are inert.
+     * one entry and reads only the first.
      *
      */
     modifications?: Array<{
         /**
-         * Set to `hide` to hide the field
+         * Hides the field. Both spellings are live: the editor writes `hide`
+         * and reads it back, while the server's conditional-required check
+         * recognizes only `hidden`. Neither side accepts the other's value, so
+         * a rule authored through the API with `hidden` hides nothing in the
+         * editor, and one authored in the editor does not relax a required
+         * field on save. Both are declared because real spaces hold both;
+         * prefer `hide` for anything the editor will open.
+         *
          */
-        display?: 'hide';
+        display?: 'hide' | 'hidden';
         /**
          * `true` makes the field required, `false` makes it explicitly not
-         * required. The two modifications are mutually exclusive: `display`
-         * wins when both are set.
+         * required. Setting it alongside `display` is ambiguous rather than
+         * layered: the editor lets `display` win, while the server only skips
+         * the required check for the `hidden` spelling. Set one or the other.
          *
          */
         required?: boolean;

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -940,11 +940,11 @@ export type BaseFieldRoot = {
      */
     pos?: number;
     /**
-     * Conditions set on the field for conditional visibility
+     * Conditions set on the field for conditional visibility. The editor writes
+     * one setting and evaluates only the first, so further entries are inert.
+     *
      */
-    conditional_settings?: Array<{
-        [key: string]: unknown;
-    }>;
+    conditional_settings?: Array<ConditionalSettingRoot>;
 };
 
 /**
@@ -1052,6 +1052,79 @@ export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+/**
+ * A conditional rule attached to a field: when `rule_conditions` match the
+ * block's content, the editor applies `modifications` to this field.
+ *
+ * Nothing here is required. The editor writes a setting the moment the operator
+ * adds a rule row, before any of it is filled in, so a saved block can hold a
+ * half-configured setting.
+ *
+ */
+export type ConditionalSettingRoot = {
+    /**
+     * Whether every condition must match (`all`) or any one of them (`any`).
+     * A setting the editor creates starts out as `any`.
+     *
+     */
+    rule_match?: 'all' | 'any';
+    /**
+     * The conditions evaluated against the block's content
+     */
+    rule_conditions?: Array<{
+        /**
+         * The field this condition reads. `null` until the operator picks one.
+         *
+         */
+        validated_object?: {
+            /**
+             * What the condition reads; only a sibling field is supported
+             */
+            type?: 'field';
+            /**
+             * Key of the sibling field within the same block
+             */
+            field_key?: string;
+            /**
+             * Which attribute of that field is compared
+             */
+            field_attr?: 'value';
+        } | null;
+        /**
+         * The comparison to run. `null` until the operator picks one.
+         * `gt`/`lt` compare numbers, or dates when both sides parse as
+         * `YYYY-MM-DD HH:mm`.
+         *
+         */
+        validation?: 'equals' | 'not_equals' | 'empty' | 'not_empty' | 'gt' | 'lt' | null;
+        /**
+         * The value compared against. Its shape follows the validated field:
+         * a string, number or boolean for most types, an asset object for an
+         * `asset` field, and `null` for `empty`/`not_empty`, which ignore it.
+         *
+         */
+        value?: unknown;
+    }>;
+    /**
+     * What to apply to this field when the conditions match. The editor writes
+     * one entry and reads only the first, so further entries are inert.
+     *
+     */
+    modifications?: Array<{
+        /**
+         * Set to `hide` to hide the field
+         */
+        display?: 'hide';
+        /**
+         * `true` makes the field required, `false` makes it explicitly not
+         * required. The two modifications are mutually exclusive: `display`
+         * wins when both are set.
+         *
+         */
+        required?: boolean;
+    }>;
+};
 
 export type MultilinkFieldValueSharedLink = {
     /**

--- a/packages/mapi-client/src/generated/overlay/_internal.gen.ts
+++ b/packages/mapi-client/src/generated/overlay/_internal.gen.ts
@@ -154,6 +154,18 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to allow custom link attributes
      */
     allow_custom_attributes?: boolean;
+    /**
+     * Path of the folder internal links are restricted to
+     */
+    link_scope?: string;
+    /**
+     * Maximum length of the input text
+     */
+    max_length?: number;
+    /**
+     * Whether to enable right-to-left text direction
+     */
+    rtl?: boolean;
 };
 
 export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -362,6 +374,10 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to use UUID for the option values
      */
     use_uuid?: boolean;
+    /**
+     * Whether to exclude the empty option
+     */
+    exclude_empty_option?: boolean;
     /**
      * Whether this Multi-Options field is a References field
      */

--- a/packages/mapi-client/src/generated/types/field.ts
+++ b/packages/mapi-client/src/generated/types/field.ts
@@ -155,16 +155,29 @@ interface FieldTypeValueMap {
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
   /**
-   * The legacy `image`/`file` types predate the asset object: they store the
-   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   * The legacy `image`/`file` types predate the asset object: they store the URL
+   * as a plain string, protocol-relative (`//a.storyblok.com/…`) unless the field
+   * sets `add_https`, which makes it absolute.
    */
   image: string;
   file: string;
   multilink: MultilinkFieldValue;
+  /**
+   * Legacy predecessor of `multilink`, storing a bare URL string rather than a
+   * link object. Read-only in practice: the editor no longer writes it.
+   */
+  link: string;
   bloks: BlockContentBase[];
   table: TableFieldValue;
   section: never;
   tab: never;
+  group: never;
+  /**
+   * Owned by a commerce integration rather than the editor, and exempt from
+   * server-side content type-checking, so the integration is the only thing that
+   * knows the shape. Narrow it where you know which one wrote the field.
+   */
+  commerce: unknown;
   custom: PluginFieldValue;
 }
 

--- a/packages/mapi-client/src/generated/types/field.ts
+++ b/packages/mapi-client/src/generated/types/field.ts
@@ -154,6 +154,12 @@ interface FieldTypeValueMap {
   options: string[];
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
+  /**
+   * The legacy `image`/`file` types predate the asset object: they store the
+   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   */
+  image: string;
+  file: string;
   multilink: MultilinkFieldValue;
   bloks: BlockContentBase[];
   table: TableFieldValue;

--- a/packages/migrations/src/map-refs.test.ts
+++ b/packages/migrations/src/map-refs.test.ts
@@ -11,9 +11,9 @@ const schemas = {
     gallery: { type: "multiasset" },
     body: { type: "bloks" },
     tags: { type: "options", source: "internal_stories" },
-    user_ids: { type: "options", source: "internal_users" },
-    tag_ids: { type: "options", source: "internal_tags" },
-    datasource_ids: { type: "options", source: "internal_datasources" },
+    related: { type: "option", source: "internal_stories" },
+    categories: { type: "options", source: "internal" },
+    style: { type: "option" },
     content: { type: "richtext" },
     title: { type: "text" },
   },
@@ -187,28 +187,28 @@ describe("mapRefs", () => {
     expect(asRecord(asRecord(blockBody[0]).image).id).toBe(20);
   });
 
-  it("should remap options field using map source variants", () => {
+  // Only `internal_stories` holds a cross-space reference. `internal` (a
+  // datasource) and `self` (inline options) hold values that mean the same
+  // thing in every space, so remapping them would corrupt the content.
+  it("should remap story-sourced option and options fields and leave the others alone", () => {
     const story = makeStory({
       tags: [101, 102],
-      user_ids: [1],
-      tag_ids: [11],
-      datasource_ids: [21],
+      related: 101,
+      categories: ["electronics", "books"],
+      style: "dark",
     });
     const maps = {
       stories: new Map([
         [101, 201],
         [102, 202],
       ]),
-      users: new Map([[1, 2]]),
-      tags: new Map([[11, 12]]),
-      datasources: new Map([[21, 22]]),
     };
     const { mappedStory } = mapRefs(story as never, { schemas, maps });
 
     expect(asRecord(mappedStory.content).tags).toEqual([201, 202]);
-    expect(asRecord(mappedStory.content).user_ids).toEqual([2]);
-    expect(asRecord(mappedStory.content).tag_ids).toEqual([12]);
-    expect(asRecord(mappedStory.content).datasource_ids).toEqual([22]);
+    expect(asRecord(mappedStory.content).related).toBe(201);
+    expect(asRecord(mappedStory.content).categories).toEqual(["electronics", "books"]);
+    expect(asRecord(mappedStory.content).style).toBe("dark");
   });
 
   it("should preserve null parent_id for root-level stories", () => {

--- a/packages/migrations/src/map-refs.ts
+++ b/packages/migrations/src/map-refs.ts
@@ -3,9 +3,6 @@ import type { Component, Story } from "./types";
 export interface RefMaps {
   assets?: Map<unknown, string | number>;
   stories?: Map<unknown, string | number>;
-  users?: Map<unknown, string | number>;
-  tags?: Map<unknown, string | number>;
-  datasources?: Map<unknown, string | number>;
 }
 
 export type ComponentSchemas = Record<string, Record<string, { type: string; source?: string }>>;
@@ -236,24 +233,30 @@ const multiassetFieldRefMapper: RefMapper = (data, options) => {
   return data.map((d) => assetFieldRefMapper(d, options));
 };
 
+/**
+ * An option field only holds a cross-space reference when its source is
+ * `internal_stories`: the value is then a story uuid (or id, with `use_uuid`
+ * off), which differs per space. Every other source is space-independent —
+ * `self` holds the inline option's own `value`, `internal` and `external` hold
+ * a datasource entry's `value`, and `internal_languages` holds a language
+ * code — so those pass through untouched.
+ */
+function mapOptionValue(value: unknown, schema: FieldSchema, maps: RefMaps): unknown {
+  if (schema.source !== "internal_stories") {
+    return value;
+  }
+  return maps.stories?.get(value) ?? value;
+}
+
+const optionFieldRefMapper: RefMapper = (data, { schema, maps }) =>
+  mapOptionValue(data, schema, maps);
+
 const optionsFieldRefMapper: RefMapper = (data, { schema, maps }) => {
   if (!Array.isArray(data)) {
     return data;
   }
 
-  const sourceMapBySchema: Record<string, Map<unknown, string | number> | undefined> = {
-    internal_stories: maps.stories,
-    internal_users: maps.users,
-    internal_tags: maps.tags,
-    internal_datasources: maps.datasources,
-  };
-
-  const sourceMap = sourceMapBySchema[schema.source ?? ""];
-  if (!sourceMap) {
-    return data;
-  }
-
-  return data.map((d) => sourceMap.get(d) ?? d);
+  return data.map((d) => mapOptionValue(d, schema, maps));
 };
 
 const fieldRefMappers = {
@@ -261,6 +264,7 @@ const fieldRefMappers = {
   bloks: bloksFieldRefMapper,
   multiasset: multiassetFieldRefMapper,
   multilink: multilinkFieldRefMapper,
+  option: optionFieldRefMapper,
   options: optionsFieldRefMapper,
   richtext: richtextFieldRefMapper,
 } as const;

--- a/packages/migrations/test/scenarios/SCENARIOS.md
+++ b/packages/migrations/test/scenarios/SCENARIOS.md
@@ -1,9 +1,14 @@
 # @storyblok/migrations Scenarios
 
-| Scenario                      | Seeds                                                                                                                            |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `has-rich-content`            | 1 component (qa_rich_page) with richtext + asset + multilink fields, and 2 stories with sample content.                          |
-| `has-various-components`      | 3 components (qa_page, qa_hero, qa_cta) with various field types (text, asset, multiasset, multilink, bloks, options, richtext). |
-| `has-datasource-values`       | 1 datasource with entries, 1 component with options field, and 2 stories using those values.                                     |
-| `has-cross-references`        | Source space: 2 components, 3 stories with cross-references. Seed with `--space $STORYBLOK_SPACE_ID`.                            |
-| `has-cross-references-target` | Target space: same components, 3 plain stories. Seed with `--space $STORYBLOK_SPACE_ID_TARGET`.                                  |
+| Scenario                      | Seeds                                                                                                                                                                                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `has-rich-content`            | 2 components (qa_rich_page, qa_rich_teaser) with richtext + asset + multiasset + multilink fields, and 2 stories. The richtext carries a `linktype: "story"` link mark and an embedded `type: "blok"` node, both of which `mapRefs` has to walk. |
+| `has-various-components`      | 3 components (qa_page, qa_hero, qa_cta) with various field types (text, asset, multiasset, multilink, bloks, options, richtext).                                                                                                                 |
+| `has-datasource-values`       | 1 datasource with entries, 1 component with options field, and 2 stories using those values.                                                                                                                                                     |
+| `has-cross-references`        | Source space: 2 components, 3 stories with cross-references. Seed with `--space $STORYBLOK_SPACE_ID`.                                                                                                                                            |
+| `has-cross-references-target` | Target space: same components, 3 plain stories. Seed with `--space $STORYBLOK_SPACE_ID_TARGET`.                                                                                                                                                  |
+
+A story's `uuid` and a multilink's `id` are both real uuid strings, and the same slug carries the
+same uuid in the source and target scenarios. Fixtures previously used the numeric story id here,
+which `mapRefs` skips, so the one scenario built to exercise remapping could not have detected a
+broken remap.

--- a/packages/migrations/test/scenarios/has-cross-references-target/components/qa_xref_page.json
+++ b/packages/migrations/test/scenarios/has-cross-references-target/components/qa_xref_page.json
@@ -8,7 +8,7 @@
   "schema": {
     "title": { "type": "text", "pos": 0 },
     "body": { "type": "bloks", "pos": 1 },
-    "hero_image": { "type": "asset", "pos": 2 },
+    "hero_image": { "type": "asset", "pos": 2, "allow_external_url": true },
     "cta_link": { "type": "multilink", "pos": 3 },
     "content": { "type": "richtext", "pos": 4 }
   },

--- a/packages/migrations/test/scenarios/has-cross-references-target/stories/qa-xref-about_2.json
+++ b/packages/migrations/test/scenarios/has-cross-references-target/stories/qa-xref-about_2.json
@@ -1,10 +1,11 @@
 {
   "id": 2,
-  "uuid": "2",
+  "uuid": "6bb71916-7273-4530-8da6-95b1919a0198",
   "name": "QA XRef About Target",
   "slug": "qa-xref-about",
   "full_slug": "qa-xref-about",
   "content": {
+    "_uid": "b815dec2-832e-4160-85ee-5724d6e96583",
     "component": "qa_xref_page",
     "title": "About Us (target)"
   }

--- a/packages/migrations/test/scenarios/has-cross-references-target/stories/qa-xref-blog_3.json
+++ b/packages/migrations/test/scenarios/has-cross-references-target/stories/qa-xref-blog_3.json
@@ -1,10 +1,11 @@
 {
   "id": 3,
-  "uuid": "3",
+  "uuid": "fd709a55-cd88-4132-8b0a-5401515541b0",
   "name": "QA XRef Blog Target",
   "slug": "qa-xref-blog",
   "full_slug": "qa-xref-blog",
   "content": {
+    "_uid": "0f789dc8-3766-4e47-8411-6ff52fb3fe91",
     "component": "qa_xref_page",
     "title": "Blog (target)"
   }

--- a/packages/migrations/test/scenarios/has-cross-references-target/stories/qa-xref-home_1.json
+++ b/packages/migrations/test/scenarios/has-cross-references-target/stories/qa-xref-home_1.json
@@ -1,10 +1,11 @@
 {
   "id": 1,
-  "uuid": "1",
+  "uuid": "a3d50cc9-eedc-4359-8f5d-7ee83a5d4b7e",
   "name": "QA XRef Home Target",
   "slug": "qa-xref-home",
   "full_slug": "qa-xref-home",
   "content": {
+    "_uid": "99f66cdf-f374-44e7-880b-7d16168b9814",
     "component": "qa_xref_page",
     "title": "Home (target)"
   }

--- a/packages/migrations/test/scenarios/has-cross-references/components/qa_xref_page.json
+++ b/packages/migrations/test/scenarios/has-cross-references/components/qa_xref_page.json
@@ -8,7 +8,7 @@
   "schema": {
     "title": { "type": "text", "pos": 0 },
     "body": { "type": "bloks", "pos": 1 },
-    "hero_image": { "type": "asset", "pos": 2 },
+    "hero_image": { "type": "asset", "pos": 2, "allow_external_url": true },
     "cta_link": { "type": "multilink", "pos": 3 },
     "content": { "type": "richtext", "pos": 4 }
   },

--- a/packages/migrations/test/scenarios/has-cross-references/stories/qa-xref-about_2.json
+++ b/packages/migrations/test/scenarios/has-cross-references/stories/qa-xref-about_2.json
@@ -1,10 +1,11 @@
 {
   "id": 2,
-  "uuid": "2",
+  "uuid": "6bb71916-7273-4530-8da6-95b1919a0198",
   "name": "QA XRef About",
   "slug": "qa-xref-about",
   "full_slug": "qa-xref-about",
   "content": {
+    "_uid": "e7093bde-9fde-447e-80db-d4db270b3872",
     "component": "qa_xref_page",
     "title": "About Us"
   }

--- a/packages/migrations/test/scenarios/has-cross-references/stories/qa-xref-blog_3.json
+++ b/packages/migrations/test/scenarios/has-cross-references/stories/qa-xref-blog_3.json
@@ -1,10 +1,11 @@
 {
   "id": 3,
-  "uuid": "3",
+  "uuid": "fd709a55-cd88-4132-8b0a-5401515541b0",
   "name": "QA XRef Blog",
   "slug": "qa-xref-blog",
   "full_slug": "qa-xref-blog",
   "content": {
+    "_uid": "434eaa78-70e6-46c6-87a2-98b09fc01903",
     "component": "qa_xref_page",
     "title": "Blog"
   }

--- a/packages/migrations/test/scenarios/has-cross-references/stories/qa-xref-home_1.json
+++ b/packages/migrations/test/scenarios/has-cross-references/stories/qa-xref-home_1.json
@@ -1,37 +1,101 @@
 {
   "id": 1,
-  "uuid": "1",
+  "uuid": "a3d50cc9-eedc-4359-8f5d-7ee83a5d4b7e",
   "name": "QA XRef Home",
   "slug": "qa-xref-home",
   "full_slug": "qa-xref-home",
   "content": {
+    "_uid": "5a19a2b3-3018-4c6f-8a51-98abbb4dd0e4",
     "component": "qa_xref_page",
     "title": "Home",
     "cta_link": {
-      "fieldtype": "multilink",
-      "linktype": "story",
-      "id": 2,
+      "id": "6bb71916-7273-4530-8da6-95b1919a0198",
       "url": "",
+      "linktype": "story",
+      "fieldtype": "multilink",
       "cached_url": "qa-xref-about"
     },
     "hero_image": {
-      "fieldtype": "asset",
-      "id": 0,
-      "filename": "https://via.placeholder.com/100x100",
-      "name": "qa-placeholder.png",
+      "id": null,
       "alt": "Placeholder",
+      "name": "",
+      "focus": "",
+      "title": "",
+      "source": "",
+      "filename": "https://via.placeholder.com/100x100",
+      "copyright": "",
+      "fieldtype": "asset",
+      "meta_data": { "alt": "Placeholder", "title": "" },
       "is_external_url": true
+    },
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "content": [
+            { "type": "text", "text": "See " },
+            {
+              "type": "text",
+              "text": "the blog",
+              "marks": [
+                {
+                  "type": "link",
+                  "attrs": {
+                    "href": "/qa-xref-blog",
+                    "uuid": "fd709a55-cd88-4132-8b0a-5401515541b0",
+                    "anchor": null,
+                    "target": "_self",
+                    "linktype": "story"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blok",
+          "attrs": {
+            "id": "8ba2ba3b-1e35-4de6-8a68-9f4f9ac67d10",
+            "body": [
+              {
+                "_uid": "i-1b7a5f68-3d54-4a26-8f2e-04a2a3cc9d17",
+                "component": "qa_xref_hero",
+                "heading": "Embedded in richtext",
+                "image": {
+                  "id": null,
+                  "alt": "",
+                  "name": "",
+                  "focus": "",
+                  "title": "",
+                  "source": "",
+                  "filename": "",
+                  "copyright": "",
+                  "fieldtype": "asset",
+                  "meta_data": {}
+                }
+              }
+            ]
+          }
+        }
+      ]
     },
     "body": [
       {
+        "_uid": "0c2b6a51-9a2f-4a1c-8f19-2a1c8f19a51c",
         "component": "qa_xref_hero",
         "heading": "Welcome",
         "image": {
-          "fieldtype": "asset",
-          "id": 0,
-          "filename": "https://via.placeholder.com/100x100",
-          "name": "qa-placeholder.png",
+          "id": null,
           "alt": "Hero image",
+          "name": "",
+          "focus": "",
+          "title": "",
+          "source": "",
+          "filename": "https://via.placeholder.com/100x100",
+          "copyright": "",
+          "fieldtype": "asset",
+          "meta_data": { "alt": "Hero image", "title": "" },
           "is_external_url": true
         }
       }

--- a/packages/migrations/test/scenarios/has-datasource-values/datasources/qa-categories_1.json
+++ b/packages/migrations/test/scenarios/has-datasource-values/datasources/qa-categories_1.json
@@ -2,9 +2,10 @@
   "id": 1,
   "name": "QA Categories",
   "slug": "qa-categories",
+  "dimensions": [],
   "entries": [
-    { "name": "Electronics", "value": "electronics" },
-    { "name": "Clothing", "value": "clothing" },
-    { "name": "Books", "value": "books" }
+    { "id": 1, "name": "Electronics", "value": "electronics", "dimension_value": "" },
+    { "id": 2, "name": "Clothing", "value": "clothing", "dimension_value": "" },
+    { "id": 3, "name": "Books", "value": "books", "dimension_value": "" }
   ]
 }

--- a/packages/migrations/test/scenarios/has-datasource-values/stories/qa-product-laptop_1.json
+++ b/packages/migrations/test/scenarios/has-datasource-values/stories/qa-product-laptop_1.json
@@ -1,10 +1,11 @@
 {
   "id": 1,
-  "uuid": "1",
+  "uuid": "c95a650f-074d-4732-845d-42565ca4227f",
   "name": "QA Product Laptop",
   "slug": "qa-product-laptop",
   "full_slug": "qa-product-laptop",
   "content": {
+    "_uid": "e91ca9f4-b33f-4846-8fcb-5ba38f7ba533",
     "component": "qa_product",
     "title": "Laptop",
     "category": "electronics",

--- a/packages/migrations/test/scenarios/has-datasource-values/stories/qa-product-tshirt_2.json
+++ b/packages/migrations/test/scenarios/has-datasource-values/stories/qa-product-tshirt_2.json
@@ -1,10 +1,11 @@
 {
   "id": 2,
-  "uuid": "2",
+  "uuid": "c98157c3-d004-439f-8ff1-72340ac567f9",
   "name": "QA Product T-Shirt",
   "slug": "qa-product-tshirt",
   "full_slug": "qa-product-tshirt",
   "content": {
+    "_uid": "9c0595f9-600e-400a-869e-415879d31ffd",
     "component": "qa_product",
     "title": "T-Shirt",
     "category": "clothing",

--- a/packages/migrations/test/scenarios/has-rich-content/components/qa_rich_page.json
+++ b/packages/migrations/test/scenarios/has-rich-content/components/qa_rich_page.json
@@ -6,11 +6,34 @@
   "is_root": true,
   "is_nestable": false,
   "schema": {
-    "title": { "type": "text", "pos": 0 },
-    "body_richtext": { "type": "richtext", "pos": 1 },
-    "hero_image": { "type": "asset", "pos": 2, "filetypes": ["images"] },
-    "cta_link": { "type": "multilink", "pos": 3 },
-    "gallery": { "type": "multiasset", "pos": 4, "filetypes": ["images"] }
+    "title": {
+      "type": "text",
+      "pos": 0
+    },
+    "body_richtext": {
+      "type": "richtext",
+      "pos": 1,
+      "restrict_components": true,
+      "restrict_type": "",
+      "component_whitelist": ["qa_rich_teaser"],
+      "component_denylist": []
+    },
+    "hero_image": {
+      "type": "asset",
+      "pos": 2,
+      "filetypes": ["images"],
+      "allow_external_url": true
+    },
+    "cta_link": {
+      "type": "multilink",
+      "pos": 3
+    },
+    "gallery": {
+      "type": "multiasset",
+      "pos": 4,
+      "filetypes": ["images"],
+      "allow_external_url": true
+    }
   },
   "created_at": "2024-01-01T00:00:00.000Z",
   "updated_at": "2024-01-01T00:00:00.000Z"

--- a/packages/migrations/test/scenarios/has-rich-content/components/qa_rich_teaser.json
+++ b/packages/migrations/test/scenarios/has-rich-content/components/qa_rich_teaser.json
@@ -1,0 +1,14 @@
+{
+  "id": 201,
+  "name": "qa_rich_teaser",
+  "display_name": "QA Rich Teaser",
+  "component_group_uuid": null,
+  "is_root": false,
+  "is_nestable": true,
+  "schema": {
+    "heading": { "type": "text", "pos": 0 },
+    "target": { "type": "multilink", "pos": 1 }
+  },
+  "created_at": "2024-01-01T00:00:00.000Z",
+  "updated_at": "2024-01-01T00:00:00.000Z"
+}

--- a/packages/migrations/test/scenarios/has-rich-content/stories/qa-rich-content-a_1.json
+++ b/packages/migrations/test/scenarios/has-rich-content/stories/qa-rich-content-a_1.json
@@ -1,10 +1,11 @@
 {
   "id": 1,
-  "uuid": "1",
+  "uuid": "e9e1ce97-01b3-4637-82bb-7280c32cf87a",
   "name": "QA Rich Content A",
   "slug": "qa-rich-content-a",
   "full_slug": "qa-rich-content-a",
   "content": {
+    "_uid": "a3d5e5a1-fd94-4dc6-8b6d-3b02b6dd7e6c",
     "component": "qa_rich_page",
     "title": "QA Story With Rich Content",
     "body_richtext": {
@@ -28,30 +29,107 @@
                   "type": "link",
                   "attrs": {
                     "href": "https://example.com",
+                    "uuid": null,
+                    "anchor": null,
+                    "target": "_blank",
                     "linktype": "url"
                   }
                 }
               ]
             }
           ]
+        },
+        {
+          "type": "paragraph",
+          "content": [
+            {
+              "type": "text",
+              "text": "Read part B",
+              "marks": [
+                {
+                  "type": "link",
+                  "attrs": {
+                    "href": "/qa-rich-content-b",
+                    "uuid": "b17bbbc0-1cc1-4fa8-8c43-7a23bd103781",
+                    "anchor": null,
+                    "target": "_self",
+                    "linktype": "story"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blok",
+          "attrs": {
+            "id": "0a0a9d4c-2fc4-4b8f-9f1b-6f5cf7b7d0a2",
+            "body": [
+              {
+                "_uid": "i-72a3e2d1-6a97-4f5b-8ad0-9c2b1e3f4a5b",
+                "component": "qa_rich_teaser",
+                "heading": "Embedded teaser",
+                "target": {
+                  "id": "b17bbbc0-1cc1-4fa8-8c43-7a23bd103781",
+                  "url": "",
+                  "linktype": "story",
+                  "fieldtype": "multilink",
+                  "cached_url": "qa-rich-content-b"
+                }
+              }
+            ]
+          }
         }
       ]
     },
     "hero_image": {
-      "fieldtype": "asset",
-      "id": 0,
-      "filename": "https://via.placeholder.com/800x400",
-      "name": "placeholder.png",
+      "id": null,
       "alt": "Hero placeholder",
+      "name": "",
+      "focus": "",
+      "title": "",
+      "source": "",
+      "filename": "https://via.placeholder.com/800x400",
+      "copyright": "",
+      "fieldtype": "asset",
+      "meta_data": { "alt": "Hero placeholder", "title": "" },
       "is_external_url": true
     },
+    "gallery": [
+      {
+        "id": null,
+        "alt": "Gallery one",
+        "name": "",
+        "focus": "",
+        "title": "",
+        "source": "",
+        "filename": "https://via.placeholder.com/400x400",
+        "copyright": "",
+        "fieldtype": "asset",
+        "meta_data": { "alt": "Gallery one", "title": "" },
+        "is_external_url": true
+      },
+      {
+        "id": null,
+        "alt": "Gallery two",
+        "name": "",
+        "focus": "",
+        "title": "",
+        "source": "",
+        "filename": "https://via.placeholder.com/400x401",
+        "copyright": "",
+        "fieldtype": "asset",
+        "meta_data": { "alt": "Gallery two", "title": "" },
+        "is_external_url": true
+      }
+    ],
     "cta_link": {
-      "fieldtype": "multilink",
       "id": "",
       "url": "https://example.com/pricing",
-      "cached_url": "https://example.com/pricing",
+      "target": "_blank",
       "linktype": "url",
-      "target": "_blank"
+      "fieldtype": "multilink",
+      "cached_url": "https://example.com/pricing"
     }
   }
 }

--- a/packages/migrations/test/scenarios/has-rich-content/stories/qa-rich-content-b_2.json
+++ b/packages/migrations/test/scenarios/has-rich-content/stories/qa-rich-content-b_2.json
@@ -1,10 +1,11 @@
 {
   "id": 2,
-  "uuid": "2",
+  "uuid": "b17bbbc0-1cc1-4fa8-8c43-7a23bd103781",
   "name": "QA Rich Content B",
   "slug": "qa-rich-content-b",
   "full_slug": "qa-rich-content-b",
   "content": {
+    "_uid": "1cd89d5b-8adb-4387-8858-6a1e7ff13be7",
     "component": "qa_rich_page",
     "title": "QA Simple Story",
     "body_richtext": {
@@ -12,7 +13,12 @@
       "content": [
         {
           "type": "paragraph",
-          "content": [{ "type": "text", "text": "A simple paragraph." }]
+          "content": [
+            {
+              "type": "text",
+              "text": "A simple paragraph."
+            }
+          ]
         }
       ]
     }

--- a/packages/migrations/test/scenarios/has-various-components/components/qa_page.json
+++ b/packages/migrations/test/scenarios/has-various-components/components/qa_page.json
@@ -6,14 +6,50 @@
   "is_root": true,
   "is_nestable": false,
   "schema": {
-    "title": { "type": "text", "pos": 0 },
-    "body": { "type": "bloks", "pos": 1 },
-    "hero_image": { "type": "asset", "pos": 2, "filetypes": ["images"] },
-    "gallery": { "type": "multiasset", "pos": 3, "filetypes": ["images"] },
-    "cta_link": { "type": "multilink", "pos": 4 },
-    "content": { "type": "richtext", "pos": 5 },
-    "category": { "type": "option", "pos": 6, "source": "internal_datasources" },
-    "related_stories": { "type": "options", "pos": 7, "source": "internal_stories" }
+    "title": {
+      "type": "text",
+      "pos": 0
+    },
+    "body": {
+      "type": "bloks",
+      "pos": 1,
+      "restrict_components": true,
+      "restrict_type": "",
+      "component_whitelist": ["qa_hero", "qa_cta"],
+      "component_denylist": []
+    },
+    "hero_image": {
+      "type": "asset",
+      "pos": 2,
+      "filetypes": ["images"]
+    },
+    "gallery": {
+      "type": "multiasset",
+      "pos": 3,
+      "filetypes": ["images"]
+    },
+    "cta_link": {
+      "type": "multilink",
+      "pos": 4
+    },
+    "content": {
+      "type": "richtext",
+      "pos": 5
+    },
+    "category": {
+      "type": "option",
+      "pos": 6,
+      "source": "internal",
+      "datasource_slug": "qa-categories"
+    },
+    "related_stories": {
+      "type": "options",
+      "pos": 7,
+      "source": "internal_stories",
+      "use_uuid": true,
+      "filter_content_type": ["qa_page"],
+      "entry_appearance": "link"
+    }
   },
   "created_at": "2024-01-01T00:00:00.000Z",
   "updated_at": "2024-01-01T00:00:00.000Z"

--- a/packages/schema/playground/astro/src/schema/blocks/banner.ts
+++ b/packages/schema/playground/astro/src/schema/blocks/banner.ts
@@ -18,11 +18,38 @@ export const bannerBlock = defineBlock({
     defineField("cta_label", {
       type: "text",
       max_length: 40,
-      conditional_settings: [{ field: "show_cta", value: true }],
+      // The editor has no "show when" rule: it hides a field when the rule
+      // matches. An unchecked boolean counts as empty, so this keeps the CTA
+      // fields hidden until `show_cta` is on.
+      conditional_settings: [
+        {
+          modifications: [{ display: "hide" }],
+          rule_match: "all",
+          rule_conditions: [
+            {
+              validated_object: { type: "field", field_key: "show_cta", field_attr: "value" },
+              validation: "empty",
+              value: null,
+            },
+          ],
+        },
+      ],
     }),
     defineField("cta_link", {
       type: "multilink",
-      conditional_settings: [{ field: "show_cta", value: true }],
+      conditional_settings: [
+        {
+          modifications: [{ display: "hide" }],
+          rule_match: "all",
+          rule_conditions: [
+            {
+              validated_object: { type: "field", field_key: "show_cta", field_attr: "value" },
+              validation: "empty",
+              value: null,
+            },
+          ],
+        },
+      ],
     }),
     defineField("background_image", { type: "asset", filetypes: ["images"] }),
   ],

--- a/packages/schema/playground/astro/src/schema/blocks/banner.ts
+++ b/packages/schema/playground/astro/src/schema/blocks/banner.ts
@@ -1,4 +1,4 @@
-import { defineBlock, defineField } from "@storyblok/schema";
+import { defineBlock, defineField, hideWhen } from "@storyblok/schema";
 
 import { headlineField } from "../fields";
 
@@ -18,38 +18,16 @@ export const bannerBlock = defineBlock({
     defineField("cta_label", {
       type: "text",
       max_length: 40,
-      // The editor has no "show when" rule: it hides a field when the rule
-      // matches. An unchecked boolean counts as empty, so this keeps the CTA
-      // fields hidden until `show_cta` is on.
-      conditional_settings: [
-        {
-          modifications: [{ display: "hide" }],
-          rule_match: "all",
-          rule_conditions: [
-            {
-              validated_object: { type: "field", field_key: "show_cta", field_attr: "value" },
-              validation: "empty",
-              value: null,
-            },
-          ],
-        },
-      ],
+      // The editor has no "show when" rule, only "hide when", so the condition
+      // is inverted: hide while `show_cta` is empty, which an unchecked boolean
+      // is. A story that has never touched `show_cta` has no value there at all,
+      // and the editor reads an absent field as no match, so the CTA fields are
+      // visible until the toggle has been used once.
+      conditional_settings: [hideWhen({ field: "show_cta", is: "empty" })],
     }),
     defineField("cta_link", {
       type: "multilink",
-      conditional_settings: [
-        {
-          modifications: [{ display: "hide" }],
-          rule_match: "all",
-          rule_conditions: [
-            {
-              validated_object: { type: "field", field_key: "show_cta", field_attr: "value" },
-              validation: "empty",
-              value: null,
-            },
-          ],
-        },
-      ],
+      conditional_settings: [hideWhen({ field: "show_cta", is: "empty" })],
     }),
     defineField("background_image", { type: "asset", filetypes: ["images"] }),
   ],

--- a/packages/schema/playground/vanilla/base/blocks/feature-card.ts
+++ b/packages/schema/playground/vanilla/base/blocks/feature-card.ts
@@ -1,4 +1,4 @@
-import { defineBlock, defineField } from "@storyblok/schema";
+import { defineBlock, defineField, hideWhen } from "@storyblok/schema";
 
 export const featureCardBlock = defineBlock({
   name: "feature_card",
@@ -15,25 +15,10 @@ export const featureCardBlock = defineBlock({
       type: "text",
       max_length: 7,
       description: "Hex color code",
-      // The editor hides a field when the rule matches, and an unchecked
-      // boolean counts as empty: hidden until `is_highlighted` is on.
-      conditional_settings: [
-        {
-          modifications: [{ display: "hide" }],
-          rule_match: "all",
-          rule_conditions: [
-            {
-              validated_object: {
-                type: "field",
-                field_key: "is_highlighted",
-                field_attr: "value",
-              },
-              validation: "empty",
-              value: null,
-            },
-          ],
-        },
-      ],
+      // Inverted on purpose: the editor only offers "hide when". An unchecked
+      // boolean counts as empty, but an untouched one is absent, which reads as
+      // no match, so this is visible on a fresh story.
+      conditional_settings: [hideWhen({ field: "is_highlighted", is: "empty" })],
     }),
   ],
 });

--- a/packages/schema/playground/vanilla/base/blocks/feature-card.ts
+++ b/packages/schema/playground/vanilla/base/blocks/feature-card.ts
@@ -15,7 +15,25 @@ export const featureCardBlock = defineBlock({
       type: "text",
       max_length: 7,
       description: "Hex color code",
-      conditional_settings: [{ field: "is_highlighted", value: true }],
+      // The editor hides a field when the rule matches, and an unchecked
+      // boolean counts as empty: hidden until `is_highlighted` is on.
+      conditional_settings: [
+        {
+          modifications: [{ display: "hide" }],
+          rule_match: "all",
+          rule_conditions: [
+            {
+              validated_object: {
+                type: "field",
+                field_key: "is_highlighted",
+                field_attr: "value",
+              },
+              validation: "empty",
+              value: null,
+            },
+          ],
+        },
+      ],
     }),
   ],
 });

--- a/packages/schema/playground/vanilla/composability/2_field-groups.ts
+++ b/packages/schema/playground/vanilla/composability/2_field-groups.ts
@@ -1,4 +1,4 @@
-import { defineField } from "@storyblok/schema";
+import { defineField, hideWhen } from "@storyblok/schema";
 
 export function seoFields() {
   return [
@@ -21,25 +21,10 @@ export function styleFields() {
     defineField("overlay_color", {
       type: "text",
       max_length: 7,
-      // The editor hides a field when the rule matches, and an unchecked
-      // boolean counts as empty: hidden until `use_overlay` is on.
-      conditional_settings: [
-        {
-          modifications: [{ display: "hide" }],
-          rule_match: "all",
-          rule_conditions: [
-            {
-              validated_object: {
-                type: "field",
-                field_key: "use_overlay",
-                field_attr: "value",
-              },
-              validation: "empty",
-              value: null,
-            },
-          ],
-        },
-      ],
+      // Inverted on purpose: the editor only offers "hide when". An unchecked
+      // boolean counts as empty, but an untouched one is absent, which reads as
+      // no match, so this is visible on a fresh story.
+      conditional_settings: [hideWhen({ field: "use_overlay", is: "empty" })],
     }),
   ];
 }

--- a/packages/schema/playground/vanilla/composability/2_field-groups.ts
+++ b/packages/schema/playground/vanilla/composability/2_field-groups.ts
@@ -21,7 +21,25 @@ export function styleFields() {
     defineField("overlay_color", {
       type: "text",
       max_length: 7,
-      conditional_settings: [{ field: "use_overlay", value: true }],
+      // The editor hides a field when the rule matches, and an unchecked
+      // boolean counts as empty: hidden until `use_overlay` is on.
+      conditional_settings: [
+        {
+          modifications: [{ display: "hide" }],
+          rule_match: "all",
+          rule_conditions: [
+            {
+              validated_object: {
+                type: "field",
+                field_key: "use_overlay",
+                field_attr: "value",
+              },
+              validation: "empty",
+              value: null,
+            },
+          ],
+        },
+      ],
     }),
   ];
 }

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -161,7 +161,11 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_custom_attributes?: boolean;
     /**
-     * Path of the folder internal links are restricted to
+     * Path of the folder internal links are restricted to. The richtext
+     * schema form does not write this option itself; it belongs to the
+     * multilink field's editor. Kept here because a space can carry it as
+     * a legacy value, not because the richtext editor produces it.
+     *
      */
     link_scope?: string;
     /**
@@ -172,7 +176,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     max_length?: number | string;
     /**
-     * Whether to enable right-to-left text direction
+     * Whether to enable right-to-left text direction. The richtext schema
+     * form does not write this option itself; it belongs to the text,
+     * textarea, and markdown fields' editors. Kept here because a space
+     * can carry it as a legacy value, not because the richtext editor
+     * produces it.
+     *
      */
     rtl?: boolean;
 };

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -488,6 +488,66 @@ export type MultiassetFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Minimum number of entries
      */
     minimum_entries?: number;
+};
+
+export type ImageFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'image';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Whether to force editors to crop the image to a fixed size
+     */
+    image_crop?: boolean;
+    /**
+     * Crop width in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_width?: number | string;
+    /**
+     * Crop height in pixels, applied when `image_crop` is true. The editor
+     * writes an empty string when the input is cleared, so the value is not
+     * always numeric.
+     *
+     */
+    image_height?: number | string;
+    /**
+     * Whether to keep the original image size when `image_crop` is true
+     */
+    keep_image_size?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
+};
+
+export type FileFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'file';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+    /**
+     * Whether to prepend `https:` to the asset URL
+     */
+    add_https?: boolean;
+    /**
+     * Numeric ID of the allowed asset folder
+     */
+    asset_folder_id?: number;
 };
 
 export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -3,7 +3,7 @@
 /**
  * A component schema field. Discriminated by the literal `type` enum on each variant.
  */
-export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | CustomFieldRoot;
+export type Field = TextFieldRoot | TextareaFieldRoot | RichtextFieldRoot | MarkdownFieldRoot | NumberFieldRoot | DatetimeFieldRoot | BooleanFieldRoot | OptionFieldRoot | OptionsFieldRoot | AssetFieldRoot | MultiassetFieldRoot | ImageFieldRoot | FileFieldRoot | MultilinkFieldRoot | LinkFieldRoot | BloksFieldRoot | TableFieldRoot | SectionFieldRoot | TabFieldRoot | GroupFieldRoot | CommerceFieldRoot | CustomFieldRoot;
 
 export type AssetFieldValue = AssetFieldValueRoot;
 
@@ -29,9 +29,12 @@ export type TextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -60,9 +63,12 @@ export type TextareaFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     default_value?: string;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Maximum length for text fields (legacy alias for max_length)
      */
@@ -159,9 +165,12 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     link_scope?: string;
     /**
-     * Maximum length of the input text
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
     /**
      * Whether to enable right-to-left text direction
      */
@@ -198,9 +207,12 @@ export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      */
     allow_multiline?: boolean;
     /**
-     * Maximum length of the input string
+     * Maximum length of the input. The schema form persists the number
+     * input's raw value, so a space can hold `"60"` just as legitimately as
+     * `60`. Coerce before comparing.
+     *
      */
-    max_length?: number;
+    max_length?: number | string;
 };
 
 export type NumberFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -597,6 +609,17 @@ export type MultilinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     asset_link_type?: boolean;
 };
 
+export type LinkFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'link';
+    /**
+     * Default value for the field
+     */
+    default_value?: string;
+};
+
 export type BloksFieldRoot = BaseFieldRoot & ValueFieldRoot & {
     /**
      * Field type discriminant
@@ -712,6 +735,20 @@ export type TabFieldRoot = BaseFieldRoot & {
      * Field keys that belong to this tab
      */
     keys?: Array<string>;
+};
+
+export type GroupFieldRoot = BaseFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'group';
+};
+
+export type CommerceFieldRoot = BaseFieldRoot & ValueFieldRoot & {
+    /**
+     * Field type discriminant
+     */
+    type: 'commerce';
 };
 
 export type CustomFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -941,7 +978,10 @@ export type BaseFieldRoot = {
     pos?: number;
     /**
      * Conditions set on the field for conditional visibility. The editor writes
-     * one setting and evaluates only the first, so further entries are inert.
+     * one setting and reads only the first, so an extra entry is invisible to it.
+     * It is not inert server-side: the conditional-required check requires every
+     * setting to match, so a second entry can only make a field harder to leave
+     * empty. Write one setting unless you mean that.
      *
      */
     conditional_settings?: Array<ConditionalSettingRoot>;
@@ -1108,18 +1148,26 @@ export type ConditionalSettingRoot = {
     }>;
     /**
      * What to apply to this field when the conditions match. The editor writes
-     * one entry and reads only the first, so further entries are inert.
+     * one entry and reads only the first.
      *
      */
     modifications?: Array<{
         /**
-         * Set to `hide` to hide the field
+         * Hides the field. Both spellings are live: the editor writes `hide`
+         * and reads it back, while the server's conditional-required check
+         * recognizes only `hidden`. Neither side accepts the other's value, so
+         * a rule authored through the API with `hidden` hides nothing in the
+         * editor, and one authored in the editor does not relax a required
+         * field on save. Both are declared because real spaces hold both;
+         * prefer `hide` for anything the editor will open.
+         *
          */
-        display?: 'hide';
+        display?: 'hide' | 'hidden';
         /**
          * `true` makes the field required, `false` makes it explicitly not
-         * required. The two modifications are mutually exclusive: `display`
-         * wins when both are set.
+         * required. Setting it alongside `display` is ambiguous rather than
+         * layered: the editor lets `display` win, while the server only skips
+         * the required check for the `hidden` spelling. Set one or the other.
          *
          */
         required?: boolean;

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -940,11 +940,11 @@ export type BaseFieldRoot = {
      */
     pos?: number;
     /**
-     * Conditions set on the field for conditional visibility
+     * Conditions set on the field for conditional visibility. The editor writes
+     * one setting and evaluates only the first, so further entries are inert.
+     *
      */
-    conditional_settings?: Array<{
-        [key: string]: unknown;
-    }>;
+    conditional_settings?: Array<ConditionalSettingRoot>;
 };
 
 /**
@@ -1052,6 +1052,79 @@ export type MultilinkFieldValueAssetLink = MultilinkFieldValueSharedLink & {
  * A rich text document node
  */
 export type RichTextFieldValueRichTextNode = RichTextFieldValueParagraphNode | RichTextFieldValueTextNode | RichTextFieldValueHeadingNode | RichTextFieldValueBlockquoteNode | RichTextFieldValueBulletListNode | RichTextFieldValueOrderedListNode | RichTextFieldValueListItemNode | RichTextFieldValueCodeBlockNode | RichTextFieldValueHardBreakNode | RichTextFieldValueHorizontalRuleNode | RichTextFieldValueImageNode | RichTextFieldValueEmojiNode | RichTextFieldValueTableNode | RichTextFieldValueTableRowNode | RichTextFieldValueTableCellNode | RichTextFieldValueTableHeaderNode | RichTextFieldValueBlockNode;
+
+/**
+ * A conditional rule attached to a field: when `rule_conditions` match the
+ * block's content, the editor applies `modifications` to this field.
+ *
+ * Nothing here is required. The editor writes a setting the moment the operator
+ * adds a rule row, before any of it is filled in, so a saved block can hold a
+ * half-configured setting.
+ *
+ */
+export type ConditionalSettingRoot = {
+    /**
+     * Whether every condition must match (`all`) or any one of them (`any`).
+     * A setting the editor creates starts out as `any`.
+     *
+     */
+    rule_match?: 'all' | 'any';
+    /**
+     * The conditions evaluated against the block's content
+     */
+    rule_conditions?: Array<{
+        /**
+         * The field this condition reads. `null` until the operator picks one.
+         *
+         */
+        validated_object?: {
+            /**
+             * What the condition reads; only a sibling field is supported
+             */
+            type?: 'field';
+            /**
+             * Key of the sibling field within the same block
+             */
+            field_key?: string;
+            /**
+             * Which attribute of that field is compared
+             */
+            field_attr?: 'value';
+        } | null;
+        /**
+         * The comparison to run. `null` until the operator picks one.
+         * `gt`/`lt` compare numbers, or dates when both sides parse as
+         * `YYYY-MM-DD HH:mm`.
+         *
+         */
+        validation?: 'equals' | 'not_equals' | 'empty' | 'not_empty' | 'gt' | 'lt' | null;
+        /**
+         * The value compared against. Its shape follows the validated field:
+         * a string, number or boolean for most types, an asset object for an
+         * `asset` field, and `null` for `empty`/`not_empty`, which ignore it.
+         *
+         */
+        value?: unknown;
+    }>;
+    /**
+     * What to apply to this field when the conditions match. The editor writes
+     * one entry and reads only the first, so further entries are inert.
+     *
+     */
+    modifications?: Array<{
+        /**
+         * Set to `hide` to hide the field
+         */
+        display?: 'hide';
+        /**
+         * `true` makes the field required, `false` makes it explicitly not
+         * required. The two modifications are mutually exclusive: `display`
+         * wins when both are set.
+         *
+         */
+        required?: boolean;
+    }>;
+};
 
 export type MultilinkFieldValueSharedLink = {
     /**

--- a/packages/schema/src/generated/overlay/_internal.gen.ts
+++ b/packages/schema/src/generated/overlay/_internal.gen.ts
@@ -154,6 +154,18 @@ export type RichtextFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to allow custom link attributes
      */
     allow_custom_attributes?: boolean;
+    /**
+     * Path of the folder internal links are restricted to
+     */
+    link_scope?: string;
+    /**
+     * Maximum length of the input text
+     */
+    max_length?: number;
+    /**
+     * Whether to enable right-to-left text direction
+     */
+    rtl?: boolean;
 };
 
 export type MarkdownFieldRoot = BaseFieldRoot & ValueFieldRoot & {
@@ -362,6 +374,10 @@ export type OptionsFieldRoot = BaseFieldRoot & ValueFieldRoot & {
      * Whether to use UUID for the option values
      */
     use_uuid?: boolean;
+    /**
+     * Whether to exclude the empty option
+     */
+    exclude_empty_option?: boolean;
     /**
      * Whether this Multi-Options field is a References field
      */

--- a/packages/schema/src/generated/overlay/zod.gen.ts
+++ b/packages/schema/src/generated/overlay/zod.gen.ts
@@ -36,7 +36,7 @@ export const zConditionalSettingRoot = z.object({
         value: z.optional(z.unknown())
     }))),
     modifications: z.optional(z.array(z.object({
-        display: z.optional(z.enum(['hide'])),
+        display: z.optional(z.enum(['hide', 'hidden'])),
         required: z.optional(z.boolean())
     })))
 });
@@ -53,6 +53,10 @@ export const zBaseFieldRoot = z.object({
     pos: z.optional(z.int()),
     conditional_settings: z.optional(z.array(zConditionalSettingRoot))
 });
+
+export const zGroupFieldRoot = zBaseFieldRoot.and(z.object({
+    type: z.enum(['group'])
+}));
 
 export const zSectionFieldRoot = zBaseFieldRoot.and(z.object({
     type: z.enum(['section']),
@@ -129,6 +133,10 @@ export const zBooleanFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.objec
     inline_label: z.optional(z.boolean())
 }));
 
+export const zCommerceFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
+    type: z.enum(['commerce'])
+}));
+
 export const zCustomFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['custom']),
     default_value: z.optional(z.string()),
@@ -173,6 +181,11 @@ export const zImageFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object(
     asset_folder_id: z.optional(z.int())
 }));
 
+export const zLinkFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
+    type: z.enum(['link']),
+    default_value: z.optional(z.string())
+}));
+
 export const zMarkdownFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['markdown']),
     default_value: z.optional(z.string()),
@@ -204,7 +217,10 @@ export const zMarkdownFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.obje
         'rtl'
     ]))),
     allow_multiline: z.optional(z.boolean()),
-    max_length: z.optional(z.int())
+    max_length: z.optional(z.union([
+        z.int(),
+        z.string()
+    ]))
 }));
 
 export const zMultiassetFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
@@ -367,7 +383,10 @@ export const zRichtextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.obje
     allow_target_blank: z.optional(z.boolean()),
     allow_custom_attributes: z.optional(z.boolean()),
     link_scope: z.optional(z.string()),
-    max_length: z.optional(z.int()),
+    max_length: z.optional(z.union([
+        z.int(),
+        z.string()
+    ])),
     rtl: z.optional(z.boolean())
 }));
 
@@ -379,7 +398,10 @@ export const zTableFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object(
 export const zTextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['text']),
     default_value: z.optional(z.string()),
-    max_length: z.optional(z.int()),
+    max_length: z.optional(z.union([
+        z.int(),
+        z.string()
+    ])),
     maxlength: z.optional(z.int()),
     minlength: z.optional(z.int()),
     size: z.optional(z.string()),
@@ -389,7 +411,10 @@ export const zTextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
 export const zTextareaFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['textarea']),
     default_value: z.optional(z.string()),
-    max_length: z.optional(z.int()),
+    max_length: z.optional(z.union([
+        z.int(),
+        z.string()
+    ])),
     maxlength: z.optional(z.int()),
     minlength: z.optional(z.int()),
     size: z.optional(z.string()),
@@ -416,10 +441,13 @@ export const zComponentSchemaField = z.union([
     zImageFieldRoot,
     zFileFieldRoot,
     zMultilinkFieldRoot,
+    zLinkFieldRoot,
     zBloksFieldRoot,
     zTableFieldRoot,
     zSectionFieldRoot,
     zTabFieldRoot,
+    zGroupFieldRoot,
+    zCommerceFieldRoot,
     zCustomFieldRoot
 ]);
 

--- a/packages/schema/src/generated/overlay/zod.gen.ts
+++ b/packages/schema/src/generated/overlay/zod.gen.ts
@@ -6,6 +6,42 @@
 import * as z from 'zod';
 
 /**
+ * A conditional rule attached to a field: when `rule_conditions` match the
+ * block's content, the editor applies `modifications` to this field.
+ *
+ * Nothing here is required. The editor writes a setting the moment the operator
+ * adds a rule row, before any of it is filled in, so a saved block can hold a
+ * half-configured setting.
+ *
+ */
+export const zConditionalSettingRoot = z.object({
+    rule_match: z.optional(z.enum(['all', 'any'])),
+    rule_conditions: z.optional(z.array(z.object({
+        validated_object: z.optional(z.union([
+            z.object({
+                type: z.optional(z.enum(['field'])),
+                field_key: z.optional(z.string()),
+                field_attr: z.optional(z.enum(['value']))
+            }),
+            z.null()
+        ])),
+        validation: z.optional(z.nullable(z.enum([
+            'equals',
+            'not_equals',
+            'empty',
+            'not_empty',
+            'gt',
+            'lt'
+        ]))),
+        value: z.optional(z.unknown())
+    }))),
+    modifications: z.optional(z.array(z.object({
+        display: z.optional(z.enum(['hide'])),
+        required: z.optional(z.boolean())
+    })))
+});
+
+/**
  * Universal identity and display properties shared by every field type
  */
 export const zBaseFieldRoot = z.object({
@@ -15,7 +51,7 @@ export const zBaseFieldRoot = z.object({
     description: z.optional(z.string()),
     tooltip: z.optional(z.boolean()),
     pos: z.optional(z.int()),
-    conditional_settings: z.optional(z.array(z.record(z.string(), z.unknown())))
+    conditional_settings: z.optional(z.array(zConditionalSettingRoot))
 });
 
 export const zSectionFieldRoot = zBaseFieldRoot.and(z.object({

--- a/packages/schema/src/generated/overlay/zod.gen.ts
+++ b/packages/schema/src/generated/overlay/zod.gen.ts
@@ -113,6 +113,30 @@ export const zDatetimeFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.obje
     disable_time: z.optional(z.boolean())
 }));
 
+export const zFileFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
+    type: z.enum(['file']),
+    default_value: z.optional(z.string()),
+    add_https: z.optional(z.boolean()),
+    asset_folder_id: z.optional(z.int())
+}));
+
+export const zImageFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
+    type: z.enum(['image']),
+    default_value: z.optional(z.string()),
+    add_https: z.optional(z.boolean()),
+    image_crop: z.optional(z.boolean()),
+    image_width: z.optional(z.union([
+        z.int(),
+        z.string()
+    ])),
+    image_height: z.optional(z.union([
+        z.int(),
+        z.string()
+    ])),
+    keep_image_size: z.optional(z.boolean()),
+    asset_folder_id: z.optional(z.int())
+}));
+
 export const zMarkdownFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({
     type: z.enum(['markdown']),
     default_value: z.optional(z.string()),
@@ -353,6 +377,8 @@ export const zComponentSchemaField = z.union([
     zOptionsFieldRoot,
     zAssetFieldRoot,
     zMultiassetFieldRoot,
+    zImageFieldRoot,
+    zFileFieldRoot,
     zMultilinkFieldRoot,
     zBloksFieldRoot,
     zTableFieldRoot,

--- a/packages/schema/src/generated/overlay/zod.gen.ts
+++ b/packages/schema/src/generated/overlay/zod.gen.ts
@@ -224,6 +224,7 @@ export const zOptionsFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.objec
     folder_slug: z.optional(z.string()),
     filter_content_type: z.optional(z.array(z.string())),
     use_uuid: z.optional(z.boolean()),
+    exclude_empty_option: z.optional(z.boolean()),
     is_reference_type: z.optional(z.boolean()),
     entry_appearance: z.optional(z.string()),
     allow_advanced_search: z.optional(z.boolean()),
@@ -304,7 +305,10 @@ export const zRichtextFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.obje
     component_group_whitelist: z.optional(z.array(z.string())),
     component_group_denylist: z.optional(z.array(z.string())),
     allow_target_blank: z.optional(z.boolean()),
-    allow_custom_attributes: z.optional(z.boolean())
+    allow_custom_attributes: z.optional(z.boolean()),
+    link_scope: z.optional(z.string()),
+    max_length: z.optional(z.int()),
+    rtl: z.optional(z.boolean())
 }));
 
 export const zTableFieldRoot = zBaseFieldRoot.and(zValueFieldRoot).and(z.object({

--- a/packages/schema/src/generated/types/field.ts
+++ b/packages/schema/src/generated/types/field.ts
@@ -155,16 +155,29 @@ interface FieldTypeValueMap {
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
   /**
-   * The legacy `image`/`file` types predate the asset object: they store the
-   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   * The legacy `image`/`file` types predate the asset object: they store the URL
+   * as a plain string, protocol-relative (`//a.storyblok.com/…`) unless the field
+   * sets `add_https`, which makes it absolute.
    */
   image: string;
   file: string;
   multilink: MultilinkFieldValue;
+  /**
+   * Legacy predecessor of `multilink`, storing a bare URL string rather than a
+   * link object. Read-only in practice: the editor no longer writes it.
+   */
+  link: string;
   bloks: BlockContentBase[];
   table: TableFieldValue;
   section: never;
   tab: never;
+  group: never;
+  /**
+   * Owned by a commerce integration rather than the editor, and exempt from
+   * server-side content type-checking, so the integration is the only thing that
+   * knows the shape. Narrow it where you know which one wrote the field.
+   */
+  commerce: unknown;
   custom: PluginFieldValue;
 }
 

--- a/packages/schema/src/generated/types/field.ts
+++ b/packages/schema/src/generated/types/field.ts
@@ -154,6 +154,12 @@ interface FieldTypeValueMap {
   options: string[];
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
+  /**
+   * The legacy `image`/`file` types predate the asset object: they store the
+   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   */
+  image: string;
+  file: string;
   multilink: MultilinkFieldValue;
   bloks: BlockContentBase[];
   table: TableFieldValue;

--- a/packages/schema/src/helpers/define-condition.test.ts
+++ b/packages/schema/src/helpers/define-condition.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { hideWhen, requiredWhen } from "./define-condition";
+
+describe("hideWhen", () => {
+  it("should build the display modification the editor writes", () => {
+    expect(hideWhen({ field: "show_cta", is: "empty" })).toEqual({
+      modifications: [{ display: "hide" }],
+      rule_match: "all",
+      rule_conditions: [
+        {
+          validated_object: { type: "field", field_key: "show_cta", field_attr: "value" },
+          validation: "empty",
+        },
+      ],
+    });
+  });
+
+  it("should omit `value` when the comparison ignores it", () => {
+    const [condition] = hideWhen({ field: "show_cta", is: "not_empty" }).rule_conditions!;
+    expect(condition).not.toHaveProperty("value");
+  });
+
+  it("should keep a falsy comparison value", () => {
+    const [condition] = hideWhen({ field: "count", is: "equals", value: 0 }).rule_conditions!;
+    expect(condition.value).toBe(0);
+  });
+
+  it("should require every condition by default and honor an explicit match", () => {
+    const conditions = [
+      { field: "a", is: "not_empty" },
+      { field: "b", is: "not_empty" },
+    ] as const;
+
+    expect(hideWhen([...conditions]).rule_match).toBe("all");
+    expect(hideWhen([...conditions], { match: "any" }).rule_match).toBe("any");
+    expect(hideWhen([...conditions]).rule_conditions).toHaveLength(2);
+  });
+});
+
+describe("requiredWhen", () => {
+  it("should build the required modification", () => {
+    expect(requiredWhen({ field: "region", is: "equals", value: "eu" })).toEqual({
+      modifications: [{ required: true }],
+      rule_match: "all",
+      rule_conditions: [
+        {
+          validated_object: { type: "field", field_key: "region", field_attr: "value" },
+          validation: "equals",
+          value: "eu",
+        },
+      ],
+    });
+  });
+});

--- a/packages/schema/src/helpers/define-condition.ts
+++ b/packages/schema/src/helpers/define-condition.ts
@@ -1,0 +1,86 @@
+import type { ConditionalSettingRoot } from "../generated/overlay/_internal.gen";
+
+/**
+ * One comparison against a sibling field in the same block.
+ *
+ * `is: 'empty'` and `is: 'not_empty'` ignore `value`. `gt`/`lt` compare numbers,
+ * or dates when both sides parse as `YYYY-MM-DD HH:mm`. An unchecked boolean
+ * counts as empty, but a field the story has never touched is absent rather than
+ * empty, and the editor treats an absent field as no match: a fresh story shows
+ * the field until the operator has toggled the reference field at least once.
+ */
+export interface FieldCondition {
+  /** Key of the sibling field to read, within the same block. */
+  field: string;
+  /** The comparison to run. */
+  is: "equals" | "not_equals" | "empty" | "not_empty" | "gt" | "lt";
+  /** The value compared against. Omit for `empty`/`not_empty`. */
+  value?: unknown;
+}
+
+/** How a multi-condition rule combines. Defaults to `all`. */
+export interface ConditionOptions {
+  match?: "all" | "any";
+}
+
+/** The wire form of a single condition inside `rule_conditions`. */
+type RuleCondition = NonNullable<ConditionalSettingRoot["rule_conditions"]>[number];
+
+function toRuleConditions(conditions: FieldCondition | FieldCondition[]): RuleCondition[] {
+  const list = Array.isArray(conditions) ? conditions : [conditions];
+
+  return list.map(({ field, is, value }) => ({
+    validated_object: { type: "field", field_key: field, field_attr: "value" },
+    validation: is,
+    ...(value === undefined ? {} : { value }),
+  }));
+}
+
+/**
+ * Hides the field while the conditions match.
+ *
+ * Emits the `hide` spelling, which is the one the editor writes and reads. The
+ * server's conditional-required check recognizes only `hidden`, so a hidden
+ * field is still required on save; use {@link requiredWhen} to drive that side.
+ *
+ * @example
+ * defineField('cta_label', {
+ *   type: 'text',
+ *   conditional_settings: [hideWhen({ field: 'show_cta', is: 'empty' })],
+ * });
+ */
+export function hideWhen(
+  conditions: FieldCondition | FieldCondition[],
+  options: ConditionOptions = {},
+): ConditionalSettingRoot {
+  return {
+    modifications: [{ display: "hide" }],
+    rule_match: options.match ?? "all",
+    rule_conditions: toRuleConditions(conditions),
+  };
+}
+
+/**
+ * Makes the field required while the conditions match.
+ *
+ * @example
+ * defineField('shipping_address', {
+ *   type: 'textarea',
+ *   conditional_settings: [
+ *     requiredWhen([
+ *       { field: 'needs_delivery', is: 'not_empty' },
+ *       { field: 'region', is: 'equals', value: 'eu' },
+ *     ]),
+ *   ],
+ * });
+ */
+export function requiredWhen(
+  conditions: FieldCondition | FieldCondition[],
+  options: ConditionOptions = {},
+): ConditionalSettingRoot {
+  return {
+    modifications: [{ required: true }],
+    rule_match: options.match ?? "all",
+    rule_conditions: toRuleConditions(conditions),
+  };
+}

--- a/packages/schema/src/helpers/define-field.test-d.ts
+++ b/packages/schema/src/helpers/define-field.test-d.ts
@@ -185,4 +185,51 @@ describe("defineField type inference", () => {
     // @ts-expect-error property does not exist when not supplied
     void f.allow;
   });
+
+  it("should accept a conditional setting on any field type", () => {
+    const f = defineField("subtitle", {
+      type: "text",
+      conditional_settings: [
+        {
+          modifications: [{ display: "hide" }],
+          rule_match: "any",
+          rule_conditions: [
+            {
+              validated_object: { type: "field", field_key: "headline", field_attr: "value" },
+              validation: "empty",
+              value: null,
+            },
+          ],
+        },
+      ],
+    });
+    expectTypeOf(f.conditional_settings[0].rule_match).toEqualTypeOf<"any">();
+  });
+
+  it("should accept the half-configured setting the editor writes before a rule is filled in", () => {
+    const _f = defineField("subtitle", {
+      type: "text",
+      conditional_settings: [
+        {
+          modifications: [{}],
+          rule_match: "any",
+          rule_conditions: [{ validated_object: null, validation: null, value: null }],
+        },
+      ],
+    });
+  });
+
+  it("should reject a validation the editor cannot write", () => {
+    const _f = defineField("subtitle", {
+      type: "text",
+      conditional_settings: [
+        {
+          modifications: [{ display: "hide" }],
+          rule_match: "any",
+          // @ts-expect-error 'contains' is not one of the six validations
+          rule_conditions: [{ validation: "contains", value: null }],
+        },
+      ],
+    });
+  });
 });

--- a/packages/schema/src/helpers/define-field.test-d.ts
+++ b/packages/schema/src/helpers/define-field.test-d.ts
@@ -207,15 +207,41 @@ describe("defineField type inference", () => {
   });
 
   it("should accept the half-configured setting the editor writes before a rule is filled in", () => {
+    // Copied verbatim from what the editor persists the moment the operator adds
+    // the first rule row: `value` is absent rather than null, and the
+    // modification is a bare object. Keep it byte-for-byte, or the test stops
+    // pinning the shape it is named after.
     const _f = defineField("subtitle", {
       type: "text",
       conditional_settings: [
         {
           modifications: [{}],
           rule_match: "any",
-          rule_conditions: [{ validated_object: null, validation: null, value: null }],
+          rule_conditions: [{ validated_object: null, validation: null }],
         },
       ],
+    });
+  });
+
+  it("should accept the bare condition the editor appends to an existing setting", () => {
+    const _f = defineField("subtitle", {
+      type: "text",
+      conditional_settings: [
+        {
+          modifications: [{}],
+          rule_match: "any",
+          rule_conditions: [{ validated_object: null, validation: null }, {}],
+        },
+      ],
+    });
+  });
+
+  it("should accept the `hidden` spelling of a display modification", () => {
+    // The editor writes `hide`; the server's conditional-required check reads
+    // `hidden`. Both reach spaces, so both have to be expressible.
+    const _f = defineField("subtitle", {
+      type: "text",
+      conditional_settings: [{ modifications: [{ display: "hidden" }] }],
     });
   });
 

--- a/packages/schema/src/helpers/field-value-matrix.test-d.ts
+++ b/packages/schema/src/helpers/field-value-matrix.test-d.ts
@@ -17,7 +17,7 @@ import { defineField } from "./define-field";
  *
  * `FieldValue` is the contract every consumer of a schema depends on, and the map
  * behind it is hand-maintained rather than derived from the OpenAPI spec — a
- * regenerate can silently change a mapping. Asserting all 17 types here makes the
+ * regenerate can silently change a mapping. Asserting all 19 types here makes the
  * map's exhaustiveness reviewable and turns any drift into a failing typecheck.
  */
 const _f = {
@@ -32,6 +32,8 @@ const _f = {
   options: defineField("a", { type: "options" }),
   asset: defineField("a", { type: "asset" }),
   multiasset: defineField("a", { type: "multiasset" }),
+  image: defineField("a", { type: "image" }),
+  file: defineField("a", { type: "file" }),
   multilink: defineField("a", { type: "multilink" }),
   bloks: defineField("a", { type: "bloks" }),
   table: defineField("a", { type: "table" }),
@@ -49,6 +51,9 @@ describe("FieldValue resolution per field type", () => {
     expectTypeOf<FieldValue<typeof _f.option>>().toEqualTypeOf<string>();
     // Stored as a string, not a JSON number — see `FieldTypeValueMap`.
     expectTypeOf<FieldValue<typeof _f.number>>().toEqualTypeOf<string>();
+    // The legacy `image`/`file` types store the bare, protocol-relative URL.
+    expectTypeOf<FieldValue<typeof _f.image>>().toEqualTypeOf<string>();
+    expectTypeOf<FieldValue<typeof _f.file>>().toEqualTypeOf<string>();
   });
 
   it("resolves the remaining scalar and structured field types", () => {
@@ -82,6 +87,8 @@ describe("FieldValueInput resolution per field type", () => {
     expectTypeOf<FieldValueInput<typeof _f.datetime>>().toEqualTypeOf<string>();
     expectTypeOf<FieldValueInput<typeof _f.option>>().toEqualTypeOf<string>();
     expectTypeOf<FieldValueInput<typeof _f.number>>().toEqualTypeOf<string>();
+    expectTypeOf<FieldValueInput<typeof _f.image>>().toEqualTypeOf<string>();
+    expectTypeOf<FieldValueInput<typeof _f.file>>().toEqualTypeOf<string>();
     expectTypeOf<FieldValueInput<typeof _f.boolean>>().toEqualTypeOf<boolean>();
     expectTypeOf<FieldValueInput<typeof _f.options>>().toEqualTypeOf<string[]>();
     expectTypeOf<FieldValueInput<typeof _f.section>>().toEqualTypeOf<never>();

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -15,6 +15,9 @@ export type { Story } from "./generated/types/story";
 export { defineBlock } from "./helpers/define-block";
 
 export type { Block, BlockFields, NestableBlock, RootBlock } from "./helpers/define-block";
+// Conditional settings
+export { hideWhen, requiredWhen } from "./helpers/define-condition";
+export type { ConditionOptions, FieldCondition } from "./helpers/define-condition";
 // Datasource
 export { defineDatasource } from "./helpers/define-datasource";
 export type { Datasource } from "./helpers/define-datasource";

--- a/packages/schema/src/validators/shapes.ts
+++ b/packages/schema/src/validators/shapes.ts
@@ -31,10 +31,14 @@ export interface SchemaFieldLike {
    */
   source?: string;
   // Value constraints enforced by `validateStory` (all optional).
-  /** `text`/`textarea`/`markdown`: maximum string length. */
-  max_length?: number;
+  /**
+   * `text`/`textarea`/`markdown`/`richtext`: maximum string length. Also a
+   * string on the wire, because the schema form persists the number input's raw
+   * value.
+   */
+  max_length?: number | string;
   /** `text`/`textarea`: legacy alias for `max_length`. */
-  maxlength?: number;
+  maxlength?: number | string;
   /** `text`/`textarea`: minimum string length. */
   minlength?: number;
   /** `number`: inclusive lower bound. */

--- a/packages/schema/src/validators/validate-story.ts
+++ b/packages/schema/src/validators/validate-story.ts
@@ -309,12 +309,12 @@ function validateFieldValue(
       checkDeclaredOption(field, value, path, entity, issues);
       break;
     case "datetime":
-    // The legacy `image`/`file` types predate the asset object and store the
-    // bare, protocol-relative URL as a string. There is nothing further to
-    // constrain: `add_https` and the crop options shape the editor, not the
-    // stored value.
+    // The legacy `image`/`file`/`link` types predate the asset and link objects
+    // and store a bare URL string. There is nothing further to constrain:
+    // `add_https` and the crop options shape the editor, not the stored value.
     case "image":
     case "file":
+    case "link":
       if (typeof value !== "string") {
         pushTypeIssue(value, "string", path, entity, issues);
       }
@@ -411,7 +411,13 @@ function validateFieldValue(
       break;
     case "section":
     case "tab":
+    case "group":
       // Layout-only field types carry no content value.
+      break;
+    case "commerce":
+      // A commerce integration owns both the schema options and the stored
+      // value, and the server exempts the type from content checks, so there is
+      // no shape to validate against.
       break;
     default:
       // Exhaustiveness guard: when a new `FieldType` is added, this fails to
@@ -554,6 +560,22 @@ function checkCount(
   }
 }
 
+/**
+ * Reads a numeric field option that the wire may hold as a string. Returns
+ * `null` for anything that is not a usable bound, so a blank input (`""`, which
+ * is what clearing the field writes) does not become a `0`-length limit.
+ */
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 /** Checks a string against optional `max_length`/`maxlength` and `minlength` bounds. */
 function checkStringLength(
   field: SchemaFieldLike,
@@ -562,7 +584,10 @@ function checkStringLength(
   entity: string,
   issues: ValidationIssue[],
 ): void {
-  const max = field.max_length ?? field.maxlength;
+  // `max_length` is `integer | string` on the wire: the schema form persists the
+  // number input's raw value. Coerce rather than compare, so a bound of `"60"`
+  // is a bound and not a string comparison that happens to work for two digits.
+  const max = toFiniteNumber(field.max_length ?? field.maxlength);
   if (max != null && value.length > max) {
     pushConstraint(
       `Text length ${value.length} exceeds the maximum of ${max}.`,

--- a/packages/schema/src/validators/validate-story.ts
+++ b/packages/schema/src/validators/validate-story.ts
@@ -309,6 +309,12 @@ function validateFieldValue(
       checkDeclaredOption(field, value, path, entity, issues);
       break;
     case "datetime":
+    // The legacy `image`/`file` types predate the asset object and store the
+    // bare, protocol-relative URL as a string. There is nothing further to
+    // constrain: `add_https` and the crop options shape the editor, not the
+    // stored value.
+    case "image":
+    case "file":
       if (typeof value !== "string") {
         pushTypeIssue(value, "string", path, entity, issues);
       }

--- a/tools/openapi-codegen/specs/mapi/components/field-types/base-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/base-field.yaml
@@ -23,6 +23,9 @@ properties:
     type: array
     description: |
       Conditions set on the field for conditional visibility. The editor writes
-      one setting and evaluates only the first, so further entries are inert.
+      one setting and reads only the first, so an extra entry is invisible to it.
+      It is not inert server-side: the conditional-required check requires every
+      setting to match, so a second entry can only make a field harder to leave
+      empty. Write one setting unless you mean that.
     items:
       $ref: ./conditional-setting.yaml

--- a/tools/openapi-codegen/specs/mapi/components/field-types/base-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/base-field.yaml
@@ -21,6 +21,8 @@ properties:
     description: Position of the field within the block
   conditional_settings:
     type: array
-    description: Conditions set on the field for conditional visibility
+    description: |
+      Conditions set on the field for conditional visibility. The editor writes
+      one setting and evaluates only the first, so further entries are inert.
     items:
-      type: object
+      $ref: ./conditional-setting.yaml

--- a/tools/openapi-codegen/specs/mapi/components/field-types/commerce-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/commerce-field.yaml
@@ -1,0 +1,18 @@
+allOf:
+  - $ref: ./base-field.yaml
+  - $ref: ./value-field.yaml
+  - type: object
+    description: |
+      Commerce field configuration, provided by a commerce integration rather than
+      by the core editor. The Management API permits the type but exempts it from
+      content type-checking, and the integration owns both the schema options and
+      the stored value, so nothing beyond the discriminant is declared and the
+      value is typed as `unknown`. Narrow it in application code if you know which
+      integration wrote it.
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum: [commerce]
+        description: Field type discriminant

--- a/tools/openapi-codegen/specs/mapi/components/field-types/conditional-setting.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/conditional-setting.yaml
@@ -51,17 +51,25 @@ properties:
     type: array
     description: |
       What to apply to this field when the conditions match. The editor writes
-      one entry and reads only the first, so further entries are inert.
+      one entry and reads only the first.
     items:
       type: object
       properties:
         display:
           type: string
-          enum: [hide]
-          description: Set to `hide` to hide the field
+          enum: [hide, hidden]
+          description: |
+            Hides the field. Both spellings are live: the editor writes `hide`
+            and reads it back, while the server's conditional-required check
+            recognizes only `hidden`. Neither side accepts the other's value, so
+            a rule authored through the API with `hidden` hides nothing in the
+            editor, and one authored in the editor does not relax a required
+            field on save. Both are declared because real spaces hold both;
+            prefer `hide` for anything the editor will open.
         required:
           type: boolean
           description: |
             `true` makes the field required, `false` makes it explicitly not
-            required. The two modifications are mutually exclusive: `display`
-            wins when both are set.
+            required. Setting it alongside `display` is ambiguous rather than
+            layered: the editor lets `display` win, while the server only skips
+            the required check for the `hidden` spelling. Set one or the other.

--- a/tools/openapi-codegen/specs/mapi/components/field-types/conditional-setting.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/conditional-setting.yaml
@@ -1,0 +1,67 @@
+type: object
+description: |
+  A conditional rule attached to a field: when `rule_conditions` match the
+  block's content, the editor applies `modifications` to this field.
+
+  Nothing here is required. The editor writes a setting the moment the operator
+  adds a rule row, before any of it is filled in, so a saved block can hold a
+  half-configured setting.
+properties:
+  rule_match:
+    type: string
+    enum: [all, any]
+    description: |
+      Whether every condition must match (`all`) or any one of them (`any`).
+      A setting the editor creates starts out as `any`.
+  rule_conditions:
+    type: array
+    description: The conditions evaluated against the block's content
+    items:
+      type: object
+      properties:
+        validated_object:
+          type: [object, "null"]
+          description: |
+            The field this condition reads. `null` until the operator picks one.
+          properties:
+            type:
+              type: string
+              enum: [field]
+              description: What the condition reads; only a sibling field is supported
+            field_key:
+              type: string
+              description: Key of the sibling field within the same block
+            field_attr:
+              type: string
+              enum: [value]
+              description: Which attribute of that field is compared
+        validation:
+          type: [string, "null"]
+          enum: [equals, not_equals, empty, not_empty, gt, lt, null]
+          description: |
+            The comparison to run. `null` until the operator picks one.
+            `gt`/`lt` compare numbers, or dates when both sides parse as
+            `YYYY-MM-DD HH:mm`.
+        value:
+          description: |
+            The value compared against. Its shape follows the validated field:
+            a string, number or boolean for most types, an asset object for an
+            `asset` field, and `null` for `empty`/`not_empty`, which ignore it.
+  modifications:
+    type: array
+    description: |
+      What to apply to this field when the conditions match. The editor writes
+      one entry and reads only the first, so further entries are inert.
+    items:
+      type: object
+      properties:
+        display:
+          type: string
+          enum: [hide]
+          description: Set to `hide` to hide the field
+        required:
+          type: boolean
+          description: |
+            `true` makes the field required, `false` makes it explicitly not
+            required. The two modifications are mutually exclusive: `display`
+            wins when both are set.

--- a/tools/openapi-codegen/specs/mapi/components/field-types/file-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/file-field.yaml
@@ -1,0 +1,25 @@
+allOf:
+  - $ref: ./base-field.yaml
+  - $ref: ./value-field.yaml
+  - type: object
+    description: |
+      File field configuration. Legacy predecessor of `asset` for non-image
+      files: the value is a protocol-relative URL string rather than an asset
+      object. The editor no longer offers it when adding a field, but existing
+      spaces still hold it, so it stays a first-class field type.
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum: [file]
+        description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
+      add_https:
+        type: boolean
+        description: Whether to prepend `https:` to the asset URL
+      asset_folder_id:
+        type: integer
+        description: Numeric ID of the allowed asset folder

--- a/tools/openapi-codegen/specs/mapi/components/field-types/group-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/group-field.yaml
@@ -1,0 +1,17 @@
+allOf:
+  - $ref: ./base-field.yaml
+  - type: object
+    description: |
+      Group (layout) field configuration. Like `section` and `tab` it holds no
+      content value: the editor skips it when seeding defaults, and the Management
+      API skips it when type-checking content. The editor's current field-group
+      feature nests fields under a `section` instead, so `group` only appears in
+      spaces that predate that. No key beyond the discriminant is grounded in
+      either runtime, which is why none is declared here.
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum: [group]
+        description: Field type discriminant

--- a/tools/openapi-codegen/specs/mapi/components/field-types/image-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/image-field.yaml
@@ -1,0 +1,47 @@
+allOf:
+  - $ref: ./base-field.yaml
+  - $ref: ./value-field.yaml
+  - type: object
+    description: |
+      Image field configuration. Legacy predecessor of `asset`: the value is a
+      protocol-relative URL string rather than an asset object. The editor no
+      longer offers it when adding a field, but existing spaces still hold it and
+      its schema form is still reachable, so it stays a first-class field type.
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum: [image]
+        description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field
+      add_https:
+        type: boolean
+        description: Whether to prepend `https:` to the asset URL
+      image_crop:
+        type: boolean
+        description: Whether to force editors to crop the image to a fixed size
+      image_width:
+        oneOf:
+          - type: integer
+          - type: string
+        description: |
+          Crop width in pixels, applied when `image_crop` is true. The editor
+          writes an empty string when the input is cleared, so the value is not
+          always numeric.
+      image_height:
+        oneOf:
+          - type: integer
+          - type: string
+        description: |
+          Crop height in pixels, applied when `image_crop` is true. The editor
+          writes an empty string when the input is cleared, so the value is not
+          always numeric.
+      keep_image_size:
+        type: boolean
+        description: Whether to keep the original image size when `image_crop` is true
+      asset_folder_id:
+        type: integer
+        description: Numeric ID of the allowed asset folder

--- a/tools/openapi-codegen/specs/mapi/components/field-types/link-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/link-field.yaml
@@ -1,0 +1,22 @@
+allOf:
+  - $ref: ./base-field.yaml
+  - $ref: ./value-field.yaml
+  - type: object
+    description: |
+      Link field configuration. Legacy predecessor of `multilink`: the value is a
+      bare URL string rather than a link object. The editor neither offers nor
+      renders it any more, so it is modelled for read paths, not for new schemas.
+      Reach for `multilink` instead. It stays a first-class field type because the
+      Management API still permits it and validates its value as a string, so
+      spaces created before `multilink` continue to hold it and `schema init` has
+      to be able to emit it.
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum: [link]
+        description: Field type discriminant
+      default_value:
+        type: string
+        description: Default value for the field

--- a/tools/openapi-codegen/specs/mapi/components/field-types/markdown-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/markdown-field.yaml
@@ -54,5 +54,10 @@ allOf:
         type: boolean
         description: Whether to allow empty paragraphs
       max_length:
-        type: integer
-        description: Maximum length of the input string
+        oneOf:
+          - type: integer
+          - type: string
+        description: |
+          Maximum length of the input. The schema form persists the number
+          input's raw value, so a space can hold `"60"` just as legitimately as
+          `60`. Coerce before comparing.

--- a/tools/openapi-codegen/specs/mapi/components/field-types/options-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/options-field.yaml
@@ -51,6 +51,9 @@ allOf:
       use_uuid:
         type: boolean
         description: Whether to use UUID for the option values
+      exclude_empty_option:
+        type: boolean
+        description: Whether to exclude the empty option
       is_reference_type:
         type: boolean
         description: Whether this Multi-Options field is a References field

--- a/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
@@ -130,7 +130,11 @@ allOf:
         description: Whether to allow custom link attributes
       link_scope:
         type: string
-        description: Path of the folder internal links are restricted to
+        description: |
+          Path of the folder internal links are restricted to. The richtext
+          schema form does not write this option itself; it belongs to the
+          multilink field's editor. Kept here because a space can carry it as
+          a legacy value, not because the richtext editor produces it.
       max_length:
         oneOf:
           - type: integer
@@ -141,4 +145,9 @@ allOf:
           `60`. Coerce before comparing.
       rtl:
         type: boolean
-        description: Whether to enable right-to-left text direction
+        description: |
+          Whether to enable right-to-left text direction. The richtext schema
+          form does not write this option itself; it belongs to the text,
+          textarea, and markdown fields' editors. Kept here because a space
+          can carry it as a legacy value, not because the richtext editor
+          produces it.

--- a/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
@@ -132,8 +132,13 @@ allOf:
         type: string
         description: Path of the folder internal links are restricted to
       max_length:
-        type: integer
-        description: Maximum length of the input text
+        oneOf:
+          - type: integer
+          - type: string
+        description: |
+          Maximum length of the input. The schema form persists the number
+          input's raw value, so a space can hold `"60"` just as legitimately as
+          `60`. Coerce before comparing.
       rtl:
         type: boolean
         description: Whether to enable right-to-left text direction

--- a/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/richtext-field.yaml
@@ -128,3 +128,12 @@ allOf:
       allow_custom_attributes:
         type: boolean
         description: Whether to allow custom link attributes
+      link_scope:
+        type: string
+        description: Path of the folder internal links are restricted to
+      max_length:
+        type: integer
+        description: Maximum length of the input text
+      rtl:
+        type: boolean
+        description: Whether to enable right-to-left text direction

--- a/tools/openapi-codegen/specs/mapi/components/field-types/text-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/text-field.yaml
@@ -14,8 +14,13 @@ allOf:
         type: string
         description: Default value for the field
       max_length:
-        type: integer
-        description: Maximum length of the input string
+        oneOf:
+          - type: integer
+          - type: string
+        description: |
+          Maximum length of the input. The schema form persists the number
+          input's raw value, so a space can hold `"60"` just as legitimately as
+          `60`. Coerce before comparing.
       maxlength:
         type: integer
         description: Maximum length for text fields (legacy alias for max_length)

--- a/tools/openapi-codegen/specs/mapi/components/field-types/textarea-field.yaml
+++ b/tools/openapi-codegen/specs/mapi/components/field-types/textarea-field.yaml
@@ -14,8 +14,13 @@ allOf:
         type: string
         description: Default value for the field
       max_length:
-        type: integer
-        description: Maximum length of the input string
+        oneOf:
+          - type: integer
+          - type: string
+        description: |
+          Maximum length of the input. The schema form persists the number
+          input's raw value, so a space can hold `"60"` just as legitimately as
+          `60`. Coerce before comparing.
       maxlength:
         type: integer
         description: Maximum length for text fields (legacy alias for max_length)

--- a/tools/openapi-codegen/specs/overlay.openapi.yaml
+++ b/tools/openapi-codegen/specs/overlay.openapi.yaml
@@ -43,6 +43,8 @@ components:
         - $ref: ./mapi/components/field-types/options-field.yaml
         - $ref: ./mapi/components/field-types/asset-field.yaml
         - $ref: ./mapi/components/field-types/multiasset-field.yaml
+        - $ref: ./mapi/components/field-types/image-field.yaml
+        - $ref: ./mapi/components/field-types/file-field.yaml
         - $ref: ./mapi/components/field-types/multilink-field.yaml
         - $ref: ./mapi/components/field-types/bloks-field.yaml
         - $ref: ./mapi/components/field-types/table-field.yaml

--- a/tools/openapi-codegen/specs/overlay.openapi.yaml
+++ b/tools/openapi-codegen/specs/overlay.openapi.yaml
@@ -46,8 +46,11 @@ components:
         - $ref: ./mapi/components/field-types/image-field.yaml
         - $ref: ./mapi/components/field-types/file-field.yaml
         - $ref: ./mapi/components/field-types/multilink-field.yaml
+        - $ref: ./mapi/components/field-types/link-field.yaml
         - $ref: ./mapi/components/field-types/bloks-field.yaml
         - $ref: ./mapi/components/field-types/table-field.yaml
         - $ref: ./mapi/components/field-types/section-field.yaml
         - $ref: ./mapi/components/field-types/tab-field.yaml
+        - $ref: ./mapi/components/field-types/group-field.yaml
+        - $ref: ./mapi/components/field-types/commerce-field.yaml
         - $ref: ./mapi/components/field-types/custom-field.yaml

--- a/tools/openapi-codegen/templates/field.ts
+++ b/tools/openapi-codegen/templates/field.ts
@@ -152,16 +152,29 @@ interface FieldTypeValueMap {
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
   /**
-   * The legacy `image`/`file` types predate the asset object: they store the
-   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   * The legacy `image`/`file` types predate the asset object: they store the URL
+   * as a plain string, protocol-relative (`//a.storyblok.com/…`) unless the field
+   * sets `add_https`, which makes it absolute.
    */
   image: string;
   file: string;
   multilink: MultilinkFieldValue;
+  /**
+   * Legacy predecessor of `multilink`, storing a bare URL string rather than a
+   * link object. Read-only in practice: the editor no longer writes it.
+   */
+  link: string;
   bloks: BlockContentBase[];
   table: TableFieldValue;
   section: never;
   tab: never;
+  group: never;
+  /**
+   * Owned by a commerce integration rather than the editor, and exempt from
+   * server-side content type-checking, so the integration is the only thing that
+   * knows the shape. Narrow it where you know which one wrote the field.
+   */
+  commerce: unknown;
   custom: PluginFieldValue;
 }
 

--- a/tools/openapi-codegen/templates/field.ts
+++ b/tools/openapi-codegen/templates/field.ts
@@ -151,6 +151,12 @@ interface FieldTypeValueMap {
   options: string[];
   asset: AssetFieldValue;
   multiasset: AssetFieldValue[];
+  /**
+   * The legacy `image`/`file` types predate the asset object: they store the
+   * bare, protocol-relative URL (`//a.storyblok.com/…`) as a string.
+   */
+  image: string;
+  file: string;
   multilink: MultilinkFieldValue;
   bloks: BlockContentBase[];
   table: TableFieldValue;


### PR DESCRIPTION
Groundwork extracted from the review of #752 and #753, split out so both of those show only their own change. They are now stacked on top of this branch.

Everything here was checked against one of two sources. Never against a round trip: the Management API stores component schemas and story content as opaque blobs, accepts almost any JSON and echoes it back, so pushing a fixture and reading it back proves storage, not shape.

1. **Sibling-repo source** — `storyfront` for what the editor writes and reads, `storyrails` for what the backend normalizes and enforces.
2. **Operator-authored data** — a block with one field of every type, a block per restriction shape, and stories covering every value shape, created by hand in a QA space and read back via MAPI.

## What's here

**`fix(schema): declare the field options the editor writes`**
`schema init` passes every wire key through verbatim, so an option a space holds but the spec does not declare produces a field the generated types cannot describe. Two were missing: `richtext` `link_scope`/`max_length`/`rtl`, and `options` `exclude_empty_option` (declared on `option` but not its multi-select sibling).

**`feat(schema): support the image and file field types`**
`image` and `file` predate the asset object and store a bare protocol-relative URL string. The editor no longer offers them when adding a field, but spaces still hold them and neither was modelled, so `schema init` emitted `defineField('x', {type: 'image'})`, which failed on the discriminant.

`add_https` and the crop options (`image_crop`, `image_width`, `image_height`, `keep_image_size`) belong to `image`/`file` alone. An `asset` and a `multiasset` created in the editor stay bare, and `storyfront` agrees: `FieldTypeAsset` computes a protocol from `add_https`, but its only consumer, `processFilename`, runs behind a `deprecated` prop that only `FieldTypeImage` and `FieldTypeFile` pass. On an `asset` field the key is inert. `image_width`/`image_height` are `integer | string`: clearing the input writes an empty string rather than removing the key.

**`fix(migrations): remap only the option sources that hold a reference`**
`optionsFieldRefMapper` keyed on `internal_users`, `internal_tags` and `internal_datasources`. None are real option sources — the editor offers `internal_stories`, `internal`, `external`, `internal_languages` and inline options — so those branches were unreachable. Of the real ones only `internal_stories` holds a cross-space reference; the others hold values that mean the same thing in every space, so remapping them would corrupt content. The singular `option` type had no mapper at all.

**`test(repo): match seed fixtures to the wire formats the editor writes`**
The corpus held shapes the editor never writes, and every one passed QA:

- Asset sidecars were named `<file>.png.meta.json` while the CLI resolves `<basename>.json` and swallows ENOENT. **Every seeded asset in every scenario had always uploaded with no metadata, silently.**
- Story `uuid`s were `"1"`…`"10"` and a multilink's `id` was the numeric story id. `mapRefs` keys on the uuid, so the one scenario built to exercise remapping could not have caught a broken remap.
- A component declared `source: "internal_datasources"` — the fixture was shaped to match the `map-refs.ts` bug above, so QA confirmed the bug.
- Folder stories carried `{component: "page"}` instead of `content_types`/`default_root`.
- `blog.json` paired `source: "internal_stories"` with `datasource_slug`, which are mutually exclusive, and it seeds into every scenario.

New coverage: `has-restrictions` holds the first fixtures in the repo containing a `component_denylist`, a `restrict_type`, or any group or tag list — while both stacked PRs are about exactly those. `has-diverse-components` gains `kitchen_sink` for the field types nothing exercised. `has-rich-content` gains a `linktype: "story"` link mark and an embedded `type: "blok"` node, both of which `mapRefs` walks.

**`docs(repo): record that the Management API never validates a shape`**
`AGENTS.md` and the QA skill now state the opaque-blob caveat and give an ordered recipe for grounding a shape: existing seeds, then storyrails, then storyfront, and only ask the operator to author it in the UI when the source does not settle it — an agent cannot produce that evidence itself.

**`feat(schema): type the conditional settings a field can carry`**
`conditional_settings` was an untyped array of objects, so every key inside a rule was `unknown`: a typo in a condition produced no error. The shape comes from `storyfront`, which both writes it (`FieldConditions/index.vue`, `FieldConditionItem.vue`) and evaluates it (`utils/validateConditionalField.ts`) — six validations, two rule matches, two modifications. Nothing is required, because the editor persists a setting the moment a rule row is added, before any of it is filled in. `kitchen_sink` gains the first conditions in the corpus.

---

## Follow-up from review

**The field type union was still incomplete.** The Management API permits 22 field types and rejects anything else on component save; the overlay declared 19, while `packages/mapi-client`'s own generated types already carried all 22. `link`, `group` and `commerce` are added, with the same argument as `image`/`file`: spaces hold them, the editor no longer offers them, and `schema init` passed the wire `type` through into a `defineField` call that failed on the discriminant.

**Two more declarations were narrower than the wire.** `modifications[].display` accepted only `hide`, but the server's conditional-required check compares against `hidden` and its own fixtures author that spelling; both are now declared and the divergence is documented. `max_length` was `integer`, but the schema form persists the number input's raw value, so spaces hold `"60"` as readily as `60`. The three text types that already declared `integer` are widened too rather than left inconsistent, and `checkStringLength` coerces.

**"Further entries are inert" was wrong on the server.** True of the editor, which reads only the first `conditional_settings` entry. The server's conditional-required check requires every setting to match, so an extra entry can only make a field harder to leave empty. That description is inlined as JSDoc into four packages, and its audience is exactly the people who can produce a multi-setting array.

**The `option` mapper fix reached only one of the two forks.** `packages/cli` carries its own copy of the story ref-mapper and had no `option` entry, so a single-select story reference pushed to another space kept the source-space uuid while the multi-select field beside it remapped correctly. Ported rather than shared: the CLI does not depend on `@storyblok/migrations`.

**`has-restrictions` could not be seeded.** It is the first scenario shipping `groups.json`/`tags.json` sidecars; `count_staged` learned to skip them but the `component_group_uuid` guard did not, so the seed refused and left the space empty. Both checks now classify by data shape, the way the CLI does. Staging also purges first, so a killed run cannot leave another scenario's components behind.

**`AGENTS.md` overstated the opaque-blob rule**, which was the load-bearing premise of the section. The API does validate a field's `type` against a closed list, so a bogus `type` returns a 422 naming every permitted value, which is cheaper than reading a sibling repo. Story content is closer to the original claim, but only until a space enables field constraints. Also reflowed to oxfmt, which `pnpm format:check` had been failing on.

**Fixture coverage.** Every option this PR declared went in without one. `kitchen_sink` now carries `link`, `group`, `image_width`/`image_height` as `""` (the cleared-input case the spec calls out), a string `max_length`, a singular `option` sourced from `internal_stories`, plus `link_scope`, `rtl` and `exclude_empty_option`. `SCENARIOS.md` states the real count (20 of 22) and says why `custom` and `commerce` are out.

**New: `hideWhen` / `requiredWhen`.** Typing `conditional_settings` made the shape checkable but left it an 18-line literal per rule, four levels deep, duplicated across three playground files. These collapse it to one line. They need a docs-site entry before release. The playground comments they replaced were also wrong: an unchecked boolean counts as empty, but an *untouched* one is absent, and the editor reads an absent field as no match, so the dependent field is visible on a fresh story.

**Breaking-change note.** `RefMaps` loses `users`, `tags` and `datasources`. The branches were provably unreachable, but it is a type-level break shipped under a `fix:` patch bump.
