### PR TITLE
chore(repo): lint and format the whole repo on commit and in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,9 +67,12 @@ jobs:
       # Every project lints itself in the `Check` step below. This one covers
       # what no project owns: repo config, the release scripts, the agent
       # scripts. Same command the root `lint` script runs.
+      #
+      # `oxlint.config.ts` imports the built `@storyblok/lint-config`, so that
+      # project has to be built first: this step runs before `Check`.
       - name: Check root lint
         if: matrix.os == 'ubuntu-latest'
-        run: pnpm exec oxlint --disable-nested-config
+        run: pnpm nx build @storyblok/lint-config && pnpm exec oxlint --disable-nested-config
 
       - name: Check
         run: pnpm nx run-many --target=build,lint,test,test:types --parallel=3 -p="${{ matrix.projects }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: pnpm format:check
 
+      # Every project lints itself in the `Check` step below. This one covers
+      # what no project owns: repo config, the release scripts, the agent
+      # scripts. Same command the root `lint` script runs.
+      - name: Check root lint
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm exec oxlint --disable-nested-config
+
       - name: Check
         run: pnpm nx run-many --target=build,lint,test,test:types --parallel=3 -p="${{ matrix.projects }}"
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,12 +64,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: pnpm format:check
 
-      # Every project lints itself in the `Check` step below. This one covers
-      # what no project owns: repo config, the release scripts, the agent
-      # scripts. Same command the root `lint` script runs.
-      #
-      # `oxlint.config.ts` imports the built `@storyblok/lint-config`, so that
-      # project has to be built first: this step runs before `Check`.
+      # Projects lint themselves in `Check` below. This covers what no project
+      # owns: repo config, the release scripts, the agent scripts. The build is
+      # needed because `oxlint.config.ts` imports `@storyblok/lint-config`.
       - name: Check root lint
         if: matrix.os == 'ubuntu-latest'
         run: pnpm nx build @storyblok/lint-config && pnpm exec oxlint --disable-nested-config

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+# --concurrent=false: the tasks are ordered, `vp fmt` has to run last.
 pnpm exec lint-staged --relative --concurrent=false

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged --relative
+pnpm exec lint-staged --relative --concurrent=false

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,9 +3,10 @@
  * @type {import('lint-staged').Configuration}
  */
 export default {
-  // No glob: every staged file goes through. A glob restated what the commands
-  // below already know, and let root scripts, `.agents/`, `.vue`, and markdown
-  // slip past both the linter and the formatter.
+  // No glob: the commands below already decide which files they handle, so a
+  // path or extension filter here can only take files away from them, and
+  // whatever it leaves out (root scripts, `.agents/`, `.vue`, markdown) is
+  // linted and formatted by nothing.
   "*": [
     // Covers what no project owns, and so nothing else lints: repo config, the
     // release scripts, the agent scripts.

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,13 +3,14 @@
  * @type {import('lint-staged').Configuration}
  */
 export default {
-  "{packages,tools}/**/*.{js,ts,jsx,tsx,astro,json}": [
-    (filenames) =>
-      `pnpm exec nx affected -t=lint --exclude="@storyblok/playground-*" --files=${filenames.join(",")} -- --fix`,
-    // `oxlint --fix` rewrites code but does not reformat it, so an autofix lands
-    // unformatted (wrong indentation, dropped trailing commas) unless the
-    // formatter runs afterwards. Repo-wide, because `nx affected` fixes whole
-    // projects and can therefore touch files that are not staged.
-    () => "pnpm exec vp fmt",
-  ],
+  // No globs, and no file list passed on: both scripts run repo-wide because
+  // they already know which files they own. Narrowing them here would duplicate
+  // that knowledge and let through everything the glob forgot: root
+  // scripts, `.agents/`, `.vue`, markdown. Nx caches the lint run, so it costs a couple
+  // of seconds when nothing changed.
+  //
+  // `oxlint --fix` rewrites code but does not reformat it, so an autofix lands
+  // unformatted (wrong indentation, dropped trailing commas) unless the
+  // formatter runs afterwards. `--concurrent=false` in the hook keeps that order.
+  "*": [() => "pnpm lint:fix", () => "pnpm format"],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,25 +3,19 @@
  * @type {import('lint-staged').Configuration}
  */
 export default {
-  // No glob: every staged file goes through, whatever its path or extension. A
-  // glob here would duplicate what the three commands already know about which
-  // files they own, and whatever it forgot would be linted and formatted by
-  // nothing. That is how root scripts, `.agents/`, `.vue`, and markdown used to
-  // slip through.
+  // No glob: every staged file goes through. A glob restated what the commands
+  // below already know, and let root scripts, `.agents/`, `.vue`, and markdown
+  // slip past both the linter and the formatter.
   "*": [
-    // Projects lint themselves, so this covers only what no project owns: repo
-    // config, the release scripts, the agent scripts. Nx cannot reach those,
-    // and it is the same command the root `lint` script runs.
+    // Covers what no project owns, and so nothing else lints: repo config, the
+    // release scripts, the agent scripts.
     () => "pnpm exec oxlint --disable-nested-config --fix",
-    // Still `affected`, not the whole repo: a lint error in a project you never
-    // touched should not block your commit. Non-project files in the list are
-    // harmless, and a change to a root file correctly affects everything.
+    // `affected`, not the whole repo: a lint error in a project you never
+    // touched should not block your commit.
     (filenames) =>
       `pnpm exec nx affected -t=lint --exclude="@storyblok/playground-*" --files=${filenames.join(",")} -- --fix`,
-    // `oxlint --fix` rewrites code but does not reformat it, so an autofix lands
-    // unformatted (wrong indentation, dropped trailing commas) unless the
-    // formatter runs afterwards. `--concurrent=false` in the hook keeps that
-    // order. Repo-wide, because the fixes above can touch unstaged files.
+    // Last, because `oxlint --fix` rewrites code without reformatting it.
+    // Repo-wide, because the fixes above can touch unstaged files.
     () => "pnpm exec vp fmt",
   ],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,14 +3,25 @@
  * @type {import('lint-staged').Configuration}
  */
 export default {
-  // No globs, and no file list passed on: both scripts run repo-wide because
-  // they already know which files they own. Narrowing them here would duplicate
-  // that knowledge and let through everything the glob forgot: root
-  // scripts, `.agents/`, `.vue`, markdown. Nx caches the lint run, so it costs a couple
-  // of seconds when nothing changed.
-  //
-  // `oxlint --fix` rewrites code but does not reformat it, so an autofix lands
-  // unformatted (wrong indentation, dropped trailing commas) unless the
-  // formatter runs afterwards. `--concurrent=false` in the hook keeps that order.
-  "*": [() => "pnpm lint:fix", () => "pnpm format"],
+  // No glob: every staged file goes through, whatever its path or extension. A
+  // glob here would duplicate what the three commands already know about which
+  // files they own, and whatever it forgot would be linted and formatted by
+  // nothing. That is how root scripts, `.agents/`, `.vue`, and markdown used to
+  // slip through.
+  "*": [
+    // Projects lint themselves, so this covers only what no project owns: repo
+    // config, the release scripts, the agent scripts. Nx cannot reach those,
+    // and it is the same command the root `lint` script runs.
+    () => "pnpm exec oxlint --disable-nested-config --fix",
+    // Still `affected`, not the whole repo: a lint error in a project you never
+    // touched should not block your commit. Non-project files in the list are
+    // harmless, and a change to a root file correctly affects everything.
+    (filenames) =>
+      `pnpm exec nx affected -t=lint --exclude="@storyblok/playground-*" --files=${filenames.join(",")} -- --fix`,
+    // `oxlint --fix` rewrites code but does not reformat it, so an autofix lands
+    // unformatted (wrong indentation, dropped trailing commas) unless the
+    // formatter runs afterwards. `--concurrent=false` in the hook keeps that
+    // order. Repo-wide, because the fixes above can touch unstaged files.
+    () => "pnpm exec vp fmt",
+  ],
 };


### PR DESCRIPTION
A markdown-only commit on another branch broke `Check formatting` in CI, because the
hook never looked at the file.

- **Pre-commit hook:** drop the glob from `lint-staged.config.js`. It matched only
  `{packages,tools}/**/*.{js,ts,jsx,tsx,astro,json}`, so a change to a root script, an
  `.agents/` script, a `.vue` file, or any markdown ran neither the linter nor the
  formatter. Every staged file now goes through, whatever its path or extension.
- **Add the root Oxlint pass to the hook.** `nx affected` can only reach files that
  belong to a project, so repo config, the release scripts, and the agent scripts were
  unreachable no matter how the glob was written. That is the gap the root pass fills.
- **Keep `nx affected` for the project lint**, rather than switching to `run-many`: a
  lint error in a project you never touched should not block your commit.
- **`--concurrent=false`** in `.husky/pre-commit`, so the formatter still runs after
  `oxlint --fix` (an autofix lands unformatted otherwise).
- **CI:** add the same root Oxlint pass. `Check` lints only the projects in the matrix,
  so nothing checked the root files there either. It needs `@storyblok/lint-config`
  built first, since `oxlint.config.ts` imports it.

## Cost

Measured locally: the root pass is 0.8s, `vp fmt` 0.7s, and `nx affected -t lint` for one
package ~5s (it pulls in that project's `build` deps).

## Verification

- Staged a root-level file with an unused variable: the hook blocks the commit and
  reverts cleanly. The old config would not have looked at it.
- Staged deliberately unformatted markdown: the hook reformats it before the commit.
- `pnpm exec oxlint --disable-nested-config` exits 0 on `main`.