### PR TITLE
chore(repo): keep private repo details out of the public repo

### DIFF
--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -38,8 +38,8 @@ Generate a spec for: $ARGUMENTS
 1. **Understand the problem** - What pain point does this solve? Who asked for it?
 2. **Determine scope** - Is this a project (multi-day, cross-cutting) or a ticket (single
    deliverable, 1-3 days)?
-3. **Research** - Read relevant code and context files, check storyrails for API contracts, look at
-   existing patterns
+3. **Research** - Read relevant code and context files, verify API contracts against the backend,
+   look at existing patterns
 4. **Write the spec** - Use the appropriate template
 
 ## What to include vs. leave to the developer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,26 +23,10 @@ We use `nx` and `pnpm` workspaces. Use commands like `pnpm nx build <package>` a
 - **Reuse first** - Before implementing, search for existing utilities, helpers, and modules in the
   package. Prefer composing over writing new.
 - **Check versions** - Look up the latest version before installing a new npm package.
-
-## Sibling repos
-
-- `../storyrails` (Storyblok backend) - Consult when verifying REST/MAPI/CAPI schemas, error shapes,
-  or endpoint behavior; `../storyrails/spec/integration/openapi/` is the source of truth.
-- `../storyfront` (headless CMS frontend) - Consult when matching UI/app behavior and you need
-  information about the visual editor, bridge protocol, or rendering in the Storyblok UI.
-- `../storyblok-bridge` (Storyblok Bridge) - Consult when verifying bridge behavior: the
-  `postMessage` protocol between the editor and a preview iframe, the editable-block attributes it
-  writes into the page, the overlay/click-to-edit UI, or the bridge lifecycle.
-- `../storyblok-docs-platform` (docs site) - Consult when publishing or updating package reference
-  docs; see `docs/docs-platform.md` for the monoblok-side conventions. User-facing documentation
-  lives there, not here: package READMEs stay minimal and link to the docs site.
-
-These sibling repos may not be available; ignore them if absent.
-
-- **IMPORTANT:** `../storyrails`, `../storyfront` and `../storyblok-bridge` are private. Never
-  reference them, their paths, file names, or internal implementation details in commit messages, PR
-  titles and descriptions, issue comments, code comments, or any other public-facing text. Describe
-  the observable API or behavior instead.
+- **IMPORTANT: Keep internal details internal** - Never reference private Storyblok repositories,
+  their paths, file names, or internal implementation details in commit messages, PR titles and
+  descriptions, issue comments, code comments, or any other public-facing text. Describe the
+  observable API or behavior instead.
 
 ## Conventions
 
@@ -103,9 +87,10 @@ For more context, read relevant files in `docs/`:
 
 - `announcements.md` - announcement article format and tone. Load when drafting a
   release/announcement post.
-- `docs-platform.md` - Docs site conventions: library doc paths, versioning, badges, space IDs. Load
-  when changes need reference docs, when versioning docs for a major release, or when adding a
-  package to the site navigation.
+- `docs-platform.md` - Docs site conventions: library doc paths, versioning, badges, space IDs.
+  User-facing documentation lives on the docs site, not here: package READMEs stay minimal and link
+  to it. Load when changes need reference docs, when versioning docs for a major release, or when
+  adding a package to the site navigation.
 - `storyblok-kotlin.md` - Kotlin Multiplatform SDK (Ktor plugin). Load when touching the Kotlin SDK.
 - `storyblok-swift.md` - Swift SDK (URLSession extension). Load when touching the Swift SDK.
 - `testing-patterns.md` - Test stack, file layout, session mocking, and Windows gotchas. Load when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,6 @@ We use `nx` and `pnpm` workspaces. Use commands like `pnpm nx build <package>` a
 - **Reuse first** - Before implementing, search for existing utilities, helpers, and modules in the
   package. Prefer composing over writing new.
 - **Check versions** - Look up the latest version before installing a new npm package.
-- **IMPORTANT: Keep internal details internal** - Never reference private Storyblok repositories,
-  their paths, file names, or internal implementation details in commit messages, PR titles and
-  descriptions, issue comments, code comments, or any other public-facing text. Describe the
-  observable API or behavior instead.
 
 ## Conventions
 

--- a/adr/0011-workers-safe-per-second-request-throttle.md
+++ b/adr/0011-workers-safe-per-second-request-throttle.md
@@ -19,8 +19,7 @@ requests until the throttle wedged, SSR handlers hung, and Cloudflare returned `
 The `capi` client did not have this hang: it released its slot on request completion (in the settled
 promise handler), not from a timer. It did, however, share the modeling bug described below.
 
-The other relevant question is what the server actually limits. Verified against the backend
-(storyrails):
+The other relevant question is what the server actually limits. Verified against the backend:
 
 - The numbers the clients pace against are enforced as **requests per second**, in a fixed
   one-second window (a Redis counter keyed by the clock second, reset when the second rolls over).

--- a/tools/openapi-codegen/specs/shared/stories/field-types/multilink-field-value.yaml
+++ b/tools/openapi-codegen/specs/shared/stories/field-types/multilink-field-value.yaml
@@ -57,10 +57,10 @@ $defs:
             type: string
             description: Link title attribute
       # Custom link attributes are string-valued by construction in the editor,
-      # but null has to pass: the anchor modal emits `null` when an existing
-      # anchor is cleared (storyfront MultiLinkAnchor.vue, `anchor.value || null`),
-      # so any link whose anchor was removed is stored with `anchor: null`. This
-      # branch carries no `properties`, so it applies to every key.
+      # but null has to pass: the editor's anchor modal emits `null` when an
+      # existing anchor is cleared, so any link whose anchor was removed is stored
+      # with `anchor: null`. This branch carries no `properties`, so it applies to
+      # every key.
       - type: object
         additionalProperties:
           type: [string, 'null']


### PR DESCRIPTION
## Why

`AGENTS.md` had a *Sibling repos* section that named three private Storyblok repositories, summarized their internals, and pointed at specific paths inside them — in a file that ships in a public repo. Three other public files leaked repository names the same way: a skill instruction, an ADR, and a comment in an overlay spec.

The section also carried the very rule it violated ("never reference these in public-facing text"), which made the contradiction easy to miss.

## What changed

- **Removed** the *Sibling repos* section from `AGENTS.md`, including the private-repo rule itself. Restating the rule here meant restating what it protects — that private repositories exist and are adjacent enough to leak from.
- **Moved** the docs-site conventions that were bundled into that section ("user-facing documentation lives on the docs site, package READMEs stay minimal and link to it") into the `docs/` list, next to the `docs-platform.md` entry where the rest of the docs guidance already lives.
- **Rephrased** the three remaining leaks to describe the observable behavior instead of the source:
  - `.agents/skills/spec/SKILL.md` — "verify API contracts against the backend"
  - `adr/0011-…` — "Verified against the backend"
  - `multilink-field-value.yaml` — "the editor's anchor modal emits `null` …"

`rg` for the four repository names now returns nothing outside `.git`.

## Where the context went

The cross-repo context is now maintained in a private `dx-workspace` repo that checks all projects out side by side and holds a single `CLAUDE.md`. Every fact removed here has an equivalent there:

| Removed from `AGENTS.md` | Now in `dx-workspace` |
| --- | --- |
| backend — REST/MAPI/CAPI schemas, error shapes, endpoint behavior, source-of-truth path | ✅ |
| frontend — visual editor, bridge integration, rendering in the UI | ✅ |
| bridge — `postMessage` protocol, editable-block attributes, overlay/click-to-edit, lifecycle | ✅ |
| docs site — reference docs live there, pointer to `docs/docs-platform.md` | ✅ |
| the private-repos rule | ✅ — owned solely by the workspace, restated there with `IMPORTANT` strength and an explicit list of which repos are public |
| "package READMEs stay minimal and link to the docs site" | stayed here — it is a monoblok convention, not cross-repo context |
| "sibling repos may not be available; ignore them if absent" | obsolete — `bootstrap.sh` checks all of them out |

## Verification

- `pnpm nx run-many -t generate:openapi` → no diff under `packages/*/src/generated/`. The spec change is a YAML comment, but the repo rule says regenerate every consumer after touching `tools/openapi-codegen/`, so it was run.
- `pnpm format` and the pre-commit lint pass clean.
- Docs-only otherwise; no behavior change.