### PR TITLE
feat(cli): confirm success at the end of schema init and push

### DIFF
--- a/packages/cli/src/commands/schema/init/index.test.ts
+++ b/packages/cli/src/commands/schema/init/index.test.ts
@@ -356,13 +356,19 @@ describe("schema init command", () => {
     expect(files.some((f) => f.endsWith("/schema.ts"))).toBe(true);
   });
 
-  it("should warn that init is a bootstrap step", async () => {
+  it("should confirm success and print next steps", async () => {
     preconditions.hasEmptyRemote();
 
     await schemaCommand.parseAsync(["node", "test", "init", "--space", DEFAULT_SPACE]);
 
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("bootstrap step"));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Success"));
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Schema workspace initialized"),
+    );
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Next steps:"));
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("source of truth"));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("schema push"));
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("should strip API-only fields but preserve user-settable fields in generated code", async () => {

--- a/packages/cli/src/commands/schema/init/index.ts
+++ b/packages/cli/src/commands/schema/init/index.ts
@@ -1,4 +1,5 @@
 import { readdir } from "node:fs/promises";
+import chalk from "chalk";
 import { resolve } from "pathe";
 
 import { colorPalette, commands } from "../../../constants";
@@ -102,14 +103,19 @@ schemaCommand
 
       writeSpinner.succeed(`Generated ${writtenFiles.length} files`);
       ui.list(writtenFiles.map((file) => displayPath(file, options.outDir)));
-      ui.warn(
-        "`schema init` is a one-time bootstrap step for adopting an existing space. Review generated files before continuing.",
+
+      ui.ok(
+        `Schema workspace initialized from space ${space} in ${chalk.hex(colorPalette.PRIMARY)(targetDisplayPath)}`,
+        true,
       );
+      ui.br();
       ui.info(
-        "After bootstrapping, keep your local schema as the source of truth and use `schema push` for ongoing changes.",
-      );
-      ui.info(
-        "Make sure `@storyblok/schema` is installed in the project that imports these files (e.g. `pnpm add @storyblok/schema`).",
+        [
+          "Next steps:",
+          `  1. Install ${chalk.hex(colorPalette.PRIMARY)("@storyblok/schema")} in the project that imports these files`,
+          "  2. Review the generated files. Your local schema is now the source of truth",
+          `  3. Use ${chalk.hex(colorPalette.PRIMARY)("storyblok schema push")} for all further schema changes. ${chalk.hex(colorPalette.PRIMARY)("schema init")} is a one-time bootstrap`,
+        ].join("\n"),
       );
     } catch (maybeError) {
       summary.failed += 1;

--- a/packages/cli/src/commands/schema/push/index.test.ts
+++ b/packages/cli/src/commands/schema/push/index.test.ts
@@ -240,6 +240,33 @@ describe("schema push command", () => {
     expect(files.some((f) => f.endsWith(`/components/${DEFAULT_SPACE}/hero.json`))).toBe(true);
   });
 
+  it("should confirm the push after the advisory warnings", async () => {
+    const localComp = makeMockComponent({ name: "hero" });
+    const staleComp = makeMockComponent({ name: "footer" });
+    preconditions.hasLocalSchema({
+      components: [localComp] as any,
+      datasources: [],
+    });
+    preconditions.hasRemoteComponents([staleComp]);
+    preconditions.hasRemoteFolders([]);
+    preconditions.hasRemoteDatasources([]);
+    preconditions.canCreateComponents([localComp]);
+
+    await schemaCommand.parseAsync(["node", "test", "push", "schema.ts", "--space", DEFAULT_SPACE]);
+
+    const { calls, invocationCallOrder } = vi.mocked(console.error).mock;
+    const confirmation = calls.findIndex(([message]) =>
+      String(message).includes(`Schema pushed to space ${DEFAULT_SPACE}`),
+    );
+    const warnings = vi.mocked(console.warn).mock.invocationCallOrder;
+
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(String(calls[confirmation]?.[0])).toContain("1 created");
+    // The confirmation is the last thing the user sees, so a run that only
+    // surfaced advisory warnings does not read as a failure.
+    expect(invocationCallOrder[confirmation]).toBeGreaterThan(Math.max(...warnings));
+  });
+
   it("should skip writing local component files when --no-write-components is used", async () => {
     const localComp = makeMockComponent({ name: "hero" });
     preconditions.hasLocalSchema({

--- a/packages/cli/src/commands/schema/push/index.ts
+++ b/packages/cli/src/commands/schema/push/index.ts
@@ -288,23 +288,23 @@ schemaCommand
         diffResult.creates === 0 &&
         diffResult.updates === 0 &&
         (!options.delete || diffResult.stale === 0);
-      if (nothingToPush) {
-        ui.ok("Everything up to date — nothing to push.");
-      } else {
+      let pushResult: Awaited<ReturnType<typeof executePush>> | null = null;
+      if (!nothingToPush) {
         const pushSpinner = ui.createSpinner("Pushing schema...");
-        let result: Awaited<ReturnType<typeof executePush>>;
         try {
-          result = await executePush(space, local, remote, diffResult, { delete: options.delete });
+          pushResult = await executePush(space, local, remote, diffResult, {
+            delete: options.delete,
+          });
         } catch (error) {
           pushSpinner.failed("Failed to push schema");
           throw error;
         }
 
-        summary.total = result.created + result.updated + result.deleted;
+        summary.total = pushResult.created + pushResult.updated + pushResult.deleted;
         summary.succeeded = summary.total;
 
         pushSpinner.succeed(
-          `Pushed ${result.created} creations, ${result.updated} updates${result.deleted > 0 ? `, ${result.deleted} deletions` : ""}.`,
+          `Pushed ${pushResult.created} creations, ${pushResult.updated} updates${pushResult.deleted > 0 ? `, ${pushResult.deleted} deletions` : ""}.`,
         );
       }
 
@@ -329,6 +329,19 @@ schemaCommand
           });
         }
       }
+
+      // 11. Confirm the outcome last, so a run that only surfaced advisory
+      // warnings does not read as a failure.
+      ui.br();
+      if (pushResult) {
+        ui.ok(
+          `Schema pushed to space ${space}. ${pushResult.created} created, ${pushResult.updated} updated${pushResult.deleted > 0 ? `, ${pushResult.deleted} deleted` : ""}.`,
+          true,
+        );
+      } else {
+        ui.ok(`Schema already up to date with space ${space}, nothing to push.`, true);
+      }
+      ui.br();
     } catch (maybeError) {
       summary.failed += 1;
       handleError(toError(maybeError), verbose);


### PR DESCRIPTION
Feedback on `schema init`: a successful run ends with one warning and two info lines, and no confirmation that anything worked. It reads like the command half-failed.

`schema push` has the same shape. A run that surfaced stale-entity or migration warnings ends on those warnings, with only a spinner line to say the push succeeded.

## What

Both commands now close with an explicit success block, printed after every advisory line.

**`schema init`**

```
✔ Generated 12 files
  .storyblok/schema/blocks/hero.ts
  ...

 Success

✔ Schema workspace initialized from space 12345 in .storyblok/schema

ℹ Next steps:
  1. Install @storyblok/schema in the project that imports these files
  2. Review the generated files. Your local schema is now the source of truth
  3. Use storyblok schema push for all further schema changes. schema init is a one-time bootstrap
```

The bootstrap caveat and the "review before continuing" nudge are no longer a warning. Nothing actually went wrong, so they become numbered next steps instead.

**`schema push`**

```
⚠️  1 stale entity(s) exist remotely but not in schema. Use --delete to remove.

 Success

✔ Schema pushed to space 12345. 1 created, 0 updated.
```

The confirmation moved below the local-component write step so it is the last thing on screen. The up-to-date case gets the same treatment: `Schema already up to date with space 12345, nothing to push.`

Both use the existing `ui.ok(message, true)` helper, matching `login`, `logout`, `languages`, `types generate`, and `create`.

Fixes DX-563
