### PR TITLE
fix(cli): make `storyblok/config` resolvable from user config files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,8 +31,14 @@
       "import": "./dist/index.mjs"
     },
     "./config": {
-      "types": "./dist/config/index.d.mts",
-      "import": "./dist/config/index.mjs"
+      "import": {
+        "types": "./dist/config/index.d.mts",
+        "default": "./dist/config/index.mjs"
+      },
+      "require": {
+        "types": "./dist/config/index.d.cts",
+        "default": "./dist/config/index.cjs"
+      }
     }
   },
   "scripts": {

--- a/packages/cli/src/entrypoints/config.test.ts
+++ b/packages/cli/src/entrypoints/config.test.ts
@@ -1,0 +1,45 @@
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { join } from "pathe";
+
+// Resolving the package by name needs the real filesystem and the built `dist`,
+// not the memfs volume the global setup installs.
+vi.unmock("node:fs");
+vi.unmock("node:fs/promises");
+
+const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+// Config loaders (jiti, ts-node, jest) resolve a user's config file imports with
+// require conditions, so `storyblok/config` has to be resolvable that way too.
+async function projectWithStoryblokInstalled(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), "storyblok-entrypoint-"));
+  temporaryDirectories.push(cwd);
+  await mkdir(join(cwd, "node_modules"));
+  await symlink(packageRoot, join(cwd, "node_modules", "storyblok"), "dir");
+
+  return cwd;
+}
+
+describe("storyblok/config", () => {
+  it("should expose defineConfig to a require-based consumer", async () => {
+    const cwd = await projectWithStoryblokInstalled();
+    const require = createRequire(join(cwd, "storyblok.config.js"));
+
+    const { defineConfig } = require("storyblok/config");
+
+    expect(defineConfig({ space: "12345" })).toEqual({ space: "12345" });
+  });
+});

--- a/packages/cli/src/lib/config/loader.test.ts
+++ b/packages/cli/src/lib/config/loader.test.ts
@@ -129,4 +129,18 @@ describe("loadConfig", () => {
 
     expect(config).toMatchObject({ space: "56789" });
   });
+
+  it("should load a config file that imports defineConfig from the CLI's own package", async () => {
+    const cwd = await createProject({
+      "storyblok.config.ts": `
+import { defineConfig } from 'storyblok/config';
+
+export default defineConfig({ space: '78901' });
+`,
+    });
+
+    const { config } = await loadProjectConfig(cwd);
+
+    expect(config).toMatchObject({ space: "78901" });
+  });
 });

--- a/packages/cli/src/lib/config/loader.ts
+++ b/packages/cli/src/lib/config/loader.ts
@@ -1,5 +1,9 @@
 import { loadConfig as c12LoadConfig, SUPPORTED_EXTENSIONS } from "c12";
 
+import { defineConfig } from "./types";
+
+const CONFIG_ENTRYPOINT_SPECIFIER = "storyblok/config";
+
 export { SUPPORTED_EXTENSIONS };
 
 /**
@@ -27,6 +31,13 @@ export async function loadConfig(options: {
       // jiti's own JITI_TSCONFIG_PATHS default is overridden by this explicit
       // option, so honour it here to leave users a way out.
       tsconfigPaths: process.env.JITI_TSCONFIG_PATHS !== "false",
+      // A CLI run through `npx`, `dlx`, or a global install is not resolvable
+      // from the user's project, so the documented
+      // `import { defineConfig } from "storyblok/config"` has nothing to
+      // resolve to. Serve the helper from the running CLI instead of failing.
+      virtualModules: {
+        [CONFIG_ENTRYPOINT_SPECIFIER]: { defineConfig },
+      },
     },
   });
 }

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -3,14 +3,22 @@ import { defineConfig } from "vite-plus";
 export default defineConfig({
   pack: [
     {
-      entry: {
-        index: "./src/index.ts",
-        "config/index": "./src/entrypoints/config.ts",
-      },
+      entry: { index: "./src/index.ts" },
       format: ["esm"],
       outDir: "./dist",
       sourcemap: true,
       clean: true,
+      dts: true,
+    },
+    // The `storyblok/config` entrypoint also ships CJS: config loaders (jiti,
+    // ts-node, jest) resolve a user's `storyblok.config.ts` imports with
+    // require conditions, so an ESM-only subpath is unresolvable for them.
+    {
+      entry: { "config/index": "./src/entrypoints/config.ts" },
+      format: ["esm", "cjs"],
+      outDir: "./dist",
+      sourcemap: true,
+      clean: false,
       dts: true,
     },
     // `types generate` copies these declarations into the user's `types/storyblok.d.ts`,


### PR DESCRIPTION
A `storyblok.config.ts` that uses the documented helper —

```ts
import { defineConfig } from 'storyblok/config'
export default defineConfig({ space: '12345' })
```

— makes **every** CLI command die before it does any work, whenever the CLI is not resolvable from the user's project:

```
$ pnpm dlx storyblok components push --from 100200300
▲ error Package subpath './config' is not defined by "exports" in …/storyblok/package.json

$ npx storyblok components push --from 100200300
▲ error Cannot find module 'storyblok/config'
  Require stack: - …/storyblok.config.ts
```

Two different messages for one cause. The config file is loaded by c12 → jiti; jiti resolves bare specifiers in the transformed config with import conditions when the package is reachable from the project, so a locally installed CLI works today. When the package is *not* in the project's resolution paths — `npx`, `pnpm dlx`, a global install — jiti falls back to require-resolution, and `./config` has no `require` condition to match.

## Install shapes

| CLI resolvable from the project | Before | After |
| --- | --- | --- |
| yes (`node_modules/storyblok`) | works | works |
| no — npm / `npx` | `Cannot find module 'storyblok/config'` | works |
| no — `pnpm dlx`, pnpm global | `Package subpath './config' is not defined` | works |

## The fix

Three parts, because no single one covers every install shape:

- **`vite.config.ts`** — the config entrypoint moves into its own pack block emitting ESM **and** CJS, so `dist/config/` ships `index.cjs` (242 B) + `index.d.cts` next to the existing `.mjs`/`.d.mts`. The 509 KB CLI bin stays ESM-only.
- **`package.json`** — `./config` gains a `require` condition with per-condition `types`, so a CJS-mode TS consumer resolves `.d.cts`. This fixes the pnpm store flavour, and any require-based loader (jest, ts-node CJS) even for a locally installed CLI.
- **`lib/config/loader.ts`** — the loader registers the running CLI's own `defineConfig` as a jiti `virtualModules` entry for `storyblok/config`. This is what fixes `npx` and global installs, where **no** exports map can help because the package is absent from the project's resolution paths. `defineConfig` is the identity function, and the running CLI is the right authority for its own config contract.

Rejected: documenting a different import specifier. The published docs and Storyblok's agent skills both tell users to write `from 'storyblok/config'`, so the fix has to make the documented pattern work rather than route around it. Flipping jiti to import conditions isn't available either — in jiti 2.7 `conditions` is a per-`resolve`-call option, not an instance option; `virtualModules` is the equivalent that needs no new build output.

Fixes DX-560
