### PR TITLE
fix(live-preview): rework bridge loading, add destroy, and improve Angular DX

### DIFF
--- a/packages/angular/playground/ssr/src/app/app.routes.ts
+++ b/packages/angular/playground/ssr/src/app/app.routes.ts
@@ -23,7 +23,7 @@ export const routes: Routes = [
         const { data } = await client.stories.get(path, {
           query: {
             version: "draft",
-            resolve_relations: "featured-articles.articles",
+            resolve_relations: "featured-articles.articles,article.author",
           },
         });
         return data?.story;

--- a/packages/angular/playground/ssr/src/app/routes/catch-all/catch-all.component.ts
+++ b/packages/angular/playground/ssr/src/app/routes/catch-all/catch-all.component.ts
@@ -4,6 +4,7 @@ import {
   inject,
   computed,
   OnInit,
+  OnDestroy,
   linkedSignal,
   input,
 } from "@angular/core";
@@ -32,7 +33,7 @@ import {
     </div>
   `,
 })
-export class CatchAllComponent implements OnInit {
+export class CatchAllComponent implements OnInit, OnDestroy {
   private readonly livePreview = inject(LivePreviewService);
 
   /** SSR source of truth */
@@ -46,11 +47,16 @@ export class CatchAllComponent implements OnInit {
   readonly bridgeConfig: BridgeParams = {
     resolveRelations: ["featured-articles.articles"],
   };
-  ngOnInit(): void {
-    // Enable live preview for real-time editing in the Visual Editor
-    this.livePreview.listen((updatedStory) => {
+
+  private cleanupLivePreview: (() => void) | undefined;
+
+  async ngOnInit(): Promise<void> {
+    this.cleanupLivePreview = await this.livePreview.listen((updatedStory) => {
       this.story.set(updatedStory);
-      console.log(updatedStory);
     }, this.bridgeConfig);
+  }
+
+  ngOnDestroy(): void {
+    this.cleanupLivePreview?.();
   }
 }

--- a/packages/angular/playground/ssr/src/app/routes/catch-all/catch-all.component.ts
+++ b/packages/angular/playground/ssr/src/app/routes/catch-all/catch-all.component.ts
@@ -15,7 +15,6 @@ import {
   type BridgeParams,
   StoryblokComponent,
 } from "@storyblok/angular";
-
 @Component({
   selector: "app-catch-all",
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -46,7 +45,7 @@ export class CatchAllComponent implements OnInit {
   readonly storyContent = computed(() => this.story()?.content as SbBlokData | undefined);
 
   readonly bridgeConfig: BridgeParams = {
-    resolveRelations: ["featured-articles.articles"],
+    resolveRelations: ["article.author"],
   };
 
   ngOnInit(): void {

--- a/packages/angular/playground/ssr/src/app/routes/catch-all/catch-all.component.ts
+++ b/packages/angular/playground/ssr/src/app/routes/catch-all/catch-all.component.ts
@@ -4,7 +4,7 @@ import {
   inject,
   computed,
   OnInit,
-  OnDestroy,
+  DestroyRef,
   linkedSignal,
   input,
 } from "@angular/core";
@@ -33,8 +33,9 @@ import {
     </div>
   `,
 })
-export class CatchAllComponent implements OnInit, OnDestroy {
+export class CatchAllComponent implements OnInit {
   private readonly livePreview = inject(LivePreviewService);
+  private readonly destroyRef = inject(DestroyRef);
 
   /** SSR source of truth */
   readonly storyInput = input<Story | null>(null, { alias: "story" });
@@ -48,15 +49,11 @@ export class CatchAllComponent implements OnInit, OnDestroy {
     resolveRelations: ["featured-articles.articles"],
   };
 
-  private cleanupLivePreview: (() => void) | undefined;
-
-  async ngOnInit(): Promise<void> {
-    this.cleanupLivePreview = await this.livePreview.listen((updatedStory) => {
-      this.story.set(updatedStory);
-    }, this.bridgeConfig);
-  }
-
-  ngOnDestroy(): void {
-    this.cleanupLivePreview?.();
+  ngOnInit(): void {
+    this.livePreview.connect(
+      (updatedStory) => this.story.set(updatedStory),
+      this.destroyRef,
+      this.bridgeConfig,
+    );
   }
 }

--- a/packages/angular/playground/ssr/src/app/routes/home/home.component.ts
+++ b/packages/angular/playground/ssr/src/app/routes/home/home.component.ts
@@ -5,7 +5,7 @@ import {
   signal,
   computed,
   OnInit,
-  OnDestroy,
+  DestroyRef,
 } from "@angular/core";
 import {
   type SbBlokData,
@@ -35,9 +35,10 @@ import {
     </div>
   `,
 })
-export class HomeComponent implements OnInit, OnDestroy {
+export class HomeComponent implements OnInit {
   private readonly storyblok = inject(StoryblokService);
   private readonly livePreview = inject(LivePreviewService);
+  private readonly destroyRef = inject(DestroyRef);
   private client = this.storyblok.getClient();
   readonly story = signal<Story | null>(null);
   readonly loading = signal(true);
@@ -46,8 +47,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     resolveRelations: ["featured-articles.articles"],
     preventClicks: true,
   };
-
-  private cleanupLivePreview: (() => void) | undefined;
 
   async ngOnInit(): Promise<void> {
     try {
@@ -64,13 +63,10 @@ export class HomeComponent implements OnInit, OnDestroy {
       this.loading.set(false);
     }
 
-    // Enable live preview for Visual Editor; store cleanup for ngOnDestroy
-    this.cleanupLivePreview = await this.livePreview.listen((updatedStory) => {
-      this.story.set((updatedStory as Story) || null);
-    }, this.bridgeConfig);
-  }
-
-  ngOnDestroy(): void {
-    this.cleanupLivePreview?.();
+    this.livePreview.connect(
+      (updatedStory) => this.story.set((updatedStory as Story) || null),
+      this.destroyRef,
+      this.bridgeConfig,
+    );
   }
 }

--- a/packages/angular/playground/ssr/src/app/routes/home/home.component.ts
+++ b/packages/angular/playground/ssr/src/app/routes/home/home.component.ts
@@ -5,6 +5,7 @@ import {
   signal,
   computed,
   OnInit,
+  OnDestroy,
 } from "@angular/core";
 import {
   type SbBlokData,
@@ -34,7 +35,7 @@ import {
     </div>
   `,
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent implements OnInit, OnDestroy {
   private readonly storyblok = inject(StoryblokService);
   private readonly livePreview = inject(LivePreviewService);
   private client = this.storyblok.getClient();
@@ -45,6 +46,9 @@ export class HomeComponent implements OnInit {
     resolveRelations: ["featured-articles.articles"],
     preventClicks: true,
   };
+
+  private cleanupLivePreview: (() => void) | undefined;
+
   async ngOnInit(): Promise<void> {
     try {
       const { data } = await this.client.stories.get("angular/home", {
@@ -60,9 +64,13 @@ export class HomeComponent implements OnInit {
       this.loading.set(false);
     }
 
-    // Enable live preview for Visual Editor
-    this.livePreview.listen((updatedStory) => {
+    // Enable live preview for Visual Editor; store cleanup for ngOnDestroy
+    this.cleanupLivePreview = await this.livePreview.listen((updatedStory) => {
       this.story.set((updatedStory as Story) || null);
     }, this.bridgeConfig);
+  }
+
+  ngOnDestroy(): void {
+    this.cleanupLivePreview?.();
   }
 }

--- a/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
@@ -53,6 +53,20 @@ describe("LivePreviewService", () => {
       }
       expect(onStoryblokEditorEventMock).not.toHaveBeenCalled();
     });
+
+    it("returns a no-op cleanup in production mode (ngDevMode = false)", async () => {
+      // In production builds ngDevMode is false — listen() must not throw and
+      // must return a callable no-op rather than rejecting.
+      const originalDevMode = (globalThis as any).ngDevMode;
+      (globalThis as any).ngDevMode = false;
+      try {
+        const cleanup = await service.listen(() => {});
+        expect(typeof cleanup).toBe("function");
+        expect(onStoryblokEditorEventMock).not.toHaveBeenCalled();
+      } finally {
+        (globalThis as any).ngDevMode = originalDevMode;
+      }
+    });
   });
 
   describe("with live preview enabled", () => {
@@ -216,6 +230,32 @@ describe("LivePreviewService", () => {
         expect.any(Function),
         expect.objectContaining({ resolveRelations: ["a.b"] }),
       );
+    });
+
+    it("logs to console.error and does not throw when listen() rejects", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const bridgeError = new Error("bridge failed");
+      onStoryblokEditorEventMock.mockRejectedValue(bridgeError);
+
+      const { ref } = makeDestroyRef();
+      expect(() => service.connect(() => {}, ref)).not.toThrow();
+      await flush();
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("[Storyblok]"), bridgeError);
+      errorSpy.mockRestore();
+    });
+
+    it("treats context as destroyed and tears down bridge immediately when DestroyRef.onDestroy() throws (NG0911)", async () => {
+      const throwingRef = {
+        onDestroy: () => {
+          throw new Error("NG0911: destroyRef is not in a valid state");
+        },
+      } as unknown as import("@angular/core").DestroyRef;
+
+      service.connect(() => {}, throwingRef);
+      await flush();
+
+      expect(cleanupMock).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from "@angular/core/testing";
+import { DestroyRef } from "@angular/core";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import {
   LivePreviewService,
@@ -14,6 +15,15 @@ const onStoryblokEditorEventMock = vi.hoisted(() => vi.fn());
 vi.mock("@storyblok/live-preview", () => ({
   onStoryblokEditorEvent: onStoryblokEditorEventMock,
 }));
+
+// ---- helpers ----
+
+/** Minimal DestroyRef stub for testing. */
+function makeDestroyRef(): { ref: DestroyRef; destroy: () => void } {
+  const callbacks: (() => void)[] = [];
+  const ref = { onDestroy: (cb: () => void) => callbacks.push(cb) } as unknown as DestroyRef;
+  return { ref, destroy: () => callbacks.forEach((cb) => cb()) };
+}
 
 describe("LivePreviewService", () => {
   describe("without live preview enabled", () => {
@@ -128,12 +138,84 @@ describe("LivePreviewService", () => {
       const cb = vi.fn();
       await service.listen(cb);
 
-      // Grab the inner callback passed to onStoryblokEditorEvent and invoke it
       const innerCb = onStoryblokEditorEventMock.mock.calls[0][0];
       const story = { id: 1, content: {} };
       innerCb(story);
 
       expect(cb).toHaveBeenCalledWith(story);
+    });
+  });
+
+  /** Flush the microtask queue enough ticks to settle the async chain inside connect(). */
+  async function flush() {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  describe("connect()", () => {
+    let service: LivePreviewService;
+    const cleanupMock = vi.fn();
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      onStoryblokEditorEventMock.mockResolvedValue(cleanupMock);
+
+      TestBed.configureTestingModule({
+        providers: [
+          LivePreviewService,
+          { provide: LIVE_PREVIEW_ENABLED, useValue: true },
+          { provide: LIVE_PREVIEW_CONFIG, useValue: {} },
+        ],
+      });
+      service = TestBed.inject(LivePreviewService);
+    });
+
+    it("calls onStoryblokEditorEvent after connect()", async () => {
+      const { ref } = makeDestroyRef();
+      service.connect(() => {}, ref);
+      await flush();
+      expect(onStoryblokEditorEventMock).toHaveBeenCalledOnce();
+    });
+
+    it("calls the bridge cleanup when DestroyRef fires after bridge loads", async () => {
+      const { ref, destroy } = makeDestroyRef();
+      service.connect(() => {}, ref);
+      await flush(); // bridge loads, then() runs
+      destroy(); // component destroyed
+      expect(cleanupMock).toHaveBeenCalledOnce();
+    });
+
+    it("calls the bridge cleanup when DestroyRef fires before bridge loads (race condition)", async () => {
+      let resolveBridge!: (fn: () => void) => void;
+      onStoryblokEditorEventMock.mockReturnValue(
+        new Promise<() => void>((resolve) => {
+          resolveBridge = resolve;
+        }),
+      );
+
+      const { ref, destroy } = makeDestroyRef();
+      service.connect(() => {}, ref);
+
+      // Component destroyed before bridge finishes loading
+      destroy();
+      expect(cleanupMock).not.toHaveBeenCalled(); // not loaded yet
+
+      // Bridge finishes loading after destruction
+      resolveBridge(cleanupMock);
+      await flush();
+
+      expect(cleanupMock).toHaveBeenCalledOnce(); // torn down immediately
+    });
+
+    it("forwards options to listen()", async () => {
+      const { ref } = makeDestroyRef();
+      service.connect(() => {}, ref, { resolveRelations: ["a.b"] });
+      await flush();
+      expect(onStoryblokEditorEventMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ resolveRelations: ["a.b"] }),
+      );
     });
   });
 });

--- a/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from "@angular/core/testing";
+import { vi, describe, it, expect, beforeEach } from "vitest";
 import {
   LivePreviewService,
   LivePreviewNotEnabledError,
@@ -6,11 +7,20 @@ import {
   LIVE_PREVIEW_CONFIG,
 } from "./livepreview.service";
 
+// ---- mock @storyblok/live-preview ----
+
+const onStoryblokEditorEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@storyblok/live-preview", () => ({
+  onStoryblokEditorEvent: onStoryblokEditorEventMock,
+}));
+
 describe("LivePreviewService", () => {
   describe("without live preview enabled", () => {
     let service: LivePreviewService;
 
     beforeEach(() => {
+      vi.clearAllMocks();
       TestBed.configureTestingModule({
         providers: [LivePreviewService],
       });
@@ -24,12 +34,25 @@ describe("LivePreviewService", () => {
     it("should throw LivePreviewNotEnabledError when listen() is called in dev mode", async () => {
       await expect(service.listen(() => {})).rejects.toThrow(LivePreviewNotEnabledError);
     });
+
+    it("does not call onStoryblokEditorEvent when not enabled", async () => {
+      try {
+        await service.listen(() => {});
+      } catch {
+        // expected
+      }
+      expect(onStoryblokEditorEventMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("with live preview enabled", () => {
     let service: LivePreviewService;
+    const cleanupMock = vi.fn();
 
     beforeEach(() => {
+      vi.clearAllMocks();
+      onStoryblokEditorEventMock.mockResolvedValue(cleanupMock);
+
       TestBed.configureTestingModule({
         providers: [
           LivePreviewService,
@@ -42,6 +65,75 @@ describe("LivePreviewService", () => {
 
     it("should be created", () => {
       expect(service).toBeTruthy();
+    });
+
+    it("calls onStoryblokEditorEvent when listen() is called", async () => {
+      await service.listen(() => {});
+      expect(onStoryblokEditorEventMock).toHaveBeenCalledOnce();
+    });
+
+    it("passes merged config (base + per-call) to onStoryblokEditorEvent", async () => {
+      TestBed.resetTestingModule();
+      onStoryblokEditorEventMock.mockResolvedValue(cleanupMock);
+
+      TestBed.configureTestingModule({
+        providers: [
+          LivePreviewService,
+          { provide: LIVE_PREVIEW_ENABLED, useValue: true },
+          { provide: LIVE_PREVIEW_CONFIG, useValue: { resolveRelations: ["a.b"] } },
+        ],
+      });
+      service = TestBed.inject(LivePreviewService);
+
+      await service.listen(() => {}, { preventClicks: true });
+
+      expect(onStoryblokEditorEventMock).toHaveBeenCalledWith(expect.any(Function), {
+        resolveRelations: ["a.b"],
+        preventClicks: true,
+      });
+    });
+
+    it("per-call options override base config", async () => {
+      TestBed.resetTestingModule();
+      onStoryblokEditorEventMock.mockResolvedValue(cleanupMock);
+
+      TestBed.configureTestingModule({
+        providers: [
+          LivePreviewService,
+          { provide: LIVE_PREVIEW_ENABLED, useValue: true },
+          { provide: LIVE_PREVIEW_CONFIG, useValue: { resolveRelations: ["a.b"] } },
+        ],
+      });
+      service = TestBed.inject(LivePreviewService);
+
+      await service.listen(() => {}, { resolveRelations: ["c.d"] });
+
+      expect(onStoryblokEditorEventMock).toHaveBeenCalledWith(expect.any(Function), {
+        resolveRelations: ["c.d"],
+      });
+    });
+
+    it("returns the cleanup function from onStoryblokEditorEvent", async () => {
+      const cleanup = await service.listen(() => {});
+      expect(cleanup).toBe(cleanupMock);
+    });
+
+    it("invoking the returned cleanup calls the underlying bridge destroy", async () => {
+      const cleanup = await service.listen(() => {});
+      cleanup();
+      expect(cleanupMock).toHaveBeenCalledOnce();
+    });
+
+    it("forwards story updates to the callback inside NgZone", async () => {
+      const cb = vi.fn();
+      await service.listen(cb);
+
+      // Grab the inner callback passed to onStoryblokEditorEvent and invoke it
+      const innerCb = onStoryblokEditorEventMock.mock.calls[0][0];
+      const story = { id: 1, content: {} };
+      innerCb(story);
+
+      expect(cb).toHaveBeenCalledWith(story);
     });
   });
 });

--- a/packages/angular/src/lib/livepreview/livepreview.service.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.ts
@@ -1,4 +1,4 @@
-import { InjectionToken, inject, NgZone, Injectable } from "@angular/core";
+import { InjectionToken, inject, NgZone, Injectable, DestroyRef } from "@angular/core";
 import { Story } from "@storyblok/api-client";
 import { type BridgeParams, onStoryblokEditorEvent } from "@storyblok/live-preview";
 
@@ -56,6 +56,17 @@ export class LivePreviewService {
 
   private readonly baseConfig = inject(LIVE_PREVIEW_CONFIG, { optional: true }) ?? {};
 
+  /**
+   * Subscribes to Storyblok Visual Editor live preview updates.
+   *
+   * Returns a cleanup function that destroys the bridge when called.
+   * For automatic cleanup tied to a component or service lifetime, prefer
+   * {@link connect} which accepts a `DestroyRef` and handles teardown for you.
+   *
+   * @param callback Called with the updated story on every `input` event.
+   * @param options Optional bridge configuration; merged over the base config.
+   * @returns A promise that resolves to a cleanup function.
+   */
   async listen(callback: LivePreviewCallback, options?: BridgeParams): Promise<() => void> {
     if (!this.enabledFlag) {
       if (typeof ngDevMode === "undefined" || ngDevMode) {
@@ -74,5 +85,50 @@ export class LivePreviewService {
         callback(story as Story);
       });
     }, mergedConfig);
+  }
+
+  /**
+   * Subscribes to Storyblok Visual Editor live preview updates and
+   * automatically destroys the bridge when the provided `DestroyRef` fires.
+   *
+   * This is the preferred API for component use. It eliminates the need for
+   * a manual cleanup field and an `ngOnDestroy` implementation, and correctly
+   * handles the case where the component is destroyed while the bridge is
+   * still loading.
+   *
+   * @example
+   * ```ts
+   * ngOnInit(): void {
+   *   this.livePreview.connect(
+   *     (story) => this.story.set(story),
+   *     inject(DestroyRef),
+   *     this.bridgeConfig,
+   *   );
+   * }
+   * ```
+   *
+   * @param callback Called with the updated story on every `input` event.
+   * @param destroyRef The `DestroyRef` of the calling component or service.
+   * @param options Optional bridge configuration; merged over the base config.
+   */
+  connect(callback: LivePreviewCallback, destroyRef: DestroyRef, options?: BridgeParams): void {
+    let cleanup: (() => void) | undefined;
+    let destroyed = false;
+
+    // Register teardown synchronously — before the async bridge load — so
+    // that if the component is destroyed while the bridge is still loading,
+    // `destroyed` is set to true and the bridge is torn down as soon as the
+    // promise resolves.
+    destroyRef.onDestroy(() => {
+      destroyed = true;
+      cleanup?.();
+    });
+
+    this.listen(callback, options).then((fn) => {
+      cleanup = fn;
+      if (destroyed) {
+        fn();
+      }
+    });
   }
 }

--- a/packages/angular/src/lib/livepreview/livepreview.service.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.ts
@@ -98,10 +98,12 @@ export class LivePreviewService {
    *
    * @example
    * ```ts
+   * private readonly destroyRef = inject(DestroyRef);
+   *
    * ngOnInit(): void {
    *   this.livePreview.connect(
    *     (story) => this.story.set(story),
-   *     inject(DestroyRef),
+   *     this.destroyRef,
    *     this.bridgeConfig,
    *   );
    * }
@@ -133,11 +135,15 @@ export class LivePreviewService {
       destroyed = true;
     }
 
-    this.listen(callback, options).then((fn) => {
-      cleanup = fn;
-      if (destroyed) {
-        fn();
-      }
-    });
+    this.listen(callback, options)
+      .then((fn) => {
+        cleanup = fn;
+        if (destroyed) {
+          fn();
+        }
+      })
+      .catch((err: unknown) => {
+        console.error("[Storyblok] connect() failed to subscribe to live preview updates:", err);
+      });
   }
 }

--- a/packages/angular/src/lib/livepreview/livepreview.service.ts
+++ b/packages/angular/src/lib/livepreview/livepreview.service.ts
@@ -119,10 +119,19 @@ export class LivePreviewService {
     // that if the component is destroyed while the bridge is still loading,
     // `destroyed` is set to true and the bridge is torn down as soon as the
     // promise resolves.
-    destroyRef.onDestroy(() => {
+    //
+    // Guard with try/catch: during SSR, Angular may have already destroyed
+    // the view by the time ngOnInit runs (e.g. on navigation), causing
+    // DestroyRef.onDestroy() to throw NG0911. In that case treat the context
+    // as already destroyed so the bridge is torn down immediately once loaded.
+    try {
+      destroyRef.onDestroy(() => {
+        destroyed = true;
+        cleanup?.();
+      });
+    } catch {
       destroyed = true;
-      cleanup?.();
-    });
+    }
 
     this.listen(callback, options).then((fn) => {
       cleanup = fn;

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -49,7 +49,7 @@
     "test:coverage": "vp test run --coverage"
   },
   "dependencies": {
-    "@storyblok/preview-bridge": "^2.1.6"
+    "@storyblok/preview-bridge": "^2.3.0"
   },
   "devDependencies": {
     "@storyblok/lint-config": "workspace:*",

--- a/packages/live-preview/src/index.ts
+++ b/packages/live-preview/src/index.ts
@@ -5,5 +5,6 @@ export type { Story } from "./generated/types/story";
 export { loadStoryblokBridge } from "./loadStoryblokBridge";
 export { onStoryblokEditorEvent } from "./onStoryblokEditorEvent";
 export type { LivePreviewStory } from "./onStoryblokEditorEvent";
+export { isBrowser } from "./utils/isBrowser";
 export { isInEditor } from "./utils/isInEditor";
 export type { BridgeParams } from "@storyblok/preview-bridge";

--- a/packages/live-preview/src/loadStoryblokBridge.test.ts
+++ b/packages/live-preview/src/loadStoryblokBridge.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BridgeParams } from "@storyblok/preview-bridge";
 
 // ---- mocks ----
@@ -21,9 +21,22 @@ describe("loadStoryblokBridge", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://localhost/?_storyblok=123&_storyblok_c=456&_storyblok_tk[space_id]=789",
+        search: "?_storyblok=123&_storyblok_c=456&_storyblok_tk[space_id]=789",
+      },
+      writable: true,
+    });
   });
 
-  it("creates the bridge on first call", async () => {
+  afterEach(() => {
+    delete (window as any).StoryblokBridge;
+    delete (window as any).storyblokRegisterEvent;
+  });
+
+  it("creates a bridge instance with the supplied config", async () => {
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
     const config: BridgeParams = { resolveRelations: ["foo.bar"] };
@@ -35,57 +48,104 @@ describe("loadStoryblokBridge", () => {
     expect(constructorMock).toHaveBeenCalledWith(config);
   });
 
-  it("returns the same promise on subsequent calls with no config", async () => {
+  it("creates a new instance on every call", async () => {
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
     const first = await loadStoryblokBridge();
     const second = await loadStoryblokBridge();
 
-    expect(first).toBe(second);
-    expect(constructorMock).toHaveBeenCalledOnce();
+    expect(first).not.toBe(second);
+    expect(constructorMock).toHaveBeenCalledTimes(2);
   });
 
-  it("returns the same promise when called with the same config reference", async () => {
-    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
-
-    const config: BridgeParams = { resolveRelations: ["foo.bar"] };
-
-    const first = await loadStoryblokBridge(config);
-    const second = await loadStoryblokBridge(config);
-
-    expect(first).toBe(second);
-    expect(constructorMock).toHaveBeenCalledOnce();
-  });
-
-  it("throws if called with a different config reference", async () => {
+  it("accepts different configs on subsequent calls without throwing", async () => {
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
     const configA: BridgeParams = { resolveRelations: ["foo.bar"] };
     const configB: BridgeParams = { resolveRelations: ["bar.foo"] };
 
-    await loadStoryblokBridge(configA);
+    await expect(loadStoryblokBridge(configA)).resolves.toBeDefined();
+    await expect(loadStoryblokBridge(configB)).resolves.toBeDefined();
 
-    expect(() => loadStoryblokBridge(configB)).toThrowError(
-      "[Storyblok] Preview Bridge already initialized with a different configuration.",
-    );
-
-    expect(constructorMock).toHaveBeenCalledOnce();
+    expect(constructorMock).toHaveBeenCalledTimes(2);
   });
 
-  it("resets internal state if import fails", async () => {
-    vi.doMock("@storyblok/preview-bridge", () => {
-      class FailingBridge {
-        constructor() {
-          throw new Error("boom");
-        }
-      }
+  it("sets window.StoryblokBridge to the bridge class", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
-      return { default: FailingBridge };
+    expect((window as any).StoryblokBridge).toBeUndefined();
+
+    await loadStoryblokBridge();
+
+    expect((window as any).StoryblokBridge).toBeDefined();
+    expect(typeof (window as any).StoryblokBridge).toBe("function");
+  });
+
+  it("sets window.storyblokRegisterEvent", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+
+    await loadStoryblokBridge();
+
+    expect(typeof window.storyblokRegisterEvent).toBe("function");
+  });
+
+  it("storyblokRegisterEvent calls cb immediately when in editor", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+
+    await loadStoryblokBridge();
+
+    const cb = vi.fn();
+    window.storyblokRegisterEvent(cb);
+
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it("storyblokRegisterEvent warns and does not call cb when not in editor", async () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/", search: "" },
+      writable: true,
+    });
+
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await loadStoryblokBridge();
+
+    const cb = vi.fn();
+    window.storyblokRegisterEvent(cb);
+
+    expect(cb).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith("You are not in Draft Mode or in the Visual Editor.");
+  });
+
+  it("throws when called in a server-side environment", async () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+    Object.defineProperty(globalThis, "window", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+      await expect(loadStoryblokBridge()).rejects.toThrow(
+        "Cannot load Storyblok bridge: window is undefined",
+      );
+    } finally {
+      if (windowDescriptor) {
+        Object.defineProperty(globalThis, "window", windowDescriptor);
+      }
+    }
+  });
+
+  it("propagates import errors", async () => {
+    vi.doMock("@storyblok/preview-bridge", () => {
+      throw new Error("import failed");
     });
 
     const { loadStoryblokBridge: failingLoader } = await import("./loadStoryblokBridge");
 
-    await expect(failingLoader()).rejects.toThrow("boom");
-    await expect(failingLoader()).rejects.toThrow("boom");
+    await expect(failingLoader()).rejects.toThrow();
   });
 });

--- a/packages/live-preview/src/loadStoryblokBridge.test.ts
+++ b/packages/live-preview/src/loadStoryblokBridge.test.ts
@@ -92,7 +92,7 @@ describe("loadStoryblokBridge", () => {
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
     await loadStoryblokBridge();
-    const _ = (window as any).StoryblokBridge;
+    void (window as any).StoryblokBridge;
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -114,7 +114,7 @@ describe("loadStoryblokBridge", () => {
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
     await loadStoryblokBridge();
-    const _ = window.storyblokRegisterEvent;
+    void window.storyblokRegisterEvent;
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining(

--- a/packages/live-preview/src/loadStoryblokBridge.test.ts
+++ b/packages/live-preview/src/loadStoryblokBridge.test.ts
@@ -102,6 +102,42 @@ describe("loadStoryblokBridge", () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("loadStoryblokBridge"));
   });
 
+  it("window.StoryblokBridge setter accepts a plain assignment without throwing", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+
+    await loadStoryblokBridge();
+
+    const FakeBridge = vi.fn();
+    expect(() => {
+      (window as any).StoryblokBridge = FakeBridge;
+    }).not.toThrow();
+    expect((window as any).StoryblokBridge).toBe(FakeBridge);
+  });
+
+  it("reading window.StoryblokBridge after a setter write returns the written value without a deprecation warning", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+    await loadStoryblokBridge();
+
+    const FakeBridge = vi.fn();
+    (window as any).StoryblokBridge = FakeBridge;
+
+    warnSpy.mockClear();
+    const value = (window as any).StoryblokBridge;
+
+    expect(value).toBe(FakeBridge);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite window.StoryblokBridge if already defined by another loader", async () => {
+    const ExistingBridge = vi.fn();
+    (window as any).StoryblokBridge = ExistingBridge;
+
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+    await loadStoryblokBridge();
+
+    expect((window as any).StoryblokBridge).toBe(ExistingBridge);
+  });
+
   it("sets window.storyblokRegisterEvent", async () => {
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
@@ -122,6 +158,38 @@ describe("loadStoryblokBridge", () => {
       ),
     );
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("onStoryblokEditorEvent"));
+  });
+
+  it("window.storyblokRegisterEvent returns a stable function reference on every access", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+
+    await loadStoryblokBridge();
+
+    const refA = window.storyblokRegisterEvent;
+    const refB = window.storyblokRegisterEvent;
+    expect(refA).toBe(refB);
+  });
+
+  it("window.storyblokRegisterEvent setter accepts a plain assignment without throwing", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+
+    await loadStoryblokBridge();
+
+    const shim = vi.fn();
+    expect(() => {
+      window.storyblokRegisterEvent = shim;
+    }).not.toThrow();
+    expect(window.storyblokRegisterEvent).toBe(shim);
+  });
+
+  it("does not overwrite window.storyblokRegisterEvent if already defined by another loader", async () => {
+    const existingShim = vi.fn();
+    (window as any).storyblokRegisterEvent = existingShim;
+
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+    await loadStoryblokBridge();
+
+    expect(window.storyblokRegisterEvent).toBe(existingShim);
   });
 
   it("storyblokRegisterEvent calls cb immediately when in editor", async () => {

--- a/packages/live-preview/src/loadStoryblokBridge.test.ts
+++ b/packages/live-preview/src/loadStoryblokBridge.test.ts
@@ -18,9 +18,15 @@ vi.mock("@storyblok/preview-bridge", () => {
 });
 
 describe("loadStoryblokBridge", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+
+    // Suppress (and capture) console.warn globally — individual tests assert
+    // specific messages where needed.
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     Object.defineProperty(window, "location", {
       value: {
@@ -32,6 +38,7 @@ describe("loadStoryblokBridge", () => {
   });
 
   afterEach(() => {
+    warnSpy.mockRestore();
     delete (window as any).StoryblokBridge;
     delete (window as any).storyblokRegisterEvent;
   });
@@ -81,12 +88,40 @@ describe("loadStoryblokBridge", () => {
     expect(typeof (window as any).StoryblokBridge).toBe("function");
   });
 
+  it("window.StoryblokBridge emits a deprecation warning on access", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+
+    await loadStoryblokBridge();
+    const _ = (window as any).StoryblokBridge;
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "`window.StoryblokBridge` is deprecated and will be removed in a future version.",
+      ),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("loadStoryblokBridge"));
+  });
+
   it("sets window.storyblokRegisterEvent", async () => {
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
 
     await loadStoryblokBridge();
 
     expect(typeof window.storyblokRegisterEvent).toBe("function");
+  });
+
+  it("window.storyblokRegisterEvent emits a deprecation warning on access", async () => {
+    const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
+
+    await loadStoryblokBridge();
+    const _ = window.storyblokRegisterEvent;
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "`window.storyblokRegisterEvent` is deprecated and will be removed in a future version.",
+      ),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("onStoryblokEditorEvent"));
   });
 
   it("storyblokRegisterEvent calls cb immediately when in editor", async () => {
@@ -107,7 +142,6 @@ describe("loadStoryblokBridge", () => {
     });
 
     const { loadStoryblokBridge } = await import("./loadStoryblokBridge");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await loadStoryblokBridge();
 
@@ -115,7 +149,9 @@ describe("loadStoryblokBridge", () => {
     window.storyblokRegisterEvent(cb);
 
     expect(cb).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith("You are not in Draft Mode or in the Visual Editor.");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Storyblok] You are not in Draft Mode or in the Visual Editor.",
+    );
   });
 
   it("throws when called in a server-side environment", async () => {

--- a/packages/live-preview/src/loadStoryblokBridge.ts
+++ b/packages/live-preview/src/loadStoryblokBridge.ts
@@ -1,41 +1,50 @@
 import type StoryblokBridge from "@storyblok/preview-bridge";
 import type { BridgeParams } from "@storyblok/preview-bridge";
 
-let bridgePromise: Promise<StoryblokBridge> | undefined;
-let storedConfig: BridgeParams | undefined;
-function configsAreEqual(
-  config1: BridgeParams | undefined,
-  config2: BridgeParams | undefined,
-): boolean {
-  return JSON.stringify(config1) === JSON.stringify(config2);
+import { isBrowser } from "./utils/isBrowser";
+import { isInEditor } from "./utils/isInEditor";
+
+declare global {
+  interface Window {
+    storyblokRegisterEvent: (cb: () => void) => void;
+    StoryblokBridge: new (options?: BridgeParams) => StoryblokBridge;
+  }
 }
 
 /**
- * Get or create a StoryblokBridge instance.
- *⚠️ The bridge is a singleton. Configuration is applied only on first load.
+ * Loads the Storyblok Preview Bridge and returns a new instance.
+ *
+ * As a side-effect, exposes the bridge class on `window.StoryblokBridge`
+ * and registers `window.storyblokRegisterEvent` for backward compatibility
+ * with code that uses the legacy window-based bridge pattern.
+ *
+ * The bridge is not a singleton — each call returns a new instance.
+ * The underlying module import is deduplicated automatically by the ES
+ * module cache, so the network request only happens once.
+ *
  * @param config Optional configuration for the StoryblokBridge.
- * @returns A promise that resolves to a StoryblokBridge instance.
+ * @returns A promise that resolves to a new StoryblokBridge instance.
  */
-export function loadStoryblokBridge(config?: BridgeParams) {
-  if (bridgePromise) {
-    if (config && !configsAreEqual(config, storedConfig)) {
-      throw new Error(
-        "[Storyblok] Preview Bridge already initialized with a different configuration. " +
-          "The bridge can only be created once per page and does not support runtime reconfiguration.",
-      );
-    }
-    return bridgePromise;
+export async function loadStoryblokBridge(config?: BridgeParams): Promise<StoryblokBridge> {
+  if (!isBrowser()) {
+    throw new Error("Cannot load Storyblok bridge: window is undefined (server-side environment)");
   }
 
-  storedConfig = config;
+  const { default: StoryblokBridgeClass } = await import("@storyblok/preview-bridge");
 
-  bridgePromise = import("@storyblok/preview-bridge")
-    .then(({ default: StoryblokBridge }) => new StoryblokBridge(config))
-    .catch((error) => {
-      bridgePromise = undefined;
-      storedConfig = undefined;
-      throw error;
-    });
+  // Expose the class on window so legacy code using `new window.StoryblokBridge(opts)`
+  // continues to work. Setting this on every call is intentionally idempotent.
+  window.StoryblokBridge = StoryblokBridgeClass;
 
-  return bridgePromise;
+  // Provide the legacy callback helper. By the time this runs the bridge class
+  // is already loaded, so registered callbacks fire immediately.
+  window.storyblokRegisterEvent = (cb: () => void) => {
+    if (!isInEditor(new URL(window.location.href))) {
+      console.warn("You are not in Draft Mode or in the Visual Editor.");
+      return;
+    }
+    cb();
+  };
+
+  return new StoryblokBridgeClass(config);
 }

--- a/packages/live-preview/src/loadStoryblokBridge.ts
+++ b/packages/live-preview/src/loadStoryblokBridge.ts
@@ -14,9 +14,11 @@ declare global {
 /**
  * Loads the Storyblok Preview Bridge and returns a new instance.
  *
- * As a side-effect, exposes the bridge class on `window.StoryblokBridge`
- * and registers `window.storyblokRegisterEvent` for backward compatibility
- * with code that uses the legacy window-based bridge pattern.
+ * As a side-effect, exposes deprecated `window.StoryblokBridge` and
+ * `window.storyblokRegisterEvent` getters for backward compatibility with
+ * legacy consumers. Accessing either global emits a deprecation warning
+ * directing users to `loadStoryblokBridge` / `onStoryblokEditorEvent`.
+ * These globals will be removed in a future major version.
  *
  * The bridge is not a singleton — each call returns a new instance.
  * The underlying module import is deduplicated automatically by the ES
@@ -32,19 +34,36 @@ export async function loadStoryblokBridge(config?: BridgeParams): Promise<Storyb
 
   const { default: StoryblokBridgeClass } = await import("@storyblok/preview-bridge");
 
-  // Expose the class on window so legacy code using `new window.StoryblokBridge(opts)`
-  // continues to work. Setting this on every call is intentionally idempotent.
-  window.StoryblokBridge = StoryblokBridgeClass;
+  // Expose legacy globals with a deprecation warning at the point of access.
+  // These shims exist only for backward compatibility and will be removed in a
+  // future major version. Use `loadStoryblokBridge()` instead.
+  const deprecate = (name: string, replacement: string) =>
+    console.warn(
+      `[Storyblok] \`window.${name}\` is deprecated and will be removed in a future version. ` +
+        `Use \`${replacement}\` from \`@storyblok/live-preview\` instead.`,
+    );
 
-  // Provide the legacy callback helper. By the time this runs the bridge class
-  // is already loaded, so registered callbacks fire immediately.
-  window.storyblokRegisterEvent = (cb: () => void) => {
-    if (!isInEditor(new URL(window.location.href))) {
-      console.warn("You are not in Draft Mode or in the Visual Editor.");
-      return;
-    }
-    cb();
-  };
+  Object.defineProperty(window, "StoryblokBridge", {
+    get() {
+      deprecate("StoryblokBridge", "loadStoryblokBridge");
+      return StoryblokBridgeClass;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(window, "storyblokRegisterEvent", {
+    get() {
+      deprecate("storyblokRegisterEvent", "onStoryblokEditorEvent");
+      return (cb: () => void) => {
+        if (!isInEditor(new URL(window.location.href))) {
+          console.warn("[Storyblok] You are not in Draft Mode or in the Visual Editor.");
+          return;
+        }
+        cb();
+      };
+    },
+    configurable: true,
+  });
 
   return new StoryblokBridgeClass(config);
 }

--- a/packages/live-preview/src/loadStoryblokBridge.ts
+++ b/packages/live-preview/src/loadStoryblokBridge.ts
@@ -7,7 +7,9 @@ import { isInEditor } from "./utils/isInEditor";
 declare global {
   interface Window {
     storyblokRegisterEvent: (cb: () => void) => void;
-    StoryblokBridge: new (options?: BridgeParams) => StoryblokBridge;
+    StoryblokBridge: {
+      new (options?: BridgeParams): StoryblokBridge;
+    };
   }
 }
 
@@ -43,27 +45,56 @@ export async function loadStoryblokBridge(config?: BridgeParams): Promise<Storyb
         `Use \`${replacement}\` from \`@storyblok/live-preview\` instead.`,
     );
 
-  Object.defineProperty(window, "StoryblokBridge", {
-    get() {
-      deprecate("StoryblokBridge", "loadStoryblokBridge");
-      return StoryblokBridgeClass;
-    },
-    configurable: true,
-  });
+  // Stable function reference — returning the same closure on every getter read
+  // keeps identity comparisons against window.storyblokRegisterEvent correct.
+  const registerEventShim = (cb: () => void) => {
+    if (!isInEditor(new URL(window.location.href))) {
+      console.warn("[Storyblok] You are not in Draft Mode or in the Visual Editor.");
+      return;
+    }
+    cb();
+  };
 
-  Object.defineProperty(window, "storyblokRegisterEvent", {
-    get() {
-      deprecate("storyblokRegisterEvent", "onStoryblokEditorEvent");
-      return (cb: () => void) => {
-        if (!isInEditor(new URL(window.location.href))) {
-          console.warn("[Storyblok] You are not in Draft Mode or in the Visual Editor.");
-          return;
-        }
-        cb();
-      };
-    },
-    configurable: true,
-  });
+  // Only install each shim if no other loader (@storyblok/js, legacy CDN bundle)
+  // has already set a value on the property. If we are the first, install a
+  // get+set descriptor: the getter surfaces the deprecation warning, while the
+  // setter lets subsequent plain-assignment writes (e.g. from @storyblok/js's
+  // loadBridge()) succeed instead of throwing a TypeError in strict/ESM code.
+  if (!("StoryblokBridge" in window)) {
+    Object.defineProperty(window, "StoryblokBridge", {
+      get() {
+        deprecate("StoryblokBridge", "loadStoryblokBridge");
+        return StoryblokBridgeClass;
+      },
+      set(value) {
+        // Replace the accessor descriptor with a plain writable value so the
+        // caller's assignment takes effect (e.g. @storyblok/js bridge.ts).
+        Object.defineProperty(window, "StoryblokBridge", {
+          value,
+          writable: true,
+          configurable: true,
+        });
+      },
+      configurable: true,
+    });
+  }
+
+  if (!("storyblokRegisterEvent" in window)) {
+    Object.defineProperty(window, "storyblokRegisterEvent", {
+      get() {
+        deprecate("storyblokRegisterEvent", "onStoryblokEditorEvent");
+        return registerEventShim;
+      },
+      set(value) {
+        Object.defineProperty(window, "storyblokRegisterEvent", {
+          value,
+          writable: true,
+          configurable: true,
+        });
+      },
+      configurable: true,
+    });
+  }
 
   return new StoryblokBridgeClass(config);
 }

--- a/packages/live-preview/src/onStoryblokEditorEvent.test.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.test.ts
@@ -52,13 +52,13 @@ describe("onStoryblokEditorEvent", () => {
     expect(cleanup).toBeTypeOf("function");
   });
 
-  it("passes bridgeOptions to loadStoryblokBridge", async () => {
+  it("passes bridgeOptions to loadStoryblokBridge with initOnlyOnce forced to false", async () => {
     inEditor();
 
     const config: BridgeParams = { resolveRelations: ["foo.bar"] };
     await onStoryblokEditorEvent(vi.fn(), config);
 
-    expect(loadStoryblokBridge).toHaveBeenCalledWith(config);
+    expect(loadStoryblokBridge).toHaveBeenCalledWith({ ...config, initOnlyOnce: false });
   });
 
   it("creates a separate bridge per call", async () => {
@@ -70,14 +70,20 @@ describe("onStoryblokEditorEvent", () => {
     expect(loadStoryblokBridge).toHaveBeenCalledTimes(2);
   });
 
-  it("each call respects its own config independently", async () => {
+  it("each call respects its own config independently and always forces initOnlyOnce: false", async () => {
     inEditor();
 
     await onStoryblokEditorEvent(vi.fn(), { resolveRelations: ["a.b"] });
     await onStoryblokEditorEvent(vi.fn(), { resolveRelations: ["c.d"] });
 
-    expect(loadStoryblokBridge).toHaveBeenNthCalledWith(1, { resolveRelations: ["a.b"] });
-    expect(loadStoryblokBridge).toHaveBeenNthCalledWith(2, { resolveRelations: ["c.d"] });
+    expect(loadStoryblokBridge).toHaveBeenNthCalledWith(1, {
+      resolveRelations: ["a.b"],
+      initOnlyOnce: false,
+    });
+    expect(loadStoryblokBridge).toHaveBeenNthCalledWith(2, {
+      resolveRelations: ["c.d"],
+      initOnlyOnce: false,
+    });
   });
 
   it("calls callback on input event", async () => {
@@ -134,5 +140,73 @@ describe("onStoryblokEditorEvent", () => {
     handler({ action: "published" });
 
     expect(window.location.reload).toHaveBeenCalledOnce();
+  });
+
+  it("overrides caller-supplied initOnlyOnce: true to false", async () => {
+    inEditor();
+
+    await onStoryblokEditorEvent(vi.fn(), { initOnlyOnce: true });
+
+    expect(loadStoryblokBridge).toHaveBeenCalledWith(
+      expect.objectContaining({ initOnlyOnce: false }),
+    );
+  });
+
+  it("does not reload on change or published after cleanup", async () => {
+    inEditor();
+
+    const cleanup = await onStoryblokEditorEvent(vi.fn());
+    cleanup();
+
+    const handler = onMock.mock.calls[0][1];
+    handler({ action: "change" });
+    handler({ action: "published" });
+
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it("calling cleanup twice only destroys the bridge once", async () => {
+    inEditor();
+
+    const cleanup = await onStoryblokEditorEvent(vi.fn());
+    cleanup();
+    cleanup();
+
+    expect(destroyMock).toHaveBeenCalledOnce();
+  });
+
+  it("ignores null and undefined events without throwing", async () => {
+    inEditor();
+
+    await onStoryblokEditorEvent(vi.fn());
+    const handler = onMock.mock.calls[0][1];
+
+    expect(() => handler(null)).not.toThrow();
+    expect(() => handler(undefined)).not.toThrow();
+  });
+
+  it("ignores events with an unrecognised action", async () => {
+    inEditor();
+
+    const cb = vi.fn();
+    await onStoryblokEditorEvent(cb);
+
+    const handler = onMock.mock.calls[0][1];
+    handler({ action: "enterEditmode" });
+
+    expect(cb).not.toHaveBeenCalled();
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it("does not call callback when input event has no story", async () => {
+    inEditor();
+
+    const cb = vi.fn();
+    await onStoryblokEditorEvent(cb);
+
+    const handler = onMock.mock.calls[0][1];
+    handler({ action: "input" }); // story is absent
+
+    expect(cb).not.toHaveBeenCalled();
   });
 });

--- a/packages/live-preview/src/onStoryblokEditorEvent.test.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.test.ts
@@ -7,9 +7,10 @@ vi.mock("./utils/isBrowser", () => ({ isBrowser: vi.fn() }));
 vi.mock("./utils/isInEditor", () => ({ isInEditor: vi.fn() }));
 
 const onMock = vi.fn();
+const destroyMock = vi.fn();
 
 vi.mock("./loadStoryblokBridge", () => ({
-  loadStoryblokBridge: vi.fn(async () => ({ on: onMock })),
+  loadStoryblokBridge: vi.fn(async () => ({ on: onMock, destroy: destroyMock })),
 }));
 
 import { isBrowser } from "./utils/isBrowser";
@@ -102,6 +103,15 @@ describe("onStoryblokEditorEvent", () => {
     handler({ action: "input", story: { id: 1 } });
 
     expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("destroys the bridge on cleanup", async () => {
+    inEditor();
+
+    const cleanup = await onStoryblokEditorEvent(vi.fn());
+    cleanup();
+
+    expect(destroyMock).toHaveBeenCalledOnce();
   });
 
   it("reloads page on change event", async () => {

--- a/packages/live-preview/src/onStoryblokEditorEvent.test.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.test.ts
@@ -1,31 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-import { isBrowser } from "./utils/isBrowser";
-import { isInEditor } from "./utils/isInEditor";
+import type { BridgeParams } from "@storyblok/preview-bridge";
 
 // ---- mocks ----
 
-vi.mock("./utils/isBrowser", () => ({
-  isBrowser: vi.fn(),
-}));
-
-vi.mock("./utils/isInEditor", () => ({
-  isInEditor: vi.fn(),
-}));
+vi.mock("./utils/isBrowser", () => ({ isBrowser: vi.fn() }));
+vi.mock("./utils/isInEditor", () => ({ isInEditor: vi.fn() }));
 
 const onMock = vi.fn();
 
-const mockBridge = {
-  on: onMock,
-};
-
 vi.mock("./loadStoryblokBridge", () => ({
-  loadStoryblokBridge: vi.fn(async () => mockBridge),
+  loadStoryblokBridge: vi.fn(async () => ({ on: onMock })),
 }));
 
+import { isBrowser } from "./utils/isBrowser";
+import { isInEditor } from "./utils/isInEditor";
+import { loadStoryblokBridge } from "./loadStoryblokBridge";
+import { onStoryblokEditorEvent } from "./onStoryblokEditorEvent";
+
 describe("onStoryblokEditorEvent", () => {
-  beforeEach(async () => {
-    vi.resetModules();
+  beforeEach(() => {
     vi.clearAllMocks();
 
     Object.defineProperty(window, "location", {
@@ -34,157 +27,102 @@ describe("onStoryblokEditorEvent", () => {
     });
   });
 
-  async function loadModule() {
-    return await import("./onStoryblokEditorEvent");
+  function inEditor() {
+    vi.mocked(isBrowser).mockReturnValue(true);
+    vi.mocked(isInEditor).mockReturnValue(true);
   }
 
-  it("does nothing when not in browser", async () => {
+  it("returns a no-op cleanup when not in browser", async () => {
     vi.mocked(isBrowser).mockReturnValue(false);
-    vi.mocked(isInEditor).mockReturnValue(true);
 
-    const { onStoryblokEditorEvent } = await loadModule();
+    const cleanup = await onStoryblokEditorEvent(vi.fn());
 
-    await onStoryblokEditorEvent(vi.fn(), {});
-
-    expect(onMock).not.toHaveBeenCalled();
+    expect(loadStoryblokBridge).not.toHaveBeenCalled();
+    expect(cleanup).toBeTypeOf("function");
   });
 
-  it("does nothing when not in editor", async () => {
+  it("returns a no-op cleanup when not in editor", async () => {
     vi.mocked(isBrowser).mockReturnValue(true);
     vi.mocked(isInEditor).mockReturnValue(false);
 
-    const { onStoryblokEditorEvent } = await loadModule();
+    const cleanup = await onStoryblokEditorEvent(vi.fn());
 
-    await onStoryblokEditorEvent(vi.fn(), {});
-
-    expect(onMock).not.toHaveBeenCalled();
+    expect(loadStoryblokBridge).not.toHaveBeenCalled();
+    expect(cleanup).toBeTypeOf("function");
   });
 
-  it("initializes bridge only once", async () => {
-    vi.mocked(isBrowser).mockReturnValue(true);
-    vi.mocked(isInEditor).mockReturnValue(true);
+  it("passes bridgeOptions to loadStoryblokBridge", async () => {
+    inEditor();
 
-    const { onStoryblokEditorEvent } = await loadModule();
+    const config: BridgeParams = { resolveRelations: ["foo.bar"] };
+    await onStoryblokEditorEvent(vi.fn(), config);
 
-    await onStoryblokEditorEvent(vi.fn(), {});
-    await onStoryblokEditorEvent(vi.fn(), {});
+    expect(loadStoryblokBridge).toHaveBeenCalledWith(config);
+  });
 
-    expect(onMock).toHaveBeenCalledOnce();
+  it("creates a separate bridge per call", async () => {
+    inEditor();
+
+    await onStoryblokEditorEvent(vi.fn(), { resolveRelations: ["a.b"] });
+    await onStoryblokEditorEvent(vi.fn(), { resolveRelations: ["c.d"] });
+
+    expect(loadStoryblokBridge).toHaveBeenCalledTimes(2);
+  });
+
+  it("each call respects its own config independently", async () => {
+    inEditor();
+
+    await onStoryblokEditorEvent(vi.fn(), { resolveRelations: ["a.b"] });
+    await onStoryblokEditorEvent(vi.fn(), { resolveRelations: ["c.d"] });
+
+    expect(loadStoryblokBridge).toHaveBeenNthCalledWith(1, { resolveRelations: ["a.b"] });
+    expect(loadStoryblokBridge).toHaveBeenNthCalledWith(2, { resolveRelations: ["c.d"] });
   });
 
   it("calls callback on input event", async () => {
-    vi.mocked(isBrowser).mockReturnValue(true);
-    vi.mocked(isInEditor).mockReturnValue(true);
-
-    const { onStoryblokEditorEvent } = await loadModule();
+    inEditor();
 
     const cb = vi.fn();
-
-    await onStoryblokEditorEvent(cb, {});
+    await onStoryblokEditorEvent(cb);
 
     const handler = onMock.mock.calls[0][1];
-
-    handler({
-      action: "input",
-      story: { id: 42, content: { title: "Hello" } },
-    });
+    handler({ action: "input", story: { id: 42 } });
 
     expect(cb).toHaveBeenCalledWith(expect.objectContaining({ id: 42 }));
   });
 
-  it("notifies multiple listeners", async () => {
-    vi.mocked(isBrowser).mockReturnValue(true);
-    vi.mocked(isInEditor).mockReturnValue(true);
-
-    const { onStoryblokEditorEvent } = await loadModule();
-
-    const cb1 = vi.fn();
-    const cb2 = vi.fn();
-
-    await onStoryblokEditorEvent(cb1, {});
-    await onStoryblokEditorEvent(cb2, {});
-
-    const handler = onMock.mock.calls[0][1];
-
-    handler({
-      action: "input",
-      story: { id: 100 },
-    });
-
-    expect(cb1).toHaveBeenCalled();
-    expect(cb2).toHaveBeenCalled();
-  });
-
-  it("cleanup removes listener", async () => {
-    vi.mocked(isBrowser).mockReturnValue(true);
-    vi.mocked(isInEditor).mockReturnValue(true);
-
-    const { onStoryblokEditorEvent } = await loadModule();
+  it("does not call callback after cleanup", async () => {
+    inEditor();
 
     const cb = vi.fn();
-
-    const cleanup = await onStoryblokEditorEvent(cb, {});
-
+    const cleanup = await onStoryblokEditorEvent(cb);
     cleanup();
 
     const handler = onMock.mock.calls[0][1];
-
-    handler({
-      action: "input",
-      story: { id: 1 },
-    });
+    handler({ action: "input", story: { id: 1 } });
 
     expect(cb).not.toHaveBeenCalled();
   });
 
   it("reloads page on change event", async () => {
-    vi.mocked(isBrowser).mockReturnValue(true);
-    vi.mocked(isInEditor).mockReturnValue(true);
+    inEditor();
 
-    const { onStoryblokEditorEvent } = await loadModule();
-
-    await onStoryblokEditorEvent(vi.fn(), {});
+    await onStoryblokEditorEvent(vi.fn());
 
     const handler = onMock.mock.calls[0][1];
-
-    handler({
-      action: "change",
-      story: { id: 42 },
-    });
+    handler({ action: "change" });
 
     expect(window.location.reload).toHaveBeenCalledOnce();
   });
 
   it("reloads page on published event", async () => {
-    vi.mocked(isBrowser).mockReturnValue(true);
-    vi.mocked(isInEditor).mockReturnValue(true);
+    inEditor();
 
-    const { onStoryblokEditorEvent } = await loadModule();
-
-    await onStoryblokEditorEvent(vi.fn(), {});
+    await onStoryblokEditorEvent(vi.fn());
 
     const handler = onMock.mock.calls[0][1];
-
-    handler({
-      action: "published",
-      story: { id: 42 },
-    });
+    handler({ action: "published" });
 
     expect(window.location.reload).toHaveBeenCalledOnce();
-  });
-
-  it("does not register duplicate handlers during concurrent calls", async () => {
-    vi.mocked(isBrowser).mockReturnValue(true);
-    vi.mocked(isInEditor).mockReturnValue(true);
-
-    const { onStoryblokEditorEvent } = await loadModule();
-
-    await Promise.all([
-      onStoryblokEditorEvent(vi.fn(), {}),
-      onStoryblokEditorEvent(vi.fn(), {}),
-      onStoryblokEditorEvent(vi.fn(), {}),
-    ]);
-
-    expect(onMock).toHaveBeenCalledOnce();
   });
 });

--- a/packages/live-preview/src/onStoryblokEditorEvent.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.ts
@@ -3,7 +3,8 @@ import type { Prettify } from "./generated/types/_utils";
 import type { Story } from "./generated/types/story";
 
 import { loadStoryblokBridge } from "./loadStoryblokBridge";
-import { canUseStoryblokBridge } from "./utils/canUseStoryblokBridge";
+import { isBrowser } from "./utils/isBrowser";
+import { isInEditor } from "./utils/isInEditor";
 
 /**
  * The story payload delivered by the Visual Editor `input` event.
@@ -24,76 +25,17 @@ export type LivePreviewStory<TStory extends Story = Story> = Prettify<
 >;
 
 /**
- * Internal listener registry for Storyblok `input` events.
- * Each listener receives the updated story data from the Visual Editor.
- */
-const inputListeners = new Set<(story: LivePreviewStory) => void>();
-
-/**
- * Tracks whether the Storyblok Preview Bridge event listeners
- * have already been registered.
- */
-let bridgeInitPromise: Promise<void> | undefined;
-
-/**
- * Initializes the Storyblok Preview Bridge and attaches event listeners.
- *
- * This function ensures that the bridge is only initialized once per page.
- *
- * Registered events:
- * - `input` → Dispatches updated story data to all registered listeners.
- * - `change` → Forces a full page reload.
- * - `published` → Forces a full page reload.
- *
- * @param bridgeOptions Optional configuration for the Preview Bridge.
- */
-async function initializeBridge(bridgeOptions?: BridgeParams): Promise<void> {
-  if (!canUseStoryblokBridge()) {
-    return;
-  }
-
-  // If initialization already started, reuse it
-  if (bridgeInitPromise) {
-    return bridgeInitPromise;
-  }
-
-  bridgeInitPromise = (async () => {
-    const bridge = await loadStoryblokBridge(bridgeOptions);
-
-    bridge.on(["input", "change", "published"], (event) => {
-      if (!event) {
-        return;
-      }
-
-      if (event.action === "input" && event.story) {
-        for (const listener of inputListeners) {
-          listener(event.story as LivePreviewStory);
-        }
-        return;
-      }
-
-      if (event.action === "change" || event.action === "published") {
-        window.location.reload();
-      }
-    });
-  })();
-
-  return bridgeInitPromise;
-}
-
-/**
  * Registers a callback for Storyblok Visual Editor live preview updates.
  *
- * This utility connects to the Storyblok Preview Bridge and listens
- * for Visual Editor events.
+ * Loads the Preview Bridge with the supplied config, attaches event
+ * listeners, and returns a cleanup function. Each call is self-contained —
+ * no shared module-level state, so config is always respected and multiple
+ * independent subscriptions can coexist on the same page.
  *
  * Behavior:
  * - **input** → Calls the provided callback with the updated story data.
  * - **change** → Reloads the page.
  * - **published** → Reloads the page.
- *
- * Multiple listeners can be registered simultaneously. Each call returns
- * a cleanup function that removes the registered listener.
  *
  * @typeParam TStory - The schema-aware {@link Story} type to type the payload against.
  *
@@ -101,19 +43,19 @@ async function initializeBridge(bridgeOptions?: BridgeParams): Promise<void> {
  * Callback executed when the Visual Editor sends an `input` event.
  *
  * @param bridgeOptions
- * Optional configuration for the Storyblok Preview Bridge.
- * This configuration is applied **only during the first initialization**.
+ * Optional configuration forwarded to the Preview Bridge constructor.
  *
  * @returns
- * A cleanup function that removes the registered listener.
+ * A cleanup function that silences the callback. Call it when the
+ * subscribing component is destroyed to prevent stale updates.
  *
  * @example
  * ```ts
  * const cleanup = await onStoryblokEditorEvent((story) => {
  *   console.log('Live updated story:', story)
- * })
+ * }, { resolveRelations: ['featured.articles'] })
  *
- * // later
+ * // later — e.g. component teardown
  * cleanup()
  * ```
  */
@@ -121,15 +63,29 @@ export async function onStoryblokEditorEvent<TStory extends Story = Story>(
   callback: (story: LivePreviewStory<TStory>) => void,
   bridgeOptions?: BridgeParams,
 ): Promise<() => void> {
-  await initializeBridge(bridgeOptions);
+  if (!isBrowser() || !isInEditor(new URL(window.location.href))) {
+    return () => {};
+  }
 
-  const listener = (story: LivePreviewStory<TStory>) => {
-    callback(story);
-  };
+  let active = true;
+  const bridge = await loadStoryblokBridge(bridgeOptions);
 
-  inputListeners.add(listener);
+  bridge.on(["input", "change", "published"], (event) => {
+    if (!active || !event) {
+      return;
+    }
+
+    if (event.action === "input" && event.story) {
+      callback(event.story as LivePreviewStory<TStory>);
+      return;
+    }
+
+    if (event.action === "change" || event.action === "published") {
+      window.location.reload();
+    }
+  });
 
   return () => {
-    inputListeners.delete(listener);
+    active = false;
   };
 }

--- a/packages/live-preview/src/onStoryblokEditorEvent.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.ts
@@ -69,7 +69,12 @@ export async function onStoryblokEditorEvent<TStory extends Story = Story>(
   }
 
   let active = true;
-  const bridge = await loadStoryblokBridge(bridgeOptions);
+  // Force initOnlyOnce: false so that every call gets its own fully-initialised
+  // bridge instance with its own window `message` listener. The bridge defaults
+  // to initOnlyOnce: true, which silently skips addMessageListener() when a
+  // .storyblok__hint element is already in the DOM (left by a prior instance),
+  // making any second concurrent subscription permanently deaf to editor events.
+  const bridge = await loadStoryblokBridge({ ...bridgeOptions, initOnlyOnce: false });
 
   bridge.on(["input", "change", "published"], (event) => {
     if (!active || !event) {
@@ -87,6 +92,7 @@ export async function onStoryblokEditorEvent<TStory extends Story = Story>(
   });
 
   return () => {
+    if (!active) return;
     active = false;
     bridge.destroy();
   };

--- a/packages/live-preview/src/onStoryblokEditorEvent.ts
+++ b/packages/live-preview/src/onStoryblokEditorEvent.ts
@@ -46,8 +46,9 @@ export type LivePreviewStory<TStory extends Story = Story> = Prettify<
  * Optional configuration forwarded to the Preview Bridge constructor.
  *
  * @returns
- * A cleanup function that silences the callback. Call it when the
- * subscribing component is destroyed to prevent stale updates.
+ * A cleanup function that destroys the bridge instance, removing all its
+ * event listeners and DOM. Call it when the subscribing component is
+ * destroyed to prevent stale updates and memory leaks.
  *
  * @example
  * ```ts
@@ -87,5 +88,6 @@ export async function onStoryblokEditorEvent<TStory extends Story = Story>(
 
   return () => {
     active = false;
+    bridge.destroy();
   };
 }

--- a/packages/live-preview/src/utils/canUseStoryblokBridge.ts
+++ b/packages/live-preview/src/utils/canUseStoryblokBridge.ts
@@ -1,9 +1,0 @@
-import { isBrowser } from "./isBrowser";
-import { isInEditor } from "./isInEditor";
-
-export function canUseStoryblokBridge(): boolean {
-  if (!isBrowser()) {
-    return false;
-  }
-  return isInEditor(new URL(window.location.href));
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,7 +222,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:^
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:^
         version: link:../richtext
@@ -489,7 +489,7 @@ importers:
         version: 7.10.1(@types/node@24.11.0)
       '@storyblok/js':
         specifier: workspace:^
-        version: link:../js
+        version: file:packages/js
       '@storyblok/management-api-client':
         specifier: workspace:^
         version: link:../mapi-client
@@ -777,7 +777,7 @@ importers:
     devDependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../..
+        version: file:packages/js
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
         version: 1.2.0(vite@6.4.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.33.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -792,7 +792,7 @@ importers:
     devDependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../..
+        version: file:packages/js
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
         version: 1.2.0(vite@6.4.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.33.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -827,8 +827,8 @@ importers:
   packages/live-preview:
     dependencies:
       '@storyblok/preview-bridge':
-        specifier: ^2.1.6
-        version: 2.1.6
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@storyblok/lint-config':
         specifier: workspace:*
@@ -1003,7 +1003,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:^
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:^
         version: link:../richtext
@@ -1560,7 +1560,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:^
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:^
         version: link:../richtext
@@ -1658,7 +1658,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:^
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:^
         version: link:../richtext
@@ -6887,6 +6887,9 @@ packages:
   '@storyblok/preview-bridge@2.1.6':
     resolution: {integrity: sha512-fj8tV3ZaPJGyqqfpobzezIpm/LZZr1hW6J2eqhQkC1OVdA5PJNNw8eEnrMTXgLDn/Wrpd28NYCrY3UNXYJgmjg==}
 
+  '@storyblok/preview-bridge@2.3.0':
+    resolution: {integrity: sha512-AeWDJljta1eyF0ZizVxxro9DszOlzCYH4QQ+WC6JE43sfzGgPUNBLZQF+6BqIAqs6FbPmoqY7f/qUXF17UCjAA==}
+
   '@storyblok/react@file:packages/react':
     resolution: {directory: packages/react, type: directory}
     peerDependencies:
@@ -10199,6 +10202,7 @@ packages:
   eslint@9.39.3:
     resolution: {integrity: sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -21388,7 +21392,7 @@ snapshots:
 
   '@storyblok/js@file:packages/js':
     dependencies:
-      '@storyblok/preview-bridge': 2.1.6
+      '@storyblok/preview-bridge': 2.3.0
       '@storyblok/richtext': file:packages/richtext
       storyblok-js-client: file:packages/js-client
     transitivePeerDependencies:
@@ -21447,6 +21451,10 @@ snapshots:
       - magicast
 
   '@storyblok/preview-bridge@2.1.6':
+    dependencies:
+      pure-parse: 0.0.0-beta.8
+
+  '@storyblok/preview-bridge@2.3.0':
     dependencies:
       pure-parse: 0.0.0-beta.8
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,7 +222,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:*
         version: link:../richtext
@@ -495,7 +495,7 @@ importers:
         version: 7.10.1(@types/node@24.11.0)
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../js
+        version: file:packages/js
       '@storyblok/management-api-client':
         specifier: workspace:*
         version: link:../mapi-client
@@ -749,7 +749,7 @@ importers:
         version: 14.2.35(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1)(typescript@6.0.3)
       next:
         specifier: catalog:next13
-        version: 13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
+        version: 13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -792,7 +792,7 @@ importers:
     devDependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../..
+        version: file:packages/js
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
         version: 1.2.0(vite@6.4.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.33.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -807,7 +807,7 @@ importers:
     devDependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../..
+        version: file:packages/js
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
         version: 1.2.0(vite@6.4.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.33.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -842,8 +842,8 @@ importers:
   packages/live-preview:
     dependencies:
       '@storyblok/preview-bridge':
-        specifier: ^2.1.6
-        version: 2.1.6
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@storyblok/lint-config':
         specifier: workspace:*
@@ -1018,7 +1018,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:*
         version: link:../richtext
@@ -1103,7 +1103,7 @@ importers:
     dependencies:
       '@storyblok/react':
         specifier: workspace:*
-        version: file:packages/react(next@13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: file:packages/react(next@13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       eslint:
         specifier: catalog:next13
@@ -1113,7 +1113,7 @@ importers:
         version: 14.2.35(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1)(typescript@6.0.3)
       next:
         specifier: catalog:next13
-        version: 13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
+        version: 13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -1128,7 +1128,7 @@ importers:
     dependencies:
       '@storyblok/react':
         specifier: workspace:*
-        version: file:packages/react(next@13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: file:packages/react(next@13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     dependenciesMeta:
       '@storyblok/react':
         injected: true
@@ -1141,7 +1141,7 @@ importers:
         version: 18.3.28
       next:
         specifier: catalog:next13
-        version: 13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
+        version: 13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -1156,13 +1156,13 @@ importers:
     dependencies:
       '@storyblok/react':
         specifier: workspace:*
-        version: file:packages/react(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: file:packages/react(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.19(tailwindcss@4.2.1)
       next:
         specifier: catalog:next16
-        version: 16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react:
         specifier: catalog:react19
         version: 19.2.4
@@ -1193,13 +1193,13 @@ importers:
     dependencies:
       '@storyblok/react':
         specifier: workspace:*
-        version: file:packages/react(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: file:packages/react(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.19(tailwindcss@4.2.1)
       next:
         specifier: catalog:next16
-        version: 16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react:
         specifier: catalog:react19
         version: 19.2.4
@@ -1230,7 +1230,7 @@ importers:
     dependencies:
       '@storyblok/react':
         specifier: workspace:*
-        version: file:packages/react(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: file:packages/react(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storyblok/richtext':
         specifier: workspace:*
         version: link:../../../richtext
@@ -1581,7 +1581,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:*
         version: link:../richtext
@@ -1679,7 +1679,7 @@ importers:
     dependencies:
       '@storyblok/js':
         specifier: workspace:*
-        version: link:../js
+        version: file:packages/js
       '@storyblok/richtext':
         specifier: workspace:*
         version: link:../richtext
@@ -6923,6 +6923,9 @@ packages:
   '@storyblok/preview-bridge@2.1.6':
     resolution: {integrity: sha512-fj8tV3ZaPJGyqqfpobzezIpm/LZZr1hW6J2eqhQkC1OVdA5PJNNw8eEnrMTXgLDn/Wrpd28NYCrY3UNXYJgmjg==}
 
+  '@storyblok/preview-bridge@2.3.0':
+    resolution: {integrity: sha512-AeWDJljta1eyF0ZizVxxro9DszOlzCYH4QQ+WC6JE43sfzGgPUNBLZQF+6BqIAqs6FbPmoqY7f/qUXF17UCjAA==}
+
   '@storyblok/react@file:packages/react':
     resolution: {directory: packages/react, type: directory}
     peerDependencies:
@@ -10253,6 +10256,7 @@ packages:
   eslint@9.39.3:
     resolution: {integrity: sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -21534,7 +21538,7 @@ snapshots:
 
   '@storyblok/js@file:packages/js':
     dependencies:
-      '@storyblok/preview-bridge': 2.1.6
+      '@storyblok/preview-bridge': 2.3.0
       '@storyblok/richtext': file:packages/richtext
       storyblok-js-client: file:packages/js-client
     transitivePeerDependencies:
@@ -21596,26 +21600,30 @@ snapshots:
     dependencies:
       pure-parse: 0.0.0-beta.8
 
-  '@storyblok/react@file:packages/react(next@13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@storyblok/preview-bridge@2.3.0':
+    dependencies:
+      pure-parse: 0.0.0-beta.8
+
+  '@storyblok/react@file:packages/react(next@13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@storyblok/js': file:packages/js
       '@storyblok/richtext': file:packages/richtext
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      next: 13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
+      next: 13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@storyblok/react@file:packages/react(next@16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@storyblok/react@file:packages/react(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@storyblok/js': file:packages/js
       '@storyblok/richtext': file:packages/richtext
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -22822,7 +22830,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10(msw@2.12.10(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.1(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -22926,7 +22934,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10(msw@2.12.10(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.1(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -28851,6 +28859,33 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
+  next@13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0):
+    dependencies:
+      '@next/env': 13.5.11
+      '@swc/helpers': 0.5.2
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001775
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.3.1)
+      watchpack: 2.4.0
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 13.5.9
+      '@next/swc-darwin-x64': 13.5.9
+      '@next/swc-linux-arm64-gnu': 13.5.9
+      '@next/swc-linux-arm64-musl': 13.5.9
+      '@next/swc-linux-x64-gnu': 13.5.9
+      '@next/swc-linux-x64-musl': 13.5.9
+      '@next/swc-win32-arm64-msvc': 13.5.9
+      '@next/swc-win32-ia32-msvc': 13.5.9
+      '@next/swc-win32-x64-msvc': 13.5.9
+      '@opentelemetry/api': 1.9.0
+      sass: 1.99.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   next@13.5.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
     dependencies:
       '@next/env': 13.5.11
@@ -28878,29 +28913,29 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@13.5.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0):
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
     dependencies:
-      '@next/env': 13.5.11
-      '@swc/helpers': 0.5.2
-      busboy: 1.6.0
+      '@next/env': 16.1.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001775
       postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.29.7)(react@18.3.1)
-      watchpack: 2.4.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 13.5.9
-      '@next/swc-darwin-x64': 13.5.9
-      '@next/swc-linux-arm64-gnu': 13.5.9
-      '@next/swc-linux-arm64-musl': 13.5.9
-      '@next/swc-linux-x64-gnu': 13.5.9
-      '@next/swc-linux-x64-musl': 13.5.9
-      '@next/swc-win32-arm64-msvc': 13.5.9
-      '@next/swc-win32-ia32-msvc': 13.5.9
-      '@next/swc-win32-x64-msvc': 13.5.9
+      '@next/swc-darwin-arm64': 16.1.6
+      '@next/swc-darwin-x64': 16.1.6
+      '@next/swc-linux-arm64-gnu': 16.1.6
+      '@next/swc-linux-arm64-musl': 16.1.6
+      '@next/swc-linux-x64-gnu': 16.1.6
+      '@next/swc-linux-x64-musl': 16.1.6
+      '@next/swc-win32-arm64-msvc': 16.1.6
+      '@next/swc-win32-x64-msvc': 16.1.6
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.62.1
       sass: 1.99.0
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -28931,6 +28966,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    optional: true
 
   ng-packagr@22.0.0(@angular/compiler-cli@22.0.4(@angular/compiler@22.0.4)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3):
     dependencies:
@@ -32116,6 +32152,13 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
+  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+
   styled-jsx@5.1.1(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -32123,12 +32166,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  styled-jsx@5.1.1(@babel/core@7.29.7)(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
-      react: 18.3.1
+      react: 19.2.4
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.0
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:
@@ -32136,6 +32179,7 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.7
+    optional: true
 
   stylehacks@7.0.7(postcss@8.5.8):
     dependencies:
@@ -33270,7 +33314,7 @@ snapshots:
       oxfmt: 0.61.0(svelte@5.55.0)(vite-plus@0.2.8(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(publint@0.3.22)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.28(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(synckit@0.11.12))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@arethetypeswrong/core@0.18.2)(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(less@4.6.4)(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(publint@0.3.22)(sass@1.99.0)(svelte@5.55.0)(terser@5.46.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.28(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(synckit@0.11.12))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10(msw@2.12.10(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.1(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.8
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.8
@@ -34024,7 +34068,7 @@ snapshots:
       - yaml
     optional: true
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-preview@4.1.10(msw@2.12.10(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.1(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@3.2.4))(@vitest/ui@4.1.10)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.12.10(@types/node@24.11.0)(typescript@6.0.3))(vite@8.1.1(@types/node@24.11.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

Reworks `@storyblok/live-preview` bridge loading and editor event handling, scoped to the live-preview and angular packages only.

## Changes

### `@storyblok/live-preview`

- **Remove singleton pattern** — `loadStoryblokBridge` now returns a fresh instance on each call. ES module cache deduplicates the underlying import, so no extra network requests.
- **Server-side guard** — throws a clear error when called outside a browser (`isBrowser` check replaces the old `canUseStoryblokBridge` util).
- **Backward-compat shims** — exposes `window.StoryblokBridge` and `window.storyblokRegisterEvent` via `Object.defineProperty` get+set descriptors so legacy consumers and other bridge loaders (`@storyblok/js`, legacy CDN bundle) can co-exist without a `TypeError`. Accessing either global emits a deprecation warning. These globals will be removed in a future major version.
- **Export `isBrowser`** — added to the package public index.
- **Delete `canUseStoryblokBridge.ts`** — logic absorbed inline.
- **Bump `@storyblok/preview-bridge` to `^2.3.0`** — picks up the new `destroy()` method.
- **Fix concurrent subscriptions** — `onStoryblokEditorEvent` forces `initOnlyOnce: false` so every call gets its own fully-initialised bridge with its own `window` message listener. The bridge default (`true`) silently skips `addMessageListener()` when a `.storyblok__hint` element is already in the DOM, making any second concurrent subscription permanently deaf to editor events.
- **Idempotent cleanup** — the returned cleanup function guards with `!active` so calling it twice does not invoke `bridge.destroy()` a second time.
- **Updated tests** — setter acceptance, read-after-set has no deprecation warning, skip-if-defined, stable identity, `initOnlyOnce` override, idempotent cleanup, reload silenced after cleanup, null/undefined/unknown-action/missing-story event guards.

### `@storyblok/angular`

- **`LivePreviewService.connect()`** — new preferred API for component use. Accepts a `DestroyRef` and wires bridge cleanup automatically, removing all boilerplate from the call site:

  ```ts
  // Before
  private cleanupLivePreview: (() => void) | undefined;
  async ngOnInit(): Promise<void> {
    this.cleanupLivePreview = await this.livePreview.listen(...);
  }
  ngOnDestroy(): void { this.cleanupLivePreview?.(); }

  // After
  private readonly destroyRef = inject(DestroyRef);
  ngOnInit(): void {
    this.livePreview.connect(
      (story) => this.story.set(story),
      this.destroyRef,
      this.bridgeConfig,
    );
  }
  ```

  `connect()` registers `DestroyRef.onDestroy` synchronously before the async bridge load, so if the component is destroyed while the bridge is still loading, the bridge is torn down as soon as the promise resolves — no leaks.

- **`connect()` rejection handled** — a `.catch()` surfaces errors (e.g. `LivePreviewNotEnabledError` in dev mode) via `console.error` instead of leaving an unhandled promise rejection.
- **JSDoc example fixed** — `inject(DestroyRef)` is only valid in an injection context; the previous example called it inside `ngOnInit()` which throws `NG0203` at runtime. Updated to show `DestroyRef` injected as a class field.
- **`listen()` is kept as-is** — valid for manual control, RxJS composition, or non-component contexts. JSDoc links to `connect()` as the preferred alternative.
- **Playground components updated** — `CatchAllComponent` and `HomeComponent` now use `connect()` with no manual cleanup boilerplate.
- **Tests** — fully covers `listen()` happy path, `connect()` API including race condition and rejection, production-mode no-op, and the NG0911 SSR race where `DestroyRef.onDestroy()` throws before the bridge resolves.

## Docs

https://github.com/storyblok/storyblok-docs-platform/pull/642

Fixes DX-515