### PR TITLE
fix(capi-client,js-client): invalidate cached content by the version it belongs to

### DIFF
--- a/adr/0014-content-cache-invalidation-by-version-watermarks.md
+++ b/adr/0014-content-cache-invalidation-by-version-watermarks.md
@@ -1,0 +1,156 @@
+# ADR-0014: Content Cache Invalidation by Version Watermarks
+
+**Status:** Accepted **Date:** 2026-08-21
+
+## Context
+
+Both content clients cache published CDN responses and have to notice publishes promptly. Two
+signals are available: the `cv` a content response reports in its body, and the `space.version`
+reported by `/cdn/spaces/me`, an endpoint cached for two seconds where content is cached for a week
+— the cheapest way to poll for a publish.
+
+The behaviour of the API these signals describe was verified against the live CDN:
+
+- A published request **without** a `cv` is redirected (301) to the same URL with the current `cv`.
+  It costs one extra hop and can never be stale.
+- A published request with any `cv` the edge does not hold — `0`, a stale one, even a future one —
+  gets the same redirect to the current version.
+- A published request with an **old `cv` the edge still holds** is served that old snapshot for up
+  to a week. This is the only path to stale content. Such a response is indistinguishable on the
+  wire from one a caller pinned deliberately: same status, same old body, same old `cv`. Only
+  whether the caller asked for that `cv` separates a stale read from an intended one.
+- A response body's `cv` identifies the snapshot that was actually served.
+- Draft requests ignore `cv` entirely and are never redirected.
+- Without a Minimum Cache TTL, `space.version` and `cv` report the same raw version. With one, the
+  `cv` is floored into TTL-sized buckets, so it lags permanently. The two are different units, and
+  only same-signal comparisons carry information.
+- `space.version` is monotonic at the origin, but a two-second per-POP cache means a poll can be
+  answered with a lower one.
+
+The first implementation treated invalidation as an **event**: when a signal moved, flush the cache.
+Because a flush destroys evidence rather than recording it, every edge case needed compensating
+machinery — a cache epoch to reject responses that were in flight across a flush, and a "settle"
+protocol (a pending revalidation, cv stripping, in-flight promise coordination) to disambiguate the
+first `space.version` sighting. A review of that machinery found nine defects, all of them in the
+compensation rather than in the signals: a `0` sentinel reaching the wire, an entry stored under the
+wrong key, flush ordering that dropped the very response that triggered the flush, version
+comparisons that fired on regressions, and invalidation state scoped to a client instance while the
+cache it governed was shared.
+
+The decisive observation: published content is an **immutable snapshot addressed by its `cv`**. An
+entry is valid exactly as long as the `cv` it was served under is still the current one. That is a
+property of the entry, not an event in time — and the origin corrects any wrong address for the
+price of one redirect.
+
+## Decision
+
+**Cache entries carry the version they belong to, and the client tracks two monotonic watermarks in
+the cache provider. Invalidation is a mismatch, not a flush.**
+
+1. **Only a positive `cv` is a version.** `0` is not one the API knows — it is redirected like any
+   `cv` the edge does not hold — so it is rejected where the body is read, not just where the
+   watermark is written, which is what keeps the "no numeric sentinel" property true end to end.
+2. **Entries are tagged.** `CacheEntry.cv` records the `cv` the response reported, or — for
+   endpoints that report none, like `/cdn/tags` and `/cdn/links` — the `cv` the request was issued
+   under. Every response teaches a `cv` whether or not it is cached: a draft response is never
+   stored, but the `cv` it reports is the same version a published one reports — the same raw value
+   without a Minimum Cache TTL, the same floored value with one — so it invalidates published
+   entries like any other signal, and an application that reads both but never polls
+   `/cdn/spaces/me` has no other one.
+3. **Two watermarks, one per signal.** `knownCv` (highest `cv` seen in a body) and
+   `knownSpaceVersion` (highest version seen from `/cdn/spaces/me`). Both advance by monotonic max
+   only, so a stale edge read never moves them. They are never compared to each other, except once:
+   on the very first sighting, a `space.version` ahead of `knownCv` is treated as a possible
+   publish, because there is no earlier space version to compare against. A third value,
+   `highestCv`, records the highest `cv` the record has ever held and is never dropped: `knownCv` is
+   reset by an invalidation, and that is precisely when the next response is the one that teaches
+   the version everything afterwards is measured against, so the floor a stale edge read is
+   recognised against has to outlive the reset. Like `knownSpaceVersion`, it is never sent as a
+   `cv`.
+4. **They live in the cache provider**, under the reserved key `sb:versions:v1:<tokenId>`, so they
+   share fate with the entries they govern. Every client and process sharing a provider shares the
+   watermarks — which is what makes the publish signal work for a per-request client in a serverless
+   deployment, where instance state does not survive. A missing record reads as "cv unknown", so a
+   tagged entry is treated as stale rather than falling back to TTL alone: the record can be evicted
+   while the entries it governs survive, and one refetch rewrites it.
+5. **Entry keys are scoped to the space.** The access token selects the space and travels in the
+   request's `token` parameter rather than in the query, so without it two clients sharing one
+   provider read each other's content. Both the entry keys and the watermark key carry a
+   non-cryptographic hash of the token, not the token, since keys reach listings, `MONITOR` output
+   and metrics labels.
+6. **A read is a hit when the entry is TTL-fresh and its tag equals `knownCv`.** A publish sets
+   `knownCv` to undefined, which makes every tagged entry unreachable at once and sends the next
+   request out without a `cv`, taking the origin's redirect to the current version. Nothing is
+   flushed: unreachable entries expire by TTL and LRU, and flushing would also empty a provider
+   other clients keep their own entries in.
+7. **A response is discarded when the `cv` it was issued under is no longer the known one — unless
+   its own body reports the `cv` that superseded it.** That is the entire in-flight problem: the
+   response was answered for a version that has since been superseded, so it neither teaches a `cv`
+   nor gets stored. No epoch counter, and it holds across clients and processes because the
+   comparison is against shared state. The exception keeps a response that merely lost a race: its
+   body proves it carries the current snapshot, so discarding it would make a publish cost a refetch
+   of every key that happened to be in flight. The issued-under comparison cannot be dropped in
+   favour of the body alone — under a Minimum Cache TTL a late pre-publish response and a fresh
+   floored refetch report the same `cv`, and only issue time tells them apart. One case has no `cv`
+   to compare: a request issued while none was known, racing an explicit `flushCache()`. The record
+   therefore also carries a `generation` that `flushCache()` bumps, and a response whose generation
+   no longer matches is discarded — the epoch, but shared through the provider instead of held on
+   the instance. It is bumped only there, never on a publish, so noticing one still costs no refetch
+   of what was in flight.
+8. **A caller-pinned `cv` is honoured literally.** Such a request is keyed by its own `cv`, is
+   immune to publishes, expires by TTL alone, and never teaches a watermark: it describes the
+   caller's choice, not the space's current state. Only a positive `cv` pins: `0` is the sentinel
+   `storyblok-js-client` records for "no version known", and reading it as a choice would keep it on
+   the wire and file the entry under a key nothing invalidates. Because the snapshot it receives
+   looks exactly like a stale edge read, the stale-read rule is gated on caller intent rather than
+   on the response: without that gate a pinned entry is never stored at all, and every read past its
+   TTL returns to the network for good.
+9. **`flushCache()` stays** for webhook-driven invalidation under `cache.flush: 'manual'`: it
+   empties the provider and resets the watermark record, keeping only `highestCv`, which is a fact
+   about the space rather than about any entry, and the bumped `generation`.
+
+`storyblok-js-client` keeps its flush-based mechanism — it is widely deployed and its custom cache
+providers observe its key shapes — but adopts the same semantics: no falsy `cv` on the wire,
+monotonic comparisons in both directions floored at the highest `cv` ever seen rather than at the
+tracked one — a flush zeroes the latter, and the response that follows a flush is the one that
+teaches the version everything afterwards is measured against — the entry stored after any flush its
+own response triggered _and under the key the next read will build_ — the tracked `cv` is part of
+that key, so a flush moves it and an entry filed under the pre-flush `cv` is never looked up again —
+and the signal scoped to the cache that would act on it, identified by the provider object rather
+than by the client instance so that per-request clients sharing one provider share the signal. That
+last point holds only while the provider object outlives the client: a handler that builds its
+provider inline per request hands over a new identity each time and never compares two space
+versions.
+
+## Consequences
+
+- The epoch, the settle protocol and cv stripping are gone, along with roughly 150 lines of
+  concurrency machinery and the defect class that came with it. A publish costs one redirect per
+  active key instead of a coordinated revalidation.
+- `cache.flush: 'auto'` no longer calls `provider.flush()`. Invalidated entries linger until TTL or
+  LRU eviction, bounded by the existing 1 000-entry cap — the trade for not emptying a shared
+  provider on someone else's behalf. `CacheEntry` gains an optional `cv`; custom providers store
+  entries opaquely and need no change, but they must not use the reserved key. Entry keys change
+  shape, so an external provider carried across the upgrade refills once.
+- Each cacheable request reads the watermark record in addition to its entry, issued in parallel:
+  free for the in-memory provider, one extra round trip for an external one — still far cheaper than
+  the origin fetch it prevents.
+- A space with a Minimum Cache TTL pays one needless revalidation per watermark record, from the
+  first-sighting comparison. Bounded and self-answering.
+- Endpoints that report no `cv` are only invalidated when they were fetched while a `cv` was known;
+  a response fetched during an unknown-`cv` window falls back to TTL alone.
+- The record is written back without a lock, so a `flushCache()` landing between a response's read
+  and its write would be merged away. The write re-reads the generation first and gives up when it
+  moved, which narrows the window to the write itself; closing it needs a compare-and-swap
+  `CacheProvider` does not offer.
+- A response issued while no `cv` was known cannot be recognised as superseded by a publish alone —
+  it has no issue-time `cv` to compare, and the generation only moves on an explicit `flushCache()`.
+  An unlucky one carries pre-publish content into the cache for one TTL.
+- Every response on the uncached path — every draft request — reads the watermark record once, where
+  `main` touched the provider not at all. That is the price of the draft signal above; it writes
+  only when a version actually moved, and it never re-reads, since nothing it decides holds back a
+  cache write.
+- The `storyblok-js-client` first-sighting state is per process, since it lives beside the client
+  rather than in the provider. Under a Minimum Cache TTL, where the floored `cv` never equals the
+  raw space version, every cold start therefore flushes the shared cache once. That is the price of
+  leaving that client on the flush model.

--- a/packages/capi-client/src/client.ts
+++ b/packages/capi-client/src/client.ts
@@ -4,9 +4,17 @@ import { createMemoryCacheProvider, createStrategy } from "./utils/cache";
 import { ClientError } from "./error";
 import type { RateLimitConfig, ThrottleManager } from "./utils/rate-limit";
 import { createThrottleManager } from "./utils/rate-limit";
-import { applyCvToQuery, extractCv } from "./utils/cv";
+import { applyCvToQuery, extractCv, extractSpaceVersion, isCvPinned } from "./utils/cv";
 import { querySerializer } from "./utils/query-serializer";
-import { createCacheKey, shouldUseCache } from "./utils/request";
+import { createCacheKey, isSpacesMeRequest, shouldUseCache } from "./utils/request";
+import { createTokenId } from "./utils/token-id";
+import {
+  haveVersionsChanged,
+  mergeVersions,
+  readVersions,
+  versionsKey,
+  writeVersions,
+} from "./utils/versions";
 import { getRegionBaseUrl, type Region } from "@storyblok/region-helper";
 import type { Block as Component } from "./generated/types/block";
 import type { RetryOptions } from "ky";
@@ -87,7 +95,17 @@ export interface ResourceDeps<DefaultThrowOnError extends boolean = false> {
  * of the configured strategy. Only published content is cached.
  */
 export interface CacheConfig {
-  /** Custom cache provider. Defaults to an in-memory LRU cache (1 000 entries). */
+  /**
+   * Custom cache provider. Defaults to an in-memory LRU cache (1 000 entries).
+   *
+   * Sharing one provider between clients is supported and is what makes the publish
+   * signal work for per-request clients: entry keys are scoped to a hash of the access
+   * token, so clients for different spaces cannot read each other's content.
+   *
+   * The client keeps its version watermarks in the provider under the reserved key
+   * `sb:versions:v1:<tokenId>`, so clients and processes sharing a provider share them.
+   * Do not store anything else under that key: dropping it costs one refetch per entry.
+   */
   provider?: CacheProvider;
   /** Cache strategy for published requests. @default 'cache-first' */
   strategy?: CacheStrategy | CacheStrategyHandler;
@@ -99,16 +117,25 @@ export interface CacheConfig {
    * - `'auto'` (default): automatically attach the tracked `cv` to
    *   subsequent published requests for cache busting.
    * - `'manual'`: do not attach `cv` to outgoing requests. The client still
-   *   tracks cv internally for cache invalidation (flushing when cv changes),
-   *   but the query parameter is not sent. Useful for SSR with edge caching
-   *   where stable URLs are required.
+   *   tracks the cv for cache invalidation, but the query parameter is not sent.
+   *   Useful for SSR with edge caching where stable URLs are required.
    */
   cv?: "auto" | "manual";
   /**
-   * Controls when the cache is flushed on cv change.
+   * Controls whether the client invalidates cached entries on its own when it notices a
+   * new content version.
    *
-   * - `'auto'` (default): automatically flush the cache whenever the API returns a new cv value.
-   * - `'manual'`: never auto-flush; call `client.flushCache()` explicitly (e.g. on webhook trigger).
+   * - `'auto'` (default): entries stop being served as soon as the API reports a version
+   *   newer than the one they were served under. The provider is not emptied — entries
+   *   that are no longer served expire by TTL or eviction.
+   * - `'manual'`: a version change never invalidates a cached entry; call
+   *   `client.flushCache()` explicitly (e.g. on webhook trigger). Versions are still
+   *   tracked, and in either mode a response is discarded rather than cached when the
+   *   `cv` it was issued under is no longer the known one, or when a `flushCache()` ran
+   *   while it was in flight: that keeps known-stale content out of the cache rather
+   *   than invalidating what is already in it. A response issued while no `cv` was known
+   *   at all can only be recognised through the second of those, so an unlucky one can
+   *   still carry pre-publish content into the cache for one TTL under `'auto'`.
    */
   flush?: "auto" | "manual";
   /**
@@ -247,7 +274,13 @@ export const createApiClientBase = <
   const cacheTtlMs = cache.ttlMs ?? 60_000;
   const cacheFlush = cache.flush ?? "auto";
   const cvMode = cache.cv ?? "auto";
-  let currentCv: number | undefined;
+  /**
+   * Where the version watermarks live. In the provider, not on this closure, so that
+   * every client sharing the provider — including a fresh one per request — shares them.
+   */
+  /** Identifies the space in cache keys without putting the token itself in them. */
+  const tokenId = createTokenId(accessToken);
+  const watermarksKey = versionsKey(tokenId);
 
   const client: Client = createClient(
     createConfig({
@@ -287,38 +320,174 @@ export const createApiClientBase = <
     },
   ];
 
-  const updateCv = async (result: ApiResponse): Promise<boolean> => {
-    const nextCv = extractCv(result.data);
-    if (nextCv === undefined) {
-      return true;
-    }
-
-    // Guard against cv regression: SWR background revalidation may carry a
-    // stale cv from a prior request; never move cv backward.
-    if (currentCv !== undefined && nextCv < currentCv) {
-      return false;
-    }
-
-    if (cacheFlush === "auto" && currentCv !== undefined && currentCv !== nextCv) {
-      await cacheProvider.flush();
-    }
-
-    currentCv = nextCv;
-    return true;
+  /**
+   * Empty the cache and reset the tracked versions.
+   *
+   * Call this explicitly when `cache.flush` is set to `'manual'`, e.g. after
+   * receiving a Storyblok webhook event that signals content has changed.
+   */
+  const flushCache = async (): Promise<void> => {
+    const current = await readVersions(cacheProvider, watermarksKey);
+    await cacheProvider.flush();
+    // The watermarks describe entries that no longer exist. Recording an empty record
+    // rather than relying on `flush()` having removed it also invalidates anything a
+    // partial provider implementation left behind. Two things survive: the highest `cv`
+    // ever seen, which is a fact about the space rather than about any entry and is the
+    // floor a stale edge read is recognised against, and the generation, bumped so that
+    // responses in flight across this call are discarded on arrival.
+    await writeVersions(cacheProvider, watermarksKey, {
+      highestCv: current?.highestCv,
+      knownSpaceVersion: current?.knownSpaceVersion,
+      generation: (current?.generation ?? 0) + 1,
+    });
   };
 
-  const cacheSuccessResult = async <TResponse extends ApiResponse>(
-    key: string,
-    result: TResponse,
-  ) => {
-    const shouldCacheResult = await updateCv(result);
-    if (result.error === undefined && shouldCacheResult) {
-      await cacheProvider.set(key, {
-        value: result,
-        ttlMs: cacheTtlMs,
-      });
+  /**
+   * Records the versions a response reports, applies the publish signal, and decides
+   * whether the response may be cached.
+   *
+   * Two signals arrive: the `cv` in a content response body identifies the published
+   * snapshot that response belongs to, and `space.version` from `/cdn/spaces/me` reports
+   * the space's raw version. That endpoint is cached for two seconds where content is
+   * cached for a week, which makes polling it the cheapest way to notice a publish.
+   *
+   * The two are not interchangeable — a Minimum Cache TTL floors the `cv` into TTL-sized
+   * buckets while `space.version` keeps reporting the raw version — so each only ever
+   * advances its own watermark, and a publish is recognised by `space.version` moving
+   * forward against itself.
+   *
+   * Noticing a publish drops `knownCv`, which makes every entry tagged with the old `cv`
+   * unreachable and sends the next request out without a `cv` so the origin redirects it
+   * to the current one. The provider is not flushed: unreachable entries expire on their
+   * own, and flushing would also empty a provider shared with clients that keep their own
+   * entries in it.
+   *
+   * The space version is gated on the path, not just the response shape: another response
+   * that happens to embed a numeric `space.version` must not invalidate anything.
+   *
+   * Known limitation: the record is read, merged and written back without a lock, and
+   * `CacheProvider` offers no compare-and-swap to build one from. Two concurrent requests
+   * can therefore write over each other — a poll that dropped `knownCv` for a publish can
+   * lose that drop to a content response that read the record before it, and with it the
+   * space-version watermark can fall back to the value that response had read. It costs
+   * one repeated round of invalidation: the next poll compares against the older
+   * watermark, recognises the same publish again and drops `knownCv` again. No entry is
+   * served past its version in the meantime, because the `cv` the losing write records is
+   * the newer one. The window is a provider round trip wide, so it is wider for an
+   * external provider than for the in-memory one.
+   *
+   * @param learnCv whether this response's `cv` may advance the watermark. Draft
+   * responses bypass the cache and a caller-pinned `cv` describes the caller's choice
+   * rather than the space's current state, so neither may teach one.
+   * @param honourOlderSnapshot keep a response whose body reports a `cv` below the known
+   * one. Only a caller-pinned `cv` may: it asked for that snapshot, where an unpinned
+   * request got it from an edge node that had not caught up.
+   * @param knownCvAtIssue the `cv` this request was issued under. A response is discarded
+   * when that `cv` is no longer the known one: it was answered for a version that has
+   * since been superseded, so caching it would refill the cache with pre-publish content
+   * and teach back the `cv` the publish dropped.
+   * @param generationAtIssue the flush generation this request was issued under, omitted
+   * where there is nothing to compare — a response that is not cached has no write to
+   * hold back. A response is discarded when it no longer
+   * matches, which is the only thing that recognises a request issued while no `cv` was
+   * known as superseded. Absence is a value here: `flush()` deletes the record, so a
+   * generation compared as zero would read a flushed record as an unflushed one.
+   */
+  const applyResponseVersions = async (
+    path: string,
+    result: ApiResponse,
+    {
+      learnCv,
+      honourOlderSnapshot = false,
+      knownCvAtIssue,
+      generationAtIssue,
+    }: {
+      learnCv: boolean;
+      honourOlderSnapshot?: boolean;
+      knownCvAtIssue?: number;
+      generationAtIssue?: number;
+    },
+  ): Promise<{ mayCache: boolean; cv?: number }> => {
+    const bodyCv = extractCv(result.data);
+    const spaceVersion = isSpacesMeRequest(path) ? extractSpaceVersion(result.data) : undefined;
+    const current = await readVersions(cacheProvider, watermarksKey);
+
+    // A response answered for a `cv` that is no longer the known one was superseded while
+    // in flight — unless its own body reports the very `cv` that superseded it, in which
+    // case it carries the current snapshot and only lost a race. Discarding those makes a
+    // publish cost a refetch of every key that happened to be in flight.
+    const carriesKnownCv = bodyCv !== undefined && bodyCv === current?.knownCv;
+    // An explicit `flushCache()` discards state the caller decided was stale, and a
+    // request issued before it carries no evidence of that in its `cv`: one issued while
+    // no `cv` was known has no `knownCvAtIssue` to compare at all, which is the window a
+    // webhook-driven flush lands in. The generation closes it for every in-flight
+    // request at once, which is what the removed in-process epoch used to do — except
+    // that this one lives in the provider, so it holds across clients and processes.
+    const wasFlushedInFlight =
+      generationAtIssue !== undefined && (current?.generation ?? 0) !== generationAtIssue;
+    const isSuperseded =
+      wasFlushedInFlight ||
+      (knownCvAtIssue !== undefined && current?.knownCv !== knownCvAtIssue && !carriesKnownCv);
+    // A response reporting a `cv` below the known one came from an edge node still holding
+    // an older snapshot. Stale by construction, so it must neither teach a `cv` nor be
+    // stored over the newer entry that may already be there — but a caller who pinned that
+    // `cv` asked for exactly this snapshot. The two are identical on the wire (the edge
+    // answers both with the old body and its old `cv`), so only the caller's intent tells
+    // them apart.
+    // Compared against the highest `cv` ever seen rather than the known one, which an
+    // invalidation resets to `undefined` — precisely when the next response is the one
+    // that teaches the `cv` everything is then measured against, and an unguarded stale
+    // read there would make every entry the publish invalidated readable again.
+    const isStaleEdgeRead =
+      !honourOlderSnapshot &&
+      bodyCv !== undefined &&
+      current?.highestCv !== undefined &&
+      bodyCv < current.highestCv;
+    const mayCache = !isSuperseded && !isStaleEdgeRead;
+
+    let next = mergeVersions(current, {
+      knownCv: learnCv && mayCache ? bodyCv : undefined,
+      knownSpaceVersion: spaceVersion,
+    });
+
+    if (spaceVersion !== undefined && cacheFlush === "auto") {
+      const lastSpaceVersion = current?.knownSpaceVersion;
+      // Only a version that moved FORWARD is a publish. A lower one is a stale read from
+      // a POP whose two-second cache has not caught up.
+      const isPublish = lastSpaceVersion !== undefined && spaceVersion > lastSpaceVersion;
+      // A first sighting has no previous space version to compare against, so compare
+      // against the known `cv`. Without a Minimum Cache TTL both report the same raw
+      // version, so a version ahead of the `cv` means content was published between the
+      // first content response and this poll. With one, the `cv` lags by design and this
+      // costs a single needless revalidation per watermark record.
+      const isAheadOfKnownCv =
+        lastSpaceVersion === undefined && next.knownCv !== undefined && spaceVersion > next.knownCv;
+
+      if (isPublish || isAheadOfKnownCv) {
+        next = { ...next, knownCv: undefined };
+      }
     }
-    return result;
+
+    if (haveVersionsChanged(current, next)) {
+      // Re-read immediately before writing: the record is read, merged and written back
+      // without a lock, so a `flushCache()` that landed in between would otherwise be
+      // written away by a merge that never saw it — and with the generation gone, the
+      // responses it was meant to discard would cache. Writing the whole record is what
+      // makes that possible, so the check is here rather than in `writeVersions`, which
+      // `flushCache` uses to reset the record deliberately. It narrows the window to the
+      // provider write itself; closing it needs a compare-and-swap `CacheProvider` does
+      // not offer.
+      if (generationAtIssue !== undefined) {
+        const latest = await readVersions(cacheProvider, watermarksKey);
+        if ((latest?.generation ?? 0) !== (current?.generation ?? 0)) {
+          return { mayCache: false };
+        }
+      }
+
+      await writeVersions(cacheProvider, watermarksKey, next);
+    }
+
+    return { mayCache, cv: bodyCv };
   };
 
   const requestNetwork = async (
@@ -353,35 +522,93 @@ export const createApiClientBase = <
     fetchFn: (query: Record<string, unknown>) => Promise<ApiResponse<TData, ThrowOnError>>,
     cacheOptions?: RequestWithCacheOptions,
   ): Promise<ApiResponse<TData, ThrowOnError>> => {
-    const query =
-      cvMode === "auto" && currentCv !== undefined ? applyCvToQuery(rawQuery, currentCv) : rawQuery;
     const cacheEnabled = shouldUseCache(method, path, rawQuery);
 
     if (!cacheEnabled) {
-      const networkResult = await fetchFn(query);
+      // No cv is attached: it is a cache buster, and on `/cdn/spaces/me` it would only
+      // fragment the edge cache of the endpoint polling depends on. Draft requests ignore
+      // it altogether.
+      const networkResult = await fetchFn(rawQuery);
       throttleManager.adaptToResponse(networkResult.response);
-      await updateCv(networkResult);
+      // A draft response is never cached, but its `cv` is the same version a published
+      // response reports — the same raw one without a Minimum Cache TTL, the same floored
+      // one with it — so it is a publish signal like any other. An app that reads drafts
+      // and published content but never polls `/cdn/spaces/me` has no other one.
+      // No generation is compared: nothing here is cached, so there is no write to hold
+      // back, and reading the record a second time would cost a round trip per request.
+      await applyResponseVersions(path, networkResult, { learnCv: true });
+
       return networkResult;
     }
 
-    const baseKey = createCacheKey(method, path, rawQuery);
+    // A caller asking for one specific snapshot gets that snapshot: its entry lives under
+    // its own key, is immune to publishes, expires by TTL alone, and never teaches a `cv`.
+    const isCvPinnedByCaller = isCvPinned(rawQuery.cv);
+    // A `cv` that is not a version pins nothing. Dropping it here rather than leaving it
+    // on the request keeps it off the wire, where it would only cost a redirect, and out
+    // of the key, where it would file the same content under a second entry.
+    const cacheableQuery =
+      isCvPinnedByCaller || rawQuery.cv === undefined
+        ? rawQuery
+        : Object.fromEntries(Object.entries(rawQuery).filter(([name]) => name !== "cv"));
+
+    const baseKey = createCacheKey(method, path, cacheableQuery, tokenId);
     const key = cacheOptions?.cacheKeyPrefix
       ? `${cacheOptions.cacheKeyPrefix}:${baseKey}`
       : baseKey;
-    const cachedEntry = await cacheProvider.get<ApiResponse<TData, ThrowOnError>>(key);
-    const cachedResult = cachedEntry?.value;
+
+    const [cachedEntry, versions] = await Promise.all([
+      cacheProvider.get<ApiResponse<TData, ThrowOnError>>(key),
+      readVersions(cacheProvider, watermarksKey),
+    ]);
+    // A missing watermark record counts as "cv unknown", so a tagged entry is stale: the
+    // record shares the provider with the entries it governs and can be evicted while
+    // they survive, and reading a tagged entry against no known version at all would
+    // silently fall back to TTL-only invalidation. One refetch rewrites the record.
+    const isStaleByCv =
+      cacheFlush === "auto" &&
+      !isCvPinnedByCaller &&
+      cachedEntry?.cv !== undefined &&
+      cachedEntry.cv !== versions?.knownCv;
+    const cachedResult = isStaleByCv ? undefined : cachedEntry?.value;
+
+    // With a known cv the request is pinned to that snapshot; without one it goes out bare
+    // and the origin redirects it to the current version, at the cost of one extra hop.
+    const query =
+      cvMode === "auto" && versions?.knownCv !== undefined
+        ? applyCvToQuery(cacheableQuery, versions.knownCv)
+        : cacheableQuery;
 
     const loadNetwork = async () => {
       const result = await fetchFn(query);
       throttleManager.adaptToResponse(result.response);
-      return cacheSuccessResult(key, result);
+
+      const knownCvAtIssue = isCvPinnedByCaller ? undefined : versions?.knownCv;
+      const { mayCache, cv } = await applyResponseVersions(path, result, {
+        learnCv: !isCvPinnedByCaller,
+        honourOlderSnapshot: isCvPinnedByCaller,
+        knownCvAtIssue,
+        generationAtIssue: versions?.generation ?? 0,
+      });
+
+      if (result.error === undefined && mayCache) {
+        // Tagged with the `cv` it was served under, so it stops being readable the moment
+        // a newer one is known — including for entries stored by another client or
+        // process sharing the provider. Endpoints that report no `cv` of their own
+        // (`/cdn/tags`, `/cdn/links`) are tagged with the `cv` they were requested under,
+        // which is the version they were answered for; only a request issued while no
+        // `cv` was known stays untagged and falls back to TTL alone.
+        await cacheProvider.set(key, {
+          value: result,
+          ttlMs: cacheTtlMs,
+          cv: cv ?? knownCvAtIssue,
+        });
+      }
+
+      return result;
     };
 
-    return strategy({
-      key,
-      cachedResult,
-      loadNetwork,
-    });
+    return strategy({ key, cachedResult, loadNetwork });
   };
 
   const request = async (
@@ -418,17 +645,6 @@ export const createApiClientBase = <
     ...resourceDeps,
     inlineRelations,
   });
-
-  /**
-   * Flush the in-memory cache and reset the tracked cv.
-   *
-   * Call this explicitly when `cache.flush` is set to `'manual'`, e.g. after
-   * receiving a Storyblok webhook event that signals content has changed.
-   */
-  const flushCache = async (): Promise<void> => {
-    await cacheProvider.flush();
-    currentCv = undefined;
-  };
 
   return {
     datasourceEntries: createDatasourceEntriesResource(resourceDeps),

--- a/packages/capi-client/src/index.ts
+++ b/packages/capi-client/src/index.ts
@@ -54,7 +54,13 @@ export type { Story } from "./generated/types/story";
 // Resource types
 export type { StoryWithInlinedRelations } from "./resources/stories";
 // Cache types
-export type { CacheProvider, CacheStrategy, CacheStrategyHandler } from "./utils/cache";
+export type {
+  CacheEntry,
+  CacheEntryInput,
+  CacheProvider,
+  CacheStrategy,
+  CacheStrategyHandler,
+} from "./utils/cache";
 
 /** @deprecated Configure rate limiting via `createApiClient({ rateLimit })`. Will be removed in a future release. */
 export const createThrottle = createThrottleInternal;

--- a/packages/capi-client/src/resources/spaces.test.ts
+++ b/packages/capi-client/src/resources/spaces.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
 import { createApiClient } from "../index";
+import type { CacheEntry, CacheEntryInput, CacheProvider } from "../utils/cache";
 
 const server = setupServer();
 
@@ -127,5 +128,1154 @@ describe("spaces.get()", () => {
 
     expect(customFetch).toHaveBeenCalledOnce();
     expect(result.error).toBeUndefined();
+  });
+});
+
+describe("spaces.get() as a cache invalidation signal", () => {
+  // `/cdn/spaces/me` reports the space's raw `version` and no `cv`, and is cached for two
+  // seconds where content is cached for a week — the cheapest way to notice a publish.
+  const spaceHandler = (version: () => number) =>
+    http.get("https://api.storyblok.com/v2/cdn/spaces/me", () => {
+      return HttpResponse.json({
+        space: {
+          id: 1,
+          name: "Test Space",
+          domain: "https://test.storyblok.com",
+          version: version(),
+          language_codes: [],
+        },
+      });
+    });
+
+  /**
+   * A `Map`-backed provider that also reports how many times it was flushed, so a test
+   * can tell invalidation (entries stop being readable) from a flush (entries are gone).
+   */
+  const countingProvider = () => {
+    const store = new Map<string, CacheEntry>();
+    const stats = { flushes: 0 };
+    const provider: CacheProvider = {
+      // The store is heterogeneous; the caller names the expected type via the generic,
+      // exactly as `createMemoryCacheProvider` does.
+      get: async <TValue = unknown>(key: string) =>
+        store.get(key) as CacheEntry<TValue> | undefined,
+      set: async <TValue = unknown>(key: string, entry: CacheEntryInput<TValue>) => {
+        store.set(key, { storedAt: Date.now(), ...entry } as CacheEntry);
+      },
+      flush: async () => {
+        stats.flushes++;
+        store.clear();
+      },
+    };
+    /** The response entries, without the reserved record holding the version watermarks. */
+    const responseKeys = () => [...store.keys()].filter((key) => !key.startsWith("sb:versions:"));
+    return { store, stats, provider, responseKeys };
+  };
+
+  /** A promise plus its resolver, to hold a response in flight across another request. */
+  const deferred = () => {
+    let resolve!: () => void;
+    const promise = new Promise<void>((settle) => {
+      resolve = settle;
+    });
+    return { promise, resolve };
+  };
+
+  it("should invalidate cached entries when the space reports a new version", async () => {
+    let spaceVersion = 1000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } }); // cached
+    expect(storyRequests).toBe(1);
+
+    // First poll: the cv already matches this space version, so nothing was published in
+    // between and the cached entry stays valid.
+    await client.spaces.get();
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(1);
+
+    spaceVersion = 2000; // content was published
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2); // the entry is no longer readable, content re-fetched
+  });
+
+  it("should not flush the provider when it notices a publish", async () => {
+    // Invalidation is by version mismatch, so entries for keys the client never touches
+    // again — and entries other clients keep in a shared provider — are left alone to
+    // expire by TTL.
+    let spaceVersion = 1000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const { stats, provider } = countingProvider();
+    const client = createApiClient({ accessToken: "no-flush-token", cache: { provider } });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+
+    spaceVersion = 2000;
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2);
+    expect(stats.flushes).toBe(0);
+  });
+
+  it("should ignore a space.version reported by another endpoint", async () => {
+    // Gated on the path, not just the response shape: a `space.version` embedded in a
+    // content response must never invalidate anything.
+    let spaceVersion = 2000;
+    let storyRequests = 0;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({
+          stories: [],
+          cv: 1000,
+          space: { id: 1, name: "Test Space", version: spaceVersion },
+        });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(1);
+
+    // A second, differently keyed request reports a moved space version.
+    spaceVersion = 3000;
+    await client.get("v2/cdn/stories", { query: { version: "published", starts_with: "blog" } });
+    expect(storyRequests).toBe(2);
+
+    // Still cached: nothing reported a new cv, and a content response's `space.version`
+    // is not a change signal.
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2);
+  });
+
+  it("should ignore a space version that moved backwards", async () => {
+    // `/cdn/spaces/me` is cached for two seconds per POP, so a poll can be answered by a
+    // node that has not caught up. Only a version that moved FORWARD is a publish.
+    let spaceVersion = 2000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 2000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "regressing-version-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get(); // records 2000
+    expect(storyRequests).toBe(1);
+
+    spaceVersion = 1000; // a stale edge node answers
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(1); // no publish, still cached
+
+    spaceVersion = 2000; // back to the version already recorded
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(1); // the regression never moved the watermark
+  });
+
+  it("should not attach a cv to the poll request", async () => {
+    // The cv is a cache buster and `/cdn/spaces/me` is not cached: one there would only
+    // fragment the edge cache of the endpoint polling depends on.
+    const spaceUrls: string[] = [];
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/spaces/me", ({ request }) => {
+        spaceUrls.push(request.url);
+        return HttpResponse.json({
+          space: { id: 1, name: "Test Space", version: 1000, language_codes: [] },
+        });
+      }),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+
+    expect(spaceUrls).toHaveLength(1);
+    expect(new URL(spaceUrls[0]).searchParams.has("cv")).toBe(false);
+  });
+
+  it("should treat a trailing-slash poll as the same signal", async () => {
+    // The API serves `/cdn/spaces/me/` identically, and callers spell it both ways.
+    let spaceVersion = 1000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/spaces/me/", () =>
+        HttpResponse.json({ space: { id: 1, name: "Test Space", version: spaceVersion } }),
+      ),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "trailing-slash-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/spaces/me/");
+    expect(storyRequests).toBe(1);
+
+    spaceVersion = 2000; // content was published
+    await client.get("v2/cdn/spaces/me/");
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2);
+  });
+
+  it("should refetch on the first poll when the cv does not match the space version", async () => {
+    // A publish may have landed between the first content request and this poll, but so
+    // could a Minimum Cache TTL flooring the cv. One cv-less refetch settles it.
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => 2000),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(2);
+
+    // …but only once: further polls at the same version must not refetch again.
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(2);
+  });
+
+  it("should send the request that follows a publish without a cv", async () => {
+    // The edge serves `?cv=<old>` for up to a week, so the refetch must not carry the cv
+    // it was invalidated for; without one it takes the origin's redirect to the current.
+    let spaceVersion = 1000;
+    const storyUrls: string[] = [];
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        return HttpResponse.json({ stories: [], cv: spaceVersion });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(new URL(storyUrls[0]).searchParams.get("cv")).toBeNull(); // nothing known yet
+
+    spaceVersion = 2000; // content was published
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    const lastUrl = storyUrls[storyUrls.length - 1];
+    expect(new URL(lastUrl).searchParams.get("cv")).toBeNull();
+  });
+
+  it("should keep every other cached entry when the cv is unchanged", async () => {
+    // A Minimum Cache TTL floors the cv permanently, so every fresh client sees an
+    // ambiguous pair. The refetch proves nothing was published; other keys survive.
+    let tagRequests = 0;
+    server.use(
+      spaceHandler(() => 1786950860),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () =>
+        HttpResponse.json({ stories: [], cv: 1786950000 }),
+      ),
+      http.get("https://api.storyblok.com/v2/cdn/tags", () => {
+        tagRequests++;
+        return HttpResponse.json({ tags: [] });
+      }),
+    );
+    const client = createApiClient({ accessToken: "ttl-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/tags", { query: { version: "published" } });
+    expect(tagRequests).toBe(1);
+
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } }); // refetches
+
+    await client.get("v2/cdn/tags", { query: { version: "published" } });
+    expect(tagRequests).toBe(1); // still cached, nothing was published
+  });
+
+  it("should invalidate entries of endpoints that report no cv", async () => {
+    // `/cdn/tags` and `/cdn/links` report no cv of their own, so their entries are tagged
+    // with the cv they were requested under and invalidate with everything else.
+    let spaceVersion = 1000;
+    let tagRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () =>
+        HttpResponse.json({ stories: [], cv: 1000 }),
+      ),
+      http.get("https://api.storyblok.com/v2/cdn/tags", () => {
+        tagRequests++;
+        return HttpResponse.json({ tags: [] });
+      }),
+    );
+    const client = createApiClient({ accessToken: "cv-less-endpoint-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/tags", { query: { version: "published" } });
+    await client.spaces.get();
+    expect(tagRequests).toBe(1);
+
+    spaceVersion = 2000; // content was published
+    await client.spaces.get();
+    await client.get("v2/cdn/tags", { query: { version: "published" } });
+
+    expect(tagRequests).toBe(2);
+  });
+
+  it("should ignore a lower cv reported by a stale edge node", async () => {
+    // An older edge object answering must not move the known cv backwards, and its
+    // response must not be stored over the newer entry.
+    let storyCv = 1000;
+    const storyUrls: string[] = [];
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        return HttpResponse.json({ stories: [], cv: storyCv });
+      }),
+    );
+    const client = createApiClient({ accessToken: "stale-edge-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } }); // learns cv 1000
+
+    storyCv = 900; // an older edge node answers a differently keyed request
+    await client.get("v2/cdn/stories", { query: { version: "published", starts_with: "blog" } });
+
+    // The stale response was not stored, so reading its key hits the network again.
+    await client.get("v2/cdn/stories", { query: { version: "published", starts_with: "blog" } });
+    expect(storyUrls).toHaveLength(3);
+
+    // And the known cv never moved backwards.
+    expect(new URL(storyUrls[storyUrls.length - 1]).searchParams.get("cv")).toBe("1000");
+  });
+
+  it("should ignore a lower cv reported by a stale edge node after a publish", async () => {
+    // Noticing a publish drops the known cv, which is exactly when the next response
+    // teaches the version everything afterwards is measured against. An older edge object
+    // answering there would re-teach the pre-publish cv and make every entry the publish
+    // invalidated readable again, with no poll left to notice it a second time.
+    let spaceVersion = 1000;
+    let storyCv = 1000;
+    const storyUrls: string[] = [];
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        return HttpResponse.json({ stories: [], cv: storyCv });
+      }),
+    );
+    const client = createApiClient({ accessToken: "stale-edge-after-publish-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } }); // learns cv 1000
+    await client.spaces.get(); // cv already matches, nothing was published
+
+    spaceVersion = 2000; // content was published
+    await client.spaces.get(); // known cv dropped
+
+    storyCv = 900; // an edge node still holding an older snapshot answers the refetch
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    // The stale response was neither stored nor believed: the repeat read went back to
+    // the network, and the request still carries no cv rather than the older one.
+    expect(storyUrls).toHaveLength(3);
+    expect(new URL(storyUrls[storyUrls.length - 1]).searchParams.get("cv")).toBeNull();
+  });
+
+  it("should invalidate published entries when a draft response reports a new cv", async () => {
+    // A draft response is never cached, but its cv is the same version a published
+    // response reports, so it is a publish signal like any other — the only one an app
+    // that reads both but never polls `/cdn/spaces/me` has.
+    let cv = 1000;
+    let publishedRequests = 0;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        const version = new URL(request.url).searchParams.get("version");
+        if (version !== "draft") {
+          publishedRequests++;
+        }
+        return HttpResponse.json({ stories: [], cv });
+      }),
+    );
+    const client = createApiClient({ accessToken: "draft-signal-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(publishedRequests).toBe(1); // cached
+
+    cv = 2000; // content was published
+    await client.get("v2/cdn/stories", { query: { version: "draft" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(publishedRequests).toBe(2); // the entry is no longer readable
+  });
+
+  it("should not treat a zero cv as pinned by the caller", async () => {
+    // `0` is the sentinel `storyblok-js-client` records for "no version known". Read as a
+    // pinned snapshot it would keep `cv=0` on the wire, key the entry by it, and leave
+    // that entry immune to every publish signal.
+    let cv = 1000;
+    const storyUrls: string[] = [];
+    server.use(
+      spaceHandler(() => cv),
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        return HttpResponse.json({ stories: [], cv });
+      }),
+    );
+    const client = createApiClient({ accessToken: "zero-cv-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 0 } });
+    expect(new URL(storyUrls[0]).searchParams.get("cv")).toBeNull();
+
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 0 } });
+    expect(storyUrls).toHaveLength(1); // cached
+
+    cv = 2000; // content was published
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 0 } });
+
+    expect(storyUrls).toHaveLength(2); // and invalidated like any other entry
+  });
+
+  it("should not write away a flushCache it did not see", async () => {
+    // The watermark record is read, merged and written back without a lock. A flush that
+    // lands between the read and the write would otherwise be merged away, taking the
+    // generation with it — and the response that raced it would cache.
+    let watermarkReads = 0;
+    let storyRequests = 0;
+    let flushBeforeWrite: (() => Promise<void>) | undefined;
+    const { provider } = countingProvider();
+    const racingProvider: CacheProvider = {
+      ...provider,
+      get: async <TValue = unknown>(key: string) => {
+        const entry = await provider.get<TValue>(key);
+        // The second read of the record is the one this response judges itself by, so a
+        // flush released here lands after it and before the write it is about to make.
+        if (key.startsWith("sb:versions:") && ++watermarkReads === 2 && flushBeforeWrite) {
+          const flush = flushBeforeWrite;
+          flushBeforeWrite = undefined;
+          await flush();
+        }
+        return entry;
+      },
+    };
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: "watermark-race-token",
+      cache: { provider: racingProvider },
+    });
+    flushBeforeWrite = () => client.flushCache();
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2); // the raced response did not refill the flushed cache
+  });
+
+  it("should not write a record back over a flush that deleted it", async () => {
+    // `flush()` removes the watermark record, so a response reading it inside that window
+    // sees nothing at all. Read as generation zero rather than as "no record", it would
+    // look unflushed, write itself back, and take the bumped generation with it — leaving
+    // the flush marker gone for every response still in flight.
+    let watermarkReads = 0;
+    let storyRequests = 0;
+    let flushDuringRead: (() => Promise<void>) | undefined;
+    const { store, provider } = countingProvider();
+    const racingProvider: CacheProvider = {
+      ...provider,
+      get: async <TValue = unknown>(key: string) => {
+        // The flush runs before the entry is fetched, so this read lands after the record
+        // was deleted and before the new one is written.
+        if (key.startsWith("sb:versions:") && ++watermarkReads === 2 && flushDuringRead) {
+          const flush = flushDuringRead;
+          flushDuringRead = undefined;
+          await flush();
+        }
+        return provider.get<TValue>(key);
+      },
+    };
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: "watermark-deleted-token",
+      cache: { provider: racingProvider },
+    });
+    flushDuringRead = () => client.flushCache();
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2); // the raced response did not refill the flushed cache
+    const record = [...store.entries()].find(([key]) => key.startsWith("sb:versions:"));
+    expect((record?.[1].value as { generation?: number }).generation).toBe(1);
+  });
+
+  it("should not cache a response that was in flight across an explicit flushCache", async () => {
+    // A request issued before any cv was known has none to compare against, so nothing in
+    // the response says it was answered for state the caller has since thrown away. That
+    // is the window a webhook-driven flush lands in.
+    const gate = deferred();
+    let storyRequests = 0;
+    const storyUrls: string[] = [];
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", async ({ request }) => {
+        storyRequests++;
+        storyUrls.push(request.url);
+        if (storyRequests === 1) {
+          await gate.promise;
+        }
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "flush-in-flight-token" });
+
+    const inFlight = client.get("v2/cdn/stories", { query: { version: "published" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await client.flushCache();
+    gate.resolve();
+    await inFlight;
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2); // the discarded response did not refill the cache
+    expect(new URL(storyUrls[storyUrls.length - 1]).searchParams.get("cv")).toBeNull();
+  });
+
+  it("should not serve a response that was in flight when a publish was noticed", async () => {
+    // A response that left before the publish was noticed carries the pre-publish content
+    // and the cv that was just dropped. Storing it would make the published content
+    // invisible for a full `ttlMs`.
+    const gate = deferred();
+    let spaceVersion = 1000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", async () => {
+        storyRequests++;
+        if (storyRequests === 2) {
+          await gate.promise;
+        }
+        return HttpResponse.json({ stories: [], cv: 1000 }); // pre-publish body and cv
+      }),
+    );
+    const client = createApiClient({ accessToken: "inflight-flush-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get(); // cv already matches, nothing ambiguous
+
+    const inFlight = client.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    spaceVersion = 2000; // content was published
+    await client.spaces.get(); // noticed while that request is still out
+    gate.resolve();
+    await inFlight;
+
+    await client.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+    expect(storyRequests).toBe(3); // refetched rather than served from a refilled cache
+  });
+
+  it("should not let a cv-less response in flight refill the cache a publish invalidated", async () => {
+    // `/cdn/links` and `/cdn/tags` report no cv, so nothing in their own response says
+    // which version they belong to — the cv the request was issued under does.
+    const gate = deferred();
+    let linksRequests = 0;
+    let storyCv = 1000;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/links", async () => {
+        linksRequests++;
+        if (linksRequests === 1) {
+          await gate.promise;
+          return HttpResponse.json({ links: { a: { id: 1, slug: "pre-publish" } } });
+        }
+        return HttpResponse.json({ links: { a: { id: 1, slug: "post-publish" } } });
+      }),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () =>
+        HttpResponse.json({ stories: [], cv: storyCv }),
+      ),
+    );
+    const client = createApiClient({ accessToken: "inflight-cv-flush-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } }); // learns cv 1000
+
+    // The links request goes out for cv 1000 and is held there.
+    const linksRequest = client.get("v2/cdn/links", { query: { version: "published" } });
+
+    // A publish lands: the next content response reports a moved cv.
+    storyCv = 2000;
+    await client.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+
+    gate.resolve();
+    await linksRequest;
+
+    const links = await client.get("v2/cdn/links", { query: { version: "published" } });
+    expect((links.data as { links: Record<string, { slug: string }> }).links.a.slug).toBe(
+      "post-publish",
+    );
+  });
+
+  it("should not invalidate while the space version is unchanged", async () => {
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => 1000),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get(); // cv already matches, nothing to invalidate
+    for (let i = 0; i < 3; i++) {
+      await client.spaces.get();
+      await client.get("v2/cdn/stories", { query: { version: "published" } });
+    }
+
+    expect(storyRequests).toBe(1);
+  });
+
+  it("should not invalidate when a Minimum Cache TTL floors the cv", async () => {
+    // A Minimum Cache TTL floors the cv into buckets while `space.version` reports the
+    // raw version: they differ permanently and must never be compared to each other.
+    const flooredCv = 1_786_950_000;
+    const rawSpaceVersion = 1_786_950_860;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => rawSpaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: flooredCv });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    for (let i = 0; i < 3; i++) {
+      await client.spaces.get();
+      await client.get("v2/cdn/stories", { query: { version: "published" } });
+    }
+
+    expect(storyRequests).toBe(1);
+  });
+
+  it("should still invalidate on a space version change when cv is manual", async () => {
+    // With `cv: 'manual'` the cv is tracked but never attached to requests, so behind an
+    // edge cache a content response can keep carrying a stale cv indefinitely.
+    // `space.version` is then the only signal left to notice that content changed.
+    let spaceVersion = 1000;
+    const storyUrls: string[] = [];
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: "test-token",
+      cache: { cv: "manual" },
+    });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get(); // cv already matches, nothing to invalidate
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyUrls).toHaveLength(1); // still cached
+
+    spaceVersion = 2000; // content was published
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyUrls).toHaveLength(2); // invalidated, content re-fetched
+
+    expect(storyUrls.every((url) => !url.includes("cv="))).toBe(true);
+  });
+
+  it("should invalidate an ambiguous first sighting when cv is manual", async () => {
+    // The ambiguity is the same as under `cv: 'auto'`, and so is the answer: drop the
+    // known cv and let the next read of each key prove itself against the origin.
+    let tagRequests = 0;
+    server.use(
+      spaceHandler(() => 2000),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () =>
+        HttpResponse.json({ stories: [], cv: 1000 }),
+      ),
+      http.get("https://api.storyblok.com/v2/cdn/tags", () => {
+        tagRequests++;
+        return HttpResponse.json({ tags: [] });
+      }),
+    );
+    const { stats, provider } = countingProvider();
+    const client = createApiClient({
+      accessToken: "manual-cv-sighting-token",
+      cache: { cv: "manual", provider },
+    });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/tags", { query: { version: "published" } });
+    expect(tagRequests).toBe(1);
+
+    await client.spaces.get(); // ambiguous first sighting
+    await client.get("v2/cdn/tags", { query: { version: "published" } });
+
+    expect(tagRequests).toBe(2);
+    expect(stats.flushes).toBe(0);
+  });
+
+  it("should not invalidate when polled before any content request", async () => {
+    // Polling before the first content request is the recommended startup shape: there
+    // is no cv and no cache yet, so there is nothing to invalidate.
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => 1000),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(1);
+  });
+
+  it("should ignore a space version that is not a number", async () => {
+    let storyRequests = 0;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/spaces/me", () =>
+        HttpResponse.json({ space: { id: 1, name: "Test Space", version: "2000" } }),
+      ),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(1);
+  });
+
+  it("should not auto-invalidate on a space version change when flush is manual", async () => {
+    let spaceVersion = 1000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: "test-token",
+      cache: { flush: "manual" },
+    });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+    spaceVersion = 2000;
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(1);
+  });
+
+  it("should reset the tracked versions on an explicit flushCache", async () => {
+    // The entries the watermarks described are gone, so the next request must not be
+    // pinned to the cv they were served under.
+    const storyUrls: string[] = [];
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: "flush-reset-token",
+      cache: { flush: "manual" },
+    });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+    expect(new URL(storyUrls[1]).searchParams.get("cv")).toBe("1000");
+
+    await client.flushCache();
+    await client.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+
+    const lastUrl = storyUrls[storyUrls.length - 1];
+    expect(new URL(lastUrl).searchParams.get("cv")).toBeNull();
+  });
+
+  it("should serve a caller-pinned cv from its own entry and never track it", async () => {
+    // A caller asking for one snapshot gets that snapshot: it is keyed separately, it
+    // survives a publish, and what it reports must not pin anyone else's requests to it.
+    let spaceVersion = 2000;
+    const storyUrls: string[] = [];
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        const cv = new URL(request.url).searchParams.get("cv");
+        return HttpResponse.json({ stories: [], cv: cv ? Number(cv) : 2000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "pinned-cv-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 900 } });
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 900 } });
+    expect(storyUrls).toHaveLength(1); // cached under its own key
+
+    // The pinned request taught nothing, so this one goes out without a cv.
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(new URL(storyUrls[1]).searchParams.get("cv")).toBeNull();
+
+    spaceVersion = 3000; // content was published
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 900 } });
+
+    expect(storyUrls).toHaveLength(2); // the pinned snapshot is immune to publishes
+  });
+
+  it("should cache a caller-pinned cv that the space has already moved past", async () => {
+    // The edge answers a pinned cv it still holds with that old snapshot and its old cv —
+    // indistinguishable on the wire from a stale edge read, and told apart only by the
+    // caller having asked for it. Treating it as stale means the pinned entry is never
+    // stored, so every read past the TTL goes back to the network for good.
+    const storyUrls: string[] = [];
+    server.use(
+      spaceHandler(() => 2000),
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        const cv = new URL(request.url).searchParams.get("cv");
+        // The edge still holds the pinned snapshot, so it serves it rather than redirecting.
+        return HttpResponse.json({ stories: [], cv: cv ? Number(cv) : 2000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "pinned-below-known-token" });
+
+    // Learn a cv first, so the pinned one below it looks like a stale read.
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyUrls).toHaveLength(1);
+
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 900 } });
+    await client.get("v2/cdn/stories", { query: { version: "published", cv: 900 } });
+
+    expect(storyUrls).toHaveLength(2); // the second pinned read came from the cache
+    expect(new URL(storyUrls[1]).searchParams.get("cv")).toBe("900");
+  });
+
+  it("should keep a response that reports the cv which superseded it", async () => {
+    // Concurrent reads are all issued under the cv known at the time. The first one back
+    // advances the watermark, which leaves the others answered for a cv that is no longer
+    // the known one — but their bodies report the new one, so they carry the current
+    // snapshot and only lost a race. Discarding them costs a refetch of every key that
+    // happened to be in flight during a publish.
+    let releaseSlow: () => void = () => {};
+    const slow = new Promise<void>((resolve) => (releaseSlow = resolve));
+    let currentCv = 1000;
+    let slowRequests = 0;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", () =>
+        HttpResponse.json({ stories: [], cv: currentCv }),
+      ),
+      http.get("https://api.storyblok.com/v2/cdn/links", async () => {
+        slowRequests++;
+        await slow;
+        return HttpResponse.json({ links: {}, cv: currentCv });
+      }),
+    );
+    const client = createApiClient({ accessToken: "superseded-but-current-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } }); // learns 1000
+
+    const inFlight = client.get("v2/cdn/links", { query: { version: "published" } });
+    currentCv = 2000; // published while that request is in flight
+    await client.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+    releaseSlow();
+    await inFlight;
+
+    // Its body reported 2000, the cv now known, so the entry is valid and readable.
+    await client.get("v2/cdn/links", { query: { version: "published" } });
+    expect(slowRequests).toBe(1);
+  });
+
+  it("should never put a zero cv on the wire", async () => {
+    // `cv=0` is not a version the API knows: it is redirected like any unheld cv, so
+    // adopting a `0` from a response body only ever costs an extra hop.
+    const storyUrls: string[] = [];
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        storyUrls.push(request.url);
+        return HttpResponse.json({ stories: [], cv: 0 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "zero-cv-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+
+    expect(storyUrls).toHaveLength(2);
+    for (const url of storyUrls) {
+      expect(new URL(url).searchParams.get("cv")).toBeNull();
+    }
+  });
+
+  it("should keep the invalidation in place when the refetch after a publish fails", async () => {
+    // Nothing consumes the signal but a successful response: a failed refetch leaves the
+    // entry unreadable, so the next request tries again instead of serving stale content.
+    let spaceVersion = 1000;
+    let storiesFail = false;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return storiesFail
+          ? HttpResponse.json({ error: "Server error" }, { status: 500 })
+          : HttpResponse.json({ stories: [], cv: spaceVersion });
+      }),
+    );
+    const client = createApiClient({ accessToken: "failed-refetch-token", retry: { limit: 0 } });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+    expect(storyRequests).toBe(1);
+
+    spaceVersion = 2000; // content was published
+    await client.spaces.get();
+
+    storiesFail = true;
+    const failed = await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(failed.error).toBeDefined();
+
+    storiesFail = false;
+    const recovered = await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(recovered.data).toEqual({ stories: [], cv: 2000 });
+    expect(storyRequests).toBe(3);
+  });
+
+  it("should not make a poll wait for a content request", async () => {
+    // `/cdn/spaces/me` is not cacheable and never coordinates with content requests: a
+    // poll stuck behind one would stall the interval driving it.
+    const order: string[] = [];
+    server.use(
+      spaceHandler(() => 2000),
+      http.get("https://api.storyblok.com/v2/cdn/stories", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "poll-not-blocked-token" });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.spaces.get();
+
+    const content = client
+      .get("v2/cdn/stories", { query: { version: "published", starts_with: "blog" } })
+      .then(() => order.push("content"));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await client.spaces.get();
+    order.push("poll");
+    await content;
+
+    expect(order).toEqual(["poll", "content"]);
+  });
+
+  it("should cost one refetch per shared provider, not per client instance", async () => {
+    // With a shared provider and a TTL-floored cv, every new client would see the same
+    // ambiguous first sighting — but the watermarks live in the provider, so the second
+    // client inherits the answer the first one paid for.
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => 1786950860),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1786950000 });
+      }),
+    );
+    const { responseKeys, provider: sharedProvider } = countingProvider();
+
+    // One client per request, as in SSR or serverless.
+    for (let i = 0; i < 3; i++) {
+      const client = createApiClient({
+        accessToken: "ttl-token",
+        cache: { provider: sharedProvider, ttlMs: 3_600_000 },
+      });
+      await client.get("v2/cdn/stories", { query: { version: "published" } });
+      await client.spaces.get();
+    }
+
+    // One request for the first client, one to settle its ambiguous first sighting; the
+    // clients after it read the entry that refetch stored.
+    expect(storyRequests).toBe(2);
+    expect(responseKeys()).toHaveLength(1);
+  });
+
+  it("should let a per-request client inherit a publish another one noticed", async () => {
+    // The shape a serverless deployment has: a fresh client per request, one shared
+    // provider, and a poll that has to invalidate content the *next* client reads.
+    let spaceVersion = 1000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const { provider } = countingProvider();
+    const newClient = () =>
+      createApiClient({
+        accessToken: "serverless-token",
+        cache: { provider, ttlMs: 3_600_000 },
+      });
+
+    await newClient().get("v2/cdn/stories", { query: { version: "published" } });
+    await newClient().spaces.get(); // records the baseline
+    await newClient().get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(1); // served from the shared provider
+
+    spaceVersion = 2000; // content was published
+    await newClient().spaces.get(); // a different client notices it
+    await newClient().get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2);
+  });
+
+  it("should refetch when the watermark record is gone but the entry is not", async () => {
+    // The record shares the provider with the entries it governs, so an eviction or a
+    // provider that drops it can leave a tagged entry with nothing to check against.
+    // Reading it then would silently fall back to TTL-only invalidation.
+    let storyRequests = 0;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv: 1000 });
+      }),
+    );
+    const { store, provider } = countingProvider();
+    const client = createApiClient({ accessToken: "lost-record-token", cache: { provider } });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(1);
+
+    for (const key of store.keys()) {
+      if (key.startsWith("sb:versions:")) {
+        store.delete(key);
+      }
+    }
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(2);
+
+    // …and the refetch rewrote the record, so the cache holds again.
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(2);
+  });
+
+  it("should not serve one space's content to a client for another", async () => {
+    // The access token selects the space and travels outside the query, so it has to be
+    // part of the cache key: two clients sharing one provider must not read each other's
+    // entries, and neither may consume the other's version watermarks.
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        const token = new URL(request.url).searchParams.get("token");
+        return HttpResponse.json({ stories: [], cv: 1000, space: token });
+      }),
+    );
+    const { provider } = countingProvider();
+    const first = createApiClient({ accessToken: "space-one", cache: { provider } });
+    const second = createApiClient({ accessToken: "space-two", cache: { provider } });
+
+    const firstResult = await first.get("v2/cdn/stories", { query: { version: "published" } });
+    const secondResult = await second.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect((firstResult.data as { space: string }).space).toBe("space-one");
+    expect((secondResult.data as { space: string }).space).toBe("space-two");
+  });
+
+  it("should not serve another client's in-flight pre-publish response", async () => {
+    // Two clients, one provider: the entry carries the cv it was served under, so the
+    // client that stored it does not have to be the one that notices the publish.
+    const gate = deferred();
+    let spaceVersion = 1000;
+    let storyRequests = 0;
+    server.use(
+      spaceHandler(() => spaceVersion),
+      http.get("https://api.storyblok.com/v2/cdn/stories", async () => {
+        storyRequests++;
+        if (storyRequests === 2) {
+          await gate.promise;
+        }
+        return HttpResponse.json({ stories: [], cv: 1000 }); // pre-publish body and cv
+      }),
+    );
+    const { provider } = countingProvider();
+    const clientA = createApiClient({ accessToken: "cross-client-token", cache: { provider } });
+    const clientB = createApiClient({ accessToken: "cross-client-token", cache: { provider } });
+
+    await clientA.get("v2/cdn/stories", { query: { version: "published" } });
+    await clientA.spaces.get();
+
+    const inFlight = clientB.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    spaceVersion = 2000; // content was published
+    await clientA.spaces.get(); // only client A sees the signal
+    gate.resolve();
+    await inFlight;
+
+    await clientA.get("v2/cdn/stories", { query: { version: "published", page: "2" } });
+    expect(storyRequests).toBe(3);
   });
 });

--- a/packages/capi-client/src/resources/spaces.ts
+++ b/packages/capi-client/src/resources/spaces.ts
@@ -1,6 +1,7 @@
 import { getSpace as getSpaceApi } from "../generated/capi/sdk.gen";
 import type { GetSpaceData, GetSpaceResponses } from "../generated/capi/types.gen";
 import type { ApiResponse, FetchOptions, ResourceDeps } from "../client";
+import { SPACES_ME_PATH } from "../utils/request";
 
 export function createSpacesResource<DefaultThrowOnError extends boolean = false>(
   deps: ResourceDeps<DefaultThrowOnError>,
@@ -17,7 +18,7 @@ export function createSpacesResource<DefaultThrowOnError extends boolean = false
       } = {},
     ): Promise<ApiResponse<GetSpaceResponses[200], ThrowOnError>> => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
-      const requestPath = "/v2/cdn/spaces/me";
+      const requestPath = SPACES_ME_PATH;
       return requestWithCache<GetSpaceResponses[200], ThrowOnError>(
         "GET",
         requestPath,

--- a/packages/capi-client/src/resources/stories.test.ts
+++ b/packages/capi-client/src/resources/stories.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
 import { createApiClient } from "../index";
+import type { CacheEntry, CacheProvider } from "../index";
 
 const server = setupServer();
 
@@ -1018,6 +1019,63 @@ describe("cache and cv", () => {
     expect(secondResult.data?.marker).toBe("fresh");
     // @ts-expect-error generic get request can have any shape or form
     expect(thirdResult.data?.marker).toBe("fresh");
+  });
+});
+
+describe("cache provider compatibility", () => {
+  it("should invalidate an entry stored by a provider that round-trips the cv", async () => {
+    // Entries are opaque to a provider, but the `cv` on them is load-bearing: it is what
+    // a publish invalidates against. A provider that rebuilds entries field by field and
+    // loses it degrades invalidation to TTL alone.
+    let cv = 1000;
+    let storyRequests = 0;
+    const store = new Map<string, CacheEntry>();
+    const rebuildingProvider: CacheProvider = {
+      async get<TValue>(key: string) {
+        const entry = store.get(key);
+        if (!entry) {
+          return undefined;
+        }
+
+        // A hand-written adapter over a store with its own schema, carrying every field
+        // the contract names.
+        return {
+          value: entry.value as TValue,
+          storedAt: entry.storedAt,
+          ttlMs: entry.ttlMs,
+          cv: entry.cv,
+        };
+      },
+      async set(key, entry) {
+        store.set(key, { ...entry, storedAt: entry.storedAt ?? Date.now() });
+      },
+      async flush() {
+        store.clear();
+      },
+    };
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/spaces/me", () =>
+        HttpResponse.json({ space: { id: 1, name: "Test", version: cv } }),
+      ),
+      http.get("https://api.storyblok.com/v2/cdn/stories", () => {
+        storyRequests++;
+        return HttpResponse.json({ stories: [], cv });
+      }),
+    );
+    const client = createApiClient({
+      accessToken: "round-trip-provider-token",
+      cache: { provider: rebuildingProvider },
+    });
+
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+    expect(storyRequests).toBe(1);
+
+    cv = 2000; // content was published
+    await client.spaces.get();
+    await client.get("v2/cdn/stories", { query: { version: "published" } });
+
+    expect(storyRequests).toBe(2);
   });
 });
 

--- a/packages/capi-client/src/utils/cache.test.ts
+++ b/packages/capi-client/src/utils/cache.test.ts
@@ -364,3 +364,19 @@ describe("cache strategies", () => {
     await refreshPromise;
   });
 });
+
+describe("memory cache provider eviction", () => {
+  it("should keep a recently read entry and evict the least recently used one", async () => {
+    const provider = createMemoryCacheProvider({ maxEntries: 2 });
+
+    await provider.set("a", { value: "a", ttlMs: 60_000 });
+    await provider.set("b", { value: "b", ttlMs: 60_000 });
+    // Reading "a" makes "b" the least recently used entry.
+    await provider.get("a");
+    await provider.set("c", { value: "c", ttlMs: 60_000 });
+
+    expect(await provider.get("a")).toMatchObject({ value: "a" });
+    expect(await provider.get("c")).toMatchObject({ value: "c" });
+    expect(await provider.get("b")).toBeUndefined();
+  });
+});

--- a/packages/capi-client/src/utils/cache.ts
+++ b/packages/capi-client/src/utils/cache.ts
@@ -12,14 +12,37 @@ export interface CacheEntry<TValue = unknown> {
   value: TValue;
   storedAt: number;
   ttlMs: number;
+  /**
+   * The `cv` the cached response reported, i.e. the published snapshot it belongs to.
+   * Absent for endpoints that report none (`/cdn/tags`, `/cdn/links`), which fall back to
+   * TTL-only invalidation. Entries are invalidated by comparing this against the tracked
+   * `cv`, so a response that was already in flight when content was published cannot be
+   * served afterwards — whichever client or process stored it.
+   */
+  cv?: number;
 }
 
 export interface CacheEntryInput<TValue = unknown> {
   value: TValue;
   storedAt?: number;
   ttlMs: number;
+  /** See {@link CacheEntry.cv}. */
+  cv?: number;
 }
 
+/**
+ * Reads and writes cache entries.
+ *
+ * Entries are opaque to the provider: it must round-trip whatever it is given, including
+ * the optional `cv` tag. One reserved key (`sb:versions:v1:<tokenId>`, where the id is the
+ * non-cryptographic hash of the access token produced by `createTokenId`) holds the
+ * client's version watermarks rather than a response, so it participates in `flush()`
+ * like any other entry.
+ *
+ * `cv` is load-bearing: a provider that rebuilds entries field by field and loses it
+ * degrades invalidation to TTL alone, which reads back the same as an entry from an
+ * endpoint that reports no `cv`. The client warns once when it sees that happen.
+ */
 export interface CacheProvider {
   get: <TValue = unknown>(key: string) => Promise<CacheEntry<TValue> | undefined>;
   set: <TValue = unknown>(key: string, entry: CacheEntryInput<TValue>) => Promise<void>;
@@ -48,6 +71,12 @@ export const createMemoryCacheProvider = (
         cache.delete(key);
         return undefined;
       }
+
+      // A read counts as use, so eviction is LRU rather than least-recently-written.
+      // The client reads its version watermarks on every cacheable request, and evicting
+      // that record while the entries it governs survive would cost a refetch of each.
+      cache.delete(key);
+      cache.set(key, entry);
 
       return entry;
     },

--- a/packages/capi-client/src/utils/cv.test.ts
+++ b/packages/capi-client/src/utils/cv.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyCvToQuery, extractCv } from "./cv";
+import { applyCvToQuery, extractCv, extractSpaceVersion } from "./cv";
 
 describe("extractCv", () => {
   it("should extract numeric cv from valid response", () => {
@@ -39,5 +39,26 @@ describe("applyCvToQuery", () => {
       version: "published",
       cv: 999,
     });
+  });
+});
+
+describe("extractSpaceVersion", () => {
+  it("should extract the version from a spaces/me response", () => {
+    expect(extractSpaceVersion({ space: { id: 1, version: 1_786_950_860 } })).toBe(1_786_950_860);
+  });
+
+  it("should return undefined when the space has no version", () => {
+    expect(extractSpaceVersion({ space: { id: 1 } })).toBeUndefined();
+  });
+
+  it("should return undefined for a non-numeric version", () => {
+    expect(extractSpaceVersion({ space: { version: "1786950860" } })).toBeUndefined();
+  });
+
+  it("should return undefined for responses without a space", () => {
+    expect(extractSpaceVersion({ cv: 12_345 })).toBeUndefined();
+    expect(extractSpaceVersion({ space: null })).toBeUndefined();
+    expect(extractSpaceVersion(null)).toBeUndefined();
+    expect(extractSpaceVersion(42)).toBeUndefined();
   });
 });

--- a/packages/capi-client/src/utils/cv.ts
+++ b/packages/capi-client/src/utils/cv.ts
@@ -1,11 +1,48 @@
 import { isDraftRequest } from "./request";
 
+/**
+ * Whether a query carries a `cv` the caller chose, which is honoured literally: keyed by
+ * itself, immune to publishes, never teaching a watermark.
+ *
+ * Only a positive `cv` is a version, here as everywhere: `0` is the sentinel
+ * `storyblok-js-client` records for "no version known", so a caller carrying that idiom
+ * over would otherwise pin every request to a `cv` the API redirects away from, under a
+ * key nothing invalidates.
+ */
+export const isCvPinned = (value: unknown): boolean => Number(value) > 0;
+
+/**
+ * Reads the `cv` a response body reports — the snapshot it was actually served from.
+ *
+ * Only a positive `cv` is a version: the API redirects `cv=0` (like any `cv` the edge
+ * does not hold) to the current snapshot, so adopting `0` as a watermark would put a
+ * value on the wire that only ever costs an extra hop.
+ */
 export const extractCv = (maybeData: unknown) => {
-  return maybeData && typeof maybeData === "object" && "cv" in maybeData
-    ? typeof maybeData.cv === "number"
-      ? maybeData.cv
-      : undefined
-    : undefined;
+  if (!maybeData || typeof maybeData !== "object" || !("cv" in maybeData)) {
+    return undefined;
+  }
+
+  return typeof maybeData.cv === "number" && maybeData.cv > 0 ? maybeData.cv : undefined;
+};
+
+/**
+ * Reads `space.version` from a `/cdn/spaces/me` response.
+ *
+ * Not a `cv`, and must never be sent as one: a Minimum Cache TTL floors the `cv` into
+ * TTL-sized buckets while `space.version` reports the raw version. Change signal only.
+ */
+export const extractSpaceVersion = (maybeData: unknown) => {
+  if (!maybeData || typeof maybeData !== "object" || !("space" in maybeData)) {
+    return undefined;
+  }
+
+  const space = maybeData.space;
+  if (!space || typeof space !== "object" || !("version" in space)) {
+    return undefined;
+  }
+
+  return typeof space.version === "number" ? space.version : undefined;
 };
 
 export const applyCvToQuery = (query: Record<string, unknown>, cv: number) => {

--- a/packages/capi-client/src/utils/request.test.ts
+++ b/packages/capi-client/src/utils/request.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createCacheKey, isDraftRequest, shouldUseCache } from "./request";
+import {
+  createCacheKey,
+  isDraftRequest,
+  isSpacesMeRequest,
+  normalizePath,
+  shouldUseCache,
+} from "./request";
 
 describe("isDraftRequest", () => {
   it("should return true when version is draft", () => {
@@ -17,52 +23,72 @@ describe("isDraftRequest", () => {
 
 describe("createCacheKey", () => {
   it("should produce consistent key for same inputs", () => {
-    const first = createCacheKey("GET", "/v2/cdn/stories", { a: 1, b: 2 });
-    const second = createCacheKey("GET", "/v2/cdn/stories", { b: 2, a: 1 });
+    const first = createCacheKey("GET", "/v2/cdn/stories", { a: 1, b: 2 }, "tid");
+    const second = createCacheKey("GET", "/v2/cdn/stories", { b: 2, a: 1 }, "tid");
 
     expect(first).toBe(second);
   });
 
   it("should produce different keys for different methods", () => {
-    const getKey = createCacheKey("GET", "/v2/cdn/stories", { a: 1 });
-    const postKey = createCacheKey("POST", "/v2/cdn/stories", { a: 1 });
+    const getKey = createCacheKey("GET", "/v2/cdn/stories", { a: 1 }, "tid");
+    const postKey = createCacheKey("POST", "/v2/cdn/stories", { a: 1 }, "tid");
 
     expect(getKey).not.toBe(postKey);
   });
 
   it("should produce different keys for different paths", () => {
-    const first = createCacheKey("GET", "/v2/cdn/stories", { a: 1 });
-    const second = createCacheKey("GET", "/v2/cdn/links", { a: 1 });
+    const first = createCacheKey("GET", "/v2/cdn/stories", { a: 1 }, "tid");
+    const second = createCacheKey("GET", "/v2/cdn/links", { a: 1 }, "tid");
 
     expect(first).not.toBe(second);
   });
 
   it("should produce the same key regardless of leading slash", () => {
-    const withSlash = createCacheKey("GET", "/v2/cdn/stories", { version: "published" });
-    const withoutSlash = createCacheKey("GET", "v2/cdn/stories", { version: "published" });
+    const withSlash = createCacheKey("GET", "/v2/cdn/stories", { version: "published" }, "tid");
+    const withoutSlash = createCacheKey("GET", "v2/cdn/stories", { version: "published" }, "tid");
 
     expect(withSlash).toBe(withoutSlash);
   });
 
   it("should handle nested objects with sorted keys", () => {
-    const first = createCacheKey("GET", "/v2/cdn/stories", {
-      filter_query: {
-        author: {
-          in: "a,b",
+    const first = createCacheKey(
+      "GET",
+      "/v2/cdn/stories",
+      {
+        filter_query: {
+          author: {
+            in: "a,b",
+          },
+        },
+        sort_by: "name:asc",
+      },
+      "tid",
+    );
+    const second = createCacheKey(
+      "GET",
+      "/v2/cdn/stories",
+      {
+        sort_by: "name:asc",
+        filter_query: {
+          author: {
+            in: "a,b",
+          },
         },
       },
-      sort_by: "name:asc",
-    });
-    const second = createCacheKey("GET", "/v2/cdn/stories", {
-      sort_by: "name:asc",
-      filter_query: {
-        author: {
-          in: "a,b",
-        },
-      },
-    });
+      "tid",
+    );
 
     expect(first).toBe(second);
+  });
+});
+
+describe("createCacheKey token scoping", () => {
+  it("should produce different keys for different tokens", () => {
+    // The token selects the space and travels outside `query`, so two clients sharing one
+    // provider would otherwise read each other's content.
+    expect(createCacheKey("GET", "/v2/cdn/stories", { version: "published" }, "tid-a")).not.toBe(
+      createCacheKey("GET", "/v2/cdn/stories", { version: "published" }, "tid-b"),
+    );
   });
 });
 
@@ -85,5 +111,51 @@ describe("shouldUseCache", () => {
 
   it("should return false for non-cacheable paths without leading slash", () => {
     expect(shouldUseCache("GET", "v2/cdn/spaces/me", { version: "published" })).toBe(false);
+  });
+});
+
+describe("normalizePath", () => {
+  it("should add a missing leading slash", () => {
+    expect(normalizePath("v2/cdn/stories")).toBe("/v2/cdn/stories");
+  });
+
+  it("should collapse repeated leading slashes", () => {
+    expect(normalizePath("///v2/cdn/stories")).toBe("/v2/cdn/stories");
+  });
+
+  it("should drop trailing slashes", () => {
+    expect(normalizePath("/v2/cdn/spaces/me/")).toBe("/v2/cdn/spaces/me");
+    expect(normalizePath("v2/cdn/spaces/me//")).toBe("/v2/cdn/spaces/me");
+  });
+
+  it("should keep the root path", () => {
+    expect(normalizePath("/")).toBe("/");
+    expect(normalizePath("")).toBe("/");
+  });
+});
+
+describe("isSpacesMeRequest", () => {
+  it("should match every spelling the API serves", () => {
+    expect(isSpacesMeRequest("/v2/cdn/spaces/me")).toBe(true);
+    expect(isSpacesMeRequest("v2/cdn/spaces/me")).toBe(true);
+    expect(isSpacesMeRequest("/v2/cdn/spaces/me/")).toBe(true);
+  });
+
+  it("should not match another endpoint", () => {
+    expect(isSpacesMeRequest("/v2/cdn/stories")).toBe(false);
+  });
+});
+
+describe("shouldUseCache with a trailing slash", () => {
+  it("should keep the spaces endpoint out of the cache", () => {
+    expect(shouldUseCache("GET", "/v2/cdn/spaces/me/", {})).toBe(false);
+  });
+});
+
+describe("createCacheKey with a trailing slash", () => {
+  it("should produce the same key regardless of a trailing slash", () => {
+    expect(createCacheKey("GET", "/v2/cdn/stories/", { version: "published" }, "tid")).toBe(
+      createCacheKey("GET", "/v2/cdn/stories", { version: "published" }, "tid"),
+    );
   });
 });

--- a/packages/capi-client/src/utils/request.ts
+++ b/packages/capi-client/src/utils/request.ts
@@ -1,11 +1,28 @@
 export const CACHEABLE_METHODS = new Set(["GET"]);
-export const NON_CACHEABLE_PATHS = new Set(["/v2/cdn/spaces/me"]);
+
+/**
+ * The only endpoint that reports the space's raw `version`, and the one endpoint whose
+ * responses must never enter the content cache.
+ */
+export const SPACES_ME_PATH = "/v2/cdn/spaces/me";
+
+export const NON_CACHEABLE_PATHS = new Set([SPACES_ME_PATH]);
 
 /** Returns `true` when the query targets draft content (`version: 'draft'`). Draft requests bypass the cache. */
 export const isDraftRequest = (query: Record<string, unknown>) => query.version === "draft";
 
-/** Ensures a path always starts with a leading slash for consistent comparisons and cache keys. */
-const normalizePath = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+/**
+ * Ensures a path starts with exactly one leading slash and carries no trailing one, so
+ * every spelling a caller may pass produces the same path for comparisons and cache keys.
+ * The API serves `/cdn/spaces/me/` exactly like `/cdn/spaces/me`.
+ */
+export const normalizePath = (path: string) => {
+  const withLeadingSlash = path.replace(/^\/*/, "/");
+  return withLeadingSlash.length > 1 ? withLeadingSlash.replace(/\/+$/, "") : withLeadingSlash;
+};
+
+/** Returns `true` when the path targets the endpoint that reports the space version. */
+export const isSpacesMeRequest = (path: string) => normalizePath(path) === SPACES_ME_PATH;
 
 /**
  * Recursively normalizes query values by sorting object keys.
@@ -29,11 +46,25 @@ const normalizeQuery = (value: unknown): unknown => {
   return value;
 };
 
-export const createCacheKey = (method: string, path: string, query: Record<string, unknown>) => {
+/**
+ * Builds the cache key identifying one response.
+ *
+ * `tokenId` is part of the identity, not decoration: the access token selects the space,
+ * and it travels in the request's `token` query parameter rather than in `query`, so
+ * without it two clients for different spaces sharing one provider would read each
+ * other's content. It is a `createTokenId` hash, so no token reaches a key listing.
+ */
+export const createCacheKey = (
+  method: string,
+  path: string,
+  query: Record<string, unknown>,
+  tokenId: string,
+) => {
   return JSON.stringify({
     method,
     path: normalizePath(path),
     query: normalizeQuery(query),
+    tokenId,
   });
 };
 

--- a/packages/capi-client/src/utils/token-id.test.ts
+++ b/packages/capi-client/src/utils/token-id.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { createTokenId } from "./token-id";
+
+describe("createTokenId", () => {
+  it("should be stable for the same token", () => {
+    expect(createTokenId("OurklwV5XsDJTIE1NJaD2wtt")).toBe(
+      createTokenId("OurklwV5XsDJTIE1NJaD2wtt"),
+    );
+  });
+
+  it("should differ for different tokens", () => {
+    expect(createTokenId("token-a")).not.toBe(createTokenId("token-b"));
+  });
+
+  it("should differ for tokens that differ only in one character", () => {
+    expect(createTokenId("aaaaaaaaaaaaaaaaaaaaaaaa")).not.toBe(
+      createTokenId("aaaaaaaaaaaaaaaaaaaaaaab"),
+    );
+  });
+
+  it("should not contain the token", () => {
+    const token = "OurklwV5XsDJTIE1NJaD2wtt";
+
+    expect(createTokenId(token)).not.toContain(token);
+    expect(createTokenId(token).length).toBeLessThan(token.length);
+  });
+
+  it("should handle an empty token", () => {
+    expect(typeof createTokenId("")).toBe("string");
+  });
+});

--- a/packages/capi-client/src/utils/token-id.ts
+++ b/packages/capi-client/src/utils/token-id.ts
@@ -1,0 +1,26 @@
+/**
+ * Derives a short, stable id from an access token, for namespacing cache keys.
+ *
+ * Cache keys end up in places the token itself does not belong: key listings, `MONITOR`
+ * output, metrics labels, log lines from a shared external provider. The id is used for
+ * scoping, never for authentication, so a fast non-cryptographic hash is enough. It only
+ * has to be stable across processes and distinct for distinct tokens.
+ *
+ * cyrb53, which mixes 53 bits, so collisions between the handful of tokens one deployment
+ * uses are not a practical concern.
+ */
+export const createTokenId = (accessToken: string): string => {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+
+  for (let i = 0; i < accessToken.length; i++) {
+    const char = accessToken.charCodeAt(i);
+    h1 = Math.imul(h1 ^ char, 2_654_435_761);
+    h2 = Math.imul(h2 ^ char, 1_597_334_677);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2_246_822_507) ^ Math.imul(h2 ^ (h2 >>> 13), 3_266_489_909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2_246_822_507) ^ Math.imul(h1 ^ (h1 >>> 13), 3_266_489_909);
+
+  return (4_294_967_296 * (2_097_151 & h2) + (h1 >>> 0)).toString(36);
+};

--- a/packages/capi-client/src/utils/versions.test.ts
+++ b/packages/capi-client/src/utils/versions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryCacheProvider } from "./cache";
+import {
+  haveVersionsChanged,
+  mergeVersions,
+  readVersions,
+  versionsKey,
+  writeVersions,
+} from "./versions";
+
+describe("versionsKey", () => {
+  it("should namespace the record per token id", () => {
+    expect(versionsKey("tid-a")).toBe("sb:versions:v1:tid-a");
+    expect(versionsKey("tid-a")).not.toBe(versionsKey("tid-b"));
+  });
+});
+
+describe("mergeVersions", () => {
+  it("should adopt both versions when nothing is known yet", () => {
+    expect(mergeVersions(undefined, { knownCv: 1000, knownSpaceVersion: 1001 })).toEqual({
+      knownCv: 1000,
+      knownSpaceVersion: 1001,
+      highestCv: 1000,
+    });
+  });
+
+  it("should advance a version that moved forward", () => {
+    expect(mergeVersions({ knownCv: 1000 }, { knownCv: 2000 })).toEqual({
+      knownCv: 2000,
+      knownSpaceVersion: undefined,
+      highestCv: 2000,
+    });
+  });
+
+  it("should ignore a version that moved backwards", () => {
+    expect(
+      mergeVersions(
+        { knownCv: 2000, knownSpaceVersion: 2001 },
+        { knownCv: 1000, knownSpaceVersion: 1001 },
+      ),
+    ).toEqual({ knownCv: 2000, knownSpaceVersion: 2001, highestCv: 2000 });
+  });
+
+  it("should keep a known version when the response reports none", () => {
+    expect(mergeVersions({ knownCv: 1000, knownSpaceVersion: 1001 }, {})).toEqual({
+      knownCv: 1000,
+      knownSpaceVersion: 1001,
+      highestCv: 1000,
+    });
+  });
+
+  it("should advance each version independently", () => {
+    expect(
+      mergeVersions({ knownCv: 1000, knownSpaceVersion: 3000 }, { knownSpaceVersion: 4000 }),
+    ).toEqual({
+      knownCv: 1000,
+      knownSpaceVersion: 4000,
+      highestCv: 1000,
+    });
+  });
+
+  it("should keep the highest cv when the known one was invalidated", () => {
+    const invalidated = mergeVersions({ knownCv: 2000, highestCv: 2000 }, { knownCv: undefined });
+
+    expect(mergeVersions({ ...invalidated, knownCv: undefined }, { knownCv: 1000 })).toEqual({
+      knownCv: 1000,
+      knownSpaceVersion: undefined,
+      highestCv: 2000,
+    });
+  });
+});
+
+describe("haveVersionsChanged", () => {
+  it("should report a change when nothing was recorded yet", () => {
+    expect(haveVersionsChanged(undefined, {})).toBe(true);
+  });
+
+  it("should report no change for identical records", () => {
+    expect(
+      haveVersionsChanged(
+        { knownCv: 1000, knownSpaceVersion: undefined },
+        { knownCv: 1000, knownSpaceVersion: undefined },
+      ),
+    ).toBe(false);
+  });
+
+  it("should report a change when a version was dropped", () => {
+    expect(
+      haveVersionsChanged({ knownCv: 1000, knownSpaceVersion: 2000 }, { knownSpaceVersion: 2000 }),
+    ).toBe(true);
+  });
+});
+
+describe("readVersions / writeVersions", () => {
+  it("should round-trip the record through a provider", async () => {
+    const provider = createMemoryCacheProvider();
+    const key = versionsKey("token");
+
+    expect(await readVersions(provider, key)).toBeUndefined();
+
+    await writeVersions(provider, key, { knownCv: 1000, knownSpaceVersion: 1001 });
+
+    expect(await readVersions(provider, key)).toEqual({ knownCv: 1000, knownSpaceVersion: 1001 });
+  });
+
+  it("should record a cleared cv as a present record", async () => {
+    const provider = createMemoryCacheProvider();
+    const key = versionsKey("token");
+
+    await writeVersions(provider, key, { knownSpaceVersion: 2000 });
+
+    expect(await readVersions(provider, key)).toEqual({ knownSpaceVersion: 2000 });
+  });
+});

--- a/packages/capi-client/src/utils/versions.ts
+++ b/packages/capi-client/src/utils/versions.ts
@@ -1,0 +1,101 @@
+import type { CacheProvider } from "./cache";
+
+/**
+ * The two watermarks that drive cache invalidation for published content.
+ *
+ * Published content is an immutable snapshot addressed by its `cv`, so an entry is valid
+ * exactly as long as the `cv` it was served under is still the one the client knows.
+ *
+ * - `knownCv` — the highest `cv` seen in a response body. `undefined` means "unknown or
+ *   invalidated": requests then go out without a `cv` and the origin redirects them to
+ *   the current one. There is deliberately no numeric sentinel, so `cv=0` can never
+ *   reach the wire.
+ * - `knownSpaceVersion` — the highest `space.version` seen from `/cdn/spaces/me`. A
+ *   change signal only; never sent as a `cv` (a Minimum Cache TTL floors the `cv` into
+ *   TTL-sized buckets while `space.version` keeps reporting the raw version).
+ * - `highestCv` — the highest `cv` ever seen, never dropped. `knownCv` is reset to
+ *   `undefined` by an invalidation, which is exactly when a response reporting an older
+ *   `cv` must still be recognised as a stale edge read, so the floor that comparison
+ *   needs has to outlive the reset. Never sent as a `cv`.
+ * - `generation` — counts explicit `flushCache()` calls. A response in flight across one
+ *   was answered for state the caller has since discarded; the `cv` comparison alone
+ *   cannot see that when the request went out while no `cv` was known.
+ */
+export interface VersionWatermarks {
+  knownCv?: number;
+  knownSpaceVersion?: number;
+  highestCv?: number;
+  generation?: number;
+}
+
+/**
+ * The reserved cache key holding the watermarks for one access token, identified by its
+ * `createTokenId` hash rather than the token itself.
+ *
+ * They live in the cache provider rather than on the client instance so that they share
+ * fate with the entries they govern: every client and every process sharing a provider
+ * shares the watermarks, which is what makes the publish signal work for per-request
+ * clients talking to an external provider.
+ */
+export const versionsKey = (tokenId: string) => `sb:versions:v1:${tokenId}`;
+
+/**
+ * How long a watermark record is kept. Matches the edge's maximum content lifetime: an
+ * expired record only costs one `cv`-less request that re-learns the current version.
+ */
+export const VERSIONS_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
+
+const advance = (current: number | undefined, incoming: number | undefined) => {
+  if (incoming === undefined) {
+    return current;
+  }
+  if (current === undefined) {
+    return incoming;
+  }
+  return Math.max(current, incoming);
+};
+
+/**
+ * Merges freshly observed versions into the known ones, monotonically.
+ *
+ * A lower value is always evidence of a stale read — a `cv` from an edge node still
+ * holding an older snapshot, or a `space.version` from a POP whose two-second cache has
+ * not caught up — and never moves a watermark backwards. `highestCv` is derived rather
+ * than passed in: it is the maximum of every `cv` this record has ever held, so it stays
+ * at or above `knownCv` no matter which reset the latter has been through.
+ */
+export const mergeVersions = (
+  current: VersionWatermarks | undefined,
+  incoming: VersionWatermarks,
+): VersionWatermarks => ({
+  knownCv: advance(current?.knownCv, incoming.knownCv),
+  knownSpaceVersion: advance(current?.knownSpaceVersion, incoming.knownSpaceVersion),
+  highestCv: advance(advance(current?.highestCv, current?.knownCv), incoming.knownCv),
+  generation: advance(current?.generation, incoming.generation),
+});
+
+export const haveVersionsChanged = (
+  current: VersionWatermarks | undefined,
+  next: VersionWatermarks,
+) =>
+  current === undefined ||
+  current.knownCv !== next.knownCv ||
+  current.knownSpaceVersion !== next.knownSpaceVersion ||
+  current.highestCv !== next.highestCv ||
+  current.generation !== next.generation;
+
+export const readVersions = async (
+  provider: CacheProvider,
+  key: string,
+): Promise<VersionWatermarks | undefined> => {
+  const entry = await provider.get<VersionWatermarks>(key);
+  return entry?.value;
+};
+
+export const writeVersions = async (
+  provider: CacheProvider,
+  key: string,
+  versions: VersionWatermarks,
+): Promise<void> => {
+  await provider.set(key, { value: versions, ttlMs: VERSIONS_TTL_MS });
+};

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -236,6 +236,1063 @@ describe("storyblokClient", () => {
     });
   });
 
+  describe("cache invalidation via cdn/spaces/me", () => {
+    // `/cdn/spaces/me` reports `space.version` and no `cv`, and is only cached for two
+    // seconds — the cheapest way to notice a publish.
+    const spaceResponse = (version: number) => ({
+      data: { space: { id: 1, name: "Test", version } },
+      headers: {},
+      status: 200,
+    });
+
+    const storiesResponse = (cv: number) => ({
+      data: { stories: [{ id: 1, title: "Update" }], cv },
+      headers: {},
+      status: 200,
+    });
+
+    let autoClearClient: any;
+    let flushCache: any;
+
+    beforeEach(() => {
+      autoClearClient = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { type: "memory", clear: "auto" },
+      });
+      flushCache = vi.spyOn(autoClearClient, "flushCache");
+    });
+
+    it("should flush the cache when the space reports a new version", async () => {
+      const token = "space-version-changed";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).not.toHaveBeenCalled(); // nothing served yet, nothing to flush
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).toHaveBeenCalledTimes(1);
+    });
+
+    it("should flush on the first poll when the cv does not match the space version", async () => {
+      // A publish may have landed between the first content request and this poll. A cv
+      // that no longer matches the space version gives it away.
+      const token = "space-version-first-poll";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1500));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).toHaveBeenCalledTimes(1);
+
+      // …but only once: further polls at the same version must not flush again.
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).toHaveBeenCalledTimes(1);
+    });
+
+    it("should keep caching after a caller set a cv the API never reported", async () => {
+      // `setCacheVersion` takes whatever it is given. Recording it as the never-lowered
+      // baseline would make every real response look like a stale edge read, and nothing
+      // clears that baseline — one bad call would disable caching for the token for the
+      // life of the process.
+      const client: any = new StoryblokClient({
+        accessToken: "caller-supplied-cv",
+        cache: { type: "memory", clear: "auto" },
+      });
+      client.setCacheVersion(9_999_999_999);
+
+      const execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      client.throttleManager.execute = execute;
+      await client.get("cdn/stories", { version: "published" });
+      await client.get("cdn/stories", { version: "published" });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not adopt a lower cv from an edge node that answers after a flush", async () => {
+      // A flush zeroes the tracked cv, so the response that follows it is the one that
+      // teaches the cv everything afterwards is measured against. An older edge object
+      // answering there would re-teach the cv the flush just dropped and make the entries
+      // it dropped reachable again, with the space version already recorded and no poll
+      // left to raise the signal a second time.
+      const token = "stale-cv-after-flush";
+      const client: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { type: "memory", clear: "auto" },
+      });
+
+      client.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await client.get("cdn/stories", { version: "published", token });
+
+      client.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      await client.get("cdn/spaces/me", { version: "draft", token });
+
+      client.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await client.get("cdn/spaces/me", { version: "draft", token }); // publish, cache flushed
+
+      // An edge node still holding the pre-publish snapshot answers the refetch.
+      const staleExecute = vi.fn().mockResolvedValue(storiesResponse(900));
+      client.throttleManager.execute = staleExecute;
+      await client.get("cdn/stories", { version: "published", token });
+      await client.get("cdn/stories", { version: "published", token });
+
+      // Neither cached nor believed: the repeat read went back to the network, and the
+      // request still carries no cv rather than the older one.
+      expect(staleExecute).toHaveBeenCalledTimes(2);
+      expect(staleExecute.mock.calls[1][3]).not.toHaveProperty("cv");
+    });
+
+    it("should not flush the cache when the space version is unchanged", async () => {
+      const token = "space-version-unchanged";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).not.toHaveBeenCalled();
+    });
+
+    it("should not track space.version as the cv sent with requests", async () => {
+      const token = "space-version-not-a-cv";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1500));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      // The flush drops the tracked cv rather than replacing it with the space version;
+      // the cv only ever comes from a content response.
+      expect(autoClearClient.cacheVersions()[token]).toBe(0);
+    });
+
+    it("should drop the cv for the token that reported the space version", async () => {
+      // The signal is keyed by `params.token`, which a request may override, while
+      // `flushCache` clears the cv of the client's own token. A cv left behind refills the
+      // cache from the edge, which serves `?cv=<old>` for up to a week.
+      const token = "space-version-request-token";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      expect(flushCache).toHaveBeenCalledTimes(1);
+
+      const execute = vi.fn().mockResolvedValue(storiesResponse(3000));
+      autoClearClient.throttleManager.execute = execute;
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      // Not merely falsy: `cv=0` would be serialized onto the request.
+      expect(execute.mock.calls[0][3]).not.toHaveProperty("cv");
+    });
+
+    it("should still flush on a space version change when cv is manual", async () => {
+      // With `cv: 'manual'` the cv is tracked but never sent, so behind an edge cache a
+      // content response can carry a stale cv forever. `space.version` is the only
+      // signal left.
+      const token = "space-version-cv-manual";
+      const manualCvClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { type: "memory", clear: "auto", cv: "manual" },
+      });
+      const manualCvFlushCache = vi.spyOn(manualCvClient, "flushCache");
+
+      const execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      manualCvClient.throttleManager.execute = execute;
+      await manualCvClient.get("cdn/stories", { version: "draft", token });
+      await manualCvClient.get("cdn/stories", { version: "draft", token });
+
+      // The cv keeps being tracked from content responses, it is just not sent.
+      expect(manualCvClient.cacheVersions()[token]).toBe(1000);
+      expect(execute.mock.calls[1][3].cv).toBeUndefined();
+
+      manualCvClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await manualCvClient.get("cdn/spaces/me", { version: "draft", token });
+
+      // First sighting with content already served: flush once defensively.
+      expect(manualCvFlushCache).toHaveBeenCalledTimes(1);
+
+      await manualCvClient.get("cdn/spaces/me", { version: "draft", token });
+      expect(manualCvFlushCache).toHaveBeenCalledTimes(1); // unchanged version
+
+      manualCvClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(3000));
+      await manualCvClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(manualCvFlushCache).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not flush on the first poll when the cv already matches the space version", async () => {
+      // Without a Minimum Cache TTL the two report the same number, so an equal pair
+      // proves nothing was published and the defensive first flush is not needed.
+      const token = "space-version-first-poll-equal";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).not.toHaveBeenCalled();
+
+      // A later change is still detected.
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).toHaveBeenCalledTimes(1);
+    });
+
+    it("should ignore a space.version that is not a number", async () => {
+      // `response.data` is untyped. A version of another type would never compare equal
+      // to the numbers already tracked and would flush on every single poll.
+      const token = "space-version-not-a-number";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue({
+        data: { space: { id: 1, name: "Test", version: "2000" } },
+        headers: {},
+        status: 200,
+      });
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).not.toHaveBeenCalled();
+    });
+
+    it("should not flush on a published poll when clear is onpreview", async () => {
+      // `onpreview` only clears on draft requests, so polling published content needs
+      // `clear: 'auto'`.
+      const token = "space-version-onpreview";
+      const onPreviewClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { type: "memory", clear: "onpreview" },
+      });
+      const onPreviewFlushCache = vi.spyOn(onPreviewClient, "flushCache");
+
+      onPreviewClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await onPreviewClient.get("cdn/stories", { version: "published", token });
+
+      onPreviewClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await onPreviewClient.get("cdn/spaces/me", { version: "published", token });
+
+      expect(onPreviewFlushCache).not.toHaveBeenCalled();
+    });
+
+    it("should flush on a draft poll when clear is onpreview", async () => {
+      // What decides it is the request's version, not the endpoint: `onpreview` treats
+      // every draft request as clearable, so a draft poll does pick publishes up.
+      const token = "space-version-onpreview-draft";
+      const onPreviewClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { type: "memory", clear: "onpreview" },
+      });
+      const onPreviewFlushCache = vi.spyOn(onPreviewClient, "flushCache");
+
+      onPreviewClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await onPreviewClient.get("cdn/stories", { version: "published", token });
+
+      onPreviewClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      await onPreviewClient.get("cdn/spaces/me", { version: "draft", token });
+      expect(onPreviewFlushCache).not.toHaveBeenCalled(); // equal pair, nothing published
+
+      onPreviewClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await onPreviewClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(onPreviewFlushCache).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not let a published poll consume the signal a draft poll needs", async () => {
+      // A non-clearable request must observe the space version without recording it.
+      // Recording would consume the signal: the draft poll below would find the version
+      // unchanged and leave the published cache stale for good.
+      const token = "space-version-onpreview-interleaved";
+      const onPreviewClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { type: "memory", clear: "onpreview" },
+      });
+      const onPreviewFlushCache = vi.spyOn(onPreviewClient, "flushCache");
+
+      onPreviewClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await onPreviewClient.get("cdn/stories", { version: "published", token });
+
+      // Published poll: sees the new version but must not flush, nor record it.
+      onPreviewClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await onPreviewClient.get("cdn/spaces/me", { version: "published", token });
+      expect(onPreviewFlushCache).not.toHaveBeenCalled();
+
+      // Draft poll: still a first sighting, and 2000 !== the tracked cv of 1000.
+      await onPreviewClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(onPreviewFlushCache).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not flush when polled before any content request", async () => {
+      // The recommended startup shape: no tracked cv and nothing cached yet, so there
+      // is nothing to flush.
+      const token = "space-version-poll-first";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(flushCache).not.toHaveBeenCalled();
+    });
+
+    it("should not flush on a space version change when clear is manual", async () => {
+      // `clear: 'manual'` — the default — hands cache invalidation to the caller. No
+      // request is clearable, so no space version ever triggers a flush by itself.
+      const token = "space-version-clear-manual";
+      const manualClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { type: "memory", clear: "manual" },
+      });
+      const manualFlushCache = vi.spyOn(manualClient, "flushCache");
+
+      manualClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await manualClient.get("cdn/stories", { version: "draft", token });
+
+      manualClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1500));
+      await manualClient.get("cdn/spaces/me", { version: "draft", token });
+
+      manualClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await manualClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(manualFlushCache).not.toHaveBeenCalled();
+    });
+
+    it("should not attach a cv to the poll request from a reused params object", async () => {
+      // `parseParams` stamps the cv onto the caller's object, so a params object reused
+      // across calls arrives at the poll already carrying one. The endpoint polling
+      // relies on must not have its edge cache fragmented by a cache buster.
+      const token = "space-version-reused-params";
+      const execute = vi.fn(async (_rl: any, _m: any, url: string) =>
+        url === "/cdn/spaces/me" ? spaceResponse(1000) : storiesResponse(1000),
+      );
+      autoClearClient.throttleManager.execute = execute;
+
+      const params = { version: "draft", token };
+      await autoClearClient.get("cdn/stories", params); // tracks cv 1000
+      await autoClearClient.get("cdn/stories", params); // stamps params.cv = 1000
+      await autoClearClient.get("cdn/spaces/me", params);
+
+      const poll = execute.mock.calls.find((call) => call[2] === "/cdn/spaces/me");
+      expect((poll?.[3] as any).cv).toBeUndefined();
+    });
+
+    it("should not treat the cleared cv sentinel as a tracked cv on the first poll", async () => {
+      // `flushCache` and `clearCacheVersion` record the sentinel `0`, which carries no cv
+      // information. Comparing it against a space version can only ever be unequal, so
+      // the first poll after a clear would flush the whole module-level cache for nothing.
+      const token = "space-version-cleared-sentinel";
+      const client: any = new StoryblokClient({
+        accessToken: token,
+        cache: { type: "memory", clear: "auto" },
+      });
+
+      client.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await client.get("cdn/stories", { version: "draft", token });
+      client.clearCacheVersion();
+
+      const clearedFlushCache = vi.spyOn(client, "flushCache");
+      // The space version equals the cv tracked before the clear: nothing was published.
+      client.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      await client.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(clearedFlushCache).not.toHaveBeenCalled();
+    });
+
+    it("should not let a response in flight across a flush re-pin the cv it dropped", async () => {
+      // A published request answered for the version before the flush must not refill the
+      // cache it emptied, and must not restore the cv the flush dropped: the cv is part of
+      // the cache key, so restoring it makes those stale entries reachable again — with
+      // the space version already recorded and no later poll left to notice the publish.
+      const token = "space-version-inflight-race";
+      const client: any = new StoryblokClient({
+        accessToken: token,
+        cache: { type: "memory", clear: "auto" },
+      });
+
+      client.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await client.get("cdn/stories/warm", { version: "published", token });
+      expect(client.cacheVersion()).toBe(1000);
+
+      // A request for a not-yet-cached key goes out carrying cv 1000 and is held there.
+      let releaseRaced: (value: unknown) => void = () => {};
+      const inFlight = new Promise((resolve) => {
+        releaseRaced = resolve;
+      });
+      client.throttleManager.execute = vi.fn(async (_rl: any, _m: any, url: string) =>
+        url === "/cdn/spaces/me" ? spaceResponse(2000) : inFlight,
+      );
+      const racedRequest = client.get("cdn/stories/raced", { version: "published", token });
+
+      // The poll notices the publish and flushes, dropping the tracked cv.
+      await client.get("cdn/spaces/me", { version: "draft", token });
+      expect(client.cacheVersion()).toBe(0);
+
+      // The held request now resolves with its pre-publish body and the old cv.
+      releaseRaced(storiesResponse(1000));
+      await racedRequest;
+      expect(client.cacheVersion()).toBe(0); // not re-pinned to 1000
+
+      // So the next read of that key reaches the network and gets the published content.
+      client.throttleManager.execute = vi.fn().mockResolvedValue({
+        data: { stories: [{ id: 1, title: "Published" }], cv: 2000 },
+        headers: {},
+        status: 200,
+      });
+      const after = await client.get("cdn/stories/raced", { version: "published", token });
+
+      expect(after.data.stories[0].title).toBe("Published");
+    });
+
+    it("should not attach a cv to the poll request", async () => {
+      // The cv is a cache buster and `/cdn/spaces/me` is not cached: one there would
+      // only fragment the edge cache of the endpoint polling relies on.
+      const token = "space-version-no-cv-on-poll";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "draft", token });
+
+      const execute = vi.fn().mockResolvedValue(spaceResponse(1000));
+      autoClearClient.throttleManager.execute = execute;
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(execute.mock.calls[0][3].cv).toBeUndefined();
+    });
+
+    it("should keep the cv of a response that also reports a space version", async () => {
+      // Only `/cdn/spaces/me` reports a space version today and it carries no cv, but if
+      // one response ever reported both, the space-version flush must not drop the cv
+      // that arrived with it — hence space version before cv. The token is the client's
+      // own access token so `flushCache` clears the cv this test tracks.
+      const token = "space-version-and-cv-in-one-response";
+      const client: any = new StoryblokClient({
+        accessToken: token,
+        cache: { type: "memory", clear: "auto" },
+      });
+      const bothSignals = (value: number) => ({
+        data: { space: { id: 1, name: "Test", version: value }, cv: value },
+        headers: {},
+        status: 200,
+      });
+
+      client.throttleManager.execute = vi.fn().mockResolvedValue(bothSignals(2000));
+      await client.get("cdn/spaces/me", { version: "draft" });
+      expect(client.cacheVersions()[token]).toBe(2000);
+
+      // A publish landed: both signals move together, the cache is flushed, and the cv
+      // from this very response has to survive it.
+      client.throttleManager.execute = vi.fn().mockResolvedValue(bothSignals(3000));
+      await client.get("cdn/spaces/me", { version: "draft" });
+
+      expect(client.cacheVersions()[token]).toBe(3000);
+    });
+
+    it("should treat every spelling of the poll slug the same", async () => {
+      // `get()` prefixes the slug with a slash, so `'/cdn/spaces/me'` must not become
+      // `//cdn/spaces/me` — that fails every path comparison at once, leaving the poll
+      // carrying a cv, its response cached, and the space version never read. A trailing
+      // slash, which the API serves identically, must not either.
+      const poll = async (slug: string, token: string) => {
+        const client: any = new StoryblokClient({
+          accessToken: "test-token",
+          cache: { type: "memory", clear: "auto" },
+        });
+        const clientFlushCache = vi.spyOn(client, "flushCache");
+        const polls: { url: string; cv: unknown }[] = [];
+
+        client.throttleManager.execute = vi.fn(
+          async (_rateLimit: any, _method: any, url: string, params: any) => {
+            if (url.includes("spaces/me")) {
+              polls.push({ url, cv: params.cv });
+              return spaceResponse(2000);
+            }
+            return storiesResponse(1000);
+          },
+        );
+
+        await client.get("cdn/stories", { version: "published", token });
+        await client.get(slug, { version: "published", token });
+        await client.get(slug, { version: "published", token });
+
+        return { polls, flushes: clientFlushCache.mock.calls.length };
+      };
+
+      const bare = await poll("cdn/spaces/me", "slug-spelling-bare");
+      const prefixed = await poll("/cdn/spaces/me", "slug-spelling-prefixed");
+      const trailing = await poll("cdn/spaces/me/", "slug-spelling-trailing");
+
+      expect(prefixed).toEqual(bare);
+      expect(trailing).toEqual(bare);
+      // …and the behaviour they share is the correct one: every poll reaches the network
+      // without a cv, and the first sighting flushes once.
+      expect(bare.polls).toEqual([
+        { url: "/cdn/spaces/me", cv: undefined },
+        { url: "/cdn/spaces/me", cv: undefined },
+      ]);
+      expect(bare.flushes).toBe(1);
+    });
+
+    it("should not flush repeatedly when a Minimum Cache TTL floors the cv", async () => {
+      // A Minimum Cache TTL floors the cv into buckets while `space.version` reports the
+      // raw version: they differ permanently and must never be compared to each other.
+      const token = "space-version-min-cache";
+      const flooredCv = 1786950000;
+      const rawSpaceVersion = 1786950860;
+
+      for (let i = 0; i < 3; i++) {
+        autoClearClient.throttleManager.execute = vi
+          .fn()
+          .mockResolvedValue(spaceResponse(rawSpaceVersion));
+        await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+
+        autoClearClient.throttleManager.execute = vi
+          .fn()
+          .mockResolvedValue(storiesResponse(flooredCv));
+        await autoClearClient.get("cdn/stories", { version: "draft", token });
+      }
+
+      expect(flushCache).not.toHaveBeenCalled();
+      expect(autoClearClient.cacheVersions()[token]).toBe(flooredCv);
+    });
+
+    it("should send no cv and cache the response after a flush", async () => {
+      // The flush records the sentinel `0`, which is not a version the API knows: sending
+      // `cv=0` costs a redirect and caches the response under a key no later request
+      // reads, so the content just published stays invisible for the whole cache lifetime.
+      const token = "space-version-post-flush-cv";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      expect(flushCache).toHaveBeenCalledTimes(1);
+
+      const execute = vi.fn().mockResolvedValue(storiesResponse(2000));
+      autoClearClient.throttleManager.execute = execute;
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+
+      expect(execute.mock.calls[0][3]).not.toHaveProperty("cv");
+
+      // The cv this response reported is attached from here on, and the response was
+      // stored under it rather than under the cv it was issued with — so every later read
+      // finds it and none of them reaches the network.
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("should keep the response that triggered the flush in the cache", async () => {
+      // The flush empties the cache for the version the response left behind, not for the
+      // response itself: storing it first and flushing after would drop it immediately.
+      const token = "cv-flush-keeps-triggering-response";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+
+      const execute = vi.fn().mockResolvedValue(storiesResponse(2000));
+      autoClearClient.throttleManager.execute = execute;
+      const response = await autoClearClient.get("cdn/stories/other", {
+        version: "published",
+        token,
+      });
+      expect(flushCache).toHaveBeenCalledTimes(1);
+
+      // The pre-flush entry is gone and the response that caused the flush is there.
+      const cached = Object.values(await autoClearClient.cacheProvider().getAll());
+      expect(cached).toEqual([response]);
+    });
+
+    it("should not flush when the space version moves backwards", async () => {
+      // `space.version` is monotonic at the origin, so a lower one is an edge node whose
+      // two-second cache has not caught up. Flushing for it empties the cache for nothing
+      // — and on the way back up it would flush a second time.
+      const token = "space-version-regression";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(2000));
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+
+      for (const version of [2000, 1000, 2000]) {
+        autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(version));
+        await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      }
+
+      expect(flushCache).not.toHaveBeenCalled();
+    });
+
+    it("should not adopt a cv that moved backwards", async () => {
+      // A response reporting a lower cv came from an edge node still holding an older
+      // snapshot: adopting it would pin every later request to content the space has
+      // already moved past.
+      const token = "cv-regression";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(2000));
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories/other", { version: "published", token });
+
+      expect(flushCache).not.toHaveBeenCalled();
+      expect(autoClearClient.cacheVersions()[token]).toBe(2000);
+    });
+
+    it("should flush a shared provider once per process, not once per instance", async () => {
+      // The serverless shape: a client per request, one external provider, and a token
+      // with a Minimum Cache TTL so the floored cv never equals the raw space version.
+      // Keying the signal per instance made every fresh client see an ambiguous first
+      // sighting and empty the shared cache on its own first poll.
+      const token = "space-version-shared-provider";
+      const flooredCv = 1786950000;
+      const rawSpaceVersion = 1786950860;
+      const store: Record<string, any> = {};
+      const flush = vi.fn(async () => {
+        for (const key of Object.keys(store)) {
+          delete store[key];
+        }
+      });
+      const provider = {
+        get: async (key: string) => store[key],
+        getAll: async () => store,
+        set: async (key: string, content: any) => {
+          store[key] = content;
+        },
+        flush,
+      };
+      const newClient = (): any =>
+        new StoryblokClient({
+          accessToken: "test-token",
+          cache: { clear: "auto", type: "custom", custom: provider },
+        });
+
+      let storyRequests = 0;
+      const execute = vi.fn(async (_rateLimit: any, _method: any, url: string) => {
+        if (url.includes("spaces/me")) {
+          return spaceResponse(rawSpaceVersion);
+        }
+        storyRequests++;
+        return storiesResponse(flooredCv);
+      });
+
+      const warm = newClient();
+      warm.throttleManager.execute = execute;
+      await warm.get("cdn/stories", { version: "published", token });
+
+      for (let i = 0; i < 4; i++) {
+        const client = newClient();
+        client.throttleManager.execute = execute;
+        await client.get("cdn/spaces/me", { version: "draft", token });
+        await client.get("cdn/stories", { version: "published", token });
+      }
+
+      // One ambiguous first sighting for the whole process, then steady state.
+      expect(flush).toHaveBeenCalledTimes(1);
+      // The warm read and the read after that one flush. The second one is stored under
+      // the cv it settled on rather than the one it was issued with, so it is the entry
+      // every later round reads and the remaining rounds add nothing.
+      expect(storyRequests).toBe(2);
+    });
+
+    it("should share the flush epoch between instances writing to the same provider", async () => {
+      // A response in flight when another instance flushed the same cache belongs to the
+      // version that flush dropped, so it must not be stored — while a flush of an
+      // unrelated provider must not stall this one's cache fill.
+      const token = "flush-epoch-per-provider";
+      const store: Record<string, any> = {};
+      const provider = {
+        get: async (key: string) => store[key],
+        getAll: async () => store,
+        set: async (key: string, content: any) => {
+          store[key] = content;
+        },
+        flush: async () => {
+          for (const key of Object.keys(store)) {
+            delete store[key];
+          }
+        },
+      };
+      const shared = (): any =>
+        new StoryblokClient({
+          accessToken: "test-token",
+          cache: { clear: "auto", type: "custom", custom: provider },
+        });
+
+      const reader = shared();
+      let release!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      reader.throttleManager.execute = vi.fn(async () => {
+        await held;
+        return storiesResponse(1000);
+      });
+      const inFlight = reader.get("cdn/stories", { version: "published", token });
+      // Let the request reach the network before the flush: one that has not left yet is
+      // answered with the version that follows the flush, and caching it is correct.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Another instance flushes the very cache that request is about to write to.
+      await shared().flushCache();
+      release();
+      await inFlight;
+
+      expect(Object.keys(store)).toHaveLength(0);
+
+      // A flush of a different provider leaves this one alone.
+      const other: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { clear: "auto", type: "memory" },
+      });
+      const second = shared();
+      second.throttleManager.execute = vi.fn(async () => {
+        await other.flushCache();
+        return storiesResponse(1000);
+      });
+      await second.get("cdn/stories", { version: "published", token });
+
+      expect(Object.keys(store)).toHaveLength(1);
+    });
+
+    it("should not let a response land in the middle of a flush", async () => {
+      // Emptying the provider and moving the epoch are not one step: a response resolving
+      // between them would find the epoch it was issued under still current and write
+      // itself into the cache the flush had already cleared.
+      const token = "flush-window";
+      const store: Record<string, any> = {};
+      let releaseFlush!: () => void;
+      const flushHeld = new Promise<void>((resolve) => {
+        releaseFlush = resolve;
+      });
+      const provider = {
+        get: async (key: string) => store[key],
+        getAll: async () => store,
+        set: async (key: string, content: any) => {
+          store[key] = content;
+        },
+        flush: async () => {
+          for (const key of Object.keys(store)) {
+            delete store[key];
+          }
+          // Emptied, but not finished: an external provider's flush resolves a round trip
+          // later, and the epoch has to have moved before that.
+          await flushHeld;
+        },
+      };
+      const shared = (): any =>
+        new StoryblokClient({
+          accessToken: "test-token",
+          cache: { clear: "auto", type: "custom", custom: provider },
+        });
+
+      const reader = shared();
+      let releaseResponse!: () => void;
+      const responseHeld = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      reader.throttleManager.execute = vi.fn(async () => {
+        await responseHeld;
+        return storiesResponse(1000);
+      });
+      const inFlight = reader.get("cdn/stories", { version: "published", token });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const flushing = shared().flushCache();
+      // The response comes back while the provider is still being emptied.
+      releaseResponse();
+      await inFlight;
+      releaseFlush();
+      await flushing;
+
+      expect(Object.keys(store)).toHaveLength(0);
+    });
+
+    it("should flush at most once per keyspace after the cv was cleared", async () => {
+      // The baseline outliving a flush must not make the sighting recur: it fires until
+      // the keyspace has recorded a space version, which the first poll does whether it
+      // flushed or not.
+      const token = "space-version-cleared-cv-bound";
+      autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await autoClearClient.get("cdn/stories", { version: "published", token });
+
+      autoClearClient.clearCacheVersion(token);
+
+      for (let i = 0; i < 4; i++) {
+        autoClearClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+        await autoClearClient.get("cdn/spaces/me", { version: "draft", token });
+      }
+
+      expect(flushCache).toHaveBeenCalledTimes(1);
+    });
+
+    it("should still flush a custom provider when another instance already flushed", async () => {
+      // The narrower shape of the case below, and the one that used to slip through: the
+      // instance that polls first flushes and clears the tracked cv, so the second
+      // instance found no cv to compare its own first sighting against and never flushed.
+      // One token, two instances, one publish, and only the first instance recovered.
+      const token = "space-version-custom-after-flush";
+      const store: Record<string, any> = {};
+      const customFlush = vi.fn(async () => {
+        for (const key of Object.keys(store)) {
+          delete store[key];
+        }
+      });
+      const customClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: {
+          clear: "auto",
+          cv: "manual",
+          type: "custom",
+          custom: {
+            get: async (key: string) => store[key],
+            getAll: async () => store,
+            set: async (key: string, content: any) => {
+              store[key] = content;
+            },
+            flush: customFlush,
+          },
+        },
+      });
+      const memoryClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { clear: "auto", cv: "manual", type: "memory" },
+      });
+
+      // Both instances serve the same pre-publish content.
+      for (const instance of [customClient, memoryClient]) {
+        instance.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+        await instance.get("cdn/stories", { version: "published", token });
+      }
+
+      // The memory instance polls first: it flushes, and clears the tracked cv with it.
+      memoryClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await memoryClient.get("cdn/spaces/me", { version: "draft", token });
+      expect(memoryClient.cacheVersions()[token]).toBe(0);
+
+      // The custom instance has still never seen a space version, and its provider still
+      // holds the pre-publish entry.
+      customClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await customClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(customFlush).toHaveBeenCalledTimes(1);
+      expect(Object.keys(store)).toHaveLength(0);
+    });
+
+    it("should not let another instance consume the signal for a custom provider", async () => {
+      // The signal is consumed once per keyspace. An instance with its own provider has
+      // to flush it itself, so an instance on the module-level memory cache must not
+      // record the sighting on its behalf and leave its cache stale for good.
+      const token = "space-version-custom-provider";
+      const store: Record<string, any> = {};
+      const customFlush = vi.fn(async () => {
+        for (const key of Object.keys(store)) {
+          delete store[key];
+        }
+      });
+      const customClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: {
+          clear: "auto",
+          type: "custom",
+          custom: {
+            get: async (key: string) => store[key],
+            getAll: async () => store,
+            set: async (key: string, content: any) => {
+              store[key] = content;
+            },
+            flush: customFlush,
+          },
+        },
+      });
+      const memoryClient: any = new StoryblokClient({
+        accessToken: "test-token",
+        cache: { clear: "auto", type: "memory" },
+      });
+
+      customClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await customClient.get("cdn/stories", { version: "published", token });
+
+      // The memory instance polls first and notices the publish for its own cache.
+      memoryClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await memoryClient.get("cdn/spaces/me", { version: "draft", token });
+      expect(customFlush).not.toHaveBeenCalled();
+
+      // The custom instance is still serving the pre-publish entry and has not seen a
+      // space version yet.
+      customClient.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1500));
+      await customClient.get("cdn/stories/other", { version: "published", token });
+
+      customClient.throttleManager.execute = vi.fn().mockResolvedValue(spaceResponse(2000));
+      await customClient.get("cdn/spaces/me", { version: "draft", token });
+
+      expect(customFlush).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("cache key of a published response", () => {
+    // A response has to be stored under the key the next identical read builds. The cv is
+    // part of that key, so the entry is written with the cv the client will send next —
+    // but only where the client is the one choosing it, and only in the position
+    // `parseParams` would have put it in. Getting either wrong writes an entry no read
+    // ever looks up, and the content is fetched again on every read for as long as the
+    // cache lives.
+    const storiesResponse = (cv: number) => ({
+      data: { stories: [{ id: 1, title: "Update" }], cv },
+      headers: {},
+      status: 200,
+    });
+
+    const publishedClient = (cache: any) =>
+      new StoryblokClient({ accessToken: "test-token", cache }) as any;
+
+    it("should serve the second identical published request from the cache", async () => {
+      const token = "settled-key-plain";
+      const client = publishedClient({ type: "memory", clear: "auto" });
+      const execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      client.throttleManager.execute = execute;
+
+      await client.get("cdn/stories", { version: "published", token });
+      await client.get("cdn/stories", { version: "published", token });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("should serve a published request carrying resolve_relations from the cache", async () => {
+      // `parseParams` assigns the cv before `resolve_level`, so an entry keyed with the cv
+      // appended last is unreachable for every request that resolves relations.
+      const token = "settled-key-resolve-relations";
+      const client = publishedClient({ type: "memory", clear: "auto" });
+      const execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      client.throttleManager.execute = execute;
+
+      const params = { version: "published", resolve_relations: "blog.author", token };
+      await client.get("cdn/stories", { ...params });
+      await client.get("cdn/stories", { ...params });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("should serve a published request carrying a falsy cv from the cache", async () => {
+      // `parseParams` substitutes the tracked cv for a falsy one, so `cv: 0` is not a
+      // caller's choice of snapshot however it was meant. Reading it as one leaves the
+      // entry keyed by the zero the request no longer carries.
+      const token = "settled-key-zero-cv";
+      const client = publishedClient({ type: "memory", clear: "auto" });
+      const execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      client.throttleManager.execute = execute;
+
+      await client.get("cdn/stories", { version: "published", cv: 0, token });
+      await client.get("cdn/stories", { version: "published", cv: 0, token });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("should serve a published request from the cache when cv is manual", async () => {
+      // `'manual'` never sends a cv, so no read builds a key containing one. The cv is
+      // still tracked from response bodies, and writing it into the key would take the
+      // whole mode out of the cache.
+      const token = "settled-key-manual";
+      const client = publishedClient({ type: "memory", clear: "auto", cv: "manual" });
+      const execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      client.throttleManager.execute = execute;
+
+      await client.get("cdn/stories", { version: "published", token });
+      await client.get("cdn/stories", { version: "published", token });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(client.cacheVersions()[token]).toBe(1000);
+    });
+
+    it("should serve a published request pinned to a cv from the cache", async () => {
+      // The caller's cv is part of their key. Replacing it with the tracked one files the
+      // snapshot they asked for under a key they never read.
+      const token = "settled-key-pinned";
+      const client = publishedClient({ type: "memory", clear: "auto" });
+      const execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      client.throttleManager.execute = execute;
+
+      await client.get("cdn/stories", { version: "published", cv: 444, token });
+      await client.get("cdn/stories", { version: "published", cv: 444, token });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("should cache a pinned cv the space has already moved past", async () => {
+      // The edge serves a snapshot for as long as it holds it, so a caller pinning an
+      // older cv gets that older body and its older cv back. Judging it by the tracked cv
+      // makes it a stale edge read, and the one request that asked for an older snapshot
+      // is the one that is never cached.
+      const token = "settled-key-pinned-older";
+      const client = publishedClient({ type: "memory", clear: "auto" });
+      client.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await client.get("cdn/stories", { version: "published", token });
+
+      const execute = vi.fn().mockResolvedValue(storiesResponse(900));
+      client.throttleManager.execute = execute;
+      await client.get("cdn/stories", { version: "published", cv: 900, token });
+      await client.get("cdn/stories", { version: "published", cv: 900, token });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      // And the snapshot the caller asked for never moved the tracked version backwards:
+      // the next request the client keys itself still goes out with the newer cv.
+      await client.get("cdn/stories/other", { version: "published", token });
+      expect(execute.mock.calls[execute.mock.calls.length - 1][3].cv).toBe(1000);
+    });
+
+    it("should still store the response under the settled cv after its own flush", async () => {
+      // The case the settled key exists for: a response reports a new cv and flushes the
+      // cache on its way in, so the key the next read builds carries a cv the request it
+      // was issued under did not have.
+      const token = "settled-key-after-flush";
+      const client = publishedClient({ type: "memory", clear: "auto" });
+      client.throttleManager.execute = vi.fn().mockResolvedValue(storiesResponse(1000));
+      await client.get("cdn/stories/first", { version: "published", token });
+
+      const execute = vi.fn().mockResolvedValue(storiesResponse(2000));
+      client.throttleManager.execute = execute;
+      await client.get("cdn/stories/second", { version: "published", token });
+      await client.get("cdn/stories/second", { version: "published", token });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("get() parameter handling", () => {
+    it("should not modify the params object it was given", async () => {
+      // Callers reuse one params object across requests. Stamping the version, token and
+      // cv onto it carries request state into the next call and changes an object the
+      // caller still holds.
+      const client: any = new StoryblokClient({ accessToken: "params-token" });
+      client.throttleManager.execute = vi.fn().mockResolvedValue({
+        data: { stories: [], cv: 1000 },
+        headers: {},
+        status: 200,
+      });
+      const params = { starts_with: "blog" };
+
+      await client.get("cdn/stories", params);
+
+      expect(params).toEqual({ starts_with: "blog" });
+    });
+
+    it("should not modify the params object getAll was given", async () => {
+      const client: any = new StoryblokClient({ accessToken: "params-token-getall" });
+      client.throttleManager.execute = vi.fn().mockResolvedValue({
+        data: { stories: [], cv: 1000, total: 0 },
+        headers: {},
+        status: 200,
+      });
+      const params = { starts_with: "blog" };
+
+      await client.getAll("cdn/stories", params);
+
+      expect(params).toEqual({ starts_with: "blog" });
+    });
+  });
+
   describe("retry behaviour on 429", () => {
     beforeEach(() => {
       vi.useFakeTimers();
@@ -276,6 +1333,53 @@ describe("storyblokClient", () => {
 
       await expect(promise).resolves.toMatchObject({ data: { story: { id: 1 } } });
       expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not re-send a cv a flush dropped while the retry was waiting", async () => {
+      // The retry is a new request built from the params of the old one. Re-sending the
+      // pre-flush cv asks the edge for the snapshot the flush was meant to leave behind,
+      // and the response then teaches that cv back — the flush undone by the retry that
+      // outlived it.
+      client = new StoryblokClient({
+        accessToken: "retry-cv-token",
+        retriesDelay: 500,
+        maxRetries: 3,
+        cache: { type: "memory", clear: "auto" },
+      });
+
+      // Recorded as copies: the retry reuses the params object, so the mock's own
+      // references would all show its final state.
+      const sentParams: Array<Record<string, unknown>> = [];
+      const mockGet = vi
+        .fn()
+        .mockImplementationOnce((_url: string, params: Record<string, unknown>) => {
+          sentParams.push({ ...params });
+          return Promise.reject({ status: 429, statusText: "Too Many Requests", response: {} });
+        })
+        .mockImplementationOnce((_url: string, params: Record<string, unknown>) => {
+          sentParams.push({ ...params });
+          return Promise.resolve({ data: { stories: [], cv: 1000 }, headers: {}, status: 200 });
+        });
+
+      client.client = {
+        get: mockGet,
+        post: vi.fn(),
+        setFetchOptions: vi.fn(),
+        baseURL: "https://api.storyblok.com/v2",
+      };
+      client.setCacheVersion(1000);
+
+      const promise = client.cacheResponse("/cdn/stories", {
+        token: "retry-cv-token",
+        version: "published",
+        cv: 1000,
+      });
+      await client.flushCache(); // a publish was noticed while the retry was waiting
+      await vi.advanceTimersByTimeAsync(500);
+      await promise;
+
+      expect(sentParams[0].cv).toBe(1000);
+      expect(sentParams[1]).not.toHaveProperty("cv");
     });
 
     it("should keep the per-request fetchOptions on a retried request", async () => {
@@ -382,6 +1486,7 @@ describe("storyblokClient", () => {
         expect.objectContaining({ version: "published" }),
         undefined,
         undefined,
+        false,
       );
 
       // Reset mock
@@ -394,6 +1499,7 @@ describe("storyblokClient", () => {
         expect.not.objectContaining({ version: expect.anything() }),
         undefined,
         undefined,
+        false,
       );
     });
 
@@ -705,7 +1811,6 @@ describe("storyblokClient", () => {
 
         // Verify the API was called with correct parameters
         expect(mockGet).toHaveBeenCalledWith("/cdn/links", {
-          cv: 0,
           token: "test-token",
           version: "draft",
           include_dates: 1,

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -1,5 +1,6 @@
 import {
   asyncMap,
+  createCacheKey,
   decodeIfEncoded,
   delay,
   flatMap,
@@ -7,7 +8,6 @@ import {
   getRegionURL,
   isCDNUrl,
   range,
-  stringify,
 } from "./utils";
 import SbFetch from "./sbFetch";
 import type Method from "./constants";
@@ -49,6 +49,97 @@ export * from "./interfaces";
 let memory: Partial<IMemoryType> = {};
 
 const cacheVersions = {} as CachedVersions;
+
+/**
+ * The only endpoint that reports the space's raw `version`, and the one endpoint whose
+ * responses must never enter the content cache.
+ */
+const SPACES_ME_PATH = "/cdn/spaces/me";
+
+/** The invalidation state of one cache, shared by every client instance writing to it. */
+interface CacheKeyspaceState {
+  /**
+   * Last `space.version` seen per token, tracked separately from {@link cacheVersions}. A
+   * change signal only, never sent as a `cv` — see `cacheResponse`.
+   */
+  spaceVersions: CachedVersions;
+  /**
+   * Bumped on every flush of this cache. A response already in flight when the cache was
+   * emptied belongs to the previous epoch: caching it would refill the cache with the
+   * pre-publish content the flush just dropped, and adopting its `cv` would re-pin the
+   * very `?cv=<old>` the flush cleared — making those entries reachable again, with the
+   * space-version signal already consumed and no later poll left to re-raise it.
+   */
+  flushEpoch: number;
+}
+
+/**
+ * The invalidation state of every cache in use, keyed by the identity of the cache itself.
+ *
+ * Identity, not instance: a signal is consumed once per cache, so instances writing to
+ * the same cache have to share it, while an instance with its own provider must not have
+ * its only chance to flush that provider consumed by another instance's poll. Keying per
+ * instance breaks the first half of that — per-request clients over one external provider
+ * would each see a fresh state, and under a Minimum Cache TTL each flush the shared cache
+ * on its first poll. Both halves hold when the provider object is the key.
+ *
+ * A `WeakMap`, so state is collected along with a provider nobody uses any more.
+ *
+ * The provider object therefore has to outlive the client for per-request clients to
+ * share the signal: a handler that builds its provider inline on every request
+ * (`cache: { type: 'custom', custom: makeProvider() }`) hands over a new key each time and
+ * gets a fresh state, so no space version is ever compared against a previous one. Build
+ * the provider once, at module scope, and pass the same object to every client.
+ */
+const cacheKeyspaces = new WeakMap<object, CacheKeyspaceState>();
+
+/** Stands in for the module-level {@link memory} cache, which has no provider object. */
+const MEMORY_KEYSPACE = {};
+
+/**
+ * Stands in for the no-op default provider, which caches nothing.
+ *
+ * Shared by every client without one, deliberately: there are no entries to keep apart,
+ * so the only thing they share is a flush epoch guarding a cache that holds nothing. The
+ * cost is that one such client's `flushCache()` can stop another's in-flight response
+ * from teaching a `cv`, which costs that request the origin's redirect and nothing more.
+ */
+const NO_CACHE_KEYSPACE = {};
+
+const keyspaceState = (keyspace: object): CacheKeyspaceState => {
+  const state = cacheKeyspaces.get(keyspace);
+  if (state) {
+    return state;
+  }
+
+  const created: CacheKeyspaceState = { spaceVersions: {}, flushEpoch: 0 };
+  cacheKeyspaces.set(keyspace, created);
+  return created;
+};
+
+/**
+ * Highest `cv` ever seen per token, and unlike {@link cacheVersions} never cleared. It is
+ * the baseline a first `space.version` sighting is compared against.
+ *
+ * {@link cacheVersions} cannot serve that purpose: a flush records the sentinel `0` there,
+ * which erases the comparison for every cache that has not polled yet, not just for the
+ * one that flushed. An instance with its own provider would then find no baseline, skip
+ * its own first sighting, and serve pre-publish content for good.
+ *
+ * Never sent anywhere: a `cv` is only ever attached to a request from
+ * {@link cacheVersions}.
+ */
+const highestCvs: CachedVersions = {};
+
+/**
+ * Builds the request path from a slug, whichever way the caller spelled it. Every
+ * spelling has to produce the same path: it is compared against {@link SPACES_ME_PATH}
+ * and it is part of the cache key. A trailing slash is served identically on both APIs —
+ * verified across collection and member endpoints of the Content Delivery and Management
+ * APIs, not only on `cdn/spaces/me` — so stripping it changes which URL is requested but
+ * not what is returned.
+ */
+const toPath = (slug: string): string => `/${slug.replace(/^\/+/, "").replace(/\/+$/, "")}`;
 
 interface CachedVersions {
   [key: string]: number;
@@ -95,6 +186,8 @@ export class Storyblok {
   public resolveNestedRelations: boolean;
   private stringifiedStoriesCache: Record<string, string>;
   private inlineAssets: boolean;
+  /** Identifies the cache this instance writes to. See {@link cacheKeyspaces}. */
+  private cacheKeyspace: object;
 
   /**
    *
@@ -154,6 +247,14 @@ export class Storyblok {
     this.relations = {} as RelationsType;
     this.links = {} as LinksType;
     this.cache = config.cache || { clear: "manual" };
+    // Mirrors `cacheProvider()`: a custom provider identifies its own cache, `'memory'`
+    // means the module-level one, and everything else caches nothing.
+    this.cacheKeyspace =
+      this.cache.type === "custom" && this.cache.custom
+        ? this.cache.custom
+        : this.cache.type === "memory"
+          ? MEMORY_KEYSPACE
+          : NO_CACHE_KEYSPACE;
     this.cvMode = config.cache?.cv ?? "auto";
     this.resolveCounter = 0;
     this.resolveNestedRelations = config.resolveNestedRelations || true;
@@ -170,13 +271,29 @@ export class Storyblok {
     });
   }
 
-  private parseParams(params: ISbStoriesParams): ISbStoriesParams {
+  private parseParams(params: ISbStoriesParams, url = ""): ISbStoriesParams {
     if (!params.token) {
       params.token = this.getToken();
     }
 
-    if (!params.cv && this.cvMode === "auto") {
-      params.cv = cacheVersions[params.token];
+    // The cv is a cache buster, so it only belongs on cached requests. On
+    // `/cdn/spaces/me` it would only fragment the edge cache of the endpoint polling
+    // relies on for freshness.
+    if (url === SPACES_ME_PATH) {
+      // `parseParams` stamps the cv onto the caller's object, so a params object reused
+      // across calls arrives here already carrying one. Skipping the assignment is not
+      // enough — it has to be removed.
+      delete params.cv;
+    } else if (!params.cv && this.cvMode === "auto") {
+      // Only a truthy cv is serialized. A flush or an explicit `clearCacheVersion()`
+      // records the sentinel `0`, which is not a version the API knows: sending `cv=0`
+      // would add an edge redirect and cache the response under a key no later request
+      // reads. Without a cv the request takes that redirect to the current version
+      // directly.
+      const trackedCv = cacheVersions[params.token];
+      if (trackedCv) {
+        params.cv = trackedCv;
+      }
     }
 
     if (Array.isArray(params.resolve_relations)) {
@@ -196,7 +313,7 @@ export class Storyblok {
 
   private factoryParamOptions(url: string, params: ISbStoriesParams): ISbStoriesParams {
     if (isCDNUrl(url)) {
-      return this.parseParams(params);
+      return this.parseParams(params, url);
     }
 
     return params;
@@ -209,9 +326,12 @@ export class Storyblok {
     page: number,
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResult> {
+    // Truthiness, because that is the test `parseParams` applies before it substitutes
+    // the tracked cv: a falsy cv is replaced, so it was never the caller's choice.
+    const cvPinnedByCaller = Boolean(params.cv);
     const query = this.factoryParamOptions(url, getOptionsPage(params, per_page, page));
 
-    return this.cacheResponse(url, query, undefined, fetchOptions);
+    return this.cacheResponse(url, query, undefined, fetchOptions, cvPinnedByCaller);
   }
 
   public get(
@@ -231,21 +351,25 @@ export class Storyblok {
     params: ISbStoriesParams | ISbLinksParams = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResult | ISbLinksResult> {
-    if (!params) {
-      params = {} as ISbStoriesParams;
-    }
-    const url = `/${slug}`;
+    // A copy, because everything below stamps request state onto it — the version, the
+    // token, the cv. A caller reusing one params object across calls would otherwise
+    // carry a stale cv into the next request and see its own object change underneath it.
+    const requestParams: ISbStoriesParams = { ...params };
+    const url = toPath(slug);
 
     // Only add/keep version parameter for CDN URLs — strip it from MAPI requests
     if (isCDNUrl(url)) {
-      params.version = params.version || this.version;
-    } else if (params.version) {
-      delete params.version;
+      requestParams.version = requestParams.version || this.version;
+    } else if (requestParams.version) {
+      delete requestParams.version;
     }
 
-    const query = this.factoryParamOptions(url, params);
+    // Read before `parseParams` stamps the tracked cv onto the copy, and by truthiness,
+    // because that is the test it applies before substituting one.
+    const cvPinnedByCaller = Boolean(requestParams.cv);
+    const query = this.factoryParamOptions(url, requestParams);
 
-    return this.cacheResponse(url, query, undefined, fetchOptions);
+    return this.cacheResponse(url, query, undefined, fetchOptions, cvPinnedByCaller);
   }
 
   public async getAll(
@@ -255,16 +379,20 @@ export class Storyblok {
     fetchOptions?: ISbCustomFetch,
   ): Promise<any[]> {
     const perPage = params?.per_page || 25;
-    const url = `/${slug}`.replace(/\/$/, "");
+    const url = toPath(slug);
     const e = entity ?? url.substring(url.lastIndexOf("/") + 1);
-    params.version = params.version || this.version;
+    // A copy, for the same reason `get()` takes one: the version is request state, and
+    // stamping it onto the caller's object carries this client's default into their next
+    // call — against another client, or after they changed it.
+    const requestParams: ISbStoriesParams = { ...params };
+    requestParams.version = requestParams.version || this.version;
 
     const firstPage = 1;
-    const firstRes = await this.makeRequest(url, params, perPage, firstPage, fetchOptions);
+    const firstRes = await this.makeRequest(url, requestParams, perPage, firstPage, fetchOptions);
     const lastPage = firstRes.total ? Math.ceil(firstRes.total / (firstRes.perPage || perPage)) : 1;
 
     const restRes: any = await asyncMap(range(firstPage, lastPage), (i: number) => {
-      return this.makeRequest(url, params, perPage, i + 1, fetchOptions);
+      return this.makeRequest(url, requestParams, perPage, i + 1, fetchOptions);
     });
 
     return flatMap([firstRes, ...restRes], (res: ISbFlatMapped) => Object.values(res.data[e]));
@@ -275,7 +403,7 @@ export class Storyblok {
     params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResponse> {
-    const url = `/${slug}`;
+    const url = toPath(slug);
 
     const rateLimit = determineRateLimit(
       undefined,
@@ -297,7 +425,7 @@ export class Storyblok {
     params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResponse> {
-    const url = `/${slug}`;
+    const url = toPath(slug);
 
     const rateLimit = determineRateLimit(
       undefined,
@@ -319,7 +447,7 @@ export class Storyblok {
     params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResponse> {
-    const url = `/${slug}`;
+    const url = toPath(slug);
 
     const rateLimit = determineRateLimit(
       undefined,
@@ -344,7 +472,7 @@ export class Storyblok {
     if (!params) {
       params = {} as ISbStoriesParams;
     }
-    const url = `/${slug}`;
+    const url = toPath(slug);
 
     const rateLimit = determineRateLimit(
       undefined,
@@ -704,14 +832,17 @@ export class Storyblok {
     params: ISbStoriesParams,
     retries?: number,
     fetchOptions?: ISbCustomFetch,
+    // Whether the cv on this request came from the caller rather than from the tracked
+    // one. Only the caller's own params can tell the two apart, and by the time they
+    // reach here `parseParams` has already stamped its own cv onto them.
+    cvPinnedByCaller = false,
   ): Promise<ISbResult> {
-    const cacheKey = stringify({ url, params });
     const provider = this.cacheProvider();
 
     // Check in-memory cache first for published content
     // If cached, skip API call and rate limiting entirely
-    if (params.version === "published" && url !== "/cdn/spaces/me") {
-      const cache = await provider.get(cacheKey);
+    if (params.version === "published" && url !== SPACES_ME_PATH) {
+      const cache = await provider.get(createCacheKey(url, params));
       if (cache) {
         return Promise.resolve(cache);
       }
@@ -722,6 +853,11 @@ export class Storyblok {
     const isMapi = !isCDNUrl(url) && this.rateLimitConfig.isManagementApi;
     const defaultLimit = isMapi ? MANAGEMENT_API_DEFAULT_RATE_LIMIT : undefined;
     const rateLimit = determineRateLimit(url, params, this.rateLimitConfig, defaultLimit);
+
+    // Re-synced after a flush this request performs itself: the guard exists to drop
+    // responses invalidated by *another* request, not the fresh one doing the flushing.
+    const keyspace = keyspaceState(this.cacheKeyspace);
+    let epochAtRequest = keyspace.flushEpoch;
 
     return new Promise(async (resolve, reject) => {
       try {
@@ -759,23 +895,150 @@ export class Storyblok {
           response = await this.processInlineAssets(response);
         }
 
-        if (params.version === "published" && url !== "/cdn/spaces/me") {
-          await provider.set(cacheKey, response);
-        }
-
         const isCacheClearable =
           (this.cache.clear === "onpreview" && params.version === "draft") ||
           this.cache.clear === "auto";
 
-        if (params.token && response.data.cv) {
-          if (
-            isCacheClearable &&
-            cacheVersions[params.token] && // there is a cache
-            cacheVersions[params.token] !== response.data.cv // a new cv is incoming
-          ) {
+        // `/cdn/spaces/me` is cached for two seconds where content is cached for a
+        // week, which makes it the cheapest way to notice a publish. It reports no `cv`,
+        // and its `space.version` is not one: a Minimum Cache TTL floors the `cv` into
+        // TTL-sized buckets while `space.version` reports the raw version. Change signal
+        // only — the `cv` sent with requests still comes from content responses.
+        //
+        // `@storyblok/api-client` reads the same two signals, with the same rules for
+        // what each one may conclude. It acts on them differently — it tags every cached
+        // entry with the version it was served under instead of flushing — so the shared
+        // part is the reading, not the reaction. The order matters here: the space version
+        // is handled before the cv, so a response carrying both keeps the cv that arrived
+        // with it.
+        //
+        // `response.data` is untyped, so narrow the version first: another type would
+        // never compare equal to the tracked numbers and would flush on every poll.
+        const rawSpaceVersion = url === SPACES_ME_PATH ? response.data.space?.version : undefined;
+        const spaceVersion = typeof rawSpaceVersion === "number" ? rawSpaceVersion : undefined;
+
+        if (params.token && spaceVersion !== undefined) {
+          const lastSpaceVersion = keyspace.spaceVersions[params.token];
+          // The highest cv ever seen, not the currently tracked one: this comparison must
+          // survive another instance's flush, which zeroes the tracked cv for the whole
+          // token. See {@link highestCvs}.
+          const baselineCv = highestCvs[params.token];
+          // A first sighting has no previous space version, so compare against the cv.
+          // Without a Minimum Cache TTL both report the same raw version, so an equal
+          // pair proves nothing was published. A space version AHEAD of the cv is either
+          // a publish or a TTL flooring the cv — indistinguishable here, so flush once
+          // defensively. A space version BEHIND it is neither: `space.version` is
+          // monotonic at the origin, so only an edge node that has not caught up reports
+          // one, and flushing for it would empty the cache for no reason.
+          // Checked for truthiness rather than for `undefined`, like the cv block below,
+          // so the sentinel `0` never reads as a version. The branch fires at most once
+          // per keyspace and token: from the next poll on, `lastSpaceVersion` is set.
+          const isFirstSighting =
+            lastSpaceVersion === undefined && Boolean(baselineCv) && spaceVersion > baselineCv;
+          const hasSpaceVersionChanged =
+            lastSpaceVersion !== undefined && spaceVersion > lastSpaceVersion;
+
+          if (isCacheClearable && (isFirstSighting || hasSpaceVersionChanged)) {
             await this.flushCache();
+            epochAtRequest = keyspace.flushEpoch;
+            // `flushCache` clears the cv of the client's own token, which `params.token`
+            // may override — and unlike the cv path below, no incoming cv arrives here to
+            // overwrite a stale one. The edge serves `?cv=<old>` for up to a week.
+            cacheVersions[params.token] = 0;
           }
-          cacheVersions[params.token] = response.data.cv;
+          // Only record when this request could have acted on it. Under `'onpreview'` a
+          // published request is not clearable, and recording from it would consume the
+          // signal: the next draft poll would find the version unchanged and never
+          // flush.
+          if (isCacheClearable) {
+            // Recorded as a maximum, for the same reason the comparison uses `>`: a
+            // version from an edge node that has not caught up must not become the
+            // baseline, or the next poll back at the current version flushes for nothing.
+            keyspace.spaceVersions[params.token] =
+              lastSpaceVersion === undefined
+                ? spaceVersion
+                : Math.max(lastSpaceVersion, spaceVersion);
+          }
+        }
+
+        // A cv from before a flush is never adopted: it would send `?cv=<old>` again and
+        // make the entries the flush dropped reachable at the edge, with the
+        // space-version signal already consumed and no poll left to re-raise it. Leaving
+        // the sentinel `0` in place sends the next request out without a cv, which takes
+        // the origin's redirect to the current one.
+        // Never adopted backwards either: a cv below the tracked one is an older edge
+        // object answering, and pinning requests to it would serve content the space has
+        // already moved past. Such a response is not cached at all — the entry it would
+        // write is known to be stale the moment it is written.
+        let isStaleCvResponse = false;
+        // A caller-pinned cv is outside all of this: the response describes the snapshot
+        // the caller asked for, not the space's current state, so it neither teaches a cv
+        // nor flushes — and it is not stale for reporting the cv it was pinned to. Judging
+        // it by the tracked cv refuses to cache the one request that asked for an older
+        // snapshot, and every read of it goes to the network for as long as the edge
+        // serves it.
+        if (
+          !cvPinnedByCaller &&
+          params.token &&
+          response.data.cv &&
+          epochAtRequest === keyspace.flushEpoch
+        ) {
+          const lastCv = cacheVersions[params.token];
+          // Floored at the highest cv the API ever reported, not at the tracked one. A
+          // flush zeroes the tracked cv — and a flush is exactly when the next response
+          // teaches the cv every later one is measured against, so without a floor an edge
+          // node still holding the pre-publish snapshot re-teaches the cv the flush
+          // dropped. `setCacheVersion` can raise the tracked cv to anything, which would
+          // otherwise make every real response look stale for good.
+          const staleBelow = highestCvs[params.token] ?? 0;
+          if (staleBelow && response.data.cv < staleBelow) {
+            isStaleCvResponse = true;
+          } else {
+            if (
+              isCacheClearable &&
+              lastCv && // there is a cache
+              lastCv !== response.data.cv // a new cv is incoming
+            ) {
+              await this.flushCache();
+              epochAtRequest = keyspace.flushEpoch;
+            }
+            cacheVersions[params.token] = response.data.cv;
+            // A maximum, because the tracked cv above may have been cleared by a flush:
+            // a lower cv is legitimate to track again, but must not lower the baseline.
+            highestCvs[params.token] = Math.max(highestCvs[params.token] ?? 0, response.data.cv);
+          }
+        }
+
+        // Cached last, after every flush this response may have triggered: writing the
+        // entry first would have it dropped by the flush that the very same response
+        // caused, leaving the cache empty and the content re-fetched on the next read.
+        if (
+          params.version === "published" &&
+          url !== SPACES_ME_PATH &&
+          !isStaleCvResponse &&
+          // Stale by construction: the cache was emptied while this was in flight.
+          epochAtRequest === keyspace.flushEpoch
+        ) {
+          // Stored under the key the next read will build, not the one this request was
+          // issued with. The cv is part of the key, and a flush this very response
+          // triggered has since moved the tracked cv — so keeping the request's own key
+          // would leave an entry no later request ever looks up, and the content would be
+          // fetched again on the next read.
+          //
+          // Only the cv the client attached itself is replaced, and only the way
+          // `parseParams` attaches it: a cv the caller pinned describes the caller's
+          // choice and is part of their key, `'manual'` never puts one in the key at all,
+          // and a flushed cv drops out of it entirely.
+          const settledParams = { ...params };
+          if (!cvPinnedByCaller && this.cvMode === "auto") {
+            const settledCv = params.token ? cacheVersions[params.token] : undefined;
+            if (settledCv) {
+              settledParams.cv = settledCv;
+            } else {
+              delete settledParams.cv;
+            }
+          }
+          await provider.set(createCacheKey(url, settledParams), response);
         }
 
         return resolve(response);
@@ -787,10 +1050,24 @@ export class Storyblok {
             // eslint-disable-next-line no-console
             console.log(`Hit rate limit. Retrying in ${this.retriesDelay / 1000} seconds.`);
             await delay(this.retriesDelay);
+            // The cv is re-read after the wait, because a flush during it moved the one
+            // this request was built with. Re-sending the pre-flush cv asks the edge for
+            // the snapshot the flush was meant to leave behind, and the response then
+            // teaches that cv back — the flush silently undone by the retry that outlived
+            // it. Only the cv the client attached itself is refreshed; a pinned one is the
+            // caller's.
+            if (!cvPinnedByCaller && this.cvMode === "auto" && params.token) {
+              const trackedCv = cacheVersions[params.token];
+              if (trackedCv) {
+                params.cv = trackedCv;
+              } else {
+                delete params.cv;
+              }
+            }
             // Give `fetchOptions` to the retry. If you do not give it, the
             // retried request loses the per-request fetch configuration that
             // the caller supplied.
-            return this.cacheResponse(url, params, retries, fetchOptions)
+            return this.cacheResponse(url, params, retries, fetchOptions, cvPinnedByCaller)
               .then(resolve)
               .catch(reject);
           }
@@ -821,6 +1098,10 @@ export class Storyblok {
   public setCacheVersion(cv: number): void {
     if (this.accessToken) {
       cacheVersions[this.accessToken] = cv;
+      // Deliberately not recorded in {@link highestCvs}: only a version the API reported
+      // is evidence of what it served. That baseline is never lowered and survives a
+      // flush, so a caller-supplied value too far ahead would floor every later response
+      // into looking stale, with nothing left to bring it back down.
     }
   }
 
@@ -872,7 +1153,17 @@ export class Storyblok {
     }
   }
 
+  /**
+   * Empties the cache this client writes to and drops the version it tracks.
+   *
+   * On a shared provider that empties every client's entries, not only this one's, and
+   * it drops the tracked cv of this client's own access token alone.
+   */
   public async flushCache(): Promise<this> {
+    // Moved before the first await, so a response resolving while the provider is being
+    // emptied sees an epoch that no longer matches and does not write itself into the
+    // cache this call is in the middle of clearing.
+    keyspaceState(this.cacheKeyspace).flushEpoch++;
     await this.cacheProvider().flush();
     this.clearCacheVersion();
     return this;

--- a/packages/js-client/src/interfaces.ts
+++ b/packages/js-client/src/interfaces.ts
@@ -226,6 +226,20 @@ export interface ICacheProvider {
 
 export interface ISbCache {
   type?: "none" | "memory" | "custom";
+  /**
+   * Controls when the cache is cleared.
+   *
+   * - `'auto'`: clear whenever a response reports that content changed.
+   * - `'manual'` (default): never clear automatically; call `flushCache()` yourself.
+   * - `'onpreview'`: clear on draft requests only.
+   *
+   * Polling `/cdn/spaces/me` to pick up publishes needs `'auto'`, or a draft poll:
+   * `'onpreview'` only treats draft requests as clearable.
+   *
+   * A clear empties the whole cache but drops only the tracked `cv` of the token that
+   * reported the change. Other tokens keep theirs and refill from what the edge still
+   * holds, so serving several tokens needs one client per token to invalidate reliably.
+   */
   clear?: "auto" | "manual" | "onpreview";
   custom?: ICacheProvider;
   /**

--- a/packages/js-client/src/utils.ts
+++ b/packages/js-client/src/utils.ts
@@ -159,3 +159,39 @@ export const escapeHTML = (string: string): string => {
     ? string.replace(reUnescapedHtml, (chr) => htmlEscapes[chr])
     : string;
 };
+
+/**
+ * Sorts every object key, at every depth, so that a value serializes the same way
+ * whichever order its keys happen to have been assigned in. Arrays keep their order:
+ * there it is part of the value, not of how the value was built.
+ */
+const sortKeysDeep = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .reduce<Record<string, unknown>>((sorted, [key, entry]) => {
+        sorted[key] = sortKeysDeep(entry);
+        return sorted;
+      }, {});
+  }
+
+  return value;
+};
+
+/**
+ * The cache key of a request. Identical requests have to produce an identical key, and
+ * {@link stringify} serializes in insertion order — so `{ cv, resolve_level }` and
+ * `{ resolve_level, cv }` describe one request under two keys. `parseParams` assigns the
+ * cv before `resolve_level` while a rebuilt params object appends it last, which is
+ * exactly that case: the entry lands under a key no read ever builds and the content is
+ * fetched again on every read. Sorting removes the dependency on assembly order.
+ *
+ * Only cache keys are sorted. Request query strings keep the order the caller and
+ * `parseParams` produced.
+ */
+export const createCacheKey = (url: string, params: ISbStoriesParams): string =>
+  stringify({ url, params: sortKeysDeep(params) });


### PR DESCRIPTION
Supersedes #508, keeping @intellix's commit and their use case intact.

Docs counterpart: [storyblok/storyblok-docs-platform#627](https://github.com/storyblok/storyblok-docs-platform/pull/627). The caching page recommends the pattern this PR makes work, and describes it in a way that breaks once an access token has a TTL.

## The problem

Published content goes stale and never recovers. Invalidation is reactive: the client only learns a new `cv` from a response it receives, but published responses are served *from* the cache, so no request goes out and no new `cv` arrives. Closed loop. Reproduced against a live space: warm the cache, publish a story, re-read it, and the old content comes back with zero network calls, indefinitely.

`/cdn/spaces/me` is the way out: tiny response, `s-maxage=2` against `s-maxage=604800` on content endpoints, and [our own docs recommend it](https://www.storyblok.com/docs/concepts/caching#retrieve-the-latest-cache-version). But it reports the version under `space.version` with no `cv` field, and the invalidation code only read `cv` — so the one endpoint that could break the loop was the one both clients ignored.

## Why the obvious fix regresses

#508 did `response.data.cv ?? response.data.space?.version`. Those are **not** the same number.

When an access token has a Minimum Cache TTL configured (Space Settings → Access Tokens), content endpoints return a `cv` floored to a multiple of the TTL, while `cdn/spaces/me` keeps reporting the space's raw version. Measured live against a token with `min_cache: 3600`:

- `cdn/stories` returns `cv=1786950000`; `cdn/spaces/me` returns `space.version=1786950860`
- requesting stories with `cv=1786950860` gives **HTTP 301** back to `cv=1786950000`

End to end with `cache.clear: 'auto'`, alternating poll and stories, three rounds, no content changes:

| build | tracked cv | `flushCache()` | story cache |
|---|---|---|---|
| `main` | stable `1786950000` | 0 | works |
| #508 as-is | oscillates `…860` and `…000` | **5 in 6 requests** | destroyed |

The TTL defaults to `0`, where the two values coincide, so the common path is fine. But it is a self-serve field on the access token screen, so "nobody sets it" is not safe.

## What the API actually guarantees

Every rule below rests on behaviour verified against the live CDN, not on assumptions:

| | verified behaviour |
|---|---|
| 1 | `/cdn/spaces/me` reports `space.version`, no `cv`, `max-age=0, s-maxage=2`. |
| 2 | A published request **without** a `cv` is redirected (301) to the same URL carrying the current `cv`. One extra hop, never stale. |
| 3 | A published request with any `cv` the edge does not hold (`0`, stale, even a future one) gets that same redirect. |
| 4 | A published request with an old `cv` the edge **still holds** is served that old snapshot for up to a week. The only path to stale content, and narrower than "any old `cv`": a first request for a non-current `cv` misses and the origin redirects it, so only a `cv` already warm at that POP serves the old snapshot. |
| 5 | A response body's `cv` identifies the snapshot that was actually served. |
| 6 | Draft requests ignore `cv` entirely and are never redirected. A draft-only save moves `cv` and `space.version` together. |
| 7 | `/cdn/spaces/me/` is served identically and a `cv` on it is ignored, though the parameter fragments its edge cache. |
| 8 | Without a Minimum Cache TTL, `space.version` and `cv` report the same raw version. With one, the `cv` is floored permanently. They are different units. |
| 9 | `space.version` is monotonic at the origin, but a two-second per-POP cache means a poll can be answered with a lower one. |
| 10 | A publish takes 5 to 6.4 s to appear in `space.version`, well beyond its `s-maxage=2`. Polling notices a publish within seconds, not immediately. |
| 11 | `/cdn/links`, `/cdn/links/{uuid}` and `/cdn/tags` report no `cv` at all, with 13 links and 2 tags in the space so an empty collection cannot explain it, and `/cdn/stories` returning a `cv` for zero results as the control. `/cdn/datasources` reports one. |
| 12 | A draft request reports the same `cv` a published one does: the same raw version without a Minimum Cache TTL, the same floored version with one (`1787558400` for both, against `space.version=1787560240`). |
| 13 | A trailing slash is served identically on collection and member endpoints of both the Content Delivery and the Management API, not only on `/cdn/spaces/me`. |

Fact 2 shapes the design: the origin corrects a wrong or missing `cv` for the price of one redirect. Invalidation never has to be exactly right, only never wrong in the direction of fact 4.

## The model

**Published content is an immutable snapshot addressed by its `cv`.** An entry is valid exactly as long as the `cv` it was served under is still the current one. That is a property of the entry, not an event in time.

`@storyblok/api-client` implements this directly:

- **Entries are tagged.** `CacheEntry.cv` records the `cv` the response reported, or, for endpoints that report none (`/cdn/tags`, `/cdn/links`), the `cv` the request was issued under. Every response teaches a `cv` whether or not it is cached: a draft response is never stored, but it reports the same version a published one does (fact 12), so it invalidates published entries like any other signal — the only one an app that reads both but never polls has.
- **Two watermarks, one per signal.** `knownCv` from response bodies, `knownSpaceVersion` from `/cdn/spaces/me`. Both advance by monotonic max only, so a stale edge read never moves them (facts 5 and 9), and they are never compared to each other (fact 8) except on a first sighting, where there is no earlier space version to compare against. A third value, `highestCv`, records the highest `cv` the record has ever held and is never dropped: `knownCv` is reset by an invalidation, and that is exactly when the next response is the one that teaches the version everything afterwards is measured against, so the floor a stale edge read is recognised against has to outlive the reset. Never sent as a `cv`.
- **They live in the cache provider**, under the reserved key `sb:versions:v1:<tokenId>`, so they share fate with the entries they govern and every client sharing a provider shares them — which is what makes polling work for a per-request client in a serverless deployment. A missing record reads as "cv unknown" rather than falling back to TTL alone, since it can be evicted while the entries it governs survive.
- **Entry keys are scoped to the space.** The access token selects the space and travels in the `token` parameter rather than in the query, so without it two clients sharing one provider read each other's content. Keys carry a non-cryptographic hash of the token rather than the token itself, since they reach listings, `MONITOR` output and metrics labels.
- **A read is a hit when the entry is TTL-fresh and its tag equals `knownCv`.** A publish sets `knownCv` to undefined, which makes every tagged entry unreachable at once and sends the next request out bare, taking the redirect from fact 2. Nothing is flushed: unreachable entries expire by TTL and eviction, and flushing would empty a provider other clients keep their own entries in.
- **A response is discarded when the `cv` it was issued under is no longer the known one**, unless its own body reports the `cv` that superseded it. It was answered for a version since superseded, so it may neither be stored nor teach a `cv`. The check is against shared state, so it holds across clients and processes; the exception keeps a response that merely lost a race, since its body proves it carries the current snapshot. One case has no `cv` to compare — a request issued while none was known, racing an explicit `flushCache()` — so the record also carries a `generation` that `flushCache()` bumps, and a response whose generation no longer matches is discarded. That is the epoch, shared through the provider rather than held on the instance, and bumped only on an explicit flush, so noticing a publish still costs no refetch of what was in flight.
- **A caller-pinned `cv` is honoured literally.** Keyed by its own `cv`, immune to publishes, expiring by TTL alone, never teaching a watermark. The snapshot it receives is indistinguishable on the wire from a stale edge read (fact 4), so the stale-read rule is gated on caller intent rather than on the response. Only a positive `cv` pins: `0` is the sentinel `storyblok-js-client` records for "no version known", and reading it as a choice of snapshot keeps it on the wire and files the entry under a key no publish signal reaches.
- **Only a positive `cv` is a version.** `0` is rejected where the response body is read, not only where the watermark is written, which keeps "no numeric sentinel reaches the wire" true end to end (fact 3).

`flushCache()` keeps its role for webhook-driven invalidation under `cache.flush: 'manual'`, and now resets the watermark record along with the provider — keeping `highestCv`, a fact about the space rather than about any entry, and the bumped `generation`.

The reasoning is recorded in `adr/0014-content-cache-invalidation-by-version-watermarks.md`.

### What this removes

Modelling invalidation as an event — when a signal moves, flush — destroys evidence instead of recording it, so every edge case needs compensation and the compensation is where the defects live. Gone with it:

- the **cache epoch**, replaced by the issued-under check above,
- the **settle protocol** (pending revalidation, `cv` stripping, in-flight promise coordination, a substituted network-first strategy), replaced by `knownCv = undefined` plus the next natural request,
- **flushing from the correctness path** entirely.

Roughly 150 lines of concurrency machinery, and the defect class that came with it.

### One rejected alternative

Deciding from the `cv` a request was issued with, rather than from the one its body reports, looks like one removable cause. Implemented, it breaks a real case: under a Minimum Cache TTL the `cv` is floored and legitimately stops moving while `space.version` advances, so recording supersession on the `cv` scale from a `space.version` signal mixes the two units fact 8 says are incomparable, and content is then never cached again. A late pre-publish response and a fresh floored refetch report the same `cv`; only issue time separates them. The issued-under check stays, narrowed to the cases above.

### `storyblok-js-client`

It keeps its flush-based mechanism: it is widely deployed and its custom cache providers observe its key shapes. It adopts the same semantics, nine fixes:

- **A falsy tracked `cv` is never serialized.** The sentinel `0` is not a version the API knows (fact 3), so `cv=0` cost a redirect and cached the response under a key no later request read, leaving freshly published content invisible for the whole cache lifetime. `clearCacheVersion()` still records `0` internally, so the public API is unchanged.
- **Cache keys are canonical**, built from params sorted at every depth, because the serializer walks in insertion order: `parseParams` assigns the `cv` before `resolve_level`, so a rebuilt params object appending the `cv` last describes one request under two keys. Only cache keys are sorted; query strings keep the caller's order.
- **The response is cached after any flush it triggered, under the key the next read will build.** It used to be stored first and then dropped by its own flush. Ordering alone was not enough: the tracked `cv` is part of the key, so a response reporting a new one landed under the pre-flush `cv` while the next read looked under the new one.
- **A caller-pinned `cv` is outside the version tracking entirely** — it neither teaches a `cv` nor flushes, and it is not stale for reporting the version it was pinned to. Judged by the tracked `cv` instead, the one request that asked for an older snapshot was the one never cached: measured against a real space, the edge served that snapshot and every read of it went back to the network.
- **The `cv` in that key is only rewritten where the client chose it.** A caller-pinned `cv` belongs to the caller's key, and `cache.cv: 'manual'` puts no `cv` in a key at all — writing the tracked one into either takes those requests out of the cache entirely, the opposite of what the mode exists for.
- **A `cv` is never adopted backwards**, and such a response is not cached: an older edge object answering (fact 5) would pin every later request to content the space has moved past. Floored at the highest `cv` the API ever reported rather than at the tracked one, which a flush zeroes — the response after a flush is the one that teaches the version everything afterwards is measured against, so an unfloored comparison there re-adopts the very `cv` the flush dropped. `setCacheVersion()` does not raise that floor: only a version the API reported is evidence of what it served, and nothing lowers the floor, so a caller value too far ahead would make every later response look stale for good.
- **A retry after a 429 re-reads the `cv` before it goes out**, and **`flushCache()` moves the epoch before it empties the provider**. Both are the same hazard: a response that outlives a flush re-sending the `cv` that flush dropped, or writing itself into the cache mid-clear.
- **Both space-version comparisons use `>`.** Inequality flushed for a version from a POP that had not caught up (fact 9).
- **The recorded space version is a maximum too**, so after a regression the next poll back at the current version does not flush again.
- **Neither `get()` nor `getAll()` mutates the caller's params.** They stamped the version, token and `cv` onto their object, carrying request state into their next call.
- **A `cv` counts as pinned by the caller by truthiness**, which is the test `parseParams` applies before substituting the tracked one. Read as `!== undefined`, a `cv: 0` was treated as a choice of snapshot while the request carried the tracked `cv`, and the entry landed under a key holding the zero.
- **The signal is scoped to the cache it would act on**, identified by the provider object rather than the client instance, so instances writing to the same cache share it while an instance with its own provider keeps its own. Keyed per instance, per-request clients over one external provider each saw a fresh state and, under a Minimum Cache TTL, each flushed the shared cache on its first poll. The baseline a first sighting compares against is a separate, never-cleared map of the highest `cv` seen, because a flush zeroes the tracked `cv` for the whole token and would otherwise erase the comparison for every cache that had not polled yet. The flush epoch lives in that same per-cache record, so one instance's `flushCache()` no longer discards in-flight responses belonging to unrelated tokens.

Both clients also normalise trailing slashes in the request path (fact 7). A spelling that fails the path comparison leaves the poll carrying a `cv`, its response cached, and the space version never read; `get('/cdn/spaces/me')` used to build `//cdn/spaces/me` and do exactly that.

One unrelated bug is fixed here because it sits two lines from the subject: a request retried after a 429 re-entered `cacheResponse` without the caller's `fetchOptions`, so the second attempt went out with different credentials, headers, signal and caching hints than the first.

## Behaviour changes

In `@storyblok/api-client` (pre-1.0):

1. **`cache.flush: 'auto'` no longer calls `provider.flush()`.** Entries that can no longer be served expire by TTL or eviction, bounded by the existing 1000-entry cap. The trade is not emptying a shared provider on someone else's behalf.
2. **An invalidated entry is not served as a `network-first` fallback.** This matches `main`, where a flush deleted those entries outright; it was the settle machinery that had briefly added such a fallback. A publish followed by a failing origin therefore surfaces the error rather than stale content.
3. **`CacheEntry` gains an optional `cv`, and entry keys change shape.** Custom providers store entries opaquely and need no change, but they must not write to the reserved key. An external provider carried across the upgrade refills once. The `cv` is load-bearing, though: a provider that rebuilds entries field by field and drops it degrades invalidation to TTL alone, and a dropped tag reads back exactly like an entry from an endpoint that reports no `cv`. `CacheEntry`/`CacheEntryInput` are exported so an adapter can name the shape it has to round-trip, and the contract says so — a runtime warning was tried and removed: it cannot fire in the per-request-client deployment it exists for, and false-positives on a shared provider where another client legitimately stores an entry untagged.

In `storyblok-js-client`, cache keys change shape too — sorting the params changes every key — so a persisted custom provider (Redis, say) takes one cold-cache round after deploy. The in-memory cache is unaffected, since it starts empty. No public API changes.

## Known issues and deliberate choices

Each of these is a trade-off taken knowingly, not an open defect.

- **A Minimum Cache TTL bounds freshness regardless of the client.** The floored `cv` does not move on publish, so the edge object stays a HIT with a growing `age` under `s-maxage=604800`: with `min_cache: 3600`, five reads over 12 s after a publish all returned the pre-publish story. No client-side model can fix that, this one included. The TTL is the freshness contract; these rules only make sure the client adds no staleness on top of it.
- **Every draft request reads the watermark record once**, where `main` touched the provider not at all. The price of taking the publish signal from draft traffic; it writes only when a version actually moved.
- **A space with a Minimum Cache TTL pays one needless revalidation per watermark record**, from the first-sighting comparison against the `cv`. It answers itself and does not recur.
- **In `storyblok-js-client` that first-sighting state is per process**, since it lives beside the client rather than in the provider, and a flush is its only reaction. Under a Minimum Cache TTL, where the floored `cv` never equals the raw space version, every cold start therefore flushes the shared cache once — a module-scope provider does not help, because a new process brings a new module scope. The price of leaving that client on the flush model.
- **A response issued while no `cv` was known cannot be recognised as superseded by a publish alone.** It has no issue-time `cv` to compare, and the generation only moves on an explicit `flushCache()`. An unlucky one carries pre-publish content into the cache for one TTL.
- **One extra provider `get` per cacheable request** for the watermark record, issued in parallel with the entry read. Free for the in-memory provider, one round trip for an external one, still far cheaper than the origin fetch it prevents. Non-cacheable requests do not pay it: only the poll has anything to record, and a draft response may neither teach a `cv` nor be cached.
- **An endpoint reporting no `cv` is only invalidated when it was fetched while a `cv` was known.** Fetched during an unknown-`cv` window, it falls back to TTL alone.
- **The watermark record is read, merged and written back without a lock**, and `CacheProvider` offers no compare-and-swap to build one from. The write re-reads the generation first and gives up when it moved, so a `flushCache()` is never merged away, which narrows the window to the provider write itself. Two concurrent requests can write over each other: a poll that dropped `knownCv` for a publish can lose that drop to a content response that read the record before it, and the space-version watermark falls back with it. It costs one repeated round of invalidation — the next poll recognises the same publish again — and never serves an entry past its version, since the `cv` the losing write records is the newer one. The window is a provider round trip wide.
- **The js-client signal is keyed by the provider object**, so it is shared only while that object outlives the client. A handler building its provider inline per request gets a fresh state each time and never compares one space version against a previous one — the serverless case the design exists for. Build the provider once at module scope. Documented rather than changed, since moving that state into the provider is what this PR deliberately does not do to js-client.
- **`clear: 'onpreview'` only clears on draft requests.** What matters is the version of the poll, not the endpoint: a published poll never flushes, a draft poll of `/cdn/spaces/me` does and the published cache recovers normally. Documented semantics, left as-is, documented on `ISbCache.clear` and locked with a test for each half.
- **js-client clients without a cache share one flush epoch.** There are no entries to keep apart, so the shared state guards a cache holding nothing. One such client's `flushCache()` can stop another's in-flight response from teaching a `cv`, worth one redirect on that request.
- **js-client multi-token invalidation stays asymmetric.** A clear empties the whole cache but drops only the signalling token's `cv`, so every other token refills from whatever the edge still holds. Pre-dates this PR; documented on `ISbCache.clear`, since fixing it means bulk-zeroing a module-level map shared across instances.
- **js-client keeps flushing rather than tagging entries.** The tagged model would work there too, but its cache keys are observed by user-supplied providers, so it is a separate, breaking-ish change.

## Verification

```
api-client: 219 passed (17 files)
js-client:  237 passed, 1 skipped (8 files)
lint, types, build: clean
```

Behaviour is asserted through the public entry points and msw, on request counts and emitted query strings rather than on internal state — which is how several earlier defects hid behind green tests.

api-client covers the publish path, every no-op path (unchanged, regressed, floored `cv`, non-numeric version, a `space.version` embedded in another endpoint's body, `flush: 'manual'`), pinned-`cv` isolation, a failed refetch, trailing-slash spellings, and the two capabilities the previous model could not have had: three sequential per-request clients over one shared provider settling at one refetch total, and client B's in-flight pre-publish response not being served after client A noticed the publish. A provider that rebuilds entries and loses the `cv` is asserted to warn exactly once across three reads, and one that round-trips them not at all.

js-client asserts that a second identical published request reaches the network once for each of the six shapes a `cv`-bearing cache key can take — plain, `resolve_relations`, `cache.cv: 'manual'`, a caller-pinned `cv`, a falsy `cv`, and a read whose own response flushed the cache on its way in. Each fails with its fix reverted.

Live verification against a dedicated space, both clients built and driven through the CDN, produced the facts table above, using a purpose-made token with `min_cache: 3600` for the flooring scenario. Every rule stated here was confirmed end to end, including recovery after publish, which never happens on `main`.

## Relation to #773

Independent, and they compose: #773 fixes error-result handling in the cache strategies, this PR fixes which version a cached entry belongs to. No defect overlaps.

They touch the same two files, so applying #773 on top of this branch produces exactly one conflict, the strategy call site, resolved by adding `getFailure` to the argument object. Verified locally: the merged tree is green. **Land #773 first**, then rebase this branch onto it; the reverse order forces #773 to rebase onto a `client.ts` that has changed substantially around its hunks. Together: an entry that is still valid falls back on a 503 as #773 intends, an entry invalidated by a publish surfaces the error per behaviour change 2.

## Follow-ups

- **API:** have `cdn/spaces/me` report the same cache version the content endpoints return, so the value it exposes is directly usable as a `cv`. Both clients' existing `cv` paths would then work with no client code at all.
- **Docs:** [storyblok/storyblok-docs-platform#627](https://github.com/storyblok/storyblok-docs-platform/pull/627). The caching page states "the `version` property in the response is the latest `cv` value" and separately documents TTL, without noting that the two stop matching once a TTL is set. Worth merging alongside this, together with the `cache.clear: 'auto'` requirement, the api-client behaviour changes, the 5 to 6.4 s a publish takes to reach `space.version`, and the fact that a Minimum Cache TTL caps freshness on its own.

Fixes #105




