### PR TITLE
fix(cli): remove Eleventy template support

### DIFF
--- a/packages/cli/src/commands/create/README.md
+++ b/packages/cli/src/commands/create/README.md
@@ -20,23 +20,22 @@ The command will:
 
 ## Options
 
-| Option                      | Description                                                                   | Default               |
-| --------------------------- | ----------------------------------------------------------------------------- | --------------------- |
-| `-t, --template <template>` | Technology starter template (react, vue, svelte, astro, nuxt, next, eleventy) | Interactive selection |
-| `--skip-space`              | Skip space creation and only generate the project                             | `false`               |
-| `--token`                   | Skip space creation and generate the project with this `token`                | `false`               |
+| Option                      | Description                                                         | Default               |
+| --------------------------- | ------------------------------------------------------------------- | --------------------- |
+| `-t, --template <template>` | Technology starter template (react, vue, svelte, astro, nuxt, next) | Interactive selection |
+| `--skip-space`              | Skip space creation and only generate the project                   | `false`               |
+| `--token`                   | Skip space creation and generate the project with this `token`      | `false`               |
 
 ## Available Templates
 
-| Template   | Technology                |
-| ---------- | ------------------------- |
-| `react`    | React with TypeScript     |
-| `vue`      | Vue 3 with TypeScript     |
-| `svelte`   | SvelteKit with TypeScript |
-| `astro`    | Astro with TypeScript     |
-| `nuxt`     | Nuxt 3 with TypeScript    |
-| `next`     | Next.js with TypeScript   |
-| `eleventy` | Eleventy with JavaScript  |
+| Template | Technology                |
+| -------- | ------------------------- |
+| `react`  | React with TypeScript     |
+| `vue`    | Vue 3 with TypeScript     |
+| `svelte` | SvelteKit with TypeScript |
+| `astro`  | Astro with TypeScript     |
+| `nuxt`   | Nuxt 3 with TypeScript    |
+| `next`   | Next.js with TypeScript   |
 
 ## Examples
 
@@ -72,7 +71,7 @@ storyblok create ./projects/my-awesome-app --template astro
 5. **Create with absolute path**:
 
 ```bash
-storyblok create /Users/john/projects/my-app --template eleventy
+storyblok create /Users/john/projects/my-app --template astro
 ```
 
 ## Interactive Mode
@@ -89,7 +88,6 @@ When you don't specify a template or project path, the CLI will guide you throug
   Astro
   Nuxt 3
   Next.js
-  Eleventy
 ```
 
 ### Project Path Input
@@ -196,7 +194,7 @@ interactive mode:
 
 ```bash
 storyblok create my-project --template invalid-name
-# ⚠ Invalid template "invalid-name". Valid options are: react, vue, svelte, astro, nuxt, next, eleventy
+# ⚠ Invalid template "invalid-name". Valid options are: react, vue, svelte, astro, nuxt, next
 ```
 
 ### Directory Already Exists

--- a/packages/cli/src/commands/create/actions.test.ts
+++ b/packages/cli/src/commands/create/actions.test.ts
@@ -558,6 +558,45 @@ describe("fetchBlueprintRepositories", () => {
     });
   });
 
+  it("should exclude archived repositories", async () => {
+    const mockRepos = [
+      {
+        name: "blueprint-core-react",
+        archived: false,
+        topics: [],
+        clone_url: "https://github.com/storyblok/blueprint-core-react.git",
+        description: "A React starter",
+        updated_at: "2024-01-01T00:00:00Z",
+        stargazers_count: 75,
+      },
+      {
+        name: "blueprint-core-eleventy",
+        archived: true,
+        topics: [],
+        clone_url: "https://github.com/storyblok/blueprint-core-eleventy.git",
+        description: "An Eleventy starter",
+        updated_at: "2024-01-01T00:00:00Z",
+        stargazers_count: 10,
+      },
+    ];
+
+    const mockOctokit = {
+      rest: {
+        search: {
+          repos: vi.fn().mockResolvedValue({ data: { items: mockRepos } }),
+        },
+      },
+    };
+
+    mockedCreateOctokit.mockReturnValue(mockOctokit as any);
+
+    const blueprints = await fetchBlueprintRepositories();
+
+    expect(blueprints).toHaveLength(1);
+    expect(blueprints[0]?.value).toBe("react");
+    expect(blueprints.some((bp) => bp.value === "eleventy")).toBe(false);
+  });
+
   it("should handle errors and call show warning", async () => {
     const octokitError = new Error("GitHub API error");
     mockedCreateOctokit.mockImplementation(() => {

--- a/packages/cli/src/commands/create/actions.ts
+++ b/packages/cli/src/commands/create/actions.ts
@@ -324,7 +324,7 @@ export const fetchBlueprintRepositories = async (): Promise<Template[]> => {
 
     // Filter and convert repositories to blueprints
     const blueprints = data.items
-      .filter((repo) => repo.name.startsWith("blueprint-core-"))
+      .filter((repo) => repo.name.startsWith("blueprint-core-") && !repo.archived)
       .map(repositoryToTemplate)
       .sort((a, b) => (b.stars || 0) - (a.stars || 0));
 

--- a/packages/cli/src/commands/create/constants.ts
+++ b/packages/cli/src/commands/create/constants.ts
@@ -7,15 +7,7 @@ export interface CreateOptions {
   token?: string; // Access token for Storyblok
   region?: RegionCode;
 }
-type TemplateTechnology =
-  | "REACT"
-  | "VUE"
-  | "SVELTE"
-  | "ASTRO"
-  | "NUXT"
-  | "NEXTJS"
-  | "ELEVENTY"
-  | "ANGULAR";
+type TemplateTechnology = "REACT" | "VUE" | "SVELTE" | "ASTRO" | "NUXT" | "NEXTJS" | "ANGULAR";
 
 export interface Template {
   name: string;
@@ -62,12 +54,6 @@ export const templates: Record<TemplateTechnology, Template> = {
     value: "nextjs",
     template: "https://github.com/storyblok/blueprint-core-nextjs",
     location: "https://localhost:3000/",
-  },
-  ELEVENTY: {
-    name: "Eleventy",
-    value: "eleventy",
-    template: "https://github.com/storyblok/blueprint-core-eleventy",
-    location: "https://localhost:8080/",
   },
   ANGULAR: {
     name: "Angular",


### PR DESCRIPTION
## What

Removes Eleventy as a supported starter template from the `storyblok create` command.

## Why

The `blueprint-core-eleventy` GitHub repository has been archived and Eleventy is no longer supported as a CLI starter template.

## Changes

- **`constants.ts`**: Removed `ELEVENTY` from the `TemplateTechnology` union and from the `templates` record (affects the offline fallback list)
- **`actions.ts`**: Filter out archived repos from the live GitHub blueprint fetch — the GitHub search API includes archived repos by default, so `blueprint-core-eleventy` was still appearing in the interactive picker
- **`actions.test.ts`**: Added a test asserting archived repos are excluded from the template list
- **`README.md`**: Removed all Eleventy references from the create command docs

## Testing

```
pnpm nx test storyblok --run   # 1286 passed
pnpm nx lint:fix storyblok     # 0 errors
```