### PR TITLE
fix(nuxt): improve types in the package based on quality audit

### DIFF
--- a/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
+++ b/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts
@@ -1,8 +1,8 @@
 import type { AsyncData, AsyncDataOptions, NuxtError } from "#app";
 import { useAsyncData } from "#app";
 import {
-  type ISbResult,
   type ISbStoriesParams,
+  type ISbStory,
   type StoryblokBridgeConfigV2,
   useStoryblokApi,
   useStoryblokBridge,
@@ -12,8 +12,10 @@ import { computed, type ComputedRef, type MaybeRefOrGetter, type Ref, toValue, w
 /**
  * Options for the useAsyncStoryblok composable.
  * Extends Nuxt's AsyncDataOptions with Storyblok-specific configuration.
+ *
+ * @typeParam T - The story's `content` shape. Defaults to `any`.
  */
-export interface UseAsyncStoryblokOptions extends AsyncDataOptions<ISbResult> {
+export interface UseAsyncStoryblokOptions<T = any> extends AsyncDataOptions<ISbStory<T>> {
   /**
    * Storyblok API parameters for fetching stories.
    *
@@ -37,10 +39,10 @@ interface AsyncDataExecuteOptions {
   dedupe?: "cancel" | "defer";
 }
 
-export interface UseAsyncStoryblokResult {
-  story: ComputedRef<ISbResult["data"]["story"]>;
+export interface UseAsyncStoryblokResult<T = any> {
+  story: ComputedRef<ISbStory<T>["data"]["story"] | undefined>;
   /** In Nuxt 3: null when not loaded. In Nuxt 4: undefined when not loaded. */
-  data: Ref<ISbResult | null | undefined>;
+  data: Ref<ISbStory<T> | null | undefined>;
   pending: Ref<boolean>;
   /** In Nuxt 3: null when no error. In Nuxt 4: undefined when no error. */
   error: Ref<NuxtError<unknown> | null | undefined>;
@@ -126,10 +128,10 @@ const stableStringify = (obj: Record<string, any>): string => {
  * </script>
  * ```
  */
-export async function useAsyncStoryblok(
+export async function useAsyncStoryblok<T = any>(
   url: string,
-  options: UseAsyncStoryblokOptions,
-): Promise<UseAsyncStoryblokResult> {
+  options: UseAsyncStoryblokOptions<T>,
+): Promise<UseAsyncStoryblokResult<T>> {
   const storyblokApiInstance = useStoryblokApi();
   const { api, bridge = {}, ...rest } = options;
   const uniqueKey = (): string => `${stableStringify(toValue(api))}${url}`;
@@ -146,7 +148,7 @@ export async function useAsyncStoryblok(
     uniqueKey,
     () => storyblokApiInstance.get(`cdn/stories/${url}`, { ...toValue(api) }),
     rest,
-  )) as AsyncData<ISbResult, NuxtError<unknown>>;
+  )) as AsyncData<ISbStory<T>, NuxtError<unknown>>;
 
   // Register bridge for live preview updates (client-side only)
   // Use watch instead of onMounted because lifecycle hooks must be registered before the first await

--- a/packages/nuxt/src/type-tests.test-d.ts
+++ b/packages/nuxt/src/type-tests.test-d.ts
@@ -3,7 +3,10 @@
  *
  * These are compile-time only; nothing here is bundled into `dist`.
  */
-import type { UseAsyncStoryblokOptions } from "./runtime/composables/useAsyncStoryblok";
+import type {
+  UseAsyncStoryblokOptions,
+  UseAsyncStoryblokResult,
+} from "./runtime/composables/useAsyncStoryblok";
 
 /** `bridge` is optional: the composable defaults it to `{}` at runtime. */
 export const bridgeIsOptional: UseAsyncStoryblokOptions = {
@@ -19,3 +22,20 @@ export const bridgeIsAccepted: UseAsyncStoryblokOptions = {
 /** `api` stays required. */
 // @ts-expect-error -- `api` is required
 export const apiIsRequired: UseAsyncStoryblokOptions = {};
+
+/** Without a type argument, `story.content` stays `any` (backward compatible). */
+export const untypedStory: UseAsyncStoryblokResult["story"] = null as any;
+export const untypedContentIsAny: string = untypedStory!.value!.content;
+
+interface HomeContent {
+  title: string;
+}
+
+/** Passing a type argument flows through to `story.value.content`. */
+export const typedOptions: UseAsyncStoryblokOptions<HomeContent> = {
+  api: { version: "draft" },
+};
+export const typedStory: UseAsyncStoryblokResult<HomeContent>["story"] = null as any;
+export const typedTitle: string = typedStory!.value!.content.title;
+// @ts-expect-error -- `content` is `HomeContent`, which has no `nonexistent` field
+export const typedTitleWrongField = typedStory!.value!.content.nonexistent;

--- a/packages/nuxt/src/types.ts
+++ b/packages/nuxt/src/types.ts
@@ -1,9 +1,11 @@
+import type { ISbConfig } from "@storyblok/vue";
+
 export interface PublicModuleOptions {
   enableSudoMode: boolean;
   usePlugin: boolean; // legacy opt. for enableSudoMode
   bridge: boolean; // storyblok bridge on/off
   devtools: boolean; // enable nuxt/devtools integration
-  apiOptions: any; // storyblok-js-client options
+  apiOptions: ISbConfig; // storyblok-js-client options
   componentsDir: string; // enable storyblok global directory for components
   enableServerClient: boolean; // keep accessToken server-side only
 }


### PR DESCRIPTION
- **Generic useAsyncStoryblok<T>** ([useAsyncStoryblok.ts](vscode-webview://192rh5tjrkns3v8t3s64q5ldik7k2adsp8to43dehm9bjg9i1u6d/packages/nuxt/src/runtime/composables/useAsyncStoryblok.ts)) — UseAsyncStoryblokOptions<T> and UseAsyncStoryblokResult<T> are now generic over the story's content type, using ISbStory<T> (re-exported from @storyblok/vue) instead of the non-generic ISbResult. Default T = any keeps every existing call site compiling unchanged
- **apiOptions: any** → ISbConfig ([types.ts](vscode-webview://192rh5tjrkns3v8t3s64q5ldik7k2adsp8to43dehm9bjg9i1u6d/packages/nuxt/src/types.ts)) — properly typed against storyblok-js-client's config shape (also re-exported via @storyblok/vue, no new dependency).
- **Type-level regression tests** ([type-tests.test-d.ts](vscode-webview://192rh5tjrkns3v8t3s64q5ldik7k2adsp8to43dehm9bjg9i1u6d/packages/nuxt/src/type-tests.test-d.ts)) — added cases proving the default (untyped) usage still yields any and that a supplied generic flows through to story.value.content, including a `@ts-expect-error` for an invalid field access.

## Biggest DX Improvement

New callers can do 

```ts
const story = useAsyncStoryblok<HomeContent>('home', { api });

console.log(story.value.content) // HomeContent instead of any
```

Previously, this needed a custom wrapper on the module to achieve that (believe, I did it once or twice in previous projects so I know the struggle - and extremely happy to ship that change :))