### PR TITLE
test(angular): expand LivePreviewService unit tests

### DIFF
--- a/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
@@ -1,4 +1,6 @@
+import { NgZone } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
+import { vi } from "vitest";
 import {
   LivePreviewService,
   LivePreviewNotEnabledError,
@@ -6,14 +8,28 @@ import {
   LIVE_PREVIEW_CONFIG,
 } from "./livepreview.service";
 
+// ---- mocks ----
+
+const onStoryblokEditorEventMock = vi.fn(
+  async (_cb: (story: unknown) => void, _config?: unknown): Promise<() => void> =>
+    () => {},
+);
+
+vi.mock("@storyblok/live-preview", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onStoryblokEditorEvent: (cb: any, config: any) => onStoryblokEditorEventMock(cb, config),
+}));
+
 describe("LivePreviewService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe("without live preview enabled", () => {
     let service: LivePreviewService;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [LivePreviewService],
-      });
+      TestBed.configureTestingModule({ providers: [LivePreviewService] });
       service = TestBed.inject(LivePreviewService);
     });
 
@@ -21,7 +37,7 @@ describe("LivePreviewService", () => {
       expect(service).toBeTruthy();
     });
 
-    it("should throw LivePreviewNotEnabledError when listen() is called in dev mode", async () => {
+    it("throws LivePreviewNotEnabledError when listen() is called in dev mode", async () => {
       await expect(service.listen(() => {})).rejects.toThrow(LivePreviewNotEnabledError);
     });
   });
@@ -29,12 +45,14 @@ describe("LivePreviewService", () => {
   describe("with live preview enabled", () => {
     let service: LivePreviewService;
 
+    const baseConfig = { resolveLinks: "url" as const };
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [
           LivePreviewService,
           { provide: LIVE_PREVIEW_ENABLED, useValue: true },
-          { provide: LIVE_PREVIEW_CONFIG, useValue: {} },
+          { provide: LIVE_PREVIEW_CONFIG, useValue: baseConfig },
         ],
       });
       service = TestBed.inject(LivePreviewService);
@@ -42,6 +60,52 @@ describe("LivePreviewService", () => {
 
     it("should be created", () => {
       expect(service).toBeTruthy();
+    });
+
+    it("passes merged config to onStoryblokEditorEvent", async () => {
+      const pageConfig = { resolveRelations: ["featured-articles.articles"] };
+      await service.listen(() => {}, pageConfig);
+
+      expect(onStoryblokEditorEventMock).toHaveBeenCalledWith(expect.any(Function), {
+        ...baseConfig,
+        ...pageConfig,
+      });
+    });
+
+    it("creates a separate subscription per listen() call", async () => {
+      await service.listen(() => {}, { resolveRelations: ["a.b"] });
+      await service.listen(() => {}, { resolveRelations: ["c.d"] });
+
+      expect(onStoryblokEditorEventMock).toHaveBeenCalledTimes(2);
+      expect(onStoryblokEditorEventMock).toHaveBeenNthCalledWith(1, expect.any(Function), {
+        ...baseConfig,
+        resolveRelations: ["a.b"],
+      });
+      expect(onStoryblokEditorEventMock).toHaveBeenNthCalledWith(2, expect.any(Function), {
+        ...baseConfig,
+        resolveRelations: ["c.d"],
+      });
+    });
+
+    it("wraps the callback in NgZone.run()", async () => {
+      await service.listen(() => {});
+
+      const wrappedCallback = onStoryblokEditorEventMock.mock.calls[0][0];
+      const ngZone = TestBed.inject(NgZone);
+      const runSpy = vi.spyOn(ngZone, "run");
+
+      wrappedCallback({ id: 1 });
+
+      expect(runSpy).toHaveBeenCalledOnce();
+    });
+
+    it("returns the cleanup from onStoryblokEditorEvent", async () => {
+      const cleanup = vi.fn();
+      onStoryblokEditorEventMock.mockResolvedValueOnce(cleanup);
+
+      const result = await service.listen(() => {});
+
+      expect(result).toBe(cleanup);
     });
   });
 });


### PR DESCRIPTION
## Summary

Stacked on #771.

Expands the `LivePreviewService` unit tests in `@storyblok/angular` to properly isolate `@storyblok/live-preview` and cover config-merging behaviour.

### Changes

- Mock `onStoryblokEditorEvent` via `vi.mock` to isolate the service under test
- Add `beforeEach(() => vi.clearAllMocks())` to prevent cross-test leakage
- Add assertion: merged config (`baseConfig + pageConfig`) is forwarded to `onStoryblokEditorEvent`
- Provide a concrete `baseConfig` (`resolveLinks: 'url'`) instead of an empty object
- Rename test labels to drop redundant `should` prefix

Fixes DX-515