### PR TITLE
fix(capi-client): treat HTTP error results as failures in the cache strategies

### DIFF
--- a/packages/capi-client/src/client.ts
+++ b/packages/capi-client/src/client.ts
@@ -48,6 +48,17 @@ const getFailure = (result: ApiResponse): StrategyFailure | undefined =>
     ? undefined
     : { transient: isTransientStatus(result.response?.status ?? 0), error: result.error };
 
+/**
+ * Describes the failure a rejection represents. A `ClientError` is an HTTP answer the
+ * origin gave — the shape an error takes with `throwOnError` enabled — and is classified
+ * by its status like any other. Anything else got no answer at all: a timeout, a DNS
+ * failure, an aborted socket. Those are transient by nature.
+ */
+const getThrownFailure = (error: unknown): StrategyFailure => ({
+  transient: error instanceof ClientError ? isTransientStatus(error.response.status) : true,
+  error,
+});
+
 export type HttpRequestMethod = <TData = unknown>(
   path: string,
   options?: HttpRequestOptions,
@@ -398,6 +409,7 @@ export const createApiClientBase = <
       cachedResult,
       loadNetwork,
       getFailure,
+      getThrownFailure,
     });
   };
 

--- a/packages/capi-client/src/client.ts
+++ b/packages/capi-client/src/client.ts
@@ -1,6 +1,11 @@
 import { createClient, createConfig } from "./generated/capi/client";
-import type { CacheProvider, CacheStrategy, CacheStrategyHandler } from "./utils/cache";
-import { createMemoryCacheProvider, createStrategy } from "./utils/cache";
+import type {
+  CacheProvider,
+  CacheStrategy,
+  CacheStrategyHandler,
+  StrategyFailure,
+} from "./utils/cache";
+import { createMemoryCacheProvider, createStrategy, isTransientStatus } from "./utils/cache";
 import { ClientError } from "./error";
 import type { RateLimitConfig, ThrottleManager } from "./utils/rate-limit";
 import { createThrottleManager } from "./utils/rate-limit";
@@ -31,6 +36,17 @@ export type ApiResponse<
   : { data?: Data; error?: ClientError; response: Response; request: Request };
 
 export type HttpRequestOptions = Omit<RequestOptions, "method" | "security" | "url">;
+
+/**
+ * Describes the failure a response represents, or `undefined` if it succeeded. The cache
+ * strategies cannot inspect an `ApiResponse` themselves, and with `throwOnError` disabled
+ * an HTTP error resolves rather than rejects — so without this they would only ever see a
+ * transport-level failure.
+ */
+const getFailure = (result: ApiResponse): StrategyFailure | undefined =>
+  result.error === undefined
+    ? undefined
+    : { transient: isTransientStatus(result.response?.status ?? 0), error: result.error };
 
 export type HttpRequestMethod = <TData = unknown>(
   path: string,
@@ -381,6 +397,7 @@ export const createApiClientBase = <
       key,
       cachedResult,
       loadNetwork,
+      getFailure,
     });
   };
 

--- a/packages/capi-client/src/resources/stories.test.ts
+++ b/packages/capi-client/src/resources/stories.test.ts
@@ -996,6 +996,89 @@ describe("cache and cv", () => {
     },
   );
 
+  it.each([500, 502, 503, 429, 408])(
+    "should serve the cached response when network-first hits a %i with throwOnError",
+    async (status) => {
+      // With `throwOnError` the same outage rejects instead of resolving. The fallback has
+      // to recognise it there too, or the strategy would depend on a client-wide flag.
+      let fail = false;
+      server.use(
+        http.get("https://api.storyblok.com/v2/cdn/links", () =>
+          fail
+            ? HttpResponse.json({ error: "Nope" }, { status })
+            : HttpResponse.json({ links: {}, marker: "cached", cv: 1 }),
+        ),
+      );
+      const client = createApiClient({
+        accessToken: "test-token",
+        throwOnError: true,
+        retry: { limit: 0 },
+        cache: { strategy: "network-first" },
+      });
+
+      await client.get("v2/cdn/links", { query: { version: "published" } });
+
+      fail = true;
+      const result = await client.get("v2/cdn/links", { query: { version: "published" } });
+
+      // @ts-expect-error generic get request can have any shape or form
+      expect(result.data?.marker).toBe("cached");
+    },
+  );
+
+  it.each([400, 401, 403, 404, 422])(
+    "should surface a %i with network-first and throwOnError instead of the cached response",
+    async (status) => {
+      // A definitive answer rejects rather than resolving here, and a rejection the cache
+      // swallows is the same masked deletion as a returned one.
+      let fail = false;
+      server.use(
+        http.get("https://api.storyblok.com/v2/cdn/links", () =>
+          fail
+            ? HttpResponse.json({ error: "Nope" }, { status })
+            : HttpResponse.json({ links: {}, marker: "cached", cv: 1 }),
+        ),
+      );
+      const client = createApiClient({
+        accessToken: "test-token",
+        throwOnError: true,
+        retry: { limit: 0 },
+        cache: { strategy: "network-first" },
+      });
+
+      await client.get("v2/cdn/links", { query: { version: "published" } });
+
+      fail = true;
+      await expect(
+        client.get("v2/cdn/links", { query: { version: "published" } }),
+      ).rejects.toMatchObject({ response: { status } });
+    },
+  );
+
+  it("should serve the cached response when network-first hits a transport failure", async () => {
+    // A request that got no answer at all is transient by nature: nothing was said about
+    // whether the resource still exists.
+    let fail = false;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/links", () =>
+        fail ? HttpResponse.error() : HttpResponse.json({ links: {}, marker: "cached", cv: 1 }),
+      ),
+    );
+    const client = createApiClient({
+      accessToken: "test-token",
+      retry: { limit: 0 },
+      cache: { strategy: "network-first" },
+    });
+
+    await client.get("v2/cdn/links", { query: { version: "published" } });
+
+    fail = true;
+    const result = await client.get("v2/cdn/links", { query: { version: "published" } });
+
+    // @ts-expect-error generic get request can have any shape or form
+    expect(result.data?.marker).toBe("cached");
+  });
+
   it("should surface a transient error with network-first when nothing is cached", async () => {
     server.use(
       http.get("https://api.storyblok.com/v2/cdn/links", () =>

--- a/packages/capi-client/src/resources/stories.test.ts
+++ b/packages/capi-client/src/resources/stories.test.ts
@@ -1032,6 +1032,34 @@ describe("cache and cv", () => {
     expect(requestCount).toBe(1);
   });
 
+  it("should report a background swr revalidation that came back 5xx", async () => {
+    // The revalidation resolves with an error result rather than throwing, so without
+    // recognising it the entry would go stale with no signal to the caller at all.
+    let fail = false;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/links", () =>
+        fail
+          ? HttpResponse.json({ error: "Nope" }, { status: 503 })
+          : HttpResponse.json({ links: {}, cv: 1 }),
+      ),
+    );
+    const onRevalidationError = vi.fn();
+    const client = createApiClient({
+      accessToken: "test-token",
+      retry: { limit: 0 },
+      cache: { strategy: "swr", onRevalidationError },
+    });
+
+    await client.get("v2/cdn/links", { query: { version: "published" } });
+
+    fail = true;
+    const result = await client.get("v2/cdn/links", { query: { version: "published" } });
+
+    // The cached entry is still served — reporting must not make swr blocking.
+    expect(result.error).toBeUndefined();
+    await vi.waitFor(() => expect(onRevalidationError).toHaveBeenCalledTimes(1));
+  });
+
   it("should return cached response and revalidate in background with swr strategy", async () => {
     let requestCount = 0;
     server.use(

--- a/packages/capi-client/src/resources/stories.test.ts
+++ b/packages/capi-client/src/resources/stories.test.ts
@@ -936,6 +936,102 @@ describe("cache and cv", () => {
     expect(requestCount).toBe(2); // page 1 still served from cache after receiving stale cv
   });
 
+  it.each([500, 502, 503, 429, 408])(
+    "should serve the cached response when network-first hits a %i",
+    async (status) => {
+      // An HTTP error resolves rather than rejects unless `throwOnError` is enabled, so
+      // without recognising the error result `network-first` would surface the outage to
+      // the caller while a perfectly good cached entry sat unused.
+      let fail = false;
+      server.use(
+        http.get("https://api.storyblok.com/v2/cdn/links", () =>
+          fail
+            ? HttpResponse.json({ error: "Nope" }, { status })
+            : HttpResponse.json({ links: {}, marker: "cached", cv: 1 }),
+        ),
+      );
+      const client = createApiClient({
+        accessToken: "test-token",
+        retry: { limit: 0 },
+        cache: { strategy: "network-first" },
+      });
+
+      await client.get("v2/cdn/links", { query: { version: "published" } });
+
+      fail = true;
+      const result = await client.get("v2/cdn/links", { query: { version: "published" } });
+
+      expect(result.error).toBeUndefined();
+      // @ts-expect-error generic get request can have any shape or form
+      expect(result.data?.marker).toBe("cached");
+    },
+  );
+
+  it.each([400, 401, 403, 404, 422])(
+    "should surface a %i with network-first instead of the cached response",
+    async (status) => {
+      // A definitive answer must not be masked by a cached copy: a 404 means the entry is
+      // gone, a 401 means the token no longer works.
+      let fail = false;
+      server.use(
+        http.get("https://api.storyblok.com/v2/cdn/links", () =>
+          fail
+            ? HttpResponse.json({ error: "Nope" }, { status })
+            : HttpResponse.json({ links: {}, marker: "cached", cv: 1 }),
+        ),
+      );
+      const client = createApiClient({
+        accessToken: "test-token",
+        retry: { limit: 0 },
+        cache: { strategy: "network-first" },
+      });
+
+      await client.get("v2/cdn/links", { query: { version: "published" } });
+
+      fail = true;
+      const result = await client.get("v2/cdn/links", { query: { version: "published" } });
+
+      expect(result.error).toBeDefined();
+      expect(result.response.status).toBe(status);
+    },
+  );
+
+  it("should surface a transient error with network-first when nothing is cached", async () => {
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/links", () =>
+        HttpResponse.json({ error: "Nope" }, { status: 503 }),
+      ),
+    );
+    const client = createApiClient({
+      accessToken: "test-token",
+      retry: { limit: 0 },
+      cache: { strategy: "network-first" },
+    });
+
+    const result = await client.get("v2/cdn/links", { query: { version: "published" } });
+
+    expect(result.error).toBeDefined();
+    expect(result.response.status).toBe(503);
+  });
+
+  it("should not serve a cached response for a transient error with cache-first", async () => {
+    // Only `network-first` falls back. `cache-first` never reaches the network while a
+    // valid entry exists, so an error there means the entry was already gone.
+    let requestCount = 0;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/links", () => {
+        requestCount++;
+        return HttpResponse.json({ error: "Nope" }, { status: 503 });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token", retry: { limit: 0 } });
+
+    const result = await client.get("v2/cdn/links", { query: { version: "published" } });
+
+    expect(result.response.status).toBe(503);
+    expect(requestCount).toBe(1);
+  });
+
   it("should return cached response and revalidate in background with swr strategy", async () => {
     let requestCount = 0;
     server.use(

--- a/packages/capi-client/src/utils/cache.test.ts
+++ b/packages/capi-client/src/utils/cache.test.ts
@@ -388,6 +388,64 @@ describe("cache strategies", () => {
     expect(onRevalidationError).toHaveBeenCalledWith("not found");
   });
 
+  it.each([
+    ["resolved with a failure", "failed", { transient: true, error: "boom" }],
+    ["rejected", undefined, undefined],
+  ])(
+    "should report a swr revalidation that %s once when the callback throws",
+    async (_label, resolvedValue, failure) => {
+      // Nothing awaits the revalidation, so a callback that throws must not leave the
+      // chain rejected, and must not be re-entered with its own failure in place of the
+      // one it was reporting.
+      const onRevalidationError = vi.fn(() => {
+        throw new Error("callback blew up");
+      });
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const strategy = createSwrStrategy({ onRevalidationError });
+      const loadNetwork =
+        resolvedValue === undefined
+          ? vi.fn().mockRejectedValue("network down")
+          : vi.fn().mockResolvedValue(resolvedValue);
+
+      const result = await strategy({
+        key: "k",
+        cachedResult: "cached",
+        loadNetwork,
+        getFailure: () => failure,
+      });
+
+      expect(result).toBe("cached");
+      await vi.waitFor(() => expect(onRevalidationError).toHaveBeenCalledTimes(1));
+      expect(onRevalidationError).toHaveBeenCalledWith(failure?.error ?? "network down");
+      expect(consoleError).toHaveBeenCalled();
+
+      consoleError.mockRestore();
+    },
+  );
+
+  it("should survive a swr getFailure that throws", async () => {
+    // `getFailure` is caller-supplied like the callback, and runs in the same unawaited
+    // chain, so it must not be able to end the revalidation as an unhandled rejection.
+    const onRevalidationError = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const strategy = createSwrStrategy({ onRevalidationError });
+
+    const result = await strategy({
+      key: "k",
+      cachedResult: "cached",
+      loadNetwork: vi.fn().mockResolvedValue("fresh"),
+      getFailure: () => {
+        throw new Error("classifier blew up");
+      },
+    });
+
+    expect(result).toBe("cached");
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(onRevalidationError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
   it("should not report a successful swr revalidation", async () => {
     const onRevalidationError = vi.fn();
     const strategy = createSwrStrategy({ onRevalidationError });

--- a/packages/capi-client/src/utils/cache.test.ts
+++ b/packages/capi-client/src/utils/cache.test.ts
@@ -351,6 +351,59 @@ describe("cache strategies", () => {
     );
   });
 
+  it("should report a swr revalidation that resolved with a failure", async () => {
+    // The revalidation came back 5xx, which resolves rather than throws, so reporting
+    // only from `catch` would drop it silently.
+    const onRevalidationError = vi.fn();
+    const strategy = createSwrStrategy({ onRevalidationError });
+    const loadNetwork = vi.fn().mockResolvedValue("failed");
+
+    const result = await strategy({
+      key: "k",
+      cachedResult: "cached",
+      loadNetwork,
+      getFailure: (value) => (value === "failed" ? { transient: true, error: "boom" } : undefined),
+    });
+
+    expect(result).toBe("cached");
+    await vi.waitFor(() => expect(onRevalidationError).toHaveBeenCalledTimes(1));
+    expect(onRevalidationError).toHaveBeenCalledWith("boom");
+  });
+
+  it("should report a definitive swr revalidation failure too", async () => {
+    // Unlike the fallback in `network-first`, reporting is not limited to transient
+    // failures: a revalidation that 404s is worth surfacing to the caller as well.
+    const onRevalidationError = vi.fn();
+    const strategy = createSwrStrategy({ onRevalidationError });
+    const loadNetwork = vi.fn().mockResolvedValue("gone");
+
+    await strategy({
+      key: "k",
+      cachedResult: "cached",
+      loadNetwork,
+      getFailure: () => ({ transient: false, error: "not found" }),
+    });
+
+    await vi.waitFor(() => expect(onRevalidationError).toHaveBeenCalledTimes(1));
+    expect(onRevalidationError).toHaveBeenCalledWith("not found");
+  });
+
+  it("should not report a successful swr revalidation", async () => {
+    const onRevalidationError = vi.fn();
+    const strategy = createSwrStrategy({ onRevalidationError });
+    const loadNetwork = vi.fn().mockResolvedValue("fresh");
+
+    await strategy({
+      key: "k",
+      cachedResult: "cached",
+      loadNetwork,
+      getFailure: () => undefined,
+    });
+
+    await vi.waitFor(() => expect(loadNetwork).toHaveBeenCalledTimes(1));
+    expect(onRevalidationError).not.toHaveBeenCalled();
+  });
+
   it("should call console.warn by default when swr revalidation fails", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const strategy = createSwrStrategy();

--- a/packages/capi-client/src/utils/cache.test.ts
+++ b/packages/capi-client/src/utils/cache.test.ts
@@ -4,6 +4,7 @@ import {
   createCacheFirstStrategy,
   createMemoryCacheProvider,
   createNetworkFirstStrategy,
+  isTransientStatus,
   createSwrStrategy,
 } from "./cache";
 
@@ -258,6 +259,52 @@ describe("cache strategies", () => {
     expect(result).toBe("cached");
   });
 
+  it("should fall back to cached result with network-first on a transient error result", async () => {
+    // With `throwOnError` disabled an HTTP error resolves instead of rejecting, so the
+    // fallback cannot live in `catch` alone.
+    const strategy = createNetworkFirstStrategy();
+    const loadNetwork = vi.fn().mockResolvedValue("failed");
+
+    const result = await strategy({
+      key: "k",
+      cachedResult: "cached",
+      loadNetwork,
+      getFailure: (value) => (value === "failed" ? { transient: true, error: "boom" } : undefined),
+    });
+
+    expect(result).toBe("cached");
+  });
+
+  it("should return a definitive error result with network-first instead of the cache", async () => {
+    // A 404 or 401 is an answer, not an outage: serving a cached copy would mask a
+    // deleted story or a revoked token.
+    const strategy = createNetworkFirstStrategy();
+    const loadNetwork = vi.fn().mockResolvedValue("not-found");
+
+    const result = await strategy({
+      key: "k",
+      cachedResult: "cached",
+      loadNetwork,
+      getFailure: () => ({ transient: false, error: "gone" }),
+    });
+
+    expect(result).toBe("not-found");
+  });
+
+  it("should return the network result with network-first when no failure reporter is given", async () => {
+    // The reporter is optional, so custom handlers and callers that omit it are unchanged.
+    const strategy = createNetworkFirstStrategy();
+    const loadNetwork = vi.fn().mockResolvedValue("network");
+
+    const result = await strategy({
+      key: "k",
+      cachedResult: "cached",
+      loadNetwork,
+    });
+
+    expect(result).toBe("network");
+  });
+
   it("should throw with network-first when no cached result exists", async () => {
     const strategy = createNetworkFirstStrategy();
     const loadNetwork = vi.fn().mockRejectedValue(new Error("boom"));
@@ -362,5 +409,15 @@ describe("cache strategies", () => {
 
     resolveRefresh?.();
     await refreshPromise;
+  });
+});
+
+describe("isTransientStatus", () => {
+  it.each([408, 413, 429, 500, 502, 503, 504])("should treat %i as transient", (status) => {
+    expect(isTransientStatus(status)).toBe(true);
+  });
+
+  it.each([200, 301, 400, 401, 403, 404, 422])("should treat %i as definitive", (status) => {
+    expect(isTransientStatus(status)).toBe(false);
   });
 });

--- a/packages/capi-client/src/utils/cache.ts
+++ b/packages/capi-client/src/utils/cache.ts
@@ -17,6 +17,18 @@ interface StrategyContext<TData> {
    * custom strategy handlers and callers that do not supply it keep working.
    */
   getFailure?: (value: TData) => StrategyFailure | undefined;
+  /**
+   * Describes the failure a rejection from `loadNetwork` represents.
+   *
+   * The mirror of {@link StrategyContext.getFailure} for the other way a request can
+   * fail: with `throwOnError` enabled an HTTP error rejects rather than resolving, so a
+   * definitive answer reaches a strategy as a thrown value and has to be told apart from
+   * a transport-level failure the same way.
+   *
+   * Optional: a context without it behaves as if every rejection were transient, which is
+   * what a transport-level failure is.
+   */
+  getThrownFailure?: (error: unknown) => StrategyFailure;
 }
 
 export interface StrategyFailure {
@@ -99,9 +111,12 @@ export const createMemoryCacheProvider = (
 };
 
 /**
- * Statuses that mean "try again later" rather than "here is your answer". Mirrors the set
- * the client retries, so one of these only reaches a strategy once the retries are spent
- * and the failure is a real outage.
+ * Statuses that mean "try again later" rather than "here is your answer".
+ *
+ * Every 5xx counts: the server failing to answer says nothing about whether the resource
+ * exists, so a cached copy is still the best available answer. The 4xx exceptions are the
+ * three the origin uses to ask for the same request again — a timeout, a payload it wants
+ * re-sent, and a rate limit.
  */
 const TRANSIENT_STATUS_CODES = new Set([408, 413, 429]);
 
@@ -120,7 +135,12 @@ export const createCacheFirstStrategy = (): CacheStrategyHandler => {
 };
 
 export const createNetworkFirstStrategy = (): CacheStrategyHandler => {
-  return async <TData>({ cachedResult, loadNetwork, getFailure }: StrategyContext<TData>) => {
+  return async <TData>({
+    cachedResult,
+    loadNetwork,
+    getFailure,
+    getThrownFailure,
+  }: StrategyContext<TData>) => {
     try {
       const result = await loadNetwork();
 
@@ -135,8 +155,12 @@ export const createNetworkFirstStrategy = (): CacheStrategyHandler => {
 
       return result;
     } catch (error) {
-      // network-first: try network, fall back to cached data if available.
-      if (cachedResult !== undefined) {
+      // The rule the resolved path applies has to hold here too: with `throwOnError`
+      // enabled the same 404 rejects instead of resolving, and serving a cached copy
+      // would mask the deletion just as thoroughly. Without a reporter every rejection
+      // counts as transient — a context that cannot classify only ever sees the
+      // transport-level failures, which are.
+      if (cachedResult !== undefined && getThrownFailure?.(error).transient !== false) {
         return cachedResult;
       }
 

--- a/packages/capi-client/src/utils/cache.ts
+++ b/packages/capi-client/src/utils/cache.ts
@@ -4,6 +4,26 @@ interface StrategyContext<TData> {
   key: string;
   cachedResult: TData | undefined;
   loadNetwork: () => Promise<TData>;
+  /**
+   * Describes the failure a value `loadNetwork` resolved with represents, or `undefined`
+   * when it succeeded.
+   *
+   * A failed request does not always reject: with `throwOnError` disabled — the default —
+   * an HTTP error arrives as a resolved response carrying `error`. A strategy that reacts
+   * to failure has to recognise those, and `network-first` also has to tell a temporary
+   * failure apart from a definitive one.
+   *
+   * Optional: a context without it behaves as if every resolved value succeeded, so
+   * custom strategy handlers and callers that do not supply it keep working.
+   */
+  getFailure?: (value: TData) => StrategyFailure | undefined;
+}
+
+export interface StrategyFailure {
+  /** `true` for a failure worth retrying — an outage rather than an answer. */
+  transient: boolean;
+  /** The failure itself, for reporting. */
+  error: unknown;
 }
 
 export type CacheStrategyHandler = <TData>(context: StrategyContext<TData>) => Promise<TData>;
@@ -78,6 +98,17 @@ export const createMemoryCacheProvider = (
   };
 };
 
+/**
+ * Statuses that mean "try again later" rather than "here is your answer". Mirrors the set
+ * the client retries, so one of these only reaches a strategy once the retries are spent
+ * and the failure is a real outage.
+ */
+const TRANSIENT_STATUS_CODES = new Set([408, 413, 429]);
+
+/** Returns `true` for a status that reflects a temporary failure rather than an answer. */
+export const isTransientStatus = (status: number): boolean =>
+  status >= 500 || TRANSIENT_STATUS_CODES.has(status);
+
 export const createCacheFirstStrategy = (): CacheStrategyHandler => {
   return async <TData>({ cachedResult, loadNetwork }: StrategyContext<TData>) => {
     if (cachedResult !== undefined) {
@@ -89,9 +120,20 @@ export const createCacheFirstStrategy = (): CacheStrategyHandler => {
 };
 
 export const createNetworkFirstStrategy = (): CacheStrategyHandler => {
-  return async <TData>({ cachedResult, loadNetwork }: StrategyContext<TData>) => {
+  return async <TData>({ cachedResult, loadNetwork, getFailure }: StrategyContext<TData>) => {
     try {
-      return await loadNetwork();
+      const result = await loadNetwork();
+
+      // An HTTP error is a resolved value rather than a rejection unless `throwOnError`
+      // is enabled, so falling back only in `catch` would miss the most common outage:
+      // the origin answering 5xx. A transient failure is treated exactly like a thrown
+      // network error. A definitive one — 404, 401 — is returned as it is: serving a
+      // cached copy there would mask a deletion or a revoked token.
+      if (cachedResult !== undefined && getFailure?.(result)?.transient === true) {
+        return cachedResult;
+      }
+
+      return result;
     } catch (error) {
       // network-first: try network, fall back to cached data if available.
       if (cachedResult !== undefined) {

--- a/packages/capi-client/src/utils/cache.ts
+++ b/packages/capi-client/src/utils/cache.ts
@@ -170,7 +170,17 @@ export const createNetworkFirstStrategy = (): CacheStrategyHandler => {
 };
 
 export interface SwrStrategyOptions {
-  /** Called when a background revalidation fails. Defaults to `console.warn`. */
+  /**
+   * Called when a background revalidation fails. Defaults to `console.warn`.
+   *
+   * Called once per failed revalidation, and a revalidation starts on every request that
+   * is served from the cache while none is in flight — so a lasting outage reports on
+   * every request rather than once. That is the point: the entry keeps being served
+   * stale, and how long that has been going on is what the caller needs to see.
+   *
+   * A callback that throws is reported to `console.error` and otherwise ignored, since a
+   * background revalidation is not awaited anywhere.
+   */
   onRevalidationError?: (error: unknown) => void;
 }
 
@@ -182,23 +192,44 @@ export const createSwrStrategy = (options: SwrStrategyOptions = {}): CacheStrate
   const { onRevalidationError = defaultOnRevalidationError } = options;
   const revalidations = new Map<string, Promise<unknown>>();
 
+  // Nothing awaits a revalidation, so anything thrown while reporting one — by the
+  // caller's callback or by its `getFailure` — would leave the chain rejected with no
+  // handler, which current Node defaults treat as fatal. Reporting a failure failing is
+  // not a reason to take the process down.
+  const reportGuarded = (describeFailure: () => void): void => {
+    try {
+      describeFailure();
+    } catch (reportingError) {
+      console.error("[storyblok/api-client] SWR revalidation reporting threw:", reportingError);
+    }
+  };
+
   return async <TData>({ key, cachedResult, loadNetwork, getFailure }: StrategyContext<TData>) => {
     if (cachedResult !== undefined) {
       if (!revalidations.has(key)) {
         const revalidation = loadNetwork()
-          .then((value) => {
-            // A revalidation that came back 5xx resolved rather than threw, so reporting
-            // only from `catch` would drop it silently and leave the entry to go stale
-            // with no signal at all. Every failure reaches the callback, transient or
-            // not: the caller decides what is worth acting on.
-            const failure = getFailure?.(value);
-            if (failure !== undefined) {
-              onRevalidationError(failure.error);
-            }
-          })
-          .catch((error: unknown) => {
-            onRevalidationError(error);
-          })
+          .then(
+            (value) =>
+              reportGuarded(() => {
+                // A revalidation that came back 5xx resolved rather than threw, so
+                // reporting only from the rejection path would drop it silently and leave
+                // the entry to go stale with no signal at all. Every failure reaches the
+                // callback, transient or not: the caller decides what is worth acting on.
+                const failure = getFailure?.(value);
+                if (failure !== undefined) {
+                  onRevalidationError(failure.error);
+                }
+              }),
+            // Paired with the handler above rather than chained after it, so it sees only
+            // what `loadNetwork` rejected with. A trailing `.catch` would also catch a
+            // throw from that handler and report the same revalidation twice, the second
+            // time with the reporting failure in place of the failure itself.
+            (error: unknown) => {
+              reportGuarded(() => {
+                onRevalidationError(error);
+              });
+            },
+          )
           .finally(() => {
             revalidations.delete(key);
           });

--- a/packages/capi-client/src/utils/cache.ts
+++ b/packages/capi-client/src/utils/cache.ts
@@ -158,13 +158,22 @@ export const createSwrStrategy = (options: SwrStrategyOptions = {}): CacheStrate
   const { onRevalidationError = defaultOnRevalidationError } = options;
   const revalidations = new Map<string, Promise<unknown>>();
 
-  return async <TData>({ key, cachedResult, loadNetwork }: StrategyContext<TData>) => {
+  return async <TData>({ key, cachedResult, loadNetwork, getFailure }: StrategyContext<TData>) => {
     if (cachedResult !== undefined) {
       if (!revalidations.has(key)) {
         const revalidation = loadNetwork()
+          .then((value) => {
+            // A revalidation that came back 5xx resolved rather than threw, so reporting
+            // only from `catch` would drop it silently and leave the entry to go stale
+            // with no signal at all. Every failure reaches the callback, transient or
+            // not: the caller decides what is worth acting on.
+            const failure = getFailure?.(value);
+            if (failure !== undefined) {
+              onRevalidationError(failure.error);
+            }
+          })
           .catch((error: unknown) => {
             onRevalidationError(error);
-            return undefined;
           })
           .finally(() => {
             revalidations.delete(key);


### PR DESCRIPTION
Both cache strategies that react to a failed request only ever saw *thrown* errors. With `throwOnError` disabled — the default — an HTTP error is not a rejection but a resolved `ApiResponse` carrying `error`, so the most common failure of all was invisible to both of them.

Four user-visible consequences, one root cause, one commit each. The last two came out of review.

## 1. `network-first` did not fall back on an HTTP error

It is documented as "try the network, fall back to cached data if available." The fallback lived entirely in a `catch`:

```ts
try {
  return await loadNetwork();   // a 503 resolves here, it does not throw
} catch (error) {
  if (cachedResult !== undefined) return cachedResult;
  throw error;
}
```

So the origin answering 5xx surfaced straight to the caller while a usable cached entry sat unused. Only a transport-level failure — DNS, connection reset, `fetch` rejecting — ever triggered the fallback. That inverts the intent: the case `network-first` exists to survive is a struggling origin, and that is the case it did not handle.

| scenario | before | after |
|---|---|---|
| transport error, warm cache | serves cached | serves cached |
| HTTP 503, warm cache | **surfaces the 503** | serves cached |

## 2. `swr` silently swallowed a failed background revalidation

`onRevalidationError` fired only from the `catch` of the background promise, so a revalidation that came back 5xx was dropped without a word. The cached entry went on being served with no signal that it had stopped being refreshed — the one thing the callback exists to tell you.

| scenario | before | after |
|---|---|---|
| revalidation throws | `onRevalidationError` | `onRevalidationError` |
| revalidation returns 503 | **silence** | `onRevalidationError` |

Reporting happens off the background promise, so swr stays non-blocking.

## 3. …and the same rule did not hold for rejections

Fixing (1) on the resolved path left the `catch` untouched, still falling back for anything thrown. With `throwOnError: true` the same 404 rejects instead of resolving, so whether a definitive answer surfaced came down to a client-wide flag:

| `throwOnError` | 404 with a warm cache |
|---|---|
| `false` | the 404 surfaces |
| `true` | **the cached copy is served, the deletion masked** |

A rejection is now classified the same way a resolved failure is. Reproduced first, then fixed.

## 4. `swr` could report one failure twice, then crash the process

The revalidation chain was `.then(report).catch(report)`. A callback that threw while reporting a resolved failure was immediately re-entered by the `.catch` — called a second time, with its own failure in place of the one it was reporting. If that second call threw too, the chain ended rejected with nothing awaiting it: an unhandled rejection, fatal on current Node defaults.

The handlers are now paired in a single `.then(onFulfilled, onRejected)`, so the rejection handler sees only what `loadNetwork` rejected with and cannot be reached from the fulfillment path at all. Both are total: `getFailure` and `onRevalidationError` are caller-supplied and run in a chain nobody awaits, so anything they throw is logged and dropped rather than left to escape.

## How

The strategies live in `utils/cache.ts` and are generic over `TData`, so they cannot inspect an `ApiResponse` themselves. `StrategyContext` gained two optional reporters, supplied by the client and shared by the fixes — one per way a request can fail:

```ts
getFailure?: (value: TData) => { transient: boolean; error: unknown } | undefined;
getThrownFailure?: (error: unknown) => { transient: boolean; error: unknown };
```

Keeping both in the client leaves the strategies unaware of `ClientError`. Optional is load-bearing: `cache.strategy` accepts a caller-supplied handler, and a context without the reporters behaves exactly as before — every resolved value a success, every rejection transient, which is what a transport-level failure is.

The two strategies read them differently, on purpose:

- **`network-first` falls back only on `transient`.** Serving a cached copy for a definitive answer would be wrong.
- **`swr` reports every failure.** A revalidation that 404s is worth surfacing; the caller decides what to act on.

| status | `network-first` | `swr` |
|---|---|---|
| 5xx, 429, 408, 413 | serve cached | report |
| 404 | return error — the story really is gone | report |
| 401, 403 | return error — the token really is bad | report |
| 400, 422 | return error — the request is wrong | report |

Same verdict whether the failure resolved or was thrown.

Every 5xx counts as transient: a server that fails to answer says nothing about whether the resource still exists, so a cached copy is the best available answer. The three 4xx exceptions are the ones the origin uses to ask for the same request again — a timeout, a payload it wants re-sent, and a rate limit.

`cache-first` is untouched, and covered by a test so a future change has to be deliberate: it never reaches the network while a valid entry exists, so an error there means the entry was already gone and there is nothing to fall back to.

## Verification

```
api-client:  196 passed  (149 on main, +47 here)
js-client:   194 passed | 1 skipped
lint, types: clean
```

Coverage was added at both levels, because `network-first` and swr's error path had **no integration coverage at all** — the only existing tests were three unit tests against the strategy functions.

- unit: transient error result falls back, definitive does not, a context without the reporter is unchanged, `isTransientStatus` over 13 statuses, swr reports a resolved transient failure, a resolved definitive failure, and stays quiet on success
- unit, from review: a throwing `onRevalidationError` is called once — on the resolved path and on the rejected one — and a throwing `getFailure` cannot end the revalidation as an unhandled rejection
- integration through `createApiClient` and msw: `500 / 502 / 503 / 429 / 408` each serve the cached response; `400 / 401 / 403 / 404 / 422` each surface the error; a transient error with an empty cache still surfaces; `cache-first` does not fall back; a swr revalidation returning 503 reaches `onRevalidationError` without blocking the read
- integration, from review: the same ten statuses again under `throwOnError: true`, where they reject rather than resolve, plus a transport-level failure with no status at all

Every new test was confirmed to fail with its fix reverted and pass with it in place. All four commits are independently green.
