### PR TITLE
fix(cli): load compiler options and custom fields parser with jiti

### DIFF
--- a/packages/cli/src/commands/types/generate/actions.test.ts
+++ b/packages/cli/src/commands/types/generate/actions.test.ts
@@ -50,43 +50,33 @@ vi.mock("pathe", async (importOriginal) => {
   };
 });
 
-// Mock pathToFileURL so dynamic imports resolve consistently on all platforms.
-// On Windows, pathToFileURL adds a drive-letter prefix (file:///D:/…) which
-// prevents vi.mock('/mocked/path') from intercepting the import.
-vi.mock("node:url", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:url")>();
+// Create a mock for the custom fields parser and the user module loader that
+// hands it to the code under test. vi.hoisted makes both available inside the
+// hoisted vi.mock factory below.
+const { mockCustomFieldsParser, mockLoadUserModule } = vi.hoisted(() => {
+  const customFieldsParser = vi.fn().mockImplementation((key, field) => {
+    if (field.field_type === "native-color-picker") {
+      return {
+        [key]: {
+          properties: {
+            color: { type: "string" },
+          },
+          required: ["color"],
+          type: "object",
+        },
+      };
+    }
+    return {};
+  });
   return {
-    ...actual,
-    pathToFileURL: (p: string) => ({ href: p }),
+    mockCustomFieldsParser: customFieldsParser,
+    mockLoadUserModule: vi.fn().mockResolvedValue(customFieldsParser),
   };
 });
 
-// Create a mock for the custom fields parser
-const mockCustomFieldsParser = vi.fn().mockImplementation((key, field) => {
-  if (field.field_type === "native-color-picker") {
-    return {
-      [key]: {
-        properties: {
-          color: { type: "string" },
-        },
-        required: ["color"],
-        type: "object",
-      },
-    };
-  }
-  return {};
-});
-
-// Mock the dynamic import
-vi.mock("/mocked/path", () => ({
-  default: mockCustomFieldsParser,
-}));
-
-// Mock the import function
-vi.mock("node:module", () => ({
-  import: vi.fn().mockResolvedValue({
-    default: mockCustomFieldsParser,
-  }),
+// Mock the loader used for --custom-fields-parser and --compiler-options files
+vi.mock("./load-user-module", () => ({
+  loadUserModule: mockLoadUserModule,
 }));
 
 // Set up the virtual file system with our custom fields parser
@@ -244,8 +234,8 @@ describe("generate types actions", () => {
       expect(result.length).toBeGreaterThan(0);
     }
 
-    // Verify that resolve was called with the customFieldsParser path
-    expect(resolve).toHaveBeenCalledWith("/path/to/custom/parser.ts");
+    // Verify that the parser module was loaded from the customFieldsParser path
+    expect(mockLoadUserModule).toHaveBeenCalledWith("/path/to/custom/parser.ts");
   });
 
   it("should handle compilerOptions option", async () => {
@@ -265,8 +255,8 @@ describe("generate types actions", () => {
       expect(result.length).toBeGreaterThan(0);
     }
 
-    // Verify that resolve was called with the compilerOptions path
-    expect(resolve).toHaveBeenCalledWith("/path/to/compiler/options");
+    // Verify that the options module was loaded from the compilerOptions path
+    expect(mockLoadUserModule).toHaveBeenCalledWith("/path/to/compiler/options");
   });
 
   it("should apply typePrefix to component type names", async () => {

--- a/packages/cli/src/commands/types/generate/actions.ts
+++ b/packages/cli/src/commands/types/generate/actions.ts
@@ -13,7 +13,7 @@ import type { GenerateTypesOptions } from "./constants";
 import { isStoryblokPropertyType } from "../../../utils/storyblok-property-types";
 import { getLogger } from "../../../lib/logger/logger";
 import { join, resolve } from "pathe";
-import { pathToFileURL } from "node:url";
+import { loadUserModule } from "./load-user-module";
 import { resolvePath, saveToFile } from "../../../utils/filesystem";
 import { readFileSync } from "node:fs";
 import type { ComponentPropertySchema } from "../../../types/schemas";
@@ -407,8 +407,9 @@ const loadCustomFieldsParser = async (
   ((key: string, value: Record<string, unknown>) => Record<string, unknown>) | undefined
 > => {
   try {
-    const customFieldsParser = await import(pathToFileURL(resolve(path)).href);
-    return customFieldsParser.default;
+    return await loadUserModule<
+      (key: string, value: Record<string, unknown>) => Record<string, unknown>
+    >(path);
   } catch (error) {
     handleError(error as Error);
     return undefined;
@@ -417,8 +418,7 @@ const loadCustomFieldsParser = async (
 
 async function loadCompilerOptions(path: string) {
   if (path) {
-    const compilerOptions = await import(pathToFileURL(resolve(path)).href);
-    return compilerOptions.default;
+    return await loadUserModule(path);
   }
   return {};
 }

--- a/packages/cli/src/commands/types/generate/load-user-module.test.ts
+++ b/packages/cli/src/commands/types/generate/load-user-module.test.ts
@@ -1,0 +1,89 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dirname, join } from "pathe";
+import { loadUserModule } from "./load-user-module";
+
+// jiti reads real file paths, so these tests need the real filesystem rather
+// than the memfs volume the global setup installs.
+vi.unmock("node:fs");
+vi.unmock("node:fs/promises");
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function createFile(name: string, contents: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "storyblok-user-module-"));
+  temporaryDirectories.push(directory);
+
+  const absolutePath = join(directory, name);
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, contents);
+
+  return absolutePath;
+}
+
+describe("loadUserModule", () => {
+  it("should load compiler options from a TypeScript file", async () => {
+    const path = await createFile(
+      "compiler-options.ts",
+      `const options: { additionalProperties: boolean } = { additionalProperties: false };
+export default options;
+`,
+    );
+
+    await expect(loadUserModule(path)).resolves.toEqual({ additionalProperties: false });
+  });
+
+  it("should load compiler options from a JSON file", async () => {
+    const path = await createFile("compiler-options.json", `{ "additionalProperties": false }\n`);
+
+    await expect(loadUserModule(path)).resolves.toEqual({ additionalProperties: false });
+  });
+
+  it("should load compiler options from a JavaScript file", async () => {
+    const path = await createFile(
+      "compiler-options.mjs",
+      `export default { additionalProperties: false };\n`,
+    );
+
+    await expect(loadUserModule(path)).resolves.toEqual({ additionalProperties: false });
+  });
+
+  it("should load compiler options from a CommonJS file", async () => {
+    const path = await createFile(
+      "compiler-options.cjs",
+      `module.exports = { additionalProperties: false };\n`,
+    );
+
+    await expect(loadUserModule(path)).resolves.toEqual({ additionalProperties: false });
+  });
+
+  it("should load a custom fields parser function from a TypeScript file", async () => {
+    const path = await createFile(
+      "custom-fields-parser.ts",
+      `export default function parse(key: string, value: Record<string, unknown>) {
+  return { [key]: value };
+}
+`,
+    );
+
+    const parser =
+      await loadUserModule<
+        (key: string, value: Record<string, unknown>) => Record<string, unknown>
+      >(path);
+
+    expect(parser("color", { type: "string" })).toEqual({ color: { type: "string" } });
+  });
+
+  it("should reject when the file does not exist", async () => {
+    await expect(loadUserModule("/does/not/exist/compiler-options.ts")).rejects.toThrow();
+  });
+});

--- a/packages/cli/src/commands/types/generate/load-user-module.ts
+++ b/packages/cli/src/commands/types/generate/load-user-module.ts
@@ -1,0 +1,24 @@
+import { resolve } from "pathe";
+
+/**
+ * Imports a user-provided module file, such as compiler options or a custom
+ * fields parser, and returns its default export. Node's dynamic `import()`
+ * cannot load every file users pass here: `.ts` files throw
+ * `Unknown file extension` before Node 22.18 and `.json` files require an
+ * import attribute on every version. jiti evaluates the file instead, so
+ * `.ts`, `.js`, `.mjs`, `.cjs`, and `.json` files all load consistently,
+ * matching how `storyblok.config.ts` is loaded (see `src/lib/config/loader.ts`
+ * and `loadSchemaModule` in `src/utils/schema/classify-exports.ts`).
+ */
+export async function loadUserModule<T = Record<string, unknown>>(path: string): Promise<T> {
+  const { createJiti } = await import("jiti");
+  const jiti = createJiti(import.meta.url, {
+    interopDefault: true,
+    // Reading the tsconfig throws when it extends something unresolvable, which
+    // would block type generation in a project that does not even use aliases.
+    // jiti's own JITI_TSCONFIG_PATHS default is overridden by this explicit
+    // option, so honour it here to leave users a way out.
+    tsconfigPaths: process.env.JITI_TSCONFIG_PATHS !== "false",
+  });
+  return await jiti.import<T>(resolve(path), { default: true });
+}


### PR DESCRIPTION
Fixes #307.

## Before this PR

`storyblok types generate --compiler-options ./compiler-options.ts` fails with `Unknown file extension ".ts"`. The file was loaded with a bare dynamic `import()` in `loadCompilerOptions`, which only understands what the running Node version understands:

- `.ts` files throw `Unknown file extension ".ts"` before Node 22.18 (where type stripping became the default)
- `.json` files throw `needs an import attribute of "type: json"` on every Node version, so the `.json` format that worked in CLI v3 also has no working path in v4
- only `.js`/`.mjs` files load reliably, which matches what users report in #307

`loadCustomFieldsParser` uses the same bare `import()` for `--custom-fields-parser` and fails the same way, even though the option is documented with a `.ts` example path.

## After this PR

Both files are loaded through a small shared helper, `load-user-module.ts`, that evaluates the file with jiti and returns its default export. This is the same loading strategy the CLI already uses for `storyblok.config.ts` (via c12/jiti, see #693) and for schema entry files (`loadSchemaModule`). `.ts`, `.js`, `.mjs`, `.cjs`, and `.json` files now all load consistently on every supported Node version, and the helper honours the same `JITI_TSCONFIG_PATHS=false` escape hatch as the config loader.

## Tests

- `load-user-module.test.ts` follows the real-filesystem pattern from `lib/config/loader.test.ts`: it writes fixture files to a temp directory and asserts that compiler options load from `.ts` (the regression in #307), `.json`, `.mjs`, and `.cjs`, and that a custom fields parser function loads from `.ts`.
- `actions.test.ts` previously intercepted the dynamic import through mocked `pathe.resolve`/`pathToFileURL` and a `vi.mock("/mocked/path")` module stub; it now mocks the loader module directly, which also removes the Windows-specific `pathToFileURL` workaround.

## Verification

- `vp test run` in `packages/cli`: 92 test files, 1288 tests passing
- `pnpm nx lint storyblok`, `pnpm nx test:types storyblok`, and `pnpm format`: clean

cc @maoberlehner
