### PR TITLE
chore(cli): keep backend internals out of assets transfer docs

### DIFF
--- a/packages/cli/src/commands/assets/actions.ts
+++ b/packages/cli/src/commands/assets/actions.ts
@@ -339,14 +339,12 @@ export const createAsset = async (
 /**
  * Transfers a space-local asset into the org's shared library.
  *
- * UX wording is "transfer"; the backend endpoint is still `convert`
- * (`AssetsServices::ConvertToSharedAsset`). Drop this mapping when the backend
- * ships the `convert` -> `transfer` rename. One-way only (space to shared).
+ * UX wording is "transfer"; the API endpoint is still `convert`. Drop this
+ * mapping once the API ships the `convert` -> `transfer` rename. One-way only
+ * (space to shared).
  *
- * A 403 comes from the backend authorization policy (`AssetPolicy#convert?`):
- * the target folder must exist in the shared asset library and the space must
- * have write access to it. Surface that as a friendly hint instead of a raw
- * API error.
+ * A 403 means the space lacks write access to the target folder. Surface that
+ * as a friendly hint instead of a raw API error.
  */
 export const transferAsset = async (
   spaceId: string,

--- a/packages/cli/src/commands/assets/transfer/README.md
+++ b/packages/cli/src/commands/assets/transfer/README.md
@@ -38,14 +38,14 @@ storyblok assets transfer 123456 789012 --folder-id 789 --space YOUR_SPACE_ID --
 ## Notes
 
 - **Endpoint mapping:** The CLI exposes this operation as `transfer`, but it currently calls the
-  backend `convert` endpoint (`POST /v1/spaces/{space_id}/assets/{id}/convert`), mapping
-  `--folder-id` to the required `target_asset_folder_id` query parameter. This mapping will be
-  removed once the backend ships the rename from `convert` to `transfer`.
+  `convert` endpoint (`POST /v1/spaces/{space_id}/assets/{id}/convert`), mapping `--folder-id` to
+  the required `target_asset_folder_id` query parameter. This mapping will be removed once the API
+  ships the rename from `convert` to `transfer`.
 - **Plan required:** `--folder-id` is required and has no implicit default. Omitting it fails with
   an error.
-- **403 errors:** A 403 response comes from the backend authorization policy: the target folder must
-  exist in the shared asset library and the source space must have write access to it. Grant the
-  space write access to the destination folder (or pick a folder it can write to), then retry.
+- **403 errors:** A 403 response means the source space lacks write access to the target folder.
+  Grant the space write access to the destination folder (or pick a folder it can write to), then
+  retry. A folder that does not exist in the shared asset library returns a 404 instead.
 - **`--all`:** Transfers every asset in the space into `--folder-id`. It enumerates the space's
   assets first, so `--dry-run` reports an accurate count. `--all` cannot be combined with explicit
   asset IDs or `--query`. If the space has no assets, the command exits 0 and prints a "No assets


### PR DESCRIPTION
The `assets transfer` code comment and README named internal service and policy classes from the API implementation. Describe the observable API behavior instead.

While here, correct the 403 note: a destination folder that does not exist in the shared asset library returns a 404, so 403 covers the write-access case only. The matching correction is in the reference docs PR (storyblok/storyblok-docs-platform#548).

Docs and comments only, no behavior change. Lint clean; the 118 `src/commands/assets` tests pass.