### PR TITLE
fix(cli): persist component preview templates

### DIFF
--- a/packages/cli/src/commands/components/push/actions.test.ts
+++ b/packages/cli/src/commands/components/push/actions.test.ts
@@ -1,8 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readComponentsFiles } from "./actions";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { readComponentsFiles, upsertComponent } from "./actions";
 import type { Component, ComponentFolder, InternalTag, Preset } from "../constants";
 import { vol } from "memfs";
 import { FileSystemError } from "../../../utils";
+import { getMapiClient } from "../../../api";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 // Mock components data
 const mockComponent1: Component = {
@@ -74,14 +83,16 @@ const mockGroup1: ComponentFolder = {
   id: 1,
   name: "Content",
   uuid: "group-uuid-1",
-  parent_id: undefined,
+  parent_id: null,
+  parent_uuid: null,
 };
 
 const mockGroup2: ComponentFolder = {
   id: 2,
   name: "Layout",
   uuid: "group-uuid-2",
-  parent_id: undefined,
+  parent_id: null,
+  parent_uuid: null,
 };
 
 const mockPreset1: Preset = {
@@ -107,6 +118,7 @@ const mockTag1: InternalTag = {
 describe("push components actions", () => {
   beforeEach(() => {
     vol.reset();
+    getMapiClient({ personalAccessToken: "valid-token", region: "eu" });
   });
 
   afterEach(() => {
@@ -559,6 +571,36 @@ describe("push components actions", () => {
         expect(result.components).toContainEqual(mockComponent1);
         expect(result.components).toContainEqual(mockComponent2);
       });
+    });
+  });
+
+  describe("upsertComponent", () => {
+    it("should send preview_tmpl when creating a component", async () => {
+      const preview_tmpl = "<div>Component preview</div>";
+      server.use(
+        http.post("https://mapi.storyblok.com/v1/spaces/12345/components", async ({ request }) => {
+          expect(await request.json()).toEqual({
+            component: expect.objectContaining({ preview_tmpl }),
+          });
+          return HttpResponse.json({ component: mockComponent1 }, { status: 201 });
+        }),
+      );
+
+      await upsertComponent("12345", { ...mockComponent1, preview_tmpl });
+    });
+
+    it("should send preview_tmpl when updating a component", async () => {
+      const preview_tmpl = "<div>Updated component preview</div>";
+      server.use(
+        http.put("https://mapi.storyblok.com/v1/spaces/12345/components/1", async ({ request }) => {
+          expect(await request.json()).toEqual({
+            component: expect.objectContaining({ preview_tmpl }),
+          });
+          return HttpResponse.json({ component: mockComponent1 });
+        }),
+      );
+
+      await upsertComponent("12345", { ...mockComponent1, preview_tmpl }, 1);
     });
   });
 });

--- a/packages/cli/src/commands/components/push/actions.ts
+++ b/packages/cli/src/commands/components/push/actions.ts
@@ -114,6 +114,7 @@ export const upsertComponent = async (
     color,
     icon,
     preview_field,
+    preview_tmpl,
     internal_tag_ids,
   } = component;
   const payload = {
@@ -126,6 +127,7 @@ export const upsertComponent = async (
     color: color ?? undefined,
     icon: icon ?? undefined,
     preview_field: preview_field ?? undefined,
+    preview_tmpl: preview_tmpl ?? undefined,
     internal_tag_ids: toRequestTagIds(internal_tag_ids),
   };
 


### PR DESCRIPTION
## Summary

- include `preview_tmpl` in component create and update payloads
- add request assertions covering both paths
- include CLI test files in TypeScript validation and align test fixtures with current API contracts

## Verification

- `pnpm --filter storyblok exec vp test run`
- `pnpm nx lint storyblok`
- `pnpm nx run storyblok:test:types`

Fixes DX-567
Fixes #796