### PR TITLE
fix(js-client): support excluding_story_fields parameter

### DIFF
--- a/packages/capi-client/src/index.ts
+++ b/packages/capi-client/src/index.ts
@@ -52,7 +52,7 @@ export type { Space, StoryLocalizedPath, StoryTranslatedSlug } from "./generated
 export type { Block as Component } from "./generated/types/block";
 export type { Story } from "./generated/types/story";
 // Resource types
-export type { StoryWithInlinedRelations } from "./resources/stories";
+export type { ExcludableStoryField, StoryWithInlinedRelations } from "./resources/stories";
 // Cache types
 export type { CacheProvider, CacheStrategy, CacheStrategyHandler } from "./utils/cache";
 

--- a/packages/capi-client/src/resources/stories.test.ts
+++ b/packages/capi-client/src/resources/stories.test.ts
@@ -277,6 +277,25 @@ describe("stories.get()", () => {
       "translated_slugs",
     );
   });
+
+  it("should omit excluding_story_fields when passed an empty array", async () => {
+    let capturedUrl: string | undefined;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories/*", ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({
+          story: makeStory("home", { component: "page", _uid: "uid-1" }),
+        });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.stories.get("home", {
+      query: { excluding_story_fields: [] as any },
+    });
+
+    expect(new URL(capturedUrl!).searchParams.has("excluding_story_fields")).toBe(false);
+  });
 });
 
 describe("stories.list()", () => {
@@ -326,12 +345,29 @@ describe("stories.list()", () => {
     const client = createApiClient({ accessToken: "test-token" });
 
     await client.stories.list({
-      query: { excluding_story_fields: "translated_slugs,alternates" },
+      query: { excluding_story_fields: "translated_slugs" },
     });
 
     expect(new URL(capturedUrl!).searchParams.get("excluding_story_fields")).toBe(
-      "translated_slugs,alternates",
+      "translated_slugs",
     );
+  });
+
+  it("should omit excluding_story_fields when passed an empty array", async () => {
+    let capturedUrl: string | undefined;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ stories: [] });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.stories.list({
+      query: { excluding_story_fields: [] as any },
+    });
+
+    expect(new URL(capturedUrl!).searchParams.has("excluding_story_fields")).toBe(false);
   });
 });
 

--- a/packages/capi-client/src/resources/stories.test.ts
+++ b/packages/capi-client/src/resources/stories.test.ts
@@ -235,6 +235,48 @@ describe("stories.get()", () => {
 
     expect(new URL(capturedUrl!).searchParams.has("find_by")).toBe(false);
   });
+
+  it("should join excluding_story_fields array into a comma-separated query param", async () => {
+    let capturedUrl: string | undefined;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories/*", ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({
+          story: makeStory("home", { component: "page", _uid: "uid-1" }),
+        });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.stories.get("home", {
+      query: { excluding_story_fields: ["translated_slugs", "alternates"] },
+    });
+
+    expect(new URL(capturedUrl!).searchParams.get("excluding_story_fields")).toBe(
+      "translated_slugs,alternates",
+    );
+  });
+
+  it("should forward excluding_story_fields string unchanged", async () => {
+    let capturedUrl: string | undefined;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories/*", ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({
+          story: makeStory("home", { component: "page", _uid: "uid-1" }),
+        });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.stories.get("home", {
+      query: { excluding_story_fields: "translated_slugs" },
+    });
+
+    expect(new URL(capturedUrl!).searchParams.get("excluding_story_fields")).toBe(
+      "translated_slugs",
+    );
+  });
 });
 
 describe("stories.list()", () => {
@@ -252,6 +294,44 @@ describe("stories.list()", () => {
 
     expect(result.error).toBeUndefined();
     expect(Array.isArray(result.data?.stories)).toBe(true);
+  });
+
+  it("should join excluding_story_fields array into a comma-separated query param", async () => {
+    let capturedUrl: string | undefined;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ stories: [] });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.stories.list({
+      query: { excluding_story_fields: ["translated_slugs", "alternates", "created_at"] },
+    });
+
+    expect(new URL(capturedUrl!).searchParams.get("excluding_story_fields")).toBe(
+      "translated_slugs,alternates,created_at",
+    );
+  });
+
+  it("should forward excluding_story_fields string unchanged", async () => {
+    let capturedUrl: string | undefined;
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ stories: [] });
+      }),
+    );
+    const client = createApiClient({ accessToken: "test-token" });
+
+    await client.stories.list({
+      query: { excluding_story_fields: "translated_slugs,alternates" },
+    });
+
+    expect(new URL(capturedUrl!).searchParams.get("excluding_story_fields")).toBe(
+      "translated_slugs,alternates",
+    );
   });
 });
 

--- a/packages/capi-client/src/resources/stories.ts
+++ b/packages/capi-client/src/resources/stories.ts
@@ -22,6 +22,31 @@ import type { ApiResponse, FetchOptions, ResourceDeps } from "../client";
 import type { Block as Component, RootBlock as RootComponents } from "../generated/types/block";
 import type { Story } from "../generated/types/story";
 
+/**
+ * Top-level story fields that can be excluded from CDN API responses via
+ * the `excluding_story_fields` parameter. Fields not in this list are
+ * silently ignored by the API.
+ */
+export type ExcludableStoryField =
+  | "alternates"
+  | "created_at"
+  | "default_full_slug"
+  | "first_published_at"
+  | "group_id"
+  | "is_startpage"
+  | "lang"
+  | "meta_data"
+  | "parent_id"
+  | "path"
+  | "position"
+  | "published_at"
+  | "release_id"
+  | "sort_by_date"
+  | "tag_list"
+  | "taxonomy_terms"
+  | "translated_slugs"
+  | "updated_at";
+
 type InlinedStoryContentField =
   | string
   | number
@@ -186,6 +211,7 @@ export function createStoriesResource<
       options: {
         query?: Omit<NonNullable<GetStoryByIdData["query"]>, "resolve_relations"> & {
           resolve_relations?: ResolveRelationsStr;
+          excluding_story_fields?: ExcludableStoryField | ExcludableStoryField[];
         };
         signal?: AbortSignal;
         throwOnError?: ThrowOnError;
@@ -198,7 +224,16 @@ export function createStoriesResource<
       >
     > => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
-      const typedQuery = (query ?? {}) as NonNullable<GetStoryByIdData["query"]>;
+      const { excluding_story_fields, ...restQuery } = query;
+      const normalizedQuery = {
+        ...restQuery,
+        ...(excluding_story_fields !== undefined && {
+          excluding_story_fields: Array.isArray(excluding_story_fields)
+            ? excluding_story_fields.join(",")
+            : excluding_story_fields,
+        }),
+      };
+      const typedQuery = normalizedQuery as NonNullable<GetStoryByIdData["query"]>;
       const resolvedQuery =
         typeof identifier === "string" && UUID_RE.test(identifier) && !typedQuery.find_by
           ? { ...typedQuery, find_by: "uuid" }
@@ -265,6 +300,7 @@ export function createStoriesResource<
       options: {
         query?: Omit<NonNullable<ListStoriesData["query"]>, "resolve_relations"> & {
           resolve_relations?: ResolveRelationsStr;
+          excluding_story_fields?: ExcludableStoryField | ExcludableStoryField[];
         };
         signal?: AbortSignal;
         throwOnError?: ThrowOnError;
@@ -277,7 +313,16 @@ export function createStoriesResource<
       >
     > => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
-      const typedQuery = (query ?? {}) as NonNullable<ListStoriesData["query"]>;
+      const { excluding_story_fields, ...restQuery } = query;
+      const normalizedQuery = {
+        ...restQuery,
+        ...(excluding_story_fields !== undefined && {
+          excluding_story_fields: Array.isArray(excluding_story_fields)
+            ? excluding_story_fields.join(",")
+            : excluding_story_fields,
+        }),
+      };
+      const typedQuery = normalizedQuery as NonNullable<ListStoriesData["query"]>;
       const requestPath = "/v2/cdn/stories";
       return requestWithCache(
         "GET",

--- a/packages/capi-client/src/resources/stories.ts
+++ b/packages/capi-client/src/resources/stories.ts
@@ -238,7 +238,10 @@ export function createStoriesResource<
     > => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
       const { excluding_story_fields, ...restQuery } = query;
-      const normalizedQuery = { ...restQuery, ...excludingStoryFieldsParam(excluding_story_fields) };
+      const normalizedQuery = {
+        ...restQuery,
+        ...excludingStoryFieldsParam(excluding_story_fields),
+      };
       const typedQuery = normalizedQuery as NonNullable<GetStoryByIdData["query"]>;
       const resolvedQuery =
         typeof identifier === "string" && UUID_RE.test(identifier) && !typedQuery.find_by
@@ -320,7 +323,10 @@ export function createStoriesResource<
     > => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
       const { excluding_story_fields, ...restQuery } = query;
-      const normalizedQuery = { ...restQuery, ...excludingStoryFieldsParam(excluding_story_fields) };
+      const normalizedQuery = {
+        ...restQuery,
+        ...excludingStoryFieldsParam(excluding_story_fields),
+      };
       const typedQuery = normalizedQuery as NonNullable<ListStoriesData["query"]>;
       const requestPath = "/v2/cdn/stories";
       return requestWithCache(

--- a/packages/capi-client/src/resources/stories.ts
+++ b/packages/capi-client/src/resources/stories.ts
@@ -47,6 +47,19 @@ export type ExcludableStoryField =
   | "translated_slugs"
   | "updated_at";
 
+/**
+ * Returns a spread-ready query fragment for `excluding_story_fields`:
+ * - array with items  → `{ excluding_story_fields: "a,b,c" }`
+ * - empty array / undefined → `{}` (param omitted)
+ * - string → `{ excluding_story_fields: "a,b,c" }` (unchanged)
+ */
+function excludingStoryFieldsParam(
+  value: ExcludableStoryField | ExcludableStoryField[] | undefined,
+): { excluding_story_fields: string } | Record<never, never> {
+  const str = Array.isArray(value) ? (value.length > 0 ? value.join(",") : undefined) : value;
+  return str !== undefined ? { excluding_story_fields: str } : {};
+}
+
 type InlinedStoryContentField =
   | string
   | number
@@ -225,14 +238,7 @@ export function createStoriesResource<
     > => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
       const { excluding_story_fields, ...restQuery } = query;
-      const normalizedQuery = {
-        ...restQuery,
-        ...(excluding_story_fields !== undefined && {
-          excluding_story_fields: Array.isArray(excluding_story_fields)
-            ? excluding_story_fields.join(",")
-            : excluding_story_fields,
-        }),
-      };
+      const normalizedQuery = { ...restQuery, ...excludingStoryFieldsParam(excluding_story_fields) };
       const typedQuery = normalizedQuery as NonNullable<GetStoryByIdData["query"]>;
       const resolvedQuery =
         typeof identifier === "string" && UUID_RE.test(identifier) && !typedQuery.find_by
@@ -314,14 +320,7 @@ export function createStoriesResource<
     > => {
       const { query = {}, signal, throwOnError, fetchOptions } = options;
       const { excluding_story_fields, ...restQuery } = query;
-      const normalizedQuery = {
-        ...restQuery,
-        ...(excluding_story_fields !== undefined && {
-          excluding_story_fields: Array.isArray(excluding_story_fields)
-            ? excluding_story_fields.join(",")
-            : excluding_story_fields,
-        }),
-      };
+      const normalizedQuery = { ...restQuery, ...excludingStoryFieldsParam(excluding_story_fields) };
       const typedQuery = normalizedQuery as NonNullable<ListStoriesData["query"]>;
       const requestPath = "/v2/cdn/stories";
       return requestWithCache(

--- a/packages/capi-client/src/utils/fetch-rel-uuids.test.ts
+++ b/packages/capi-client/src/utils/fetch-rel-uuids.test.ts
@@ -155,4 +155,31 @@ describe("fetchMissingRelations", () => {
       }),
     ).rejects.toBeDefined();
   });
+
+  it("should forward excluding_story_fields from baseQuery to the secondary request", async () => {
+    const seenExcludingStoryFields: Array<string | null> = [];
+
+    server.use(
+      http.get("https://api.storyblok.com/v2/cdn/stories", ({ request }: { request: Request }) => {
+        const url = new URL(request.url);
+        seenExcludingStoryFields.push(url.searchParams.get("excluding_story_fields"));
+        const byUuids = url.searchParams.get("by_uuids") ?? "";
+        return HttpResponse.json({
+          stories: byUuids.split(",").map((uuid) => ({ uuid })),
+        });
+      }),
+    );
+
+    await fetchMissingRelations({
+      baseQuery: {
+        version: "draft",
+        excluding_story_fields: "translated_slugs,alternates",
+      },
+      client: createTestClient(),
+      throttleManager: passthroughThrottleManager,
+      uuids: ["rel-uuid-1"],
+    });
+
+    expect(seenExcludingStoryFields).toEqual(["translated_slugs,alternates"]);
+  });
 });

--- a/packages/capi-client/src/utils/fetch-rel-uuids.ts
+++ b/packages/capi-client/src/utils/fetch-rel-uuids.ts
@@ -7,6 +7,7 @@ import { chunkArray } from "./array";
 const UUID_CHUNK_SIZE = 50;
 const QUERY_CONTEXT_KEYS = new Set([
   "cv",
+  "excluding_story_fields",
   "fallback_lang",
   "from_release",
   "language",

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -1792,6 +1792,52 @@ describe("storyblokClient", () => {
         }),
       );
     });
+
+    it("should join excluding_story_fields array into a comma-separated string", async () => {
+      const storySlug = "test-story";
+      const mockStoryResponse = {
+        data: { story: { id: 123, uuid: "test-uuid", name: "Test Story", content: {} } },
+        headers: {},
+        status: 200,
+      };
+      const mockGet = vi.fn().mockResolvedValue(mockStoryResponse);
+      client.client = { get: mockGet, post: vi.fn(), setFetchOptions: vi.fn() };
+
+      await client.get(`cdn/stories/${storySlug}`, {
+        version: "draft",
+        excluding_story_fields: ["translated_slugs", "alternates", "created_at"],
+      });
+
+      expect(mockGet).toHaveBeenCalledWith(
+        `/cdn/stories/${storySlug}`,
+        expect.objectContaining({
+          excluding_story_fields: "translated_slugs,alternates,created_at",
+        }),
+      );
+    });
+
+    it("should pass excluding_story_fields string through unchanged", async () => {
+      const storySlug = "test-story";
+      const mockStoryResponse = {
+        data: { story: { id: 123, uuid: "test-uuid", name: "Test Story", content: {} } },
+        headers: {},
+        status: 200,
+      };
+      const mockGet = vi.fn().mockResolvedValue(mockStoryResponse);
+      client.client = { get: mockGet, post: vi.fn(), setFetchOptions: vi.fn() };
+
+      await client.get(`cdn/stories/${storySlug}`, {
+        version: "draft",
+        excluding_story_fields: "translated_slugs,alternates",
+      });
+
+      expect(mockGet).toHaveBeenCalledWith(
+        `/cdn/stories/${storySlug}`,
+        expect.objectContaining({
+          excluding_story_fields: "translated_slugs,alternates",
+        }),
+      );
+    });
   });
 
   describe("dynamic Rate Limiting", () => {

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -1535,6 +1535,106 @@ describe("storyblokClient", () => {
         expect.anything(),
       );
     });
+
+    it("should forward excluding_story_fields to secondary requests when resolving relations", async () => {
+      const TEST_UUID = "rel-uuid-1";
+
+      const mockResponse = {
+        data: {
+          story: {
+            uuid: "story-uuid",
+            content: { _uid: "uid", component: "page", author: TEST_UUID },
+          },
+          rel_uuids: [TEST_UUID],
+        },
+        headers: {},
+        status: 200,
+        statusText: "OK",
+      };
+
+      const mockRelationsResponse = {
+        data: {
+          stories: [
+            { uuid: TEST_UUID, name: "Author", content: { component: "author", _uid: TEST_UUID } },
+          ],
+        },
+        headers: {},
+        status: 200,
+        statusText: "OK",
+      };
+
+      const mockGet = vi
+        .fn()
+        .mockResolvedValueOnce(mockResponse)
+        .mockResolvedValueOnce(mockRelationsResponse);
+
+      client.client = { get: mockGet, post: vi.fn(), setFetchOptions: vi.fn() };
+
+      await client.get("cdn/stories/test", {
+        version: "draft",
+        resolve_relations: "page.author",
+        excluding_story_fields: ["translated_slugs", "alternates"],
+      });
+
+      // Second call is the relations fetch — it must carry excluding_story_fields
+      const relationsCallParams = mockGet.mock.calls[1][1];
+      expect(relationsCallParams).toHaveProperty(
+        "excluding_story_fields",
+        "translated_slugs,alternates",
+      );
+    });
+
+    it("should forward excluding_story_fields to secondary requests when resolving links", async () => {
+      const TEST_UUID = "link-uuid-1";
+
+      const mockResponse = {
+        data: {
+          story: {
+            uuid: "story-uuid",
+            content: { _uid: "uid", component: "page" },
+          },
+          link_uuids: [TEST_UUID],
+        },
+        headers: {},
+        status: 200,
+        statusText: "OK",
+      };
+
+      const mockLinksResponse = {
+        data: {
+          stories: [
+            {
+              uuid: TEST_UUID,
+              name: "Linked page",
+              content: { component: "page", _uid: TEST_UUID },
+            },
+          ],
+        },
+        headers: {},
+        status: 200,
+        statusText: "OK",
+      };
+
+      const mockGet = vi
+        .fn()
+        .mockResolvedValueOnce(mockResponse)
+        .mockResolvedValueOnce(mockLinksResponse);
+
+      client.client = { get: mockGet, post: vi.fn(), setFetchOptions: vi.fn() };
+
+      await client.get("cdn/stories/test", {
+        version: "draft",
+        resolve_links: "story",
+        excluding_story_fields: ["translated_slugs", "alternates"],
+      });
+
+      // Second call is the links fetch — it must carry excluding_story_fields
+      const linksCallParams = mockGet.mock.calls[1][1];
+      expect(linksCallParams).toHaveProperty(
+        "excluding_story_fields",
+        "translated_slugs,alternates",
+      );
+    });
   });
 
   // eslint-disable-next-line test/prefer-lowercase-title

--- a/packages/js-client/src/index.test.ts
+++ b/packages/js-client/src/index.test.ts
@@ -1838,6 +1838,25 @@ describe("storyblokClient", () => {
         }),
       );
     });
+
+    it("should omit excluding_story_fields when passed an empty array", async () => {
+      const storySlug = "test-story";
+      const mockStoryResponse = {
+        data: { story: { id: 123, uuid: "test-uuid", name: "Test Story", content: {} } },
+        headers: {},
+        status: 200,
+      };
+      const mockGet = vi.fn().mockResolvedValue(mockStoryResponse);
+      client.client = { get: mockGet, post: vi.fn(), setFetchOptions: vi.fn() };
+
+      await client.get(`cdn/stories/${storySlug}`, {
+        version: "draft",
+        excluding_story_fields: [] as any,
+      });
+
+      const callArgs = mockGet.mock.calls[0][1];
+      expect(callArgs).not.toHaveProperty("excluding_story_fields");
+    });
   });
 
   describe("dynamic Rate Limiting", () => {

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -187,6 +187,15 @@ export class Storyblok {
       params.resolve_relations = decodeIfEncoded(params.resolve_relations);
     }
 
+    if (Array.isArray(params.excluding_story_fields)) {
+      // Join array to the comma-separated string the API expects.
+      // Cast required: the public type is a strict literal union; the wire
+      // format is the joined string which does not match that union.
+      params.excluding_story_fields = params.excluding_story_fields.join(
+        ",",
+      ) as (typeof params)["excluding_story_fields"];
+    }
+
     if (typeof params.resolve_relations !== "undefined") {
       params.resolve_level = 2;
     }

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -74,6 +74,18 @@ const _VERSION = {
 type ObjectValues<T> = T[keyof T];
 type Version = ObjectValues<typeof _VERSION>;
 
+/**
+ * Normalises `excluding_story_fields` to the comma-separated wire format.
+ * Returns `undefined` for an empty array or a missing value so the caller
+ * can omit the param entirely instead of sending an empty string.
+ */
+function normalizeExcludingStoryFields(
+  value: ExcludableStoryField | ExcludableStoryField[] | undefined,
+): string | undefined {
+  if (Array.isArray(value)) return value.length > 0 ? value.join(",") : undefined;
+  return value;
+}
+
 export class Storyblok {
   private client: SbFetch;
   private maxRetries: number;
@@ -187,13 +199,13 @@ export class Storyblok {
       params.resolve_relations = decodeIfEncoded(params.resolve_relations);
     }
 
-    if (Array.isArray(params.excluding_story_fields)) {
-      // Join array to the comma-separated string the API expects.
+    const normalizedExcluding = normalizeExcludingStoryFields(params.excluding_story_fields);
+    if (normalizedExcluding !== undefined) {
       // Cast required: the public type is a strict literal union; the wire
       // format is the joined string which does not match that union.
-      params.excluding_story_fields = params.excluding_story_fields.join(
-        ",",
-      ) as (typeof params)["excluding_story_fields"];
+      params.excluding_story_fields = normalizedExcluding as (typeof params)["excluding_story_fields"];
+    } else {
+      delete params.excluding_story_fields;
     }
 
     if (typeof params.resolve_relations !== "undefined") {

--- a/packages/js-client/src/index.ts
+++ b/packages/js-client/src/index.ts
@@ -42,6 +42,7 @@ import type {
   ISbStory,
   ISbStoryData,
   ISbStoryParams,
+  ExcludableStoryField,
 } from "./interfaces";
 
 export * from "./interfaces";
@@ -203,7 +204,8 @@ export class Storyblok {
     if (normalizedExcluding !== undefined) {
       // Cast required: the public type is a strict literal union; the wire
       // format is the joined string which does not match that union.
-      params.excluding_story_fields = normalizedExcluding as (typeof params)["excluding_story_fields"];
+      params.excluding_story_fields =
+        normalizedExcluding as (typeof params)["excluding_story_fields"];
     } else {
       delete params.excluding_story_fields;
     }
@@ -597,6 +599,7 @@ export class Storyblok {
           version: params.version,
           starts_with: params.starts_with,
           by_uuids: chunks[chunkIndex].join(","),
+          excluding_story_fields: params.excluding_story_fields,
         });
 
         linksRes.data.stories.forEach((rel: ISbStoryData | ISbLinkURLObject | string) => {
@@ -640,6 +643,7 @@ export class Storyblok {
           starts_with: params.starts_with,
           by_uuids: chunks[chunkIndex].join(","),
           excluding_fields: params.excluding_fields,
+          excluding_story_fields: params.excluding_story_fields,
         });
 
         relationsRes.data.stories.forEach((rel: ISbStoryData) => {

--- a/packages/js-client/src/interfaces.ts
+++ b/packages/js-client/src/interfaces.ts
@@ -2,6 +2,31 @@ import type { ResponseFn } from "./sbFetch";
 import type Method from "./constants";
 import type { StoryblokContentVersionKeys } from "./constants";
 
+/**
+ * Top-level story fields that can be excluded from CDN API responses via
+ * the `excluding_story_fields` parameter. Fields not in this list are
+ * silently ignored by the API.
+ */
+export type ExcludableStoryField =
+  | "alternates"
+  | "created_at"
+  | "default_full_slug"
+  | "first_published_at"
+  | "group_id"
+  | "is_startpage"
+  | "lang"
+  | "meta_data"
+  | "parent_id"
+  | "path"
+  | "position"
+  | "published_at"
+  | "release_id"
+  | "sort_by_date"
+  | "tag_list"
+  | "taxonomy_terms"
+  | "translated_slugs"
+  | "updated_at";
+
 export interface ISbStoriesParams
   extends Partial<ISbStoryData>, ISbMultipleStoriesData, ISbAssetsParams {
   resolve_level?: number;
@@ -17,6 +42,7 @@ export interface ISbStoriesParams
   excluding_fields?: string;
   excluding_ids?: string;
   excluding_slugs?: string;
+  excluding_story_fields?: ExcludableStoryField | ExcludableStoryField[];
   fallback_lang?: string;
   filename?: string;
   filter_query?: any;
@@ -56,6 +82,7 @@ export interface ISbStoryParams {
   from_release?: string;
   language?: string;
   fallback_lang?: string;
+  excluding_story_fields?: ExcludableStoryField | ExcludableStoryField[];
 }
 
 interface Dimension {


### PR DESCRIPTION
## Problem

The CDN API accepts an `excluding_story_fields` parameter to omit top-level story fields (e.g. `translated_slugs`, `alternates`) from responses. Both clients failed to forward it correctly:

**storyblok-js-client**
- `excluding_story_fields` was not typed in `ISbStoriesParams` or `ISbStoryParams`
- When passed as an array, the `stringify` utility serialised it as bracket-style repeated keys (`excluding_story_fields[]=a&excluding_story_fields[]=b`) instead of the comma-separated string the API expects
- `excluding_story_fields` was not forwarded to the secondary requests the client makes to fetch resolved relations (`resolve_relations`) and links (`resolve_links`)

**@storyblok/api-client**
- The parameter is absent from the upstream OpenAPI spec so it was missing from the generated query types entirely
- The custom query serialiser would also have exploded arrays as repeated keys rather than joining them
- `excluding_story_fields` was not included in `QUERY_CONTEXT_KEYS`, so it was silently dropped when the client made secondary requests to fetch `rel_uuids`

## Changes

### storyblok-js-client
- Added `ExcludableStoryField` exported literal union (18 valid field names sourced from the API allowlist) to `interfaces.ts`
- Added `excluding_story_fields?: ExcludableStoryField | ExcludableStoryField[]` to `ISbStoriesParams` and `ISbStoryParams`
- Array values are joined to a comma-separated string in `parseParams` before the request is made (same pattern as `resolve_relations`)
- `excluding_story_fields` is now forwarded to the secondary `getStories` calls in both `resolveRelations` and `resolveLinks`

### @storyblok/api-client
- Added `ExcludableStoryField` literal union to `resources/stories.ts`
- Added `excluding_story_fields?: ExcludableStoryField | ExcludableStoryField[]` to the query type overrides on `stories.get()` and `stories.list()`
- Arrays are normalised to comma-separated strings inline before the query is passed to the generated SDK
- Added `"excluding_story_fields"` to `QUERY_CONTEXT_KEYS` in `fetch-rel-uuids.ts` so it is forwarded when the client fetches missing `rel_uuids`

## Tests

- **storyblok-js-client** (`src/index.test.ts`): 4 new tests — array join, string passthrough, and forwarding to resolved relations and links secondary requests
- **@storyblok/api-client** (`src/resources/stories.test.ts`): 4 new tests (2 per method) — array join and string passthrough verified against the actual HTTP URL via MSW
- **@storyblok/api-client** (`src/utils/fetch-rel-uuids.test.ts`): 1 new test — verifies `excluding_story_fields` appears on the secondary request URL