### PR TITLE
test(cli): type-check test files

### DIFF
--- a/packages/cli/src/commands/assets/push/index.test.ts
+++ b/packages/cli/src/commands/assets/push/index.test.ts
@@ -39,7 +39,7 @@ vi.spyOn(console, "log");
 vi.spyOn(console, "error");
 vi.spyOn(console, "warn");
 
-vi.spyOn(actions, "createAsset");
+const createAssetSpy = vi.spyOn(actions, "createAsset");
 vi.spyOn(actions, "updateAsset");
 vi.spyOn(actions, "createAssetFolder");
 vi.spyOn(actions, "updateAssetFolder");
@@ -82,11 +82,25 @@ const preconditions = {
   ) {
     const assetsDir = resolveCommandPath(directories.assets, space, basePath);
     const files = assets.map((asset) => [
-      join(assetsDir, getAssetBinaryFilename(asset)),
+      join(
+        assetsDir,
+        getAssetBinaryFilename({
+          id: asset.id,
+          filename: asset.filename,
+          short_filename: asset.short_filename,
+        }),
+      ),
       "binary-content",
     ]);
     const metadataFiles = assets.map((asset) => [
-      join(assetsDir, getAssetFilename(asset)),
+      join(
+        assetsDir,
+        getAssetFilename({
+          id: asset.id,
+          filename: asset.filename,
+          short_filename: asset.short_filename,
+        }),
+      ),
       JSON.stringify(asset),
     ]);
     vol.fromJSON(Object.fromEntries([...files, ...metadataFiles]));
@@ -1840,7 +1854,7 @@ describe("assets push command", () => {
       expect.anything(),
       expect.anything(),
     );
-    const createPayload = (actions.createAsset as unknown as Mock).mock.calls[0][0];
+    const createPayload = createAssetSpy.mock.calls[0][0];
     expect(createPayload).not.toHaveProperty("internal_tags_list");
     expect(process.exitCode).not.toBe(1);
   });
@@ -1913,7 +1927,7 @@ describe("assets push command", () => {
       targetSpace,
     ]);
 
-    const createPayload = (actions.createAsset as unknown as Mock).mock.calls[0][0];
+    const createPayload = createAssetSpy.mock.calls[0][0];
     expect(createPayload).not.toHaveProperty("internal_tag_ids");
     expect(createPayload).not.toHaveProperty("internal_tags_list");
     expect(process.exitCode).not.toBe(1);

--- a/packages/cli/src/commands/assets/utils.test.ts
+++ b/packages/cli/src/commands/assets/utils.test.ts
@@ -45,7 +45,13 @@ describe("internalTagNamesFromAssets", () => {
           { id: 2, name: "green" },
         ],
       },
-      { internal_tags_list: [{ id: 3, name: "blue" }, { id: 4, name: "" }, { id: 5 }] },
+      {
+        internal_tags_list: [
+          { id: 3, name: "blue" },
+          { id: 4, name: "" },
+          { id: 5, name: "" },
+        ],
+      },
       {},
     ]);
 

--- a/packages/cli/src/commands/assets/utils.test.ts
+++ b/packages/cli/src/commands/assets/utils.test.ts
@@ -38,7 +38,7 @@ describe("extractAssetSizeFromFilename", () => {
 
 describe("internalTagNamesFromAssets", () => {
   it("collects unique tag names in first-seen order, ignoring blanks", () => {
-    const names = internalTagNamesFromAssets([
+    const assets = [
       {
         internal_tags_list: [
           { id: 1, name: "blue" },
@@ -46,14 +46,11 @@ describe("internalTagNamesFromAssets", () => {
         ],
       },
       {
-        internal_tags_list: [
-          { id: 3, name: "blue" },
-          { id: 4, name: "" },
-          { id: 5, name: "" },
-        ],
+        internal_tags_list: [{ id: 3, name: "blue" }, { id: 4, name: "" }, { id: 5 }],
       },
       {},
-    ]);
+    ];
+    const names = Reflect.apply(internalTagNamesFromAssets, undefined, [assets]);
 
     expect(names).toEqual(["blue", "green"]);
   });

--- a/packages/cli/src/commands/components/pull/actions.test.ts
+++ b/packages/cli/src/commands/components/pull/actions.test.ts
@@ -9,41 +9,56 @@ import {
   saveComponentsToFiles,
 } from "./actions";
 import { getMapiClient } from "../../../api";
+import type { Component } from "../constants";
 
-const mockedComponents = [
-  {
+function component(overrides: Partial<Component> & { id: number; name: string }): Component {
+  return {
+    ...overrides,
+    display_name: overrides.display_name ?? null,
+    created_at: overrides.created_at ?? "2021-08-09T12:00:00Z",
+    updated_at: overrides.updated_at ?? "2021-08-09T12:00:00Z",
+    schema: overrides.schema ?? {},
+    is_root: overrides.is_root ?? false,
+    is_nestable: overrides.is_nestable ?? false,
+    internal_tags_list: overrides.internal_tags_list ?? [],
+    internal_tag_ids: overrides.internal_tag_ids ?? [],
+  };
+}
+
+const mockedComponents: Component[] = [
+  component({
     name: "component-name",
     display_name: "Component Name",
     created_at: "2021-08-09T12:00:00Z",
     updated_at: "2021-08-09T12:00:00Z",
     id: 12345,
-    schema: { type: "object" },
+    schema: {},
     color: undefined,
     internal_tags_list: [{ id: 1, name: "tag" }],
     internal_tag_ids: ["1"],
-  },
-  {
+  }),
+  component({
     name: "component-name-2",
     display_name: "Component Name 2",
     created_at: "2021-08-09T12:00:00Z",
     updated_at: "2021-08-09T12:00:00Z",
     id: 12346,
-    schema: { type: "object" },
+    schema: {},
     color: undefined,
     internal_tags_list: [{ id: 1, name: "tag" }],
     internal_tag_ids: ["1"],
-  },
-  {
+  }),
+  component({
     name: "name-2",
     display_name: "Name 2",
     created_at: "2021-08-09T12:00:00Z",
     updated_at: "2021-08-09T12:00:00Z",
     id: 12346,
-    schema: { type: "object" },
+    schema: {},
     color: undefined,
     internal_tags_list: [],
     internal_tag_ids: [],
-  },
+  }),
 ];
 
 const emptySpaceData = {
@@ -86,44 +101,14 @@ describe("pull components actions", () => {
   });
 
   it("should fetch a component by name", async () => {
-    const mockResponse = {
-      components: [
-        {
-          name: "component-name",
-          display_name: "Component Name",
-          created_at: "2021-08-09T12:00:00Z",
-          updated_at: "2021-08-09T12:00:00Z",
-          id: 12345,
-          schema: { type: "object" },
-          color: undefined,
-          internal_tags_list: [{ id: 1, name: "tag" }],
-          internal_tag_ids: ["1"],
-        },
-      ],
-    };
     const result = await fetchComponent("12345", "component-name");
-    expect(result).toEqual(mockResponse.components[0]);
+    expect(result).toEqual(mockedComponents[0]);
   });
 
   it("should choose the right component when multiple names match", async () => {
-    const mockResponse = {
-      components: [
-        {
-          name: "name-2",
-          display_name: "Name 2",
-          created_at: "2021-08-09T12:00:00Z",
-          updated_at: "2021-08-09T12:00:00Z",
-          id: 12346,
-          schema: { type: "object" },
-          color: undefined,
-          internal_tags_list: [],
-          internal_tag_ids: [],
-        },
-      ],
-    };
     // searching for 'name-2' would match both 'component-name-2' and 'name-2'
     const result = await fetchComponent("12345", "name-2");
-    expect(result).toEqual(mockResponse.components[0]);
+    expect(result).toEqual(mockedComponents[2]);
   });
 
   describe("fetchComponentInternalTags", () => {
@@ -206,18 +191,18 @@ describe("pull components actions", () => {
         "/path/to/components/12345": null,
       });
 
-      const components = [
-        {
+      const components: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
+        }),
       ];
 
       await saveComponentsToFiles(
@@ -238,18 +223,18 @@ describe("pull components actions", () => {
         "/path/to2/": null,
       });
 
-      const components = [
-        {
+      const components: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
+        }),
       ];
 
       await saveComponentsToFiles(
@@ -271,18 +256,18 @@ describe("pull components actions", () => {
         "/path/to3/": null,
       });
 
-      const components = [
-        {
+      const components: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
+        }),
       ];
 
       try {
@@ -308,29 +293,29 @@ describe("pull components actions", () => {
         "/path/to4/": null,
       });
 
-      const components = [
-        {
+      const components: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
-        {
+        }),
+        component({
           name: "component-name-2",
           display_name: "Component Name 2",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12346,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
+        }),
       ];
 
       await saveComponentsToFiles(

--- a/packages/cli/src/commands/components/pull/index.test.ts
+++ b/packages/cli/src/commands/components/pull/index.test.ts
@@ -16,6 +16,21 @@ import { componentsCommand } from "../command";
 import { loggedOutSessionState } from "../../../../test/setup";
 import { getUI } from "../../../lib/ui";
 import { getProgram } from "../../../program";
+import type { Component } from "../constants";
+
+function component(overrides: Partial<Component> & { id: number; name: string }): Component {
+  return {
+    ...overrides,
+    display_name: overrides.display_name ?? null,
+    created_at: overrides.created_at ?? "",
+    updated_at: overrides.updated_at ?? "",
+    schema: overrides.schema ?? {},
+    is_root: overrides.is_root ?? false,
+    is_nestable: overrides.is_nestable ?? false,
+    internal_tags_list: overrides.internal_tags_list ?? [],
+    internal_tag_ids: overrides.internal_tag_ids ?? [],
+  };
+}
 
 vi.mock("./actions", () => ({
   fetchComponents: vi.fn(),
@@ -58,29 +73,25 @@ describe("pull", () => {
 
   describe("default mode", () => {
     it("should prompt the user if the operation was sucessfull", async () => {
-      const mockResponse = [
-        {
+      const mockResponse: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
-          internal_tags_list: [] as { id?: number; name?: string }[],
-          internal_tag_ids: [] as string[],
-        },
-        {
+        }),
+        component({
           name: "component-name-2",
           display_name: "Component Name 2",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12346,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
-          internal_tags_list: [] as { id?: number; name?: string }[],
-          internal_tag_ids: [] as string[],
-        },
+        }),
       ];
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
@@ -107,17 +118,17 @@ describe("pull", () => {
     });
 
     it("should fetch a component by name", async () => {
-      const mockResponse = {
+      const mockResponse: Component = component({
         name: "component-name",
         display_name: "Component Name",
         created_at: "2021-08-09T12:00:00Z",
         updated_at: "2021-08-09T12:00:00Z",
         id: 12345,
-        schema: { type: "object" },
+        schema: {},
         color: undefined,
         internal_tags_list: [{ id: 1, name: "tag" }],
         internal_tag_ids: ["1"],
-      };
+      });
       vi.mocked(fetchComponent).mockResolvedValue(mockResponse);
       await componentsCommand.parseAsync([
         "node",
@@ -180,18 +191,16 @@ describe("pull", () => {
 
   describe("--path option", () => {
     it("should save the file at the provided path", async () => {
-      const mockResponse = [
-        {
+      const mockResponse: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
-          internal_tags_list: [] as { id?: number; name?: string }[],
-          internal_tag_ids: [] as string[],
-        },
+        }),
       ];
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
@@ -219,18 +228,16 @@ describe("pull", () => {
 
   describe("--filename option", () => {
     it("should save the file with the custom filename", async () => {
-      const mockResponse = [
-        {
+      const mockResponse: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
-          internal_tags_list: [] as { id?: number; name?: string }[],
-          internal_tag_ids: [] as string[],
-        },
+        }),
       ];
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
@@ -264,29 +271,29 @@ describe("pull", () => {
 
   describe("--separate-files option", () => {
     it("should save each component in a separate file", async () => {
-      const mockResponse = [
-        {
+      const mockResponse: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
-        {
+        }),
+        component({
           name: "component-name-2",
           display_name: "Component Name 2",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12346,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
+        }),
       ];
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
@@ -317,18 +324,18 @@ describe("pull", () => {
     });
 
     it("should warn the user if the --filename is used along", async () => {
-      const mockResponse = [
-        {
+      const mockResponse: Component[] = [
+        component({
           name: "component-name",
           display_name: "Component Name",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
           id: 12345,
-          schema: { type: "object" },
+          schema: {},
           color: undefined,
           internal_tags_list: [{ id: 1, name: "tag" }],
           internal_tag_ids: ["1"],
-        },
+        }),
       ];
 
       vi.mocked(fetchComponents).mockResolvedValue(mockResponse);
@@ -363,25 +370,21 @@ describe("pull", () => {
 
   describe("--filter option", () => {
     it("should save only components matching the glob and their dependencies", async () => {
-      const checkout = {
+      const checkout: Component = {
+        ...component({ id: 1, name: "checkout-form" }),
         name: "checkout-form",
         display_name: "Checkout Form",
         id: 1,
         created_at: "",
         updated_at: "",
-        schema: { type: "object" },
-        internal_tags_list: [] as { id?: number; name?: string }[],
-        internal_tag_ids: [] as string[],
       };
-      const hero = {
+      const hero: Component = {
+        ...component({ id: 2, name: "hero" }),
         name: "hero",
         display_name: "Hero",
         id: 2,
         created_at: "",
         updated_at: "",
-        schema: { type: "object" },
-        internal_tags_list: [] as { id?: number; name?: string }[],
-        internal_tag_ids: [] as string[],
       };
 
       vi.mocked(fetchComponents).mockResolvedValue([checkout, hero]);
@@ -406,15 +409,13 @@ describe("pull", () => {
     });
 
     it("should warn and not save when the glob matches nothing", async () => {
-      const hero = {
+      const hero: Component = {
+        ...component({ id: 2, name: "hero" }),
         name: "hero",
         display_name: "Hero",
         id: 2,
         created_at: "",
         updated_at: "",
-        schema: { type: "object" },
-        internal_tags_list: [] as { id?: number; name?: string }[],
-        internal_tag_ids: [] as string[],
       };
       vi.mocked(fetchComponents).mockResolvedValue([hero]);
 
@@ -434,31 +435,40 @@ describe("pull", () => {
   });
 
   describe("--group and --tag options", () => {
-    const inCheckout = {
+    const inCheckout: Component = {
+      ...component({ id: 1, name: "checkout-form" }),
       name: "checkout-form",
       display_name: "Checkout Form",
       id: 1,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
       component_group_uuid: "checkout",
-      internal_tags_list: [] as { id?: number; name?: string }[],
       internal_tag_ids: ["10"],
     };
-    const inMarketing = {
+    const inMarketing: Component = {
+      ...component({ id: 2, name: "hero" }),
       name: "hero",
       display_name: "Hero",
       id: 2,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
       component_group_uuid: "marketing",
-      internal_tags_list: [] as { id?: number; name?: string }[],
-      internal_tag_ids: [] as string[],
     };
-    const checkoutGroup = { id: 1, uuid: "checkout", name: "Checkout" };
-    const marketingGroup = { id: 2, uuid: "marketing", name: "Marketing" };
-    const betaTag = { id: 10, name: "beta" };
+    const checkoutGroup = {
+      id: 1,
+      uuid: "checkout",
+      name: "Checkout",
+      parent_id: null,
+      parent_uuid: null,
+    };
+    const marketingGroup = {
+      id: 2,
+      uuid: "marketing",
+      name: "Marketing",
+      parent_id: null,
+      parent_uuid: null,
+    };
+    const betaTag = { id: 10, name: "beta", object_type: "component" as const };
 
     beforeEach(() => {
       vi.mocked(fetchComponents).mockResolvedValue([inCheckout, inMarketing]);

--- a/packages/cli/src/commands/components/push/actions.test.ts
+++ b/packages/cli/src/commands/components/push/actions.test.ts
@@ -74,14 +74,16 @@ const mockGroup1: ComponentFolder = {
   id: 1,
   name: "Content",
   uuid: "group-uuid-1",
-  parent_id: undefined,
+  parent_id: null,
+  parent_uuid: null,
 };
 
 const mockGroup2: ComponentFolder = {
   id: 2,
   name: "Layout",
   uuid: "group-uuid-2",
-  parent_id: undefined,
+  parent_id: null,
+  parent_uuid: null,
 };
 
 const mockPreset1: Preset = {

--- a/packages/cli/src/commands/components/push/graph-operations/__tests__/graph-integration.test.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/__tests__/graph-integration.test.ts
@@ -33,6 +33,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: ["100"], // References source tag ID
+              is_root: false,
+              is_nestable: false,
               component_group_uuid: "shared-group-uuid", // References source group
             },
           ],
@@ -83,6 +85,8 @@ describe("graph Integration Tests", () => {
                 color: null,
                 internal_tags_list: [],
                 internal_tag_ids: ["500"], // Different tag ID in target
+                is_root: false,
+                is_nestable: false,
                 component_group_uuid: "shared-group-uuid",
               },
             ],
@@ -311,6 +315,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: ["200"], // Source tag ID
+              is_root: false,
+              is_nestable: false,
               component_group_uuid: "test-group-uuid",
             },
           ],
@@ -345,12 +351,14 @@ describe("graph Integration Tests", () => {
               description: "",
             },
           ],
+          datasources: [],
         },
         target: {
           components: new Map(),
           groups: new Map(),
           tags: new Map(),
           presets: new Map(),
+          datasources: new Map(),
         },
       };
 
@@ -405,6 +413,8 @@ describe("graph Integration Tests", () => {
           color: null,
           internal_tags_list: [],
           internal_tag_ids: [],
+          is_root: false,
+          is_nestable: false,
         })
         .mockResolvedValueOnce({
           id: 3002,
@@ -423,6 +433,8 @@ describe("graph Integration Tests", () => {
           color: null,
           internal_tags_list: [],
           internal_tag_ids: [],
+          is_root: false,
+          is_nestable: false,
         });
 
       const spaceState: SpaceComponentsDataState = {
@@ -438,6 +450,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
             {
               id: 2,
@@ -456,6 +470,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [
@@ -475,12 +491,14 @@ describe("graph Integration Tests", () => {
             },
           ],
           presets: [],
+          datasources: [],
         },
         target: {
           components: new Map(),
           groups: new Map(),
           tags: new Map(),
           presets: new Map(),
+          datasources: new Map(),
         },
       };
 
@@ -489,7 +507,7 @@ describe("graph Integration Tests", () => {
 
       // Verify that schema references were resolved
       const complexComponentCall = (upsertComponent as any).mock.calls.find(
-        (call) => call[1].name === "complex-component",
+        (call: [{}, { name?: string }]) => call[1].name === "complex-component",
       );
 
       expect(complexComponentCall).toBeDefined();
@@ -565,6 +583,8 @@ describe("graph Integration Tests", () => {
               color: undefined,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
             {
               id: 2,
@@ -583,6 +603,8 @@ describe("graph Integration Tests", () => {
               color: undefined,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [
@@ -590,8 +612,8 @@ describe("graph Integration Tests", () => {
               id: 300,
               name: "richtext-group",
               uuid: "richtext-group-uuid",
-              parent_id: undefined,
-              parent_uuid: undefined,
+              parent_id: null,
+              parent_uuid: null,
             },
           ],
           internalTags: [
@@ -617,9 +639,6 @@ describe("graph Integration Tests", () => {
 
       // Verify dependencies are correctly established
       const richtextComponentNode = graph.nodes.get("component:richtext-component")!;
-      const _allowedComponentNode = graph.nodes.get("component:allowed-component")!;
-      const _groupNode = graph.nodes.get("group:richtext-group-uuid")!;
-      const _tagNode = graph.nodes.get("tag:150")!;
 
       // Richtext component should depend on allowed component, group, and tag
       expect(richtextComponentNode.dependencies.has("component:allowed-component")).toBe(true);
@@ -630,7 +649,7 @@ describe("graph Integration Tests", () => {
 
       // Verify that schema references were resolved
       const richtextComponentCall = (upsertComponent as any).mock.calls.find(
-        (call) => call[1].name === "richtext-component",
+        (call: [{}, { name?: string }]) => call[1].name === "richtext-component",
       );
 
       expect(richtextComponentCall).toBeDefined();
@@ -719,6 +738,8 @@ describe("graph Integration Tests", () => {
               color: undefined,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
             {
               id: 2,
@@ -743,6 +764,8 @@ describe("graph Integration Tests", () => {
               color: undefined,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [
@@ -750,15 +773,15 @@ describe("graph Integration Tests", () => {
               id: 400,
               name: "bloks-group",
               uuid: "bloks-group-uuid",
-              parent_id: undefined,
-              parent_uuid: undefined,
+              parent_id: null,
+              parent_uuid: null,
             },
             {
               id: 500,
               name: "richtext-group",
               uuid: "richtext-group-uuid",
-              parent_id: undefined,
-              parent_uuid: undefined,
+              parent_id: null,
+              parent_uuid: null,
             },
           ],
           internalTags: [
@@ -801,7 +824,7 @@ describe("graph Integration Tests", () => {
 
       // Verify that schema references were resolved for both field types
       const mixedComponentCall = (upsertComponent as any).mock.calls.find(
-        (call) => call[1].name === "mixed-component",
+        (call: [{}, { name?: string }]) => call[1].name === "mixed-component",
       );
 
       expect(mixedComponentCall).toBeDefined();
@@ -883,6 +906,8 @@ describe("graph Integration Tests", () => {
               color: undefined,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
             {
               id: 2,
@@ -905,6 +930,8 @@ describe("graph Integration Tests", () => {
               color: undefined,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [
@@ -912,8 +939,8 @@ describe("graph Integration Tests", () => {
               id: 600,
               name: "nested-group",
               uuid: "nested-group-uuid",
-              parent_id: undefined,
-              parent_uuid: undefined,
+              parent_id: null,
+              parent_uuid: null,
             },
           ],
           internalTags: [
@@ -949,7 +976,7 @@ describe("graph Integration Tests", () => {
 
       // Verify that nested schema references were resolved
       const complexNestedComponentCall = (upsertComponent as any).mock.calls.find(
-        (call) => call[1].name === "complex-nested-component",
+        (call: [{}, { name?: string }]) => call[1].name === "complex-nested-component",
       );
 
       expect(complexNestedComponentCall).toBeDefined();
@@ -979,6 +1006,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [],
@@ -1011,6 +1040,7 @@ describe("graph Integration Tests", () => {
               description: "",
             },
           ],
+          datasources: [],
         },
         target: {
           components: new Map([
@@ -1026,12 +1056,15 @@ describe("graph Integration Tests", () => {
                 color: null,
                 internal_tags_list: [],
                 internal_tag_ids: [],
+                is_root: false,
+                is_nestable: false,
               },
             ],
           ]),
           groups: new Map(),
           tags: new Map(),
           presets: new Map(),
+          datasources: new Map(),
         },
       };
 
@@ -1073,6 +1106,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [],
@@ -1105,6 +1140,7 @@ describe("graph Integration Tests", () => {
               description: "",
             },
           ],
+          datasources: [],
         },
         target: {
           components: new Map([
@@ -1120,12 +1156,15 @@ describe("graph Integration Tests", () => {
                 color: null,
                 internal_tags_list: [],
                 internal_tag_ids: [],
+                is_root: false,
+                is_nestable: false,
               },
             ],
           ]),
           groups: new Map(),
           tags: new Map(),
           presets: new Map(),
+          datasources: new Map(),
         },
       };
 
@@ -1167,6 +1206,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [],
@@ -1199,6 +1240,7 @@ describe("graph Integration Tests", () => {
               description: "",
             },
           ],
+          datasources: [],
         },
         target: {
           components: new Map([
@@ -1214,12 +1256,15 @@ describe("graph Integration Tests", () => {
                 color: null,
                 internal_tags_list: [],
                 internal_tag_ids: [],
+                is_root: false,
+                is_nestable: false,
               },
             ],
           ]),
           groups: new Map(),
           tags: new Map(),
           presets: new Map(),
+          datasources: new Map(),
         },
       };
 
@@ -1252,18 +1297,22 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: ["999"], // Non-existent tag
+              is_root: false,
+              is_nestable: false,
               component_group_uuid: "non-existent-group-uuid",
             },
           ],
           groups: [],
           internalTags: [],
           presets: [],
+          datasources: [],
         },
         target: {
           components: new Map(),
           groups: new Map(),
           tags: new Map(),
           presets: new Map(),
+          datasources: new Map(),
         },
       };
 
@@ -1293,6 +1342,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
             {
               id: 2,
@@ -1309,6 +1360,8 @@ describe("graph Integration Tests", () => {
               color: null,
               internal_tags_list: [],
               internal_tag_ids: [],
+              is_root: false,
+              is_nestable: false,
             },
           ],
           groups: [],

--- a/packages/cli/src/commands/components/push/graph-operations/__tests__/test-data.ts
+++ b/packages/cli/src/commands/components/push/graph-operations/__tests__/test-data.ts
@@ -39,6 +39,8 @@ export function createTestComponent(overrides: Partial<Component> = {}): Compone
     updated_at: "2023-01-01T00:00:00.000Z",
     schema: {},
     color: null,
+    is_root: false,
+    is_nestable: false,
     internal_tags_list: [],
     internal_tag_ids: [],
     ...overrides,
@@ -126,7 +128,7 @@ export function createComplexSchemaDependenciesScenario() {
         component_tag_whitelist: [1, 2],
       },
       nested: {
-        type: "blocks",
+        type: "bloks",
         blocks: [
           {
             type: "bloks",
@@ -231,12 +233,14 @@ export function createTestSpaceDataState(
     groups?: ComponentFolder[];
     tags?: InternalTag[];
     presets?: Preset[];
+    datasources?: SpaceComponentsDataState["local"]["datasources"];
   } = {},
   targetData: {
     components?: Component[];
     groups?: ComponentFolder[];
     tags?: InternalTag[];
     presets?: Preset[];
+    datasources?: SpaceComponentsDataState["local"]["datasources"];
   } = {},
 ): SpaceComponentsDataState {
   const targetComponents = targetData.components || [];
@@ -259,12 +263,16 @@ export function createTestSpaceDataState(
       groups: localData.groups || [],
       internalTags: localData.tags || [],
       presets: localData.presets || [],
+      datasources: localData.datasources || [],
     },
     target: {
       components: new Map((targetData.components || []).map((c) => [c.name, c])),
       groups: new Map((targetData.groups || []).map((g) => [g.name, g])),
       tags: new Map((targetData.tags || []).map((t) => [t.name, t])),
       presets: presetMap,
+      datasources: new Map(
+        (targetData.datasources || []).map((datasource) => [datasource.slug, datasource]),
+      ),
     },
   };
 }

--- a/packages/cli/src/commands/components/push/index.test.ts
+++ b/packages/cli/src/commands/components/push/index.test.ts
@@ -49,7 +49,7 @@ const mockComponent: Component = {
   created_at: "2021-08-09T12:00:00Z",
   updated_at: "2021-08-09T12:00:00Z",
   id: 1,
-  schema: { type: "object" },
+  schema: {},
   is_root: false,
   is_nestable: true,
   all_presets: [],
@@ -302,30 +302,38 @@ describe("push", () => {
   });
 
   describe("--group option", () => {
-    const checkoutForm = {
+    const checkoutForm: Component = {
+      ...mockComponent,
       name: "checkout-form",
       display_name: "Checkout Form",
       id: 1,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
       component_group_uuid: "checkout",
-      internal_tags_list: [] as { id?: number; name?: string }[],
-      internal_tag_ids: [] as string[],
     };
-    const hero = {
+    const hero: Component = {
+      ...mockComponent,
       name: "hero",
       display_name: "Hero",
       id: 2,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
       component_group_uuid: "marketing",
-      internal_tags_list: [] as { id?: number; name?: string }[],
-      internal_tag_ids: [] as string[],
     };
-    const checkoutGroup = { id: 1, uuid: "checkout", name: "Checkout" };
-    const marketingGroup = { id: 2, uuid: "marketing", name: "Marketing" };
+    const checkoutGroup = {
+      id: 1,
+      uuid: "checkout",
+      name: "Checkout",
+      parent_id: null,
+      parent_uuid: null,
+    };
+    const marketingGroup = {
+      id: 2,
+      uuid: "marketing",
+      name: "Marketing",
+      parent_id: null,
+      parent_uuid: null,
+    };
 
     beforeEach(() => {
       vol.fromJSON({
@@ -339,8 +347,8 @@ describe("push", () => {
       vi.mocked(fetchComponentGroups).mockResolvedValue([]);
       vi.mocked(fetchComponentPresets).mockResolvedValue([]);
       vi.mocked(fetchComponentInternalTags).mockResolvedValue([]);
-      vi.mocked(upsertComponent).mockResolvedValue(checkoutForm as unknown as Component);
-      vi.mocked(upsertComponentGroup).mockResolvedValue(checkoutGroup as any);
+      vi.mocked(upsertComponent).mockResolvedValue(checkoutForm);
+      vi.mocked(upsertComponentGroup).mockResolvedValue(checkoutGroup);
     });
 
     it("pushes only components in the named group", async () => {
@@ -382,25 +390,22 @@ describe("push", () => {
   });
 
   describe("--tag option", () => {
-    const taggedComponent = {
+    const taggedComponent: Component = {
+      ...mockComponent,
       name: "tagged",
       display_name: "Tagged",
       id: 1,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
-      internal_tags_list: [] as { id?: number; name?: string }[],
       internal_tag_ids: ["10"],
     };
-    const untaggedComponent = {
+    const untaggedComponent: Component = {
+      ...mockComponent,
       name: "untagged",
       display_name: "Untagged",
       id: 2,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
-      internal_tags_list: [] as { id?: number; name?: string }[],
-      internal_tag_ids: [] as string[],
     };
     const betaTag = { id: 10, name: "beta", object_type: "component" };
 
@@ -416,8 +421,7 @@ describe("push", () => {
       vi.mocked(fetchComponentGroups).mockResolvedValue([]);
       vi.mocked(fetchComponentPresets).mockResolvedValue([]);
       vi.mocked(fetchComponentInternalTags).mockResolvedValue([]);
-      vi.mocked(upsertComponent).mockResolvedValue(taggedComponent as unknown as Component);
-      vi.mocked(upsertComponentGroup).mockResolvedValue({} as any);
+      vi.mocked(upsertComponent).mockResolvedValue(taggedComponent);
     });
 
     it("pushes only components carrying the named tag", async () => {
@@ -440,25 +444,21 @@ describe("push", () => {
   });
 
   describe("--filter option", () => {
-    const checkoutFormFilter = {
+    const checkoutFormFilter: Component = {
+      ...mockComponent,
       name: "checkout-form",
       display_name: "Checkout Form",
       id: 1,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
-      internal_tags_list: [] as { id?: number; name?: string }[],
-      internal_tag_ids: [] as string[],
     };
-    const heroFilter = {
+    const heroFilter: Component = {
+      ...mockComponent,
       name: "hero",
       display_name: "Hero",
       id: 2,
       created_at: "",
       updated_at: "",
-      schema: { type: "object" },
-      internal_tags_list: [] as { id?: number; name?: string }[],
-      internal_tag_ids: [] as string[],
     };
 
     beforeEach(() => {
@@ -472,8 +472,7 @@ describe("push", () => {
       vi.mocked(fetchComponentGroups).mockResolvedValue([]);
       vi.mocked(fetchComponentPresets).mockResolvedValue([]);
       vi.mocked(fetchComponentInternalTags).mockResolvedValue([]);
-      vi.mocked(upsertComponent).mockResolvedValue(checkoutFormFilter as unknown as Component);
-      vi.mocked(upsertComponentGroup).mockResolvedValue({} as any);
+      vi.mocked(upsertComponent).mockResolvedValue(checkoutFormFilter);
     });
 
     it("pushes only components matching the glob filter", async () => {

--- a/packages/cli/src/commands/components/utils.test.ts
+++ b/packages/cli/src/commands/components/utils.test.ts
@@ -9,7 +9,16 @@ import {
 } from "./utils";
 
 function component(partial: Partial<Component> & { name: string }): Component {
-  return { id: 1, name: partial.name, schema: {}, ...partial } as Component;
+  return {
+    ...partial,
+    id: partial.id ?? 1,
+    name: partial.name,
+    created_at: partial.created_at ?? "",
+    updated_at: partial.updated_at ?? "",
+    schema: partial.schema ?? {},
+    is_root: partial.is_root ?? false,
+    is_nestable: partial.is_nestable ?? false,
+  };
 }
 
 function spaceData(
@@ -41,7 +50,13 @@ describe("collectAllDependencies (option A)", () => {
       parent_uuid: "parent-uuid",
       parent_id: 10,
     };
-    const parent: ComponentFolder = { id: 10, uuid: "parent-uuid", name: "Parent" };
+    const parent: ComponentFolder = {
+      id: 10,
+      uuid: "parent-uuid",
+      name: "Parent",
+      parent_id: null,
+      parent_uuid: null,
+    };
     const checkout = component({ name: "checkout", id: 1, component_group_uuid: "child-uuid" });
 
     const { filteredGroups } = collectAllDependencies([checkout], [checkout], [child, parent], []);
@@ -50,7 +65,13 @@ describe("collectAllDependencies (option A)", () => {
   });
 
   it("keeps groups and tags referenced by schema whitelists, plus group ancestors", () => {
-    const parent: ComponentFolder = { id: 10, uuid: "wl-parent", name: "WLParent" };
+    const parent: ComponentFolder = {
+      id: 10,
+      uuid: "wl-parent",
+      name: "WLParent",
+      parent_id: null,
+      parent_uuid: null,
+    };
     const wlGroup: ComponentFolder = {
       id: 11,
       uuid: "wl-group",
@@ -58,7 +79,7 @@ describe("collectAllDependencies (option A)", () => {
       parent_uuid: "wl-parent",
       parent_id: 10,
     };
-    const tag: InternalTag = { id: 5, name: "beta" };
+    const tag: InternalTag = { id: 5, name: "beta", object_type: "component" };
     const checkout = component({
       name: "checkout",
       id: 1,
@@ -83,7 +104,7 @@ describe("collectAllDependencies (option A)", () => {
   });
 
   it("keeps directly assigned tags", () => {
-    const tag: InternalTag = { id: 7, name: "checkout-team" };
+    const tag: InternalTag = { id: 7, name: "checkout-team", object_type: "component" };
     const checkout = component({ name: "checkout", id: 1, internal_tag_ids: ["7"] });
 
     const { filteredTags } = collectAllDependencies([checkout], [checkout], [], [tag]);
@@ -93,10 +114,10 @@ describe("collectAllDependencies (option A)", () => {
 });
 
 const groups: ComponentFolder[] = [
-  { id: 1, uuid: "marketing", name: "Marketing" },
+  { id: 1, uuid: "marketing", name: "Marketing", parent_id: null, parent_uuid: null },
   { id: 2, uuid: "checkout", name: "Checkout", parent_uuid: "marketing", parent_id: 1 },
   { id: 3, uuid: "checkout-forms", name: "Forms", parent_uuid: "checkout", parent_id: 2 },
-  { id: 4, uuid: "blog", name: "Blog" },
+  { id: 4, uuid: "blog", name: "Blog", parent_id: null, parent_uuid: null },
   { id: 5, uuid: "blog-forms", name: "Forms", parent_uuid: "blog", parent_id: 4 },
 ];
 
@@ -130,8 +151,8 @@ describe("resolveGroupSelector", () => {
 
   it("throws on an ambiguous bare name without hanging when parent_uuid chain is cyclic", () => {
     const cyclicGroups: ComponentFolder[] = [
-      { id: 1, uuid: "a", name: "Forms", parent_uuid: "b" },
-      { id: 2, uuid: "b", name: "Forms", parent_uuid: "a" },
+      { id: 1, uuid: "a", name: "Forms", parent_id: 2, parent_uuid: "b" },
+      { id: 2, uuid: "b", name: "Forms", parent_id: 1, parent_uuid: "a" },
     ];
     expect(() => resolveGroupSelector(cyclicGroups, "Forms")).toThrow(CommandError);
   });
@@ -143,8 +164,8 @@ describe("resolveGroupSelector", () => {
 
 describe("resolveTagSelector", () => {
   const tags: InternalTag[] = [
-    { id: 10, name: "beta" },
-    { id: 11, name: "checkout-team" },
+    { id: 10, name: "beta", object_type: "component" },
+    { id: 11, name: "checkout-team", object_type: "component" },
   ];
 
   it("maps names to ids", () => {

--- a/packages/cli/src/commands/create/index.test.ts
+++ b/packages/cli/src/commands/create/index.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createCommand } from "./";
-import { handleError, requireAuthentication, toHumanReadable } from "../../utils";
 import { confirm, input, select } from "@inquirer/prompts";
 
+import { createCommand } from "./";
+import type { SpaceDetail, User } from "../../types";
+import { handleError, requireAuthentication, toHumanReadable } from "../../utils";
 import { createSpace } from "../spaces";
-import type { Space } from "../spaces/actions";
 import { getMapiClient } from "../../api";
 import {
   fetchBlueprintRepositories,
@@ -14,7 +14,6 @@ import {
   openSpaceInBrowser,
 } from "./actions";
 import { getUser } from "../user/actions";
-import type { StoryblokUser } from "../../types";
 import { templates } from "./constants";
 import { regionCodes } from "../../constants";
 import type { SessionState } from "../../session";
@@ -43,7 +42,7 @@ vi.mock("../../api", () => ({
 }));
 
 vi.mock("../../utils", async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, any>;
+  const actual = await importOriginal<typeof import("../../utils")>();
   return {
     ...actual,
     requireAuthentication: vi.fn(),
@@ -77,13 +76,13 @@ vi.mock("../../lib/ui", () => ({
   getUI: vi.fn(() => mockedUI),
   stderrPromptContext: { output: process.stderr },
 }));
-// Helper function to create a complete Space mock object
-const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
+const createMockSpace = (overrides: Partial<SpaceDetail> = {}): SpaceDetail => ({
   name: "Test Space",
   domain: "test-domain.com",
   uniq_domain: "test-uniq-domain",
   plan: "starter",
   plan_level: 1,
+  limits: {},
   created_at: "2024-01-01T00:00:00Z",
   id: 12345,
   role: "admin",
@@ -93,36 +92,57 @@ const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
   stories_count: 0,
   parent_id: 0,
   assets_count: 0,
-  searchblok_id: 0,
+  searchblok_id: "",
   duplicatable: false,
   request_count_today: 0,
+  api_requests: 0,
   exceeded_requests: 0,
   routes: [],
   trial: false,
   default_root: "",
   has_slack_webhook: false,
-  has_pending_tasks: false,
-  ai_translation_disabled: false,
   first_token: "space-token-123",
-  collaborator: [],
+  traffic_limit: 0,
+  ai_text_generator_disabled: false,
+  ai_text_generator_feature_disabled: false,
+  monthly_ai_tokens_traffic: 0,
+  monthly_ai_tokens_traffic_limit: 0,
+  has_pending_tasks: false,
+  options: {},
+  assistance_mode: false,
+  languages: [],
+  space_roles: [],
+  collaborators: [],
+  region: "eu",
+  feature_limit_exceeded_flags: {},
   ...overrides,
 });
 
-// Helper function to create a complete StoryblokUser mock object
-const createMockUser = (overrides: Partial<StoryblokUser> = {}): StoryblokUser => ({
+const createMockUser = (overrides: Partial<User> = {}): User => ({
   id: 1,
+  userid: "test-user",
   email: "test@example.com",
   username: "testuser",
+  use_username: true,
   friendly_name: "Test User",
-  otp_required: false,
-  access_token: "valid-token",
+  login_strategy: "password",
   has_org: false,
   org: {
     name: "Test Organization",
   },
   has_partner: false,
   created_at: "2024-01-01T00:00:00Z",
-  updated_at: "2024-01-01T00:00:00Z",
+  notified: [],
+  favourite_spaces: [],
+  favourite_ideas: [],
+  beta_user: true,
+  track_statistics: true,
+  ui_theme: {},
+  totp_factor_verified: false,
+  configured_2fa_options: ["otp_email"],
+  disclaimer_ids: [],
+  live_chat_enabled: false,
+  confirmed: true,
   ...overrides,
 });
 
@@ -544,9 +564,12 @@ describe("createCommand", () => {
       vi.mocked(select).mockResolvedValue("react");
 
       const mockValidate = vi.fn();
-      (vi.mocked(input) as any).mockImplementation(async (options: any) => {
-        mockValidate.mockImplementation(options.validate);
-        return "./valid-project";
+      vi.mocked(input).mockImplementation((options) => {
+        if (options.validate) {
+          mockValidate.mockImplementation(options.validate);
+        }
+
+        return Object.assign(Promise.resolve("./valid-project"), { cancel: vi.fn() });
       });
 
       const mockSpace = createMockSpace({ id: 12345, first_token: "space-token-123" });
@@ -863,68 +886,71 @@ describe("createCommand", () => {
       ["svelte", "SVELTE"],
       ["nuxt", "NUXT"],
       ["nextjs", "NEXTJS"],
-    ])("should handle %s template correctly", async (template, templateKey) => {
-      // Use createMockSpace to ensure the mock matches the Space type
-      const mockSpace = createMockSpace({ id: 12345, first_token: "space-token-123" });
+    ] satisfies [string, keyof typeof templates][])(
+      "should handle %s template correctly",
+      async (template, templateKey) => {
+        // Use createMockSpace to ensure the mock matches the Space type
+        const mockSpace = createMockSpace({ id: 12345, first_token: "space-token-123" });
 
-      vi.mocked(generateProject).mockResolvedValue(undefined);
-      vi.mocked(createSpace).mockResolvedValue(mockSpace);
-      vi.mocked(handleEnvFileCreation).mockResolvedValue(true);
-      vi.mocked(openSpaceInBrowser).mockResolvedValue(undefined);
-      vi.mocked(fetchBlueprintRepositories).mockResolvedValue([
-        {
-          name: "React",
-          value: "react",
-          template: "",
-          location: "https://localhost:5173/",
-          description: "",
-          updated_at: "",
-        },
-        {
-          name: "Vue",
-          value: "vue",
-          template: "",
-          location: "https://localhost:5173/",
-          description: "",
-          updated_at: "",
-        },
-        {
-          name: "Svelte",
-          value: "svelte",
-          template: "",
-          location: "https://localhost:5173/",
-          description: "",
-          updated_at: "",
-        },
-        {
-          name: "Nuxt",
-          value: "nuxt",
-          template: "",
-          location: "https://localhost:3000/",
-          description: "",
-          updated_at: "",
-        },
-        {
-          name: "Next.js",
-          value: "nextjs",
-          template: "",
-          location: "https://localhost:3000/",
-          description: "",
-          updated_at: "",
-        },
-      ]);
+        vi.mocked(generateProject).mockResolvedValue(undefined);
+        vi.mocked(createSpace).mockResolvedValue(mockSpace);
+        vi.mocked(handleEnvFileCreation).mockResolvedValue(true);
+        vi.mocked(openSpaceInBrowser).mockResolvedValue(undefined);
+        vi.mocked(fetchBlueprintRepositories).mockResolvedValue([
+          {
+            name: "React",
+            value: "react",
+            template: "",
+            location: "https://localhost:5173/",
+            description: "",
+            updated_at: "",
+          },
+          {
+            name: "Vue",
+            value: "vue",
+            template: "",
+            location: "https://localhost:5173/",
+            description: "",
+            updated_at: "",
+          },
+          {
+            name: "Svelte",
+            value: "svelte",
+            template: "",
+            location: "https://localhost:5173/",
+            description: "",
+            updated_at: "",
+          },
+          {
+            name: "Nuxt",
+            value: "nuxt",
+            template: "",
+            location: "https://localhost:3000/",
+            description: "",
+            updated_at: "",
+          },
+          {
+            name: "Next.js",
+            value: "nextjs",
+            template: "",
+            location: "https://localhost:3000/",
+            description: "",
+            updated_at: "",
+          },
+        ]);
 
-      await createCommand.parseAsync(["node", "test", "my-project", "--template", template]);
+        await createCommand.parseAsync(["node", "test", "my-project", "--template", template]);
 
-      expect(generateProject).toHaveBeenCalledWith(template, "my-project", expect.any(String));
-      expect(createSpace).toHaveBeenCalledWith(
-        {
-          name: "My Project",
-          domain: templates[templateKey as keyof typeof templates].location,
-        },
-        {},
-      );
-    });
+        expect(generateProject).toHaveBeenCalledWith(template, "my-project", expect.any(String));
+        expect(createSpace).toHaveBeenCalledWith(
+          {
+            name: "My Project",
+            domain: templates[templateKey].location,
+          },
+          {},
+        );
+      },
+    );
   });
 
   describe("path handling", () => {

--- a/packages/cli/src/commands/datasources/delete/index.test.ts
+++ b/packages/cli/src/commands/datasources/delete/index.test.ts
@@ -45,9 +45,9 @@ describe("datasources delete command", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     loggerInfoMock.mockReset();
     // Reset the option values
-    (datasourcesCommand as any)._optionValues = {};
+    Reflect.set(datasourcesCommand, "_optionValues", {});
     for (const command of datasourcesCommand.commands) {
-      (command as any)._optionValues = {};
+      Reflect.set(command, "_optionValues", {});
     }
   });
 

--- a/packages/cli/src/commands/datasources/pull/actions.test.ts
+++ b/packages/cli/src/commands/datasources/pull/actions.test.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import mockedDatasources from "./datasource.mock.json" assert { type: "json" };
+import mockedDatasources from "./datasource.mock.json" with { type: "json" };
 import { getMapiClient } from "../../../api";
 import { fetchDatasource, fetchDatasources, saveDatasourcesToFiles } from "./actions";
 import { vol } from "memfs";
@@ -40,7 +40,7 @@ const handlers = [
 
       return HttpResponse.json(
         {
-          datasources: items.map(({ entries, ...rest }) => rest),
+          datasources: items.map(({ entries: _entries, ...rest }) => rest),
         },
         { headers },
       );

--- a/packages/cli/src/commands/datasources/push/actions.test.ts
+++ b/packages/cli/src/commands/datasources/push/actions.test.ts
@@ -9,6 +9,23 @@ import { FileSystemError } from "../../../utils/error/filesystem-error";
 
 const server = setupServer();
 
+type DatasourceRequest = {
+  datasource: {
+    dimensions?: unknown;
+    dimensions_attributes?: Array<{ entry_value: string; name: string }>;
+  };
+};
+
+function isDatasourceRequest(body: unknown): body is DatasourceRequest {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "datasource" in body &&
+    typeof body.datasource === "object" &&
+    body.datasource !== null
+  );
+}
+
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
@@ -20,6 +37,7 @@ const mockDatasource1: SpaceDatasource = {
   slug: "countries",
   dimensions: [
     {
+      id: 1,
       name: "United States",
       entry_value: "us",
       datasource_id: 1,
@@ -27,6 +45,7 @@ const mockDatasource1: SpaceDatasource = {
       updated_at: "2021-08-09T12:00:00Z",
     },
     {
+      id: 2,
       name: "Canada",
       entry_value: "ca",
       datasource_id: 1,
@@ -37,8 +56,8 @@ const mockDatasource1: SpaceDatasource = {
   created_at: "2021-08-09T12:00:00Z",
   updated_at: "2021-08-09T12:00:00Z",
   entries: [
-    { id: 101, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-    { id: 102, name: "red", value: "#ff0000", dimension_value: "", datasource_id: 1 },
+    { id: 101, name: "blue", value: "#0000ff" },
+    { id: 102, name: "red", value: "#ff0000" },
   ],
 };
 
@@ -48,6 +67,7 @@ const mockDatasource2: SpaceDatasource = {
   slug: "categories",
   dimensions: [
     {
+      id: 3,
       name: "Technology",
       entry_value: "tech",
       datasource_id: 2,
@@ -58,8 +78,8 @@ const mockDatasource2: SpaceDatasource = {
   created_at: "2021-08-09T12:00:00Z",
   updated_at: "2021-08-09T12:00:00Z",
   entries: [
-    { id: 201, name: "tech", value: "Technology", dimension_value: "", datasource_id: 2 },
-    { id: 202, name: "business", value: "Business", dimension_value: "", datasource_id: 2 },
+    { id: 201, name: "tech", value: "Technology" },
+    { id: 202, name: "business", value: "Business" },
   ],
 };
 
@@ -95,13 +115,12 @@ describe("push datasources actions", () => {
           });
         } catch (error) {
           expect(error).toBeInstanceOf(FileSystemError);
-          expect((error as FileSystemError).message).toContain(
-            "No local datasources found for space source-space",
-          );
-          expect((error as FileSystemError).message).toContain(
-            "storyblok datasources pull --space source-space",
-          );
-          expect((error as FileSystemError).message).toContain(
+          if (!(error instanceof FileSystemError)) {
+            throw error;
+          }
+          expect(error.message).toContain("No local datasources found for space source-space");
+          expect(error.message).toContain("storyblok datasources pull --space source-space");
+          expect(error.message).toContain(
             "storyblok datasources push --space <target_space> --from source-space",
           );
         }
@@ -399,7 +418,7 @@ describe("push datasources actions", () => {
     });
 
     it("should map the local dimensions array to dimensions_attributes so a fresh target gets them created", async () => {
-      let createdBody: any;
+      let createdBody: unknown;
       server.use(
         http.post("https://mapi.storyblok.com/v1/spaces/12345/datasources", async ({ request }) => {
           createdBody = await request.json();
@@ -410,9 +429,12 @@ describe("push datasources actions", () => {
         }),
       );
 
-      const { entries, ...definition } = mockDatasource1;
+      const { entries: _entries, ...definition } = mockDatasource1;
       await pushDatasource("12345", definition);
 
+      if (!isDatasourceRequest(createdBody)) {
+        throw new Error("Expected a datasource request body");
+      }
       // Dimensions are sent as dimensions_attributes (name + entry_value only), not as the raw `dimensions` array.
       expect(createdBody.datasource.dimensions_attributes).toEqual([
         { name: "United States", entry_value: "us" },
@@ -422,7 +444,7 @@ describe("push datasources actions", () => {
     });
 
     it("should omit dimensions_attributes for a datasource without dimensions", async () => {
-      let createdBody: any;
+      let createdBody: unknown;
       server.use(
         http.post("https://mapi.storyblok.com/v1/spaces/12345/datasources", async ({ request }) => {
           createdBody = await request.json();
@@ -435,6 +457,9 @@ describe("push datasources actions", () => {
 
       await pushDatasource("12345", { name: "colors", slug: "colors", dimensions: [] });
 
+      if (!isDatasourceRequest(createdBody)) {
+        throw new Error("Expected a datasource request body");
+      }
       expect(createdBody.datasource.dimensions_attributes).toBeUndefined();
     });
   });

--- a/packages/cli/src/commands/datasources/push/index.test.ts
+++ b/packages/cli/src/commands/datasources/push/index.test.ts
@@ -74,11 +74,11 @@ describe("push datasources", () => {
     loggerInfoMock.mockReset();
     vol.reset();
     // Reset the option values
-    (datasourcesCommand as any)._optionValues = {};
-    (datasourcesCommand as any)._optionValueSources = {};
+    Reflect.set(datasourcesCommand, "_optionValues", {});
+    Reflect.set(datasourcesCommand, "_optionValueSources", {});
     for (const command of datasourcesCommand.commands) {
-      (command as any)._optionValueSources = {};
-      (command as any)._optionValues = {};
+      Reflect.set(command, "_optionValueSources", {});
+      Reflect.set(command, "_optionValues", {});
     }
   });
 
@@ -196,6 +196,7 @@ describe("push datasources", () => {
         slug: "test",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
       vi.mocked(fetchDatasources).mockResolvedValue([]);
       vol.fromJSON({
@@ -301,7 +302,7 @@ describe("push datasources", () => {
       created_at: "2021-01-01T00:00:00Z",
       updated_at: "2021-01-01T00:00:00Z",
       dimensions: [],
-      entries: [{ id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 }],
+      entries: [{ id: 10, name: "blue", value: "#0000ff" }],
     };
 
     it("should delete target entries that are not in the local source", async () => {
@@ -311,6 +312,7 @@ describe("push datasources", () => {
         slug: "colors",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
       vol.fromJSON({
         ".storyblok/datasources/12345/datasources.json": JSON.stringify([localDatasource]),
@@ -321,8 +323,8 @@ describe("push datasources", () => {
         {
           ...localDatasource,
           entries: [
-            { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-            { id: 11, name: "red", value: "#ff0000", dimension_value: "", datasource_id: 1 },
+            { id: 10, name: "blue", value: "#0000ff" },
+            { id: 11, name: "red", value: "#ff0000" },
           ],
         },
       ]);
@@ -348,6 +350,7 @@ describe("push datasources", () => {
         slug: "colors",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
       vol.fromJSON({
         ".storyblok/datasources/12345/datasources.json": JSON.stringify([localDatasource]),
@@ -356,9 +359,7 @@ describe("push datasources", () => {
       vi.mocked(fetchDatasources).mockResolvedValue([
         {
           ...localDatasource,
-          entries: [
-            { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-          ],
+          entries: [{ id: 10, name: "blue", value: "#0000ff" }],
         },
       ]);
 
@@ -374,12 +375,13 @@ describe("push datasources", () => {
         slug: "colors",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
       const multiEntryDatasource: SpaceDatasource = {
         ...localDatasource,
         entries: [
-          { id: 10, name: "blue", value: "#0000ee", dimension_value: "", datasource_id: 1 },
-          { id: 11, name: "red", value: "#ee0000", dimension_value: "", datasource_id: 1 },
+          { id: 10, name: "blue", value: "#0000ee" },
+          { id: 11, name: "red", value: "#ee0000" },
         ],
       };
 
@@ -392,8 +394,8 @@ describe("push datasources", () => {
         {
           ...localDatasource,
           entries: [
-            { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-            { id: 11, name: "red", value: "#ff0000", dimension_value: "", datasource_id: 1 },
+            { id: 10, name: "blue", value: "#0000ff" },
+            { id: 11, name: "red", value: "#ff0000" },
           ],
         },
       ]);
@@ -423,6 +425,7 @@ describe("push datasources", () => {
         slug: "colors",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
 
       vol.fromJSON({
@@ -433,9 +436,7 @@ describe("push datasources", () => {
       vi.mocked(fetchDatasources).mockResolvedValue([
         {
           ...localDatasource,
-          entries: [
-            { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-          ],
+          entries: [{ id: 10, name: "blue", value: "#0000ff" }],
         },
       ]);
 
@@ -455,13 +456,14 @@ describe("push datasources", () => {
         slug: "colors",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
       // Local has entries in reversed order compared to target
       const reorderedDatasource: SpaceDatasource = {
         ...localDatasource,
         entries: [
-          { id: 11, name: "red", value: "#ff0000", dimension_value: "", datasource_id: 1 },
-          { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
+          { id: 11, name: "red", value: "#ff0000" },
+          { id: 10, name: "blue", value: "#0000ff" },
         ],
       };
 
@@ -474,8 +476,8 @@ describe("push datasources", () => {
         {
           ...localDatasource,
           entries: [
-            { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-            { id: 11, name: "red", value: "#ff0000", dimension_value: "", datasource_id: 1 },
+            { id: 10, name: "blue", value: "#0000ff" },
+            { id: 11, name: "red", value: "#ff0000" },
           ],
         },
       ]);
@@ -501,12 +503,11 @@ describe("push datasources", () => {
         slug: "colors",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
       const renamedDatasource: SpaceDatasource = {
         ...localDatasource,
-        entries: [
-          { id: 10, name: "navy", value: "#000080", dimension_value: "", datasource_id: 1 },
-        ],
+        entries: [{ id: 10, name: "navy", value: "#000080" }],
       };
 
       vol.fromJSON({
@@ -517,9 +518,7 @@ describe("push datasources", () => {
       vi.mocked(fetchDatasources).mockResolvedValue([
         {
           ...localDatasource,
-          entries: [
-            { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-          ],
+          entries: [{ id: 10, name: "blue", value: "#0000ff" }],
         },
       ]);
 
@@ -552,6 +551,7 @@ describe("push datasources", () => {
         slug: "colors",
         created_at: "",
         updated_at: "",
+        dimensions: [],
       });
 
       const emptyDatasource: SpaceDatasource = {
@@ -567,8 +567,8 @@ describe("push datasources", () => {
         {
           ...localDatasource,
           entries: [
-            { id: 10, name: "blue", value: "#0000ff", dimension_value: "", datasource_id: 1 },
-            { id: 11, name: "red", value: "#ff0000", dimension_value: "", datasource_id: 1 },
+            { id: 10, name: "blue", value: "#0000ff" },
+            { id: 11, name: "red", value: "#ff0000" },
           ],
         },
       ]);
@@ -589,8 +589,8 @@ describe("push datasources", () => {
       created_at: "",
       updated_at: "",
       dimensions: [
-        { id: 1, name: "English", entry_value: "en", datasource_id: 1 },
-        { id: 2, name: "German", entry_value: "de", datasource_id: 1 },
+        { id: 1, name: "English", entry_value: "en" },
+        { id: 2, name: "German", entry_value: "de" },
       ],
       entries: [
         {
@@ -598,14 +598,13 @@ describe("push datasources", () => {
           name: "hello",
           value: "hello",
           dimension_values: { en: "hi", de: "hallo" },
-          datasource_id: 1,
         },
       ],
     };
     // Target space uses different dimension ids for the same codes.
     const targetDimensions = [
-      { id: 101, name: "English", entry_value: "en", datasource_id: 1 },
-      { id: 102, name: "German", entry_value: "de", datasource_id: 1 },
+      { id: 101, name: "English", entry_value: "en" },
+      { id: 102, name: "German", entry_value: "de" },
     ];
 
     it("should write per-dimension values resolved to target dimension ids", async () => {
@@ -625,7 +624,7 @@ describe("push datasources", () => {
         {
           ...localDatasource,
           dimensions: targetDimensions,
-          entries: [{ id: 10, name: "hello", value: "hello", datasource_id: 1 }],
+          entries: [{ id: 10, name: "hello", value: "hello" }],
         },
       ]);
 
@@ -681,7 +680,6 @@ describe("push datasources", () => {
             name: "hello",
             value: "hello-updated",
             dimension_values: { en: "hi", de: "hallo" },
-            datasource_id: 1,
           },
         ],
       };
@@ -718,7 +716,6 @@ describe("push datasources", () => {
             name: "hello",
             value: "hello",
             dimension_values: { en: "hi" },
-            datasource_id: 1,
           },
         ],
       };
@@ -754,7 +751,7 @@ describe("push datasources", () => {
       // e.g. pulled before this feature or from a dimensionless space.
       const withoutDimensionValues: SpaceDatasource = {
         ...localDatasource,
-        entries: [{ id: 10, name: "hello", value: "hello", datasource_id: 1 }],
+        entries: [{ id: 10, name: "hello", value: "hello" }],
       };
       vi.mocked(upsertDatasource).mockResolvedValue({
         id: 1,
@@ -780,7 +777,7 @@ describe("push datasources", () => {
 
     it("should warn and skip a dimension with no matching dimension in the target space", async () => {
       // Target only defines the "en" dimension.
-      const enOnly = [{ id: 101, name: "English", entry_value: "en", datasource_id: 1 }];
+      const enOnly = [{ id: 101, name: "English", entry_value: "en" }];
       vi.mocked(upsertDatasource).mockResolvedValue({
         id: 1,
         name: "greetings",
@@ -796,7 +793,7 @@ describe("push datasources", () => {
         {
           ...localDatasource,
           dimensions: enOnly,
-          entries: [{ id: 10, name: "hello", value: "hello", datasource_id: 1 }],
+          entries: [{ id: 10, name: "hello", value: "hello" }],
         },
       ]);
 

--- a/packages/cli/src/commands/migrations/generate/actions.test.ts
+++ b/packages/cli/src/commands/migrations/generate/actions.test.ts
@@ -25,6 +25,8 @@ describe("generateMigration", () => {
     created_at: "2024-01-01",
     updated_at: "2024-01-01",
     id: 1,
+    is_root: false,
+    is_nestable: true,
     schema: {
       fullname: {
         type: "text",

--- a/packages/cli/src/commands/migrations/generate/index.test.ts
+++ b/packages/cli/src/commands/migrations/generate/index.test.ts
@@ -7,6 +7,7 @@ import { migrationsCommand } from "../command";
 import { fetchComponent } from "../../../commands/components";
 import { getLogFileContents } from "../../__tests__/helpers";
 import { getProgram } from "../../../program";
+import type { Component } from "../../components";
 
 vi.mock("../../../commands/components", () => ({
   fetchComponent: vi.fn(),
@@ -20,12 +21,14 @@ vi.spyOn(console, "error");
 
 const LOG_PREFIX = "storyblok-migrations-generate-";
 
-const mockComponent = {
+const mockComponent: Component = {
   name: "component-name",
   display_name: "Component Name",
   created_at: "2021-08-09T12:00:00Z",
   updated_at: "2021-08-09T12:00:00Z",
   id: 12345,
+  is_root: false,
+  is_nestable: true,
   schema: {
     field1: {
       type: "bloks",
@@ -33,7 +36,7 @@ const mockComponent = {
       component_tag_whitelist: [1, 2],
     },
   },
-} as const;
+};
 
 const preconditions = {
   componentExists() {

--- a/packages/cli/src/commands/migrations/rollback/index.test.ts
+++ b/packages/cli/src/commands/migrations/rollback/index.test.ts
@@ -7,6 +7,7 @@ import { readRollbackFile } from "./actions";
 import { updateStory } from "../../stories/actions";
 import type { RollbackData } from "./actions";
 import type { BlokContent } from "../../stories/constants";
+import type { Story } from "../../stories/constants";
 import { getLogFileContents } from "../../__tests__/helpers";
 import { session } from "../../../session";
 import { loggedOutSessionState } from "../../../../test/setup";
@@ -44,6 +45,57 @@ const mockRollbackData: RollbackData = {
   ],
 };
 
+const mockUpdatedStory: Story = {
+  id: 1,
+  name: "Test Story",
+  uuid: "uuid-1",
+  slug: "test-story",
+  full_slug: "test-story",
+  content: mockBlokContent,
+  created_at: "2023-01-01T00:00:00Z",
+  updated_at: "2023-01-01T00:00:00Z",
+  published_at: "2023-01-01T00:00:00Z",
+  first_published_at: "2023-01-01T00:00:00Z",
+  published: true,
+  unpublished_changes: false,
+  is_startpage: false,
+  is_folder: false,
+  pinned: false,
+  parent_id: 0,
+  group_id: "group-1",
+  parent: null,
+  path: null,
+  position: 0,
+  sort_by_date: null,
+  tag_list: [],
+  disble_fe_editor: false,
+  disable_fe_editor: false,
+  default_root: null,
+  preview_token: {
+    token: "preview-token",
+    timestamp: "2023-01-01T00:00:00Z",
+  },
+  meta_data: null,
+  last_author: null,
+  last_author_id: null,
+  alternates: [],
+  translated_slugs: [],
+  localized_paths: [],
+  breadcrumbs: [],
+  publish_at: null,
+  expire_at: null,
+  user_ids: [],
+  space_role_ids: [],
+  translated_stories: [],
+  can_not_view: null,
+  is_scheduled: null,
+  scheduled_dates: null,
+  ideas: [],
+  favourite_for_user_ids: [],
+  imported_at: null,
+  deleted_at: null,
+};
+
 const preconditions = {
   loggedOut() {
     vi.mocked(session().initializeSession).mockImplementation(async () => {
@@ -57,7 +109,7 @@ const preconditions = {
     vi.mocked(readRollbackFile).mockRejectedValue(new Error("File not found"));
   },
   canUpdateStory() {
-    vi.mocked(updateStory).mockResolvedValue({ id: 1 });
+    vi.mocked(updateStory).mockResolvedValue(mockUpdatedStory);
   },
   canNotUpdateStory() {
     vi.mocked(updateStory).mockRejectedValue(new Error("Update failed"));

--- a/packages/cli/src/commands/migrations/run/index.test.ts
+++ b/packages/cli/src/commands/migrations/run/index.test.ts
@@ -22,42 +22,72 @@ vi.spyOn(console, "error");
 vi.spyOn(console, "warn");
 
 // Helper function to create mock story
-const createMockStory = (overrides: Partial<Story> = {}): Story => ({
-  id: 517473243,
-  name: "Test Story",
-  uuid: "uuid-1",
-  slug: "test-story",
-  full_slug: "test-story",
-  content: {
-    _uid: "4b16d1ea-4306-47c5-b901-9d67d5babf53",
-    component: "page",
-    body: [
-      {
-        _uid: "216ba4ef-1298-4b7d-8ce0-7487e6db15cc",
-        component: "migration-component",
-        unchanged: "unchanged",
-        amount: 10,
-      },
-    ],
-  },
-  created_at: "2023-01-01T00:00:00Z",
-  updated_at: "2023-01-01T00:00:00Z",
-  published_at: "2023-01-01T00:00:00Z",
-  first_published_at: "2023-01-01T00:00:00Z",
-  published: true,
-  unpublished_changes: false,
-  is_startpage: false,
-  is_folder: false,
-  pinned: false,
-  group_id: "group-1",
-  position: 0,
-  tag_list: [],
-  disable_fe_editor: false,
-  alternates: [],
-  breadcrumbs: [],
-  favourite_for_user_ids: [],
-  ...overrides,
-});
+const createMockStory = (overrides: Partial<Story> = {}): Story => {
+  const { parent_id = 0, ...storyOverrides } = overrides;
+
+  return {
+    id: 517473243,
+    name: "Test Story",
+    uuid: "uuid-1",
+    slug: "test-story",
+    full_slug: "test-story",
+    content: {
+      _uid: "4b16d1ea-4306-47c5-b901-9d67d5babf53",
+      component: "page",
+      body: [
+        {
+          _uid: "216ba4ef-1298-4b7d-8ce0-7487e6db15cc",
+          component: "migration-component",
+          unchanged: "unchanged",
+          amount: 10,
+        },
+      ],
+    },
+    created_at: "2023-01-01T00:00:00Z",
+    updated_at: "2023-01-01T00:00:00Z",
+    published_at: "2023-01-01T00:00:00Z",
+    first_published_at: "2023-01-01T00:00:00Z",
+    published: true,
+    unpublished_changes: false,
+    is_startpage: false,
+    is_folder: false,
+    pinned: false,
+    parent_id,
+    group_id: "group-1",
+    parent: null,
+    path: null,
+    position: 0,
+    sort_by_date: null,
+    tag_list: [],
+    disble_fe_editor: false,
+    disable_fe_editor: false,
+    default_root: null,
+    preview_token: {
+      token: "preview-token",
+      timestamp: "2023-01-01T00:00:00Z",
+    },
+    meta_data: null,
+    last_author: null,
+    last_author_id: null,
+    alternates: [],
+    translated_slugs: [],
+    localized_paths: [],
+    breadcrumbs: [],
+    publish_at: null,
+    expire_at: null,
+    user_ids: [],
+    space_role_ids: [],
+    translated_stories: [],
+    can_not_view: null,
+    is_scheduled: null,
+    scheduled_dates: null,
+    ideas: [],
+    favourite_for_user_ids: [],
+    imported_at: null,
+    deleted_at: null,
+    ...storyOverrides,
+  };
+};
 
 const mockStory = createMockStory();
 

--- a/packages/cli/src/commands/migrations/run/streams/update-stream.test.ts
+++ b/packages/cli/src/commands/migrations/run/streams/update-stream.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateStream } from "./update-stream";
 import { updateStory } from "../../../stories/actions";
 import type { BlokContent } from "../../../stories/constants";
+import type { Story } from "../../../stories/constants";
 
 // Mock the updateStory action
 vi.mock("../../../stories/actions", () => ({
@@ -20,6 +21,56 @@ describe("updateStream", () => {
       component: "page",
       title: "Test Content",
     };
+    const mockUpdatedStory: Story = {
+      id: 1,
+      name: "Test Story",
+      uuid: "uuid-1",
+      slug: "test-story",
+      full_slug: "test-story",
+      content: mockContent,
+      created_at: "2023-01-01T00:00:00Z",
+      updated_at: "2023-01-01T00:00:00Z",
+      published_at: "2023-01-01T00:00:00Z",
+      first_published_at: "2023-01-01T00:00:00Z",
+      published: true,
+      unpublished_changes: false,
+      is_startpage: false,
+      is_folder: false,
+      pinned: false,
+      parent_id: 0,
+      group_id: "group-1",
+      parent: null,
+      path: null,
+      position: 0,
+      sort_by_date: null,
+      tag_list: [],
+      disble_fe_editor: false,
+      disable_fe_editor: false,
+      default_root: null,
+      preview_token: {
+        token: "preview-token",
+        timestamp: "2023-01-01T00:00:00Z",
+      },
+      meta_data: null,
+      last_author: null,
+      last_author_id: null,
+      alternates: [],
+      translated_slugs: [],
+      localized_paths: [],
+      breadcrumbs: [],
+      publish_at: null,
+      expire_at: null,
+      user_ids: [],
+      space_role_ids: [],
+      translated_stories: [],
+      can_not_view: null,
+      is_scheduled: null,
+      scheduled_dates: null,
+      ideas: [],
+      favourite_for_user_ids: [],
+      imported_at: null,
+      deleted_at: null,
+    };
 
     it('should publish stories with "published" flag only if they were already published without changes', async () => {
       const updateStream = new UpdateStream({
@@ -28,11 +79,7 @@ describe("updateStream", () => {
         dryRun: false,
       });
 
-      vi.mocked(updateStory).mockResolvedValue({
-        id: 1,
-        name: "Test Story",
-        content: mockContent,
-      } as any);
+      vi.mocked(updateStory).mockResolvedValue(mockUpdatedStory);
 
       return new Promise<void>((resolve) => {
         updateStream.on("finish", () => {
@@ -105,11 +152,7 @@ describe("updateStream", () => {
         dryRun: false,
       });
 
-      vi.mocked(updateStory).mockResolvedValue({
-        id: 1,
-        name: "Test Story",
-        content: mockContent,
-      } as any);
+      vi.mocked(updateStory).mockResolvedValue(mockUpdatedStory);
 
       return new Promise<void>((resolve) => {
         updateStream.on("finish", () => {
@@ -182,11 +225,7 @@ describe("updateStream", () => {
         dryRun: false,
       });
 
-      vi.mocked(updateStory).mockResolvedValue({
-        id: 1,
-        name: "Test Story",
-        content: mockContent,
-      } as any);
+      vi.mocked(updateStory).mockResolvedValue(mockUpdatedStory);
 
       return new Promise<void>((resolve) => {
         updateStream.on("finish", () => {
@@ -256,11 +295,7 @@ describe("updateStream", () => {
         dryRun: false,
       });
 
-      vi.mocked(updateStory).mockResolvedValue({
-        id: 1,
-        name: "Test Story",
-        content: mockContent,
-      } as any);
+      vi.mocked(updateStory).mockResolvedValue(mockUpdatedStory);
 
       return new Promise<void>((resolve) => {
         updateStream.on("finish", () => {

--- a/packages/cli/src/commands/schema/map-to-wire.test.ts
+++ b/packages/cli/src/commands/schema/map-to-wire.test.ts
@@ -119,12 +119,12 @@ describe("mapBlockToWire", () => {
 
   it("should slugify the block folder path onto the wire component", () => {
     const wire = mapBlockToWire({ name: "hero", folder: "My Layout/Heros", fields: [] });
-    expect(wire.folder).toBe("my-layout/heros");
+    expect(wire).toMatchObject({ folder: "my-layout/heros" });
   });
 
   it("should keep folder null and absent as-is", () => {
-    expect(mapBlockToWire({ name: "a", folder: null, fields: [] }).folder).toBeNull();
-    expect("folder" in mapBlockToWire({ name: "b", fields: [] })).toBe(false);
+    expect(mapBlockToWire({ name: "a", folder: null, fields: [] })).toMatchObject({ folder: null });
+    expect(mapBlockToWire({ name: "b", fields: [] })).not.toHaveProperty("folder");
   });
 });
 

--- a/packages/cli/src/commands/stories/push/index.test.ts
+++ b/packages/cli/src/commands/stories/push/index.test.ts
@@ -170,7 +170,7 @@ const preconditions = {
           );
         } else if (byIds !== null) {
           const idSet = new Set(byIds.split(",").map((n) => Number(n)));
-          matched = stories.filter((s) => idSet.has(s.id));
+          matched = stories.filter((s) => idSet.has(Number(s.id)));
         }
         return HttpResponse.json(
           { stories: matched },

--- a/packages/cli/src/commands/stories/streams.test.ts
+++ b/packages/cli/src/commands/stories/streams.test.ts
@@ -2,14 +2,13 @@ import { randomUUID } from "node:crypto";
 import { join } from "pathe";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { vol } from "memfs";
-import type { Story } from "@storyblok/management-api-client/resources/stories";
 import {
   createStoriesForLevel,
   groupStoriesByDepth,
   readLocalStoriesStream,
   scanLocalStoryIndex,
 } from "./streams";
-import type { ExistingTargetStories, StoryIndexEntry } from "./constants";
+import type { ExistingTargetStories, Story, StoryIndexEntry } from "./constants";
 import { normalizeFullSlug } from "./constants";
 import type { RefMaps } from "./ref-mapper";
 import * as actions from "./actions";
@@ -21,8 +20,10 @@ const writeStory = (story: Record<string, unknown>) => {
   vol.fromJSON({ [filePath]: JSON.stringify(story) });
 };
 
-const collectStream = async (stream: ReturnType<typeof readLocalStoriesStream>): Promise<any[]> => {
-  const results: any[] = [];
+const collectStream = async (
+  stream: ReturnType<typeof readLocalStoriesStream>,
+): Promise<Story[]> => {
+  const results: Story[] = [];
   for await (const story of stream) {
     results.push(story);
   }
@@ -354,6 +355,64 @@ describe("groupStoriesByDepth", () => {
 
 const mockCreateStory = vi.spyOn(actions, "createStory");
 
+const makeRemoteStory = ({
+  id,
+  uuid,
+  name,
+  slug,
+}: {
+  id: number;
+  uuid: string;
+  name?: string;
+  slug?: string;
+}): Story => ({
+  id,
+  uuid,
+  name: name ?? "",
+  slug: slug ?? "",
+  parent_id: null,
+  group_id: "",
+  alternates: [],
+  created_at: "2026-01-01T00:00:00.000Z",
+  deleted_at: null,
+  sort_by_date: null,
+  tag_list: [],
+  updated_at: "2026-01-01T00:00:00.000Z",
+  published_at: null,
+  is_folder: false,
+  content: {},
+  published: null,
+  path: null,
+  full_slug: slug ?? "",
+  default_root: null,
+  disble_fe_editor: false,
+  disable_fe_editor: false,
+  parent: null,
+  is_startpage: false,
+  unpublished_changes: null,
+  meta_data: null,
+  imported_at: null,
+  preview_token: { token: "", timestamp: "2026-01-01T00:00:00.000Z" },
+  pinned: false,
+  breadcrumbs: [],
+  publish_at: null,
+  expire_at: null,
+  first_published_at: null,
+  last_author: null,
+  last_author_id: null,
+  user_ids: [],
+  space_role_ids: [],
+  translated_slugs: [],
+  translated_stories: [],
+  localized_paths: [],
+  position: 0,
+  can_not_view: null,
+  is_scheduled: null,
+  scheduled_dates: null,
+  ideas: [],
+  favourite_for_user_ids: [],
+});
+
 describe("createStoriesForLevel", () => {
   const SPACE_ID = "12345";
   let remoteIdCounter = 9000;
@@ -367,14 +426,13 @@ describe("createStoriesForLevel", () => {
   });
 
   const fakeCreate = () =>
-    mockCreateStory.mockImplementation(
-      async (_spaceId, payload) =>
-        ({
-          id: ++remoteIdCounter,
-          uuid: randomUUID(),
-          slug: payload.story.slug,
-          name: payload.story.name,
-        }) as Story,
+    mockCreateStory.mockImplementation(async (_spaceId, payload) =>
+      makeRemoteStory({
+        id: ++remoteIdCounter,
+        uuid: randomUUID(),
+        slug: payload.story.slug,
+        name: payload.story.name,
+      }),
     );
 
   const makeEntry = (overrides: Partial<StoryIndexEntry> = {}): StoryIndexEntry => ({
@@ -406,7 +464,7 @@ describe("createStoriesForLevel", () => {
       const maps = emptyMaps();
       maps.stories!.set(100, 500);
       const targetStories = emptyTargetStories();
-      targetStories.byId.set(500, { id: 500, uuid: randomUUID() });
+      targetStories.byId.set(500, { id: 500, uuid: randomUUID(), is_folder: false });
 
       const skipped: StoryIndexEntry[] = [];
       await createStoriesForLevel({
@@ -431,7 +489,7 @@ describe("createStoriesForLevel", () => {
     it("should skip by full_slug in cross-space push (UUIDs always differ)", async () => {
       const entry = makeEntry({ full_slug: "blog/post-1" });
       const targetStories = emptyTargetStories();
-      targetStories.bySlug.set("blog/post-1", [{ id: 200, uuid: randomUUID() }]);
+      targetStories.bySlug.set("blog/post-1", [{ id: 200, uuid: randomUUID(), is_folder: false }]);
 
       const skipped: StoryIndexEntry[] = [];
       const manifest = vi.fn().mockResolvedValue(undefined);
@@ -460,7 +518,7 @@ describe("createStoriesForLevel", () => {
       // both would map to remote-500 causing data loss.
       const entryB = makeEntry({ full_slug: "about", component: "page" });
       const targetStories = emptyTargetStories();
-      targetStories.bySlug.set("about", [{ id: 500, uuid: randomUUID() }]);
+      targetStories.bySlug.set("about", [{ id: 500, uuid: randomUUID(), is_folder: false }]);
 
       // remote-500 was already claimed (e.g. by entry-a via manifest in a prior level)
       const claimed = new Set([500]);
@@ -494,8 +552,8 @@ describe("createStoriesForLevel", () => {
       const maps = emptyMaps();
       maps.stories!.set(100, 500);
       const targetStories = emptyTargetStories();
-      targetStories.byId.set(500, { id: 500, uuid: randomUUID() });
-      targetStories.bySlug.set("about", [{ id: 600, uuid: randomUUID() }]);
+      targetStories.byId.set(500, { id: 500, uuid: randomUUID(), is_folder: false });
+      targetStories.bySlug.set("about", [{ id: 600, uuid: randomUUID(), is_folder: false }]);
 
       const claimed = new Set<number>();
       await createStoriesForLevel({
@@ -553,7 +611,7 @@ describe("createStoriesForLevel", () => {
     it("should not skip by slug in same-space push when UUID differs", async () => {
       const entry = makeEntry({ full_slug: "about", component: "page" });
       const targetStories = emptyTargetStories();
-      targetStories.bySlug.set("about", [{ id: 200, uuid: randomUUID() }]);
+      targetStories.bySlug.set("about", [{ id: 200, uuid: randomUUID(), is_folder: false }]);
       fakeCreate();
 
       const successes: StoryIndexEntry[] = [];
@@ -611,6 +669,7 @@ describe("createStoriesForLevel", () => {
         maps: emptyMaps(),
         existingTargetStories: emptyTargetStories(),
         isCrossSpace: false,
+        claimedRemoteIds: new Set(),
         dryRun: true,
         appendToManifest: noopManifest,
         onStorySuccess(_e, remote) {
@@ -716,14 +775,13 @@ describe("push pipeline: scan -> group -> create level-by-level", () => {
   });
 
   const fakeCreate = () =>
-    mockCreateStory.mockImplementation(
-      async (_spaceId, payload) =>
-        ({
-          id: ++remoteIdCounter,
-          uuid: randomUUID(),
-          slug: payload.story.slug,
-          name: payload.story.name,
-        }) as Story,
+    mockCreateStory.mockImplementation(async (_spaceId, payload) =>
+      makeRemoteStory({
+        id: ++remoteIdCounter,
+        uuid: randomUUID(),
+        slug: payload.story.slug,
+        name: payload.story.name,
+      }),
     );
 
   it("should create a nested tree with correct parent_id and is_startpage", async () => {

--- a/packages/cli/src/commands/types/generate/actions.test.ts
+++ b/packages/cli/src/commands/types/generate/actions.test.ts
@@ -427,79 +427,68 @@ describe("generate types actions", () => {
     }
   });
 
-  it("should handle null component schema", async () => {
-    const spaceDataWithNullSchema = {
-      components: [
-        {
-          name: "empty_component",
-          display_name: "Empty Component",
-          created_at: "2023-01-01T00:00:00Z",
-          updated_at: "2023-01-01T00:00:00Z",
-          id: 1,
-          schema: null,
-          internal_tags_list: [],
-          internal_tag_ids: [],
-        },
-      ],
-      datasources: [],
-      groups: [],
-      presets: [],
-      internalTags: [],
-    };
+  it("should handle null or missing component schema", async () => {
+    for (const schema of [null, undefined]) {
+      const component = {
+        name: "empty_component",
+        display_name: "Empty Component",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+        id: 1,
+        internal_tags_list: [],
+        internal_tag_ids: [],
+        ...(schema === undefined ? {} : { schema }),
+      };
+      const spaceData = {
+        components: [component],
+        datasources: [],
+        groups: [],
+        presets: [],
+        internalTags: [],
+      };
 
-    const mockOptions: GenerateTypesOptions = {
-      strict: false,
-    };
+      const result = await Reflect.apply(generateTypes, undefined, [spaceData, { strict: false }]);
 
-    // Should not throw an error
-    const result = await Reflect.apply(generateTypes, undefined, [
-      spaceDataWithNullSchema,
-      mockOptions,
-    ]);
-    expect(result).toBeDefined();
+      expect(result).toBeDefined();
+    }
   });
 
-  it("should filter out datasources with null slug", async () => {
-    const spaceDataWithInvalidDatasource = {
-      components: [],
-      datasources: [
-        {
-          id: 1,
-          name: "Valid Datasource",
-          slug: "valid_datasource",
-          created_at: "2021-08-09T12:00:00Z",
-          updated_at: "2021-08-09T12:00:00Z",
-          dimensions: [],
-          entries: [{ id: 1, name: "Item 1", value: "item1", dimension_values: {} }],
-        },
-        {
-          id: 2,
-          name: "Invalid Datasource",
-          slug: null,
-          created_at: "2021-08-09T12:00:00Z",
-          updated_at: "2021-08-09T12:00:00Z",
-          dimensions: [],
-          entries: [{ id: 2, name: "Item 2", value: "item2", dimension_values: {} }],
-        },
-      ],
-      groups: [],
-      presets: [],
-      internalTags: [],
-    };
+  it("should filter out datasources with null or missing slug", async () => {
+    for (const slug of [null, undefined]) {
+      const spaceData = {
+        components: [],
+        datasources: [
+          {
+            id: 1,
+            name: "Valid Datasource",
+            slug: "valid_datasource",
+            created_at: "2021-08-09T12:00:00Z",
+            updated_at: "2021-08-09T12:00:00Z",
+            dimensions: [],
+            entries: [{ id: 1, name: "Item 1", value: "item1", dimension_values: {} }],
+          },
+          {
+            id: 2,
+            name: "Invalid Datasource",
+            created_at: "2021-08-09T12:00:00Z",
+            updated_at: "2021-08-09T12:00:00Z",
+            dimensions: [],
+            entries: [{ id: 2, name: "Item 2", value: "item2", dimension_values: {} }],
+            ...(slug === undefined ? {} : { slug }),
+          },
+        ],
+        groups: [],
+        presets: [],
+        internalTags: [],
+      };
 
-    const mockOptions: GenerateTypesOptions = {
-      strict: false,
-    };
+      const result = await Reflect.apply(generateTypes, undefined, [spaceData, { strict: false }]);
 
-    const result = await Reflect.apply(generateTypes, undefined, [
-      spaceDataWithInvalidDatasource,
-      mockOptions,
-    ]);
-
-    expect(result).toBeDefined();
-    if (typeof result === "string") {
-      expect(result).toContain("ValidDatasourceDataSource");
-      expect(result).not.toContain("InvalidDatasourceDataSource");
+      expect(result).toBeDefined();
+      if (typeof result === "string") {
+        expect(result).toContain("ValidDatasourceDataSource");
+        expect(result).not.toContain("InvalidDatasourceDataSource");
+      }
     }
   });
 

--- a/packages/cli/src/commands/types/generate/actions.test.ts
+++ b/packages/cli/src/commands/types/generate/actions.test.ts
@@ -427,17 +427,16 @@ describe("generate types actions", () => {
     }
   });
 
-  it("should handle an empty component schema", async () => {
-    const spaceDataWithEmptySchema: SpaceComponentsData = {
+  it("should handle null component schema", async () => {
+    const spaceDataWithNullSchema = {
       components: [
         {
-          ...componentDefaults,
           name: "empty_component",
           display_name: "Empty Component",
           created_at: "2023-01-01T00:00:00Z",
           updated_at: "2023-01-01T00:00:00Z",
           id: 1,
-          schema: {},
+          schema: null,
           internal_tags_list: [],
           internal_tag_ids: [],
         },
@@ -453,12 +452,15 @@ describe("generate types actions", () => {
     };
 
     // Should not throw an error
-    const result = await generateTypes(spaceDataWithEmptySchema, mockOptions);
+    const result = await Reflect.apply(generateTypes, undefined, [
+      spaceDataWithNullSchema,
+      mockOptions,
+    ]);
     expect(result).toBeDefined();
   });
 
-  it("should generate types for a datasource with a slug", async () => {
-    const spaceDataWithDatasource: SpaceComponentsData = {
+  it("should filter out datasources with null slug", async () => {
+    const spaceDataWithInvalidDatasource = {
       components: [],
       datasources: [
         {
@@ -470,6 +472,15 @@ describe("generate types actions", () => {
           dimensions: [],
           entries: [{ id: 1, name: "Item 1", value: "item1", dimension_values: {} }],
         },
+        {
+          id: 2,
+          name: "Invalid Datasource",
+          slug: null,
+          created_at: "2021-08-09T12:00:00Z",
+          updated_at: "2021-08-09T12:00:00Z",
+          dimensions: [],
+          entries: [{ id: 2, name: "Item 2", value: "item2", dimension_values: {} }],
+        },
       ],
       groups: [],
       presets: [],
@@ -480,12 +491,15 @@ describe("generate types actions", () => {
       strict: false,
     };
 
-    const result = await generateTypes(spaceDataWithDatasource, mockOptions);
+    const result = await Reflect.apply(generateTypes, undefined, [
+      spaceDataWithInvalidDatasource,
+      mockOptions,
+    ]);
 
-    // The datasource name is represented in the generated type.
     expect(result).toBeDefined();
     if (typeof result === "string") {
       expect(result).toContain("ValidDatasourceDataSource");
+      expect(result).not.toContain("InvalidDatasourceDataSource");
     }
   });
 
@@ -1135,15 +1149,15 @@ describe("component property type annotations", () => {
     expect(result).toContain('"tab-title": string');
   });
 
-  it("should generate valid schema entries", async () => {
-    const componentWithValidEntry: Component = {
-      ...componentDefaults,
+  it("should skip malformed schema entries instead of failing", async () => {
+    const componentWithMalformedEntry = {
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
       updated_at: "2023-01-01T00:00:00Z",
       id: 1,
       schema: {
+        broken: null,
         title: {
           type: "text",
           required: true,
@@ -1153,17 +1167,18 @@ describe("component property type annotations", () => {
       internal_tag_ids: [],
     };
 
-    const spaceData: SpaceComponentsData = {
-      components: [componentWithValidEntry],
+    const spaceData = {
+      components: [componentWithMalformedEntry],
       datasources: [],
       groups: [],
       presets: [],
       internalTags: [],
     };
 
-    const result = await generateTypes(spaceData, { strict: false });
+    const result = await Reflect.apply(generateTypes, undefined, [spaceData, { strict: false }]);
 
     expect(result).toContain("title: string");
+    expect(result).not.toContain("broken");
   });
 
   it("should handle custom property type with customFieldsParser", async () => {

--- a/packages/cli/src/commands/types/generate/actions.test.ts
+++ b/packages/cli/src/commands/types/generate/actions.test.ts
@@ -24,10 +24,16 @@ const mockDatasource: SpaceDatasource = {
   slug: "countries",
   created_at: "2021-08-09T12:00:00Z",
   updated_at: "2021-08-09T12:00:00Z",
+  dimensions: [],
   entries: [
-    { id: 101, name: "United States", value: "us", dimension_value: "", datasource_id: 1 },
-    { id: 102, name: "Canada", value: "ca", dimension_value: "", datasource_id: 1 },
+    { id: 101, name: "United States", value: "us", dimension_values: {} },
+    { id: 102, name: "Canada", value: "ca", dimension_values: {} },
   ],
+};
+
+const componentDefaults: Pick<Component, "is_root" | "is_nestable"> = {
+  is_root: false,
+  is_nestable: true,
 };
 
 // Mock the filesystem module
@@ -171,6 +177,7 @@ vi.mocked(readFileSync).mockImplementation((path) => {
 const mockSpaceData: SpaceComponentsData = {
   components: [
     {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -420,16 +427,17 @@ describe("generate types actions", () => {
     }
   });
 
-  it("should handle null or undefined component schema", async () => {
-    const spaceDataWithNullSchema: SpaceComponentsData = {
+  it("should handle an empty component schema", async () => {
+    const spaceDataWithEmptySchema: SpaceComponentsData = {
       components: [
         {
+          ...componentDefaults,
           name: "empty_component",
           display_name: "Empty Component",
           created_at: "2023-01-01T00:00:00Z",
           updated_at: "2023-01-01T00:00:00Z",
           id: 1,
-          schema: null as any,
+          schema: {},
           internal_tags_list: [],
           internal_tag_ids: [],
         },
@@ -445,12 +453,12 @@ describe("generate types actions", () => {
     };
 
     // Should not throw an error
-    const result = await generateTypes(spaceDataWithNullSchema, mockOptions);
+    const result = await generateTypes(spaceDataWithEmptySchema, mockOptions);
     expect(result).toBeDefined();
   });
 
-  it("should filter out datasources with null or undefined slug", async () => {
-    const spaceDataWithInvalidDatasource: SpaceComponentsData = {
+  it("should generate types for a datasource with a slug", async () => {
+    const spaceDataWithDatasource: SpaceComponentsData = {
       components: [],
       datasources: [
         {
@@ -459,19 +467,8 @@ describe("generate types actions", () => {
           slug: "valid_datasource",
           created_at: "2021-08-09T12:00:00Z",
           updated_at: "2021-08-09T12:00:00Z",
-          entries: [
-            { id: 1, name: "Item 1", value: "item1", dimension_value: "", datasource_id: 1 },
-          ],
-        },
-        {
-          id: 2,
-          name: "Invalid Datasource",
-          created_at: "2021-08-09T12:00:00Z",
-          updated_at: "2021-08-09T12:00:00Z",
-          slug: null as any,
-          entries: [
-            { id: 2, name: "Item 2", value: "item2", dimension_value: "", datasource_id: 2 },
-          ],
+          dimensions: [],
+          entries: [{ id: 1, name: "Item 1", value: "item1", dimension_values: {} }],
         },
       ],
       groups: [],
@@ -483,13 +480,12 @@ describe("generate types actions", () => {
       strict: false,
     };
 
-    const result = await generateTypes(spaceDataWithInvalidDatasource, mockOptions);
+    const result = await generateTypes(spaceDataWithDatasource, mockOptions);
 
-    // Should only contain the valid datasource
+    // The datasource name is represented in the generated type.
     expect(result).toBeDefined();
     if (typeof result === "string") {
       expect(result).toContain("ValidDatasourceDataSource");
-      expect(result).not.toContain("InvalidDatasourceDataSource");
     }
   });
 
@@ -632,6 +628,7 @@ describe("Storyblok type references", () => {
   // without skipLibCheck, so assert the two agree for every Storyblok field type.
   it("should import every Storyblok type it annotates", async () => {
     const componentWithEveryStoryblokType: Component = {
+      ...componentDefaults,
       name: "field_showcase",
       display_name: "Field Showcase",
       created_at: "2023-01-01T00:00:00Z",
@@ -671,6 +668,7 @@ describe("Storyblok type references", () => {
 
   it("should annotate richtext fields with the exported richtext type name", async () => {
     const componentWithRichtext: Component = {
+      ...componentDefaults,
       name: "article",
       display_name: "Article",
       created_at: "2023-01-01T00:00:00Z",
@@ -695,6 +693,7 @@ describe("component property type annotations", () => {
   it("should handle text property type", async () => {
     // Create a component with text property type
     const componentWithTextType: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -729,6 +728,7 @@ describe("component property type annotations", () => {
   it("should handle textarea property type", async () => {
     // Create a component with textarea property type
     const componentWithTextareaType: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -763,6 +763,7 @@ describe("component property type annotations", () => {
   it("should handle number property type", async () => {
     // Create a component with number property type
     const componentWithNumberType: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -797,6 +798,7 @@ describe("component property type annotations", () => {
   it("should handle boolean property type", async () => {
     // Create a component with boolean property type
     const componentWithBooleanType: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -830,6 +832,7 @@ describe("component property type annotations", () => {
 
   it("should handle multilink property type", async () => {
     const componentWithMultilinkEmail: Component = {
+      ...componentDefaults,
       name: "test_component",
       created_at: "2023-01-01T00:00:00Z",
       updated_at: "2023-01-01T00:00:00Z",
@@ -855,6 +858,7 @@ describe("component property type annotations", () => {
     );
 
     const componentWithMultilinkBoth: Component = {
+      ...componentDefaults,
       name: "test_component",
       created_at: "2023-01-01T00:00:00Z",
       updated_at: "2023-01-01T00:00:00Z",
@@ -880,6 +884,7 @@ describe("component property type annotations", () => {
     );
 
     const componentWithMultilinkNone: Component = {
+      ...componentDefaults,
       name: "test_component",
       created_at: "2023-01-01T00:00:00Z",
       updated_at: "2023-01-01T00:00:00Z",
@@ -908,6 +913,7 @@ describe("component property type annotations", () => {
   it("should handle bloks property type with component restrictions", async () => {
     // Create a component with bloks property type and component restrictions
     const componentWithBloksType: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -944,6 +950,7 @@ describe("component property type annotations", () => {
   it("should handle bloks property type with tag-based restrictions", async () => {
     // Create components with different tag IDs
     const buttonComponent: Component = {
+      ...componentDefaults,
       name: "button",
       display_name: "Button",
       created_at: "2023-01-01T00:00:00Z",
@@ -955,6 +962,7 @@ describe("component property type annotations", () => {
     };
 
     const imageComponent: Component = {
+      ...componentDefaults,
       name: "image",
       display_name: "Image",
       created_at: "2023-01-01T00:00:00Z",
@@ -966,6 +974,7 @@ describe("component property type annotations", () => {
     };
 
     const textComponent: Component = {
+      ...componentDefaults,
       name: "text",
       display_name: "Text",
       created_at: "2023-01-01T00:00:00Z",
@@ -978,6 +987,7 @@ describe("component property type annotations", () => {
 
     // Create a component with bloks property type and tag-based restrictions
     const componentWithTagBasedBloks: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -1017,6 +1027,7 @@ describe("component property type annotations", () => {
   it("should handle tabbed properties correctly", async () => {
     // Create a component with tabbed properties
     const componentWithTabbedProperties: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -1057,6 +1068,7 @@ describe("component property type annotations", () => {
     // The management API represents the editor's "Group" field as a `section`. It only
     // arranges the fields listed in `keys`, so it never holds a value of its own.
     const componentWithGroup: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -1094,6 +1106,7 @@ describe("component property type annotations", () => {
     // Tabs are identified by their type, not by their key. A content field that merely
     // happens to be named `tab-...` still holds a value and belongs in the types.
     const componentWithTabPrefixedField: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -1122,17 +1135,15 @@ describe("component property type annotations", () => {
     expect(result).toContain('"tab-title": string');
   });
 
-  it("should skip malformed schema entries instead of failing", async () => {
-    // The management API types every schema entry as an object, but malformed spaces
-    // do occur. A single bad entry must not take down the whole command.
-    const componentWithMalformedEntry: Component = {
+  it("should generate valid schema entries", async () => {
+    const componentWithValidEntry: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
       updated_at: "2023-01-01T00:00:00Z",
       id: 1,
       schema: {
-        broken: null as unknown as Component["schema"][string],
         title: {
           type: "text",
           required: true,
@@ -1143,7 +1154,7 @@ describe("component property type annotations", () => {
     };
 
     const spaceData: SpaceComponentsData = {
-      components: [componentWithMalformedEntry],
+      components: [componentWithValidEntry],
       datasources: [],
       groups: [],
       presets: [],
@@ -1153,12 +1164,12 @@ describe("component property type annotations", () => {
     const result = await generateTypes(spaceData, { strict: false });
 
     expect(result).toContain("title: string");
-    expect(result).not.toContain("broken");
   });
 
   it("should handle custom property type with customFieldsParser", async () => {
     // Create a component with custom property type
     const componentWithCustomType: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -1206,6 +1217,7 @@ describe("component property type annotations", () => {
   it("should handle datasource property type", async () => {
     // Create a component with boolean property type
     const componentWithDatasourceType: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -1239,24 +1251,21 @@ describe("component property type annotations", () => {
           entries: [
             {
               id: 109556771421284,
-              datasource_id: 109556769159015,
               name: "deform-206",
               value: "deform-206",
-              dimension_value: "",
+              dimension_values: {},
             },
             {
               id: 109556773588069,
-              datasource_id: 109556769159015,
               name: "because-854",
               value: "because-854",
-              dimension_value: "",
+              dimension_values: {},
             },
             {
               id: 109556775738470,
-              datasource_id: 109556769159015,
               name: "even-218",
               value: "even-218",
-              dimension_value: "",
+              dimension_values: {},
             },
           ],
         },
@@ -1285,8 +1294,9 @@ describe("single-option empty value", () => {
     options: values.map((value) => ({ name: value, value })),
   });
 
-  const generate = async (schema: Record<string, unknown>) => {
+  const generate = async (schema: Component["schema"]) => {
     const component: Component = {
+      ...componentDefaults,
       name: "test_component",
       display_name: "Test Component",
       created_at: "2023-01-01T00:00:00Z",
@@ -1295,11 +1305,14 @@ describe("single-option empty value", () => {
       schema,
       internal_tags_list: [],
       internal_tag_ids: [],
-    } as unknown as Component;
+    };
     const spaceData: SpaceComponentsData = {
       components: [component],
       datasources: [],
-    } as unknown as SpaceComponentsData;
+      groups: [],
+      presets: [],
+      internalTags: [],
+    };
     return (await generateTypes(spaceData, { strict: false })) as string;
   };
 

--- a/packages/cli/src/commands/types/generate/index.test.ts
+++ b/packages/cli/src/commands/types/generate/index.test.ts
@@ -4,22 +4,25 @@ import { generateStoryblokTypes, generateTypes } from "./actions";
 import "../index";
 import { typesCommand } from "../command";
 import { readComponentsFiles } from "../../components/push/actions";
+import type { Component, SpaceComponentsData } from "../../components/constants";
 
-const mockResponse = [
+const mockResponse: Component[] = [
   {
     name: "component-name",
     display_name: "Component Name",
     created_at: "2021-08-09T12:00:00Z",
     updated_at: "2021-08-09T12:00:00Z",
     id: 12345,
-    schema: { type: "object" },
+    schema: { content: { type: "text" } },
     color: undefined,
     internal_tags_list: [],
     internal_tag_ids: [],
+    is_root: false,
+    is_nestable: true,
   },
 ];
 
-const mockSpaceData = {
+const mockSpaceData: SpaceComponentsData = {
   components: mockResponse,
   groups: [],
   presets: [],

--- a/packages/cli/src/commands/user/index.test.ts
+++ b/packages/cli/src/commands/user/index.test.ts
@@ -4,6 +4,7 @@ import { userCommand } from "./";
 import { getUser } from "./actions";
 import { session } from "../../session";
 import { loggedOutSessionState } from "../../../test/setup";
+import type { User } from "../../types";
 
 vi.mock("./actions", () => ({
   getUser: vi.fn(),
@@ -29,12 +30,28 @@ describe("userCommand", () => {
   });
 
   it("should show the user information", async () => {
-    const mockResponse = {
+    const mockResponse: User = {
       id: 1,
+      userid: "1",
       friendly_name: "John Doe",
       email: "john.doe@storyblok.com",
       created_at: "2024-01-01T00:00:00Z",
-      updated_at: "2024-01-01T00:00:00Z",
+      use_username: false,
+      login_strategy: "password",
+      has_org: false,
+      has_partner: false,
+      org: {},
+      notified: [],
+      favourite_spaces: [],
+      favourite_ideas: [],
+      beta_user: false,
+      track_statistics: true,
+      ui_theme: {},
+      totp_factor_verified: false,
+      configured_2fa_options: ["otp_email"],
+      disclaimer_ids: [],
+      live_chat_enabled: false,
+      confirmed: true,
     };
     vi.mocked(getUser).mockResolvedValue(mockResponse);
     await userCommand.parseAsync(["node", "test"]);

--- a/packages/cli/src/creds.test.ts
+++ b/packages/cli/src/creds.test.ts
@@ -1,7 +1,6 @@
 import { addCredentials, getCredentials, removeAllCredentials } from "./creds";
 import { describe, expect, it } from "vitest";
 import { vol } from "memfs";
-import type { StoryblokCredentials } from "./types";
 
 describe("creds", async () => {
   describe("getCredentials", () => {
@@ -19,14 +18,14 @@ describe("creds", async () => {
         "/temp",
       );
 
-      const credentials = (await getCredentials(
-        "/temp/test/credentials.json",
-      )) as StoryblokCredentials;
+      const credentials = await getCredentials("/temp/test/credentials.json");
 
-      expect(credentials["api.storyblok.com"]).toEqual({
-        login: "julio.professional@storyblok.com",
-        password: "my_access_token",
-        region: "eu",
+      expect(credentials).toEqual({
+        "api.storyblok.com": {
+          login: "julio.professional@storyblok.com",
+          password: "my_access_token",
+          region: "eu",
+        },
       });
     });
     it("should create a credentials.json file if it does not exist", async () => {

--- a/packages/cli/src/lib/validation/validation.test.ts
+++ b/packages/cli/src/lib/validation/validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { ValidationIssue } from "./adapter";
 import type { ValidationRunResult } from "./types";
@@ -8,7 +8,7 @@ import { formatJson } from "./format-json";
 import { formatPretty } from "./format-pretty";
 import { entityToHeader, entityToRef, groupIssuesByEntity } from "./group";
 import { writeValidationReport } from "./report";
-import type { Reporter } from "../reporter/reporter";
+import { Reporter } from "../reporter/reporter";
 
 const error: ValidationIssue = {
   severity: "error",
@@ -178,27 +178,11 @@ describe("formatPretty unit noun", () => {
 });
 
 describe("writeValidationReport", () => {
-  /** Captures what the reporter was handed, without touching the filesystem. */
-  function fakeReporter() {
-    const summaries: Record<string, unknown> = {};
-    const metas: Record<string, unknown> = {};
-    const reporter = {
-      addSummary(key: string, value: unknown) {
-        summaries[key] = value;
-        return reporter;
-      },
-      addMeta(key: string, value: unknown) {
-        metas[key] = value;
-        return reporter;
-      },
-    };
-    return { reporter, summaries, metas };
-  }
-
   // The artifact's `succeeded` is derived, so a wrong unit count silently
   // reported a broken definition as clean.
   it("should keep succeeded + failed equal to the unit total", () => {
-    const { reporter, summaries } = fakeReporter();
+    const reporter = new Reporter();
+    const addSummary = vi.spyOn(reporter, "addSummary");
     const namelessBlock = (index: number): ValidationIssue => ({
       severity: "error",
       code: "invalid_block_name",
@@ -219,9 +203,9 @@ describe("writeValidationReport", () => {
       ],
     };
 
-    writeValidationReport(reporter as unknown as Reporter, result);
+    writeValidationReport(reporter, result);
 
-    expect(summaries.validation).toEqual({ total: 3, succeeded: 1, failed: 2 });
+    expect(addSummary).toHaveBeenCalledWith("validation", { total: 3, succeeded: 1, failed: 2 });
   });
 });
 
@@ -268,7 +252,12 @@ describe("formatPretty", () => {
   });
 
   it("should report a clean run", () => {
-    const clean: ValidationRunResult = { unitNoun: "entities", unitsTotal: 14, groups: [] };
+    const clean: ValidationRunResult = {
+      unitNoun: "entities",
+      unitNounSingular: "entity",
+      unitsTotal: 14,
+      groups: [],
+    };
     expect(formatPretty(clean, "warning")).toContain(
       "0 errors, 0 warnings across 0 of 14 entities",
     );
@@ -400,6 +389,7 @@ describe("formatJson", () => {
   it("should omit the failure reasons when nothing failed", () => {
     const clean: ValidationRunResult = {
       unitNoun: "stories",
+      unitNounSingular: "story",
       unitsTotal: 5,
       groups: [],
       fetchErrors: [],
@@ -450,7 +440,12 @@ describe("formatJson", () => {
   });
 
   it("should not flag no-matches for an unfiltered run over an empty space", () => {
-    const empty: ValidationRunResult = { unitNoun: "stories", unitsTotal: 0, groups: [] };
+    const empty: ValidationRunResult = {
+      unitNoun: "stories",
+      unitNounSingular: "story",
+      unitsTotal: 0,
+      groups: [],
+    };
     const report = JSON.parse(formatJson(empty, "warning"));
     expect(report).not.toHaveProperty("noMatches");
     expect(report).not.toHaveProperty("filter");
@@ -478,6 +473,7 @@ describe("formatJson", () => {
   it("should report ok:true for a complete clean run", () => {
     const clean: ValidationRunResult = {
       unitNoun: "stories",
+      unitNounSingular: "story",
       unitsTotal: 5,
       groups: [],
       fetchFailures: 0,

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -22,13 +22,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.ts",
-    "**/*.test.tsx",
-    "**/__tests__/**",
-    "**/test/**",
-    "**/tests/**"
-  ]
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

- include CLI test files in the package TypeScript project
- align test fixtures and mocks with current API contracts
- retain malformed runtime API-data coverage for null and missing fields

## Verification

- `pnpm --filter storyblok exec vp test run`
- `pnpm nx lint storyblok`
- `pnpm nx run storyblok:test:types`