### PR TITLE
fix(ci): scope pkg.pr.new concurrency group by ref

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- `Publish Any Commit` (`pkg.pr.new.yml`) keyed its concurrency group on `github.event.number`, which is empty on `push` events — so every push on every branch shared one group, and `cancel-in-progress` cancelled unrelated branches' in-flight jobs repo-wide.
- Key the group on `github.ref` instead so cancellation only applies within the same branch.

## Test plan
- [ ] Confirm two pushes to different branches no longer cancel each other's `Publish Any Commit` run
- [ ] Confirm a second push to the *same* branch still cancels the prior run (existing behavior preserved)