### PR TITLE
fix(js-client): keep fetchOptions on a retried request

### DIFF
--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -278,6 +278,51 @@ describe("storyblokClient", () => {
       expect(mockGet).toHaveBeenCalledTimes(2);
     });
 
+    it("should keep the per-request fetchOptions on a retried request", async () => {
+      client = new StoryblokClient({
+        retriesDelay: 500,
+        maxRetries: 3,
+      });
+
+      const mockGet = vi
+        .fn()
+        .mockRejectedValueOnce({
+          status: 429,
+          statusText: "Too Many Requests",
+          response: {},
+        })
+        .mockResolvedValueOnce({
+          data: { story: { id: 1 } },
+          headers: {},
+          status: 200,
+        });
+
+      const mockSetFetchOptions = vi.fn();
+      client.client = {
+        get: mockGet,
+        post: vi.fn(),
+        setFetchOptions: mockSetFetchOptions,
+        baseURL: "https://api.storyblok.com/v2",
+      };
+
+      const fetchOptions = { cache: "no-store" as RequestCache };
+      const promise = client.cacheResponse(
+        "/cdn/stories",
+        { token: "test-token" },
+        undefined,
+        fetchOptions,
+      );
+      await vi.advanceTimersByTimeAsync(500);
+      await promise;
+
+      expect(mockGet).toHaveBeenCalledTimes(2);
+      // The two attempts must apply the same fetchOptions. A retry that drops
+      // them loses the cache configuration that the caller supplied.
+      expect(mockSetFetchOptions).toHaveBeenCalledTimes(2);
+      expect(mockSetFetchOptions).toHaveBeenNthCalledWith(1, fetchOptions);
+      expect(mockSetFetchOptions).toHaveBeenNthCalledWith(2, fetchOptions);
+    });
+
     it("should give up after maxRetries 429 responses", async () => {
       client = new StoryblokClient({
         retriesDelay: 10,

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -787,7 +787,12 @@ export class Storyblok {
             // eslint-disable-next-line no-console
             console.log(`Hit rate limit. Retrying in ${this.retriesDelay / 1000} seconds.`);
             await delay(this.retriesDelay);
-            return this.cacheResponse(url, params, retries).then(resolve).catch(reject);
+            // Give `fetchOptions` to the retry. If you do not give it, the
+            // retried request loses the per-request fetch configuration that
+            // the caller supplied.
+            return this.cacheResponse(url, params, retries, fetchOptions)
+              .then(resolve)
+              .catch(reject);
           }
         }
         reject(error);


### PR DESCRIPTION
`cacheResponse` retries a request after a 429 response. It does not give `fetchOptions` to the retry. The retried request loses the fetch configuration that the caller supplied. The caller cannot see this, because the retry is internal.

## Change

Give `fetchOptions` to the recursive `cacheResponse` call.

## Test

A new test sends `fetchOptions`, makes the first attempt fail with a 429, then makes the second attempt succeed. It shows that the client applies the same options on the two attempts.

- With the change: 67 tests pass, 1 test is skipped, no type errors.
- Without the change: the new test fails.